### PR TITLE
Update GitHub Actions Workflow for Maven Deploy Snapshot

### DIFF
--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Update project version
         run: |
           currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-          newVersion="${currentVersion}-$SUFFIX"
+          currentVersionWithoutSnapshot=${currentVersion%-SNAPSHOT}
+          newVersion="${currentVersionWithoutSnapshot}-$SUFFIX-SNAPSHOT"
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot
         run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
@@ -89,7 +90,8 @@ jobs:
       - name: Update project version java 17
         run: |
           currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-          newVersion="${currentVersion}-$SUFFIX"
+          currentVersionWithoutSnapshot=${currentVersion%-SNAPSHOT}
+          newVersion="${currentVersionWithoutSnapshot}-$SUFFIX-SNAPSHOT"
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot java 17
         run: |

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -57,3 +57,47 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+
+        #java 17 build
+      - uses: actions/checkout@v3
+      - name: Set up Java for publishing to Maven Central Snapshot Repository
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: PASSPHRASE
+      - name: Prepare suffix
+        run: |
+          function prepareSuffix() {
+            local branch=$1
+            local result=${branch//\//_}
+            result=${result//#/}
+            local maxLength=10
+            if (( ${#result} > maxLength )); then
+              result=${result:0:maxLength}
+            fi
+            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
+            echo "${result}-${hashFromContent:0:10}"
+          }
+          suffix=$(prepareSuffix ${GITHUB_REF#refs/heads/})
+          echo "Suffix: $suffix"
+          echo "SUFFIX=$suffix" >> $GITHUB_ENV
+      - name: Update project version java 17
+        run: |
+          currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          newVersion="${currentVersion}-$SUFFIX"
+          mvn versions:set -DnewVersion=$newVersion --batch-mode
+      - name: Make a snapshot java 17
+        run: |
+          mvn -pl integrations/spring-boot3 clean install -am -B
+      - name: Deploy module build with java 17
+        run: |
+          mvn -Pdeploy -pl integrations/spring-boot3 deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -52,8 +52,7 @@ jobs:
           newVersion="${currentVersion}-$SUFFIX"
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot
-        # run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
-        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean package -U #testing without deploy
+        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -1,0 +1,65 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Make snapshot and deploy
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - 'release/**'
+
+jobs:
+  prepareSuffix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Prepare suffix
+        run: |
+          function prepareSuffix() {
+            local branch=$1
+            local result=${branch//\//_}
+            result=${result//#/}
+            local maxLength=10
+            if (( ${#result} > maxLength )); then
+              result=${result:0:maxLength}
+            fi
+            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
+            echo "${result}-${hashFromContent:0:10}"
+          }
+          echo "Suffix: $(prepareSuffix ${GITHUB_REF#refs/heads/})"
+
+  publish:
+    if: github.repository == 'eclipse-store/store'
+    runs-on: ubuntu-latest
+    steps:
+      - id: install-secret-key
+        name: Install gpg secret key
+        run: |
+          cat <(echo -e "${{ secrets.ORG_GPG_PRIVATE_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+      - uses: actions/checkout@v3
+      - name: Set up Java for publishing to Maven Central Snapshot Repository
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: PASSPHRASE
+      - name: Update project version
+        run: |
+          currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          newVersion="${currentVersion}-${{ needs.prepareSuffix.outputs.suffix }}"
+          mvn versions:set -DnewVersion=$newVersion --batch-mode
+      - name: Make a snapshot
+        # run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U
+        run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean package -U #testing without deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Make snapshot and deploy
+name: Make branch snapshot and deploy
 
 on:
   push:

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -10,27 +10,6 @@ on:
       - 'release/**'
 
 jobs:
-  prepareSuffix:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Prepare suffix
-        run: |
-          function prepareSuffix() {
-            local branch=$1
-            local result=${branch//\//_}
-            result=${result//#/}
-            local maxLength=10
-            if (( ${#result} > maxLength )); then
-              result=${result:0:maxLength}
-            fi
-            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
-            echo "${result}-${hashFromContent:0:10}"
-          }
-          echo "Suffix: $(prepareSuffix ${GITHUB_REF#refs/heads/})"
-
   publish:
     if: github.repository == 'eclipse-store/store'
     runs-on: ubuntu-latest
@@ -51,6 +30,20 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: PASSPHRASE
+      - name: Prepare suffix
+        run: |
+          function prepareSuffix() {
+            local branch=$1
+            local result=${branch//\//_}
+            result=${result//#/}
+            local maxLength=10
+            if (( ${#result} > maxLength )); then
+              result=${result:0:maxLength}
+            fi
+            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
+            echo "${result}-${hashFromContent:0:10}"
+          }
+          echo "Suffix: $(prepareSuffix ${GITHUB_REF#refs/heads/})"
       - name: Update project version
         run: |
           currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -43,11 +43,13 @@ jobs:
             local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
             echo "${result}-${hashFromContent:0:10}"
           }
-          echo "Suffix: $(prepareSuffix ${GITHUB_REF#refs/heads/})"
+          suffix=$(prepareSuffix ${GITHUB_REF#refs/heads/})
+          echo "Suffix: $suffix"
+          echo "SUFFIX=$suffix" >> $GITHUB_ENV
       - name: Update project version
         run: |
           currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-          newVersion="${currentVersion}-${{ needs.prepareSuffix.outputs.suffix }}"
+          newVersion="${currentVersion}-$SUFFIX"
           mvn versions:set -DnewVersion=$newVersion --batch-mode
       - name: Make a snapshot
         # run: mvn -Pdeploy -Pproduction --no-transfer-progress --batch-mode clean deploy -U


### PR DESCRIPTION
Description:

This pull request introduces several updates to the `.github/workflows/maven_deploy_snapshot_dev.yml` GitHub Actions workflow.

Changes include:

1. The workflow now runs on push events for all branches except `main` and branches that match the pattern `release/**`.
2. The `prepareSuffix` function has been updated to generate a suffix based on the branch name. This suffix is then stored in an environment variable for later use.
3. The project version is updated before the Maven build. The new version is formed by appending the suffix to the current version (without the `-SNAPSHOT` part) and then appending `-SNAPSHOT` again.
4. The workflow now includes a step to build and deploy the `integrations/spring-boot3` module with Java 17.

These changes aim to improve the automation of the Maven build and deployment process for the `eclipse-store/store` repository.