### PR TITLE
Improve Spring Integration, supplier, autocreation

### DIFF
--- a/docs/modules/misc/pages/integrations/cdi.adoc
+++ b/docs/modules/misc/pages/integrations/cdi.adoc
@@ -54,7 +54,7 @@ public void someMethod() {
 ----
 
 The _StorageManager_ configuration can be customized by CDI beans that implement the interface `org.eclipse.store.integrations.cdi.types.config.EmbeddedStorageFoundationCustomizer`.
-The `customize` method is called with an `EmbeddedStorageFoundationSupplier` which allows you to fully customize the _StorageManager_ that will be created. You can for example, add the specific Type Handlers for JDK 8 as described on the https://docs.eclipsestore.io/manual/storage/addendum/specialized-type-handlers.html[documentation].
+The `customize` method is called with an `EmbeddedStorageFoundation` which allows you to fully customize the _StorageManager_ that will be created. You can for example, add the specific Type Handlers for JDK 8 as described on the https://docs.eclipsestore.io/manual/storage/addendum/specialized-type-handlers.html[documentation].
 
 After the _StorageManager_ is created, the CDI beans that implement `org.eclipse.store.integrations.cdi.types.config.StorageManagerInitializer` are called.
 You have the opportunity to perform actions on the _StorageManager_ or root object.  Following rules apply to the _StorageManager_ that is passed to the `initialize` method of the interface.

--- a/docs/modules/misc/pages/integrations/cdi.adoc
+++ b/docs/modules/misc/pages/integrations/cdi.adoc
@@ -54,7 +54,7 @@ public void someMethod() {
 ----
 
 The _StorageManager_ configuration can be customized by CDI beans that implement the interface `org.eclipse.store.integrations.cdi.types.config.EmbeddedStorageFoundationCustomizer`.
-The `customize` method is called with an `EmbeddedStorageFoundation` which allows you to fully customize the _StorageManager_ that will be created. You can for example, add the specific Type Handlers for JDK 8 as described on the https://docs.eclipsestore.io/manual/storage/addendum/specialized-type-handlers.html[documentation].
+The `customize` method is called with an `EmbeddedStorageFoundationSupplier` which allows you to fully customize the _StorageManager_ that will be created. You can for example, add the specific Type Handlers for JDK 8 as described on the https://docs.eclipsestore.io/manual/storage/addendum/specialized-type-handlers.html[documentation].
 
 After the _StorageManager_ is created, the CDI beans that implement `org.eclipse.store.integrations.cdi.types.config.StorageManagerInitializer` are called.
 You have the opportunity to perform actions on the _StorageManager_ or root object.  Following rules apply to the _StorageManager_ that is passed to the `initialize` method of the interface.

--- a/docs/modules/misc/pages/integrations/spring-boot.adoc
+++ b/docs/modules/misc/pages/integrations/spring-boot.adoc
@@ -102,6 +102,15 @@ a new `EmbeddedStorageManager` or `EmbeddedStorageFoundationFactory` to create a
 
 It is also possible to obtain the entire configuration within the `StorageManagerConfiguration` Bean, enabling you to directly create a foundation and storage manager. This can be helpful if you need to stop storage at runtime and then restart it.
 
+== Disable Auto StorageManager creation
+If the user does not define any beans of type _EmbeddedStorageFoundation_ and _EmbeddedStorageManager_, these beans are automatically created. This behavior can be changed using the following configuration.
+[source,properties]
+----
+org.eclipse.store.auto-create-default-storage=false
+org.eclipse.store.auto-create-default-foundation=false
+----
+If these configuration items are not present, these beans are created by default.
+
 == Multiple Storage Managers
 
 You can have a more than one Storage Manager in your application. This can be useful if you want to have different storage targets for different data. For example, you might want to have a datastore for your user data and another for your product data. You can do this by creating multiple configuration classes and multiple Storage Managers.

--- a/docs/modules/misc/pages/integrations/spring-boot.adoc
+++ b/docs/modules/misc/pages/integrations/spring-boot.adoc
@@ -109,7 +109,6 @@ If the user does not define any beans of type _EmbeddedStorageFoundation_ and _E
 org.eclipse.store.auto-create-default-storage=false
 org.eclipse.store.auto-create-default-foundation=false
 ----
-If these configuration items are not present, these beans are created by default.
 
 == Multiple Storage Managers
 

--- a/integrations/spring-boot3/src/main/java/module-info.java
+++ b/integrations/spring-boot3/src/main/java/module-info.java
@@ -25,6 +25,7 @@ open module org.eclipse.store.integrations.spring.boot
     exports org.eclipse.store.integrations.spring.boot.types.converter;
     exports org.eclipse.store.integrations.spring.boot.types.factories;
     exports org.eclipse.store.integrations.spring.boot.types.concurrent;
+    exports org.eclipse.store.integrations.spring.boot.types.suppliers;
 
     requires transitive spring.beans;
     requires transitive spring.boot;

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
@@ -26,10 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.function.Supplier;
 
 @Configuration
 @AutoConfigureAfter(EclipseStoreSpringBoot.class)

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
@@ -57,7 +57,7 @@ public class DefaultEclipseStoreConfiguration
     @Bean
     @Qualifier(DEFAULT_QUALIFIER)
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.eclipse.store.foundation", name = "auto-create", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "org.eclipse.store", name = "auto-create-default-foundation", havingValue = "true", matchIfMissing = true)
     public EmbeddedStorageFoundationSupplier<EmbeddedStorageFoundation<?>> defaultStorageFoundationSupplier(
             @Qualifier(DEFAULT_QUALIFIER) EclipseStoreProperties eclipseStoreProperties,
             EmbeddedStorageFoundationFactory foundationFactory
@@ -77,7 +77,7 @@ public class DefaultEclipseStoreConfiguration
     @Bean
     @Qualifier(DEFAULT_QUALIFIER)
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "org.eclipse.store.storage", name = "auto-create", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "org.eclipse.store", name = "auto-create-default-storage", havingValue = "true", matchIfMissing = true)
     public EmbeddedStorageManager defaultStorageManager(
             EmbeddedStorageManagerFactory embeddedStorageManagerFactory,
             @Qualifier(DEFAULT_QUALIFIER) EclipseStoreProperties eclipseStoreProperties,

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
@@ -17,6 +17,7 @@ package org.eclipse.store.integrations.spring.boot.types;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageManagerFactory;
+import org.eclipse.store.integrations.spring.boot.types.suppliers.EmbeddedStorageFoundationSupplier;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -57,7 +58,7 @@ public class DefaultEclipseStoreConfiguration
     @Bean
     @Qualifier(DEFAULT_QUALIFIER)
     @ConditionalOnMissingBean
-    public Supplier<EmbeddedStorageFoundation<?>> defaultStorageFoundationSupplier(
+    public EmbeddedStorageFoundationSupplier<EmbeddedStorageFoundation<?>> defaultStorageFoundationSupplier(
             @Qualifier(DEFAULT_QUALIFIER) EclipseStoreProperties eclipseStoreProperties,
             EmbeddedStorageFoundationFactory foundationFactory
     )
@@ -80,7 +81,7 @@ public class DefaultEclipseStoreConfiguration
             EmbeddedStorageManagerFactory embeddedStorageManagerFactory,
             @Qualifier(DEFAULT_QUALIFIER) EclipseStoreProperties eclipseStoreProperties,
             @Qualifier(DEFAULT_QUALIFIER)
-            Supplier<EmbeddedStorageFoundation<?>> embeddedStorageFoundationSupplier
+            EmbeddedStorageFoundationSupplier<EmbeddedStorageFoundation<?>> embeddedStorageFoundationSupplier
     )
     {
         return embeddedStorageManagerFactory.createStorage(

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
@@ -23,8 +23,10 @@ import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.function.Supplier;
@@ -58,6 +60,7 @@ public class DefaultEclipseStoreConfiguration
     @Bean
     @Qualifier(DEFAULT_QUALIFIER)
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "org.eclipse.store.foundation", name = "auto-create", havingValue = "true", matchIfMissing = true)
     public EmbeddedStorageFoundationSupplier<EmbeddedStorageFoundation<?>> defaultStorageFoundationSupplier(
             @Qualifier(DEFAULT_QUALIFIER) EclipseStoreProperties eclipseStoreProperties,
             EmbeddedStorageFoundationFactory foundationFactory
@@ -77,6 +80,7 @@ public class DefaultEclipseStoreConfiguration
     @Bean
     @Qualifier(DEFAULT_QUALIFIER)
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "org.eclipse.store.storage", name = "auto-create", havingValue = "true", matchIfMissing = true)
     public EmbeddedStorageManager defaultStorageManager(
             EmbeddedStorageManagerFactory embeddedStorageManagerFactory,
             @Qualifier(DEFAULT_QUALIFIER) EclipseStoreProperties eclipseStoreProperties,

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -214,7 +214,7 @@ public class EclipseStoreProperties
      * If no user-defined bean with EmbeddedStorage exists, a default one will be created.
      * To prevent this automatic creation, set this flag to false.
      */
-    private boolean isAutoCreateDefaultStorage = true;
+    private boolean autoCreateDefaultStorage = true;
 
     public Class<?> getRoot()
     {
@@ -548,11 +548,11 @@ public class EclipseStoreProperties
 
     public boolean isAutoCreateDefaultStorage()
     {
-        return isAutoCreateDefaultStorage;
+        return autoCreateDefaultStorage;
     }
 
     public void setAutoCreateDefaultStorage(boolean autoCreateDefaultStorage)
     {
-        isAutoCreateDefaultStorage = autoCreateDefaultStorage;
+        this.autoCreateDefaultStorage = autoCreateDefaultStorage;
     }
 }

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -202,6 +202,20 @@ public class EclipseStoreProperties
      */
     private boolean registerJdk8Handlers;
 
+    /**
+     * This flag determines if a default foundation should be automatically created.
+     * If no user-defined bean with EmbeddedStorageFoundation exists, a default one will be created.
+     * To prevent this automatic creation, set this flag to false.
+     */
+    private boolean autoCreateDefaultFoundation = true;
+
+    /**
+     * This flag determines if a default storage should be automatically created.
+     * If no user-defined bean with EmbeddedStorage exists, a default one will be created.
+     * To prevent this automatic creation, set this flag to false.
+     */
+    private boolean isAutoCreateDefaultStorage = true;
+
     public Class<?> getRoot()
     {
         return this.root;
@@ -520,5 +534,25 @@ public class EclipseStoreProperties
     public void setRegisterJdk8Handlers(final boolean registerJdk8Handlers)
     {
         this.registerJdk8Handlers = registerJdk8Handlers;
+    }
+
+    public boolean isAutoCreateDefaultFoundation()
+    {
+        return autoCreateDefaultFoundation;
+    }
+
+    public void setAutoCreateDefaultFoundation(boolean autoCreateDefaultFoundation)
+    {
+        this.autoCreateDefaultFoundation = autoCreateDefaultFoundation;
+    }
+
+    public boolean isAutoCreateDefaultStorage()
+    {
+        return isAutoCreateDefaultStorage;
+    }
+
+    public void setAutoCreateDefaultStorage(boolean autoCreateDefaultStorage)
+    {
+        isAutoCreateDefaultStorage = autoCreateDefaultStorage;
     }
 }

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -33,7 +33,6 @@ import org.springframework.stereotype.Component;
  * The {@code EclipseStoreConfigConverter} class is a Spring component that converts the Eclipse Store properties into a map.
  * This map can then be used to configure the Eclipse Store.
  */
-@Component
 public class EclipseStoreConfigConverter
 {
 

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/suppliers/EmbeddedStorageFoundationSupplier.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/suppliers/EmbeddedStorageFoundationSupplier.java
@@ -1,0 +1,23 @@
+package org.eclipse.store.integrations.spring.boot.types.suppliers;
+
+/*-
+ * #%L
+ * EclipseStore Integrations SpringBoot
+ * %%
+ * Copyright (C) 2023 - 2024 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
+
+@FunctionalInterface
+public interface EmbeddedStorageFoundationSupplier<T extends EmbeddedStorageFoundation<?>>
+{
+    T get();
+}

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/suppliers/EmbeddedStorageFoundationSupplier.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/suppliers/EmbeddedStorageFoundationSupplier.java
@@ -17,7 +17,6 @@ package org.eclipse.store.integrations.spring.boot.types.suppliers;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
 
 @FunctionalInterface
-public interface EmbeddedStorageFoundationSupplier<T extends EmbeddedStorageFoundation<?>>
+public interface EmbeddedStorageFoundationSupplier<T extends EmbeddedStorageFoundation<?>> extends java.util.function.Supplier<T>
 {
-    T get();
 }

--- a/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/DisableStorageAutoCreateTest.java
+++ b/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/DisableStorageAutoCreateTest.java
@@ -1,5 +1,19 @@
 package test.eclipse.store.integrations.spring.boot;
 
+/*-
+ * #%L
+ * EclipseStore Integrations SpringBoot
+ * %%
+ * Copyright (C) 2023 - 2024 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/DisableStorageAutoCreateTest.java
+++ b/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/DisableStorageAutoCreateTest.java
@@ -1,0 +1,27 @@
+package test.eclipse.store.integrations.spring.boot;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource("classpath:application-storage-create-disable.properties")
+@SpringBootTest
+@ActiveProfiles("disable_auto_create")
+public class DisableStorageAutoCreateTest
+{
+
+    @Autowired
+    ApplicationContext context;
+
+    @Test
+    void name()
+    {
+       Assertions.assertThrows(NoSuchBeanDefinitionException.class, () ->  context.getBean(EmbeddedStorageManager.class));
+    }
+}

--- a/integrations/spring-boot3/src/test/resources/application-storage-create-disable.properties
+++ b/integrations/spring-boot3/src/test/resources/application-storage-create-disable.properties
@@ -1,1 +1,2 @@
-org.eclipse.store.storage.auto-create=false
+org.eclipse.store.auto-create-default-storage=false
+org.eclipse.store.auto-create-default-foundation=false

--- a/integrations/spring-boot3/src/test/resources/application-storage-create-disable.properties
+++ b/integrations/spring-boot3/src/test/resources/application-storage-create-disable.properties
@@ -1,0 +1,1 @@
+org.eclipse.store.storage.auto-create=false


### PR DESCRIPTION
Change supplier to own type, to prevent conflicts in Spring Configuration
+ remove Component annotation from the class, which is later as a bean define. 
+ add configuration to disable auto create of default foundation or storage.