### PR TITLE
Fix wrong markdown

### DIFF
--- a/docs/modules/storage/pages/configuration/properties.adoc
+++ b/docs/modules/storage/pages/configuration/properties.adoc
@@ -6,8 +6,8 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 
 [options="header",cols="1,2"]
 |===
-|Property 
-|Short Description   
+|Property
+|Short Description
 //-------------
 |storage-directory
 |The base directory of the storage in the file system. Default is `"storage"` in the working directory.
@@ -16,11 +16,11 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 |The live file system configuration. See xref:storage-targets/index.adoc[storage targets] configuration.
 
 |deletion-directory
-|If configured, the storage will not delete files. Instead of deleting a file it will be moved to this directory. 
+|If configured, the storage will not delete files. Instead of deleting a file it will be moved to this directory.
 
 |truncation-directory
 |If configured, files that will get truncated are copied into this directory.
- 
+
 |backup-directory
 |The backup directory.
 |backup-filesystem
@@ -90,7 +90,7 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 |A flag defining whether the current head file (the only file actively written to) shall be subjected to file cleanups as well.
 
 |xref:#transaction-file-maximum-size[transaction-file-maximum-size]
-Maximum file size for each channels transactions log file. If this limit is exceeded the file wile be cleaned up during housekeeping. Default is 100 MiB. 
+Maximum file size for each channels transactions log file. If this limit is exceeded the file wile be cleaned up during housekeeping. Default is 100 MiB.
 Maximum value is 1 GiB.
 |===
 
@@ -142,9 +142,9 @@ Time used for each housekeeping cycle.
 However, no matter how low the number is, one item of work will always be completed.
 But if there is nothing to clean up, no processor time will be wasted.
 Default is `10000000` (10 million nanoseconds = 10 milliseconds = 0.01 seconds).
-+ However, no matter how small the time is, one item is done at least.
+However, no matter how small the time is, one item is done at least.
 This is to avoid no-ops, if a too small time window is configured.
-+ This time budget is a "best effort" threshold, meaning when at 1ns left, a huge file has to be cleaned or the references of a huge collection have to be marked for GC, then this budget can be exceeded considerably.
+This time budget is a "best effort" threshold, meaning when at 1ns left, a huge file has to be cleaned or the references of a huge collection have to be marked for GC, then this budget can be exceeded considerably.
 
 For further information see xref:configuration/housekeeping.adoc[Housekeeping].
 
@@ -152,13 +152,13 @@ For further information see xref:configuration/housekeeping.adoc[Housekeeping].
 === data-file-minimum-size
 
 Minimum file size in bytes of a storage file to avoid merging with other files during housekeeping.
-+ Must be greater than 1, maximum is 2GB.
+Must be greater than 1, maximum is 2GB.
 
 [#data-file-maximum-size]
 === data-file-maximum-size
 
 Maximum file size in bytes of a storage file to avoid splitting in more files during housekeeping.
-+ Must be greater than 1, maximum is 2GB.
+Must be greater than 1, maximum is 2GB.
 
 TIP: Due to internal implementation details files larger than 2GB are not supported!
 
@@ -178,7 +178,7 @@ for each storage files. FileCreation entries are kept, FileDeletion entries are 
 if the storage data file still exists on the file system. Otherwise all entries related
 to deleted files are removed if the storage data file does no more exist.
 
-Default is 100 MB. 
+Default is 100 MB.
 Maximum value is 1 GB.
 
 == Involved Types

--- a/docs/modules/storage/pages/root-instances.adoc
+++ b/docs/modules/storage/pages/root-instances.adoc
@@ -3,14 +3,14 @@
 Object instances can be stored as simple records.
 One value after another as a trivial byte stream.
 References between objects are mapped with unique numbers, called _ObjectId_, or short _OID_.
-+ With both combined, byte streams and OIDs, an object graph can be stored in a simple and quick way, as well as loaded, as a whole or partially.
+With both combined, byte streams and OIDs, an object graph can be stored in a simple and quick way, as well as loaded, as a whole or partially.
 
 image::graph.png[]
 
 But there is a small catch.
 Where does it start?
 What is the first instance or reference at startup?
-+ Strictly speaking "nothing".
+Strictly speaking "nothing".
 That's why at least one instance or a reference to an instance must be registered in a special way, so that the application has a starting point from where the object graph can be loaded.
 This is a "Root Instance".
 
@@ -43,7 +43,7 @@ In the most common cases, *nothing at all*.
 The default behavior is enough to get things going.
 
 By default, a single instance can be registered as the entity graph's root, accessible via `EmbeddedStorage.root()`.
-+ Therefore, this is already a fully fledged (although tiny) database application:
+Therefore, this is already a fully fledged (although tiny) database application:
 
 [source, java]
 ----


### PR DESCRIPTION
The continuation operator ("+") is not valid at the beginning of a line (but rather at the end), and also not necessary in all fixed cases here. Therefore the plus character was rendered verbatim.