### PR TITLE
Xio transfer rework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <license.licenceFile>${basedir}/LICENSE</license.licenceFile>
         <api.version>1</api.version>
         <javadoc.failed.on.error>false</javadoc.failed.on.error>
-        <eclipse.serializer.version>2.0.0-SNAPSHOT</eclipse.serializer.version>
+        <eclipse.serializer.version>2.0.0-XIO_transf-4c63b215c7-SNAPSHOT</eclipse.serializer.version>
         <failsafe.rerunFailingTestsCount>2</failsafe.rerunFailingTestsCount>
         <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <license.licenceFile>${basedir}/LICENSE</license.licenceFile>
         <api.version>1</api.version>
         <javadoc.failed.on.error>false</javadoc.failed.on.error>
-        <eclipse.serializer.version>2.0.0-XIO_transf-4c63b215c7-SNAPSHOT</eclipse.serializer.version>
+        <eclipse.serializer.version>2.0.0-SNAPSHOT</eclipse.serializer.version>
         <failsafe.rerunFailingTestsCount>2</failsafe.rerunFailingTestsCount>
         <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
     </properties>

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -444,19 +444,19 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 			final StorageLiveDataFile.Default headFile = this.headFile;
 
-			long headfilelength = headFile.totalLength();
+			long headFileLength = headFile.totalLength();
 			
 			// do the actual file-level copying in one go at the end and validate the byte count to be sure
 			long bytes = this.writer.writeTransfer(sourceFile, copyStart, copyLength, headFile);
 			if(copyLength != bytes) {
 				
-				logger.error("Data transfer error! Expected {} bytes transfered to head file but only {} bytes had been transferred! Trying again.", copyLength, bytes);
-				headFile.truncate(headfilelength);
+				logger.error("Data transfer error! Expected {} bytes transferred to head file but only {} bytes had been transferred! Trying again.", copyLength, bytes);
+				headFile.truncate(headFileLength);
 				
 				bytes = this.writer.writeTransfer(sourceFile, copyStart, copyLength, headFile);
 				if(copyLength != bytes) {
-					logger.error("Data transfer retry error! Expected {} bytes transfered to head file but only {} bytes had been transferred! Aborting!", copyLength, bytes);
-					throw new StorageExceptionIoWriting("Transfer to head file failed, only " + bytes + " of " + copyLength + " bytes transfered.");
+					logger.error("Data transfer retry error! Expected {} bytes transferred to head file but only {} bytes had been transferred! Aborting!", copyLength, bytes);
+					throw new StorageExceptionIoWriting("Transfer to head file failed, only " + bytes + " of " + copyLength + " bytes transferred.");
 				}
 			}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -444,8 +444,21 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 			final StorageLiveDataFile.Default headFile = this.headFile;
 
+			long headfilelength = headFile.totalLength();
+			
 			// do the actual file-level copying in one go at the end and validate the byte count to be sure
-			this.writer.writeTransfer(sourceFile, copyStart, copyLength, headFile);
+			long bytes = this.writer.writeTransfer(sourceFile, copyStart, copyLength, headFile);
+			if(copyLength != bytes) {
+				
+				logger.error("Data transfer error! Expected {} bytes transfered to head file but only {} bytes had been transferred! Trying again.", copyLength, bytes);
+				headFile.truncate(headfilelength);
+				
+				bytes = this.writer.writeTransfer(sourceFile, copyStart, copyLength, headFile);
+				if(copyLength != bytes) {
+					logger.error("Data transfer retry error! Expected {} bytes transfered to head file but only {} bytes had been transferred! Aborting!", copyLength, bytes);
+					throw new StorageExceptionIoWriting("Transfer to head file failed, only " + bytes + " of " + copyLength + " bytes transfered.");
+				}
+			}
 
 			// increase content length by length of chain
 			// (15.02.2019 TM)NOTE: changed from arithmetic inside #addChainToTail to directly using copyLength in here.


### PR DESCRIPTION
This PR addresses a potential IO Error.

The java.nio.channels.FileChannel methods transferTo(long, long, WritableByteChannel) and transferFrom(ReadableByteChannel, long, long) may not write all requested bytes in one method call therefore we need to loop them until all requested data is transferred.
The missing loop may be the cause for exceptions like
```
StorageExceptionIoWriting: Physical length 3047424 of current head file 146 is not equal its expected length of 3047612
```
as documented in #95 and mentioned in #210.

The PR is related to a PR in the Eclipse Serializer project.
