### PR TITLE
Add file system target property

### DIFF
--- a/afs/aws/aws/src/main/java/org/eclipse/store/afs/aws/types/AwsFileSystemCreator.java
+++ b/afs/aws/aws/src/main/java/org/eclipse/store/afs/aws/types/AwsFileSystemCreator.java
@@ -32,9 +32,9 @@ import software.amazon.awssdk.regions.Region;
 
 public abstract class AwsFileSystemCreator extends ConfigurationBasedCreator.Abstract<AFileSystem>
 {
-	protected AwsFileSystemCreator()
+	protected AwsFileSystemCreator(final String key)
 	{
-		super(AFileSystem.class);
+		super(AFileSystem.class, key);
 	}
 
 	protected void populateBuilder(

--- a/afs/aws/dynamodb/src/main/java/org/eclipse/store/afs/aws/dynamodb/types/DynamoDbFileSystemCreator.java
+++ b/afs/aws/dynamodb/src/main/java/org/eclipse/store/afs/aws/dynamodb/types/DynamoDbFileSystemCreator.java
@@ -26,25 +26,17 @@ public class DynamoDbFileSystemCreator extends AwsFileSystemCreator
 {
 	public DynamoDbFileSystemCreator()
 	{
-		super();
+		super("aws.dynamodb");
 	}
 	
 	@Override
-	public AFileSystem create(
-		final Configuration configuration
-	)
+	public AFileSystem create(final Configuration configuration)
 	{
-		final Configuration dynamoConfiguration = configuration.child("aws.dynamodb");
-		if(dynamoConfiguration == null)
-		{
-			return null;
-		}
-		
 		final DynamoDbClientBuilder clientBuilder = DynamoDbClient.builder();
-		this.populateBuilder(clientBuilder, dynamoConfiguration);
+		this.populateBuilder(clientBuilder, configuration);
 		
 		final DynamoDbClient    client    = clientBuilder.build();
-		final boolean           cache     = dynamoConfiguration.optBoolean("cache").orElse(true);
+		final boolean           cache     = configuration.optBoolean("cache").orElse(true);
 		final DynamoDbConnector connector = cache
 			? DynamoDbConnector.Caching(client)
 			: DynamoDbConnector.New(client)

--- a/afs/aws/s3/src/main/java/org/eclipse/store/afs/aws/s3/types/S3FileSystemCreator.java
+++ b/afs/aws/s3/src/main/java/org/eclipse/store/afs/aws/s3/types/S3FileSystemCreator.java
@@ -27,26 +27,18 @@ public class S3FileSystemCreator extends AwsFileSystemCreator
 {
 	public S3FileSystemCreator()
 	{
-		super();
+		super("aws.s3");
 	}
 	
 	@Override
-	public AFileSystem create(
-		final Configuration configuration
-	)
+	public AFileSystem create(final Configuration configuration)
 	{
-		final Configuration s3Configuration = configuration.child("aws.s3");
-		if(s3Configuration == null)
-		{
-			return null;
-		}
-		
 		final S3ClientBuilder clientBuilder = S3Client.builder();
-		this.populateBuilder(clientBuilder, s3Configuration);
+		this.populateBuilder(clientBuilder, configuration);
 		
 		final S3Client    client    = clientBuilder.build();
-		final boolean     cache     = s3Configuration.optBoolean("cache").orElse(true);
-		final boolean     directory = s3Configuration.optBoolean("directory-bucket").orElse(false);
+		final boolean     cache     = configuration.optBoolean("cache").orElse(true);
+		final boolean     directory = configuration.optBoolean("directory-bucket").orElse(false);
 		final S3Connector connector =
 			directory
 				?	(cache

--- a/afs/azure/storage/src/main/java/org/eclipse/store/afs/azure/storage/types/AzureStorageFileSystemCreator.java
+++ b/afs/azure/storage/src/main/java/org/eclipse/store/afs/azure/storage/types/AzureStorageFileSystemCreator.java
@@ -29,7 +29,7 @@ public class AzureStorageFileSystemCreator extends ConfigurationBasedCreator.Abs
 {
 	public AzureStorageFileSystemCreator()
 	{
-		super(AFileSystem.class);
+		super(AFileSystem.class, "azure.storage");
 	}
 
 	@Override
@@ -37,27 +37,21 @@ public class AzureStorageFileSystemCreator extends ConfigurationBasedCreator.Abs
 		final Configuration configuration
 	)
 	{
-		final Configuration azureConfiguration = configuration.child("azure.storage");
-		if(azureConfiguration == null)
-		{
-			return null;
-		}
-
 		final BlobServiceClientBuilder clientBuilder = new BlobServiceClientBuilder();
 
-		azureConfiguration.opt("endpoint").ifPresent(
+		configuration.opt("endpoint").ifPresent(
 			value -> clientBuilder.endpoint(value)
 		);
 
-		azureConfiguration.opt("connection-string").ifPresent(
+		configuration.opt("connection-string").ifPresent(
 			value -> clientBuilder.connectionString(value)
 		);
 
-		azureConfiguration.opt("encryption-scope").ifPresent(
+		configuration.opt("encryption-scope").ifPresent(
 			value -> clientBuilder.encryptionScope(value)
 		);
 
-		azureConfiguration.opt("credentials.type").ifPresent(credentialsType ->
+		configuration.opt("credentials.type").ifPresent(credentialsType ->
 		{
 			switch(credentialsType)
 			{
@@ -65,8 +59,8 @@ public class AzureStorageFileSystemCreator extends ConfigurationBasedCreator.Abs
 				{
 					clientBuilder.credential(
 						new BasicAuthenticationCredential(
-							azureConfiguration.get("credentials.username"),
-							azureConfiguration.get("credentials.password")
+							configuration.get("credentials.username"),
+							configuration.get("credentials.password")
 						)
 					);
 				}
@@ -76,8 +70,8 @@ public class AzureStorageFileSystemCreator extends ConfigurationBasedCreator.Abs
 				{
 					clientBuilder.credential(
 						new StorageSharedKeyCredential(
-							azureConfiguration.get("credentials.account-name"),
-							azureConfiguration.get("credentials.account-key")
+							configuration.get("credentials.account-name"),
+							configuration.get("credentials.account-key")
 						)
 					);
 				}
@@ -88,7 +82,7 @@ public class AzureStorageFileSystemCreator extends ConfigurationBasedCreator.Abs
 			}
 		});
 
-		final Configuration furtherConfiguration = azureConfiguration.child("configuration");
+		final Configuration furtherConfiguration = configuration.child("configuration");
 		if(furtherConfiguration != null)
 		{
 			final com.azure.core.util.Configuration config = new com.azure.core.util.Configuration();
@@ -101,7 +95,7 @@ public class AzureStorageFileSystemCreator extends ConfigurationBasedCreator.Abs
 		}
 
 		final BlobServiceClient     client    = clientBuilder.buildClient();
-		final boolean               cache     = azureConfiguration.optBoolean("cache").orElse(true);
+		final boolean               cache     = configuration.optBoolean("cache").orElse(true);
 		final AzureStorageConnector connector = cache
 			? AzureStorageConnector.Caching(client)
 			: AzureStorageConnector.New(client)

--- a/afs/googlecloud/firestore/src/main/java/org/eclipse/store/afs/googlecloud/firestore/types/GoogleCloudFirestoreFileSystemCreator.java
+++ b/afs/googlecloud/firestore/src/main/java/org/eclipse/store/afs/googlecloud/firestore/types/GoogleCloudFirestoreFileSystemCreator.java
@@ -38,53 +38,45 @@ public class GoogleCloudFirestoreFileSystemCreator extends ConfigurationBasedCre
 		
 	public GoogleCloudFirestoreFileSystemCreator()
 	{
-		super(AFileSystem.class);
+		super(AFileSystem.class, "googlecloud.firestore");
 	}
 	
 	@Override
-	public AFileSystem create(
-		final Configuration configuration
-	)
+	public AFileSystem create(final Configuration configuration)
 	{
-		final Configuration firestoreConfiguration = configuration.child("googlecloud.firestore");
-		if(firestoreConfiguration == null)
-		{
-			return null;
-		}
-		
 		final FirestoreOptions.Builder optionsBuilder = FirestoreOptions.getDefaultInstance().toBuilder();
 				
-		firestoreConfiguration.opt("client-lib-token").ifPresent(
+		configuration.opt("client-lib-token").ifPresent(
 			value -> optionsBuilder.setClientLibToken(value)
 		);
 		
-		firestoreConfiguration.opt("database-id").ifPresent(
+		configuration.opt("database-id").ifPresent(
 			value -> optionsBuilder.setDatabaseId(value)
 		);
 		
-		firestoreConfiguration.opt("emulator-host").ifPresent(
+		configuration.opt("emulator-host").ifPresent(
 			value -> optionsBuilder.setEmulatorHost(value)
 		);
 		
-		firestoreConfiguration.opt("host").ifPresent(
+		configuration.opt("host").ifPresent(
 			value -> optionsBuilder.setHost(value)
 		);
 		
-		firestoreConfiguration.opt("project-id").ifPresent(
+		configuration.opt("project-id").ifPresent(
 			value -> optionsBuilder.setProjectId(value)
 		);
 		
-		firestoreConfiguration.opt("quota-project-id").ifPresent(
+		configuration.opt("quota-project-id").ifPresent(
 			value -> optionsBuilder.setQuotaProjectId(value)
 		);
 				
 		this.createCredentials(
-			firestoreConfiguration,
+			configuration,
 			optionsBuilder
 		);
 		
 		final Firestore                     firestore = optionsBuilder.build().getService();
-		final boolean                       cache     = firestoreConfiguration.optBoolean("cache").orElse(true);
+		final boolean                       cache     = configuration.optBoolean("cache").orElse(true);
 		final GoogleCloudFirestoreConnector connector = cache
 			? GoogleCloudFirestoreConnector.Caching(firestore)
 			: GoogleCloudFirestoreConnector.New(firestore)

--- a/afs/kafka/src/main/java/org/eclipse/store/afs/kafka/types/KafkaFileSystemCreator.java
+++ b/afs/kafka/src/main/java/org/eclipse/store/afs/kafka/types/KafkaFileSystemCreator.java
@@ -26,7 +26,7 @@ public class KafkaFileSystemCreator extends ConfigurationBasedCreator.Abstract<A
 {
 	public KafkaFileSystemCreator()
 	{
-		super(AFileSystem.class);
+		super(AFileSystem.class, "kafka");
 	}
 	
 	@Override
@@ -34,15 +34,9 @@ public class KafkaFileSystemCreator extends ConfigurationBasedCreator.Abstract<A
 		final Configuration configuration
 	)
 	{
-		final Configuration kafkaConfiguration = configuration.child("kafka-properties");
-		if(kafkaConfiguration == null)
-		{
-			return null;
-		}
-		
 		final Properties     kafkaProperties = new Properties();
-		kafkaProperties.putAll(kafkaConfiguration.coalescedMap());
-		final boolean        cache           = kafkaConfiguration.optBoolean("cache").orElse(true);
+		kafkaProperties.putAll(configuration.coalescedMap());
+		final boolean        cache           = configuration.optBoolean("cache").orElse(true);
 		final KafkaConnector connector       = cache
 			? KafkaConnector.Caching(kafkaProperties)
 			: KafkaConnector.New(kafkaProperties)

--- a/afs/oraclecloud/objectstorage/src/main/java/org/eclipse/store/afs/oraclecloud/objectstorage/types/OracleCloudObjectStorageFileSystemCreator.java
+++ b/afs/oraclecloud/objectstorage/src/main/java/org/eclipse/store/afs/oraclecloud/objectstorage/types/OracleCloudObjectStorageFileSystemCreator.java
@@ -42,24 +42,16 @@ public class OracleCloudObjectStorageFileSystemCreator extends ConfigurationBase
 
 	public OracleCloudObjectStorageFileSystemCreator()
 	{
-		super(AFileSystem.class);
+		super(AFileSystem.class, "oraclecloud.object-storage");
 	}
 
 	@Override
-	public AFileSystem create(
-		final Configuration configuration
-	)
+	public AFileSystem create(final Configuration configuration)
 	{
-		final Configuration objectStorageConfiguration = configuration.child("oraclecloud.object-storage");
-		if(objectStorageConfiguration == null)
-		{
-			return null;
-		}
-
 		String              filePath                = null;
 		String              profile                 = null;
 		Charset             charset                 = StandardCharsets.UTF_8;
-		final Configuration configFileConfiguration = objectStorageConfiguration.child("config-file");
+		final Configuration configFileConfiguration = configuration.child("config-file");
 		if(configFileConfiguration != null)
 		{
 			filePath = configFileConfiguration.get("path");
@@ -87,7 +79,7 @@ public class OracleCloudObjectStorageFileSystemCreator extends ConfigurationBase
 			;
 
 			final ClientConfigurationBuilder clientConfigurationBuilder = ClientConfiguration.builder();
-			final Configuration              clientConfiguration        = objectStorageConfiguration.child("client");
+			final Configuration              clientConfiguration        = configuration.child("client");
 			if(clientConfiguration != null)
 			{
 				this.createClientConfiguration(
@@ -100,14 +92,14 @@ public class OracleCloudObjectStorageFileSystemCreator extends ConfigurationBase
 				authDetailsProvider,
 				clientConfigurationBuilder.build()
 			);
-			objectStorageConfiguration.opt("region").ifPresent(
+			configuration.opt("region").ifPresent(
 				value -> client.setRegion(value)
 			);
-			objectStorageConfiguration.opt("endpoint").ifPresent(
+			configuration.opt("endpoint").ifPresent(
 				value -> client.setEndpoint(value)
 			);
 
-			final boolean        cache           = objectStorageConfiguration.optBoolean("cache").orElse(true);
+			final boolean        cache           = configuration.optBoolean("cache").orElse(true);
 			final OracleCloudObjectStorageConnector connector       = cache
 				? OracleCloudObjectStorageConnector.Caching(client)
 				: OracleCloudObjectStorageConnector.New(client)
@@ -116,7 +108,7 @@ public class OracleCloudObjectStorageFileSystemCreator extends ConfigurationBase
 		}
 		catch(final IOException e)
 		{
-			throw new ConfigurationException(objectStorageConfiguration, e);
+			throw new ConfigurationException(configuration, e);
 		}
 	}
 

--- a/afs/redis/src/main/java/org/eclipse/store/afs/redis/types/RedisFileSystemCreator.java
+++ b/afs/redis/src/main/java/org/eclipse/store/afs/redis/types/RedisFileSystemCreator.java
@@ -16,6 +16,7 @@ package org.eclipse.store.afs.redis.types;
 
 import org.eclipse.serializer.afs.types.AFileSystem;
 import org.eclipse.serializer.chars.XChars;
+import org.eclipse.serializer.configuration.exceptions.ConfigurationException;
 import org.eclipse.serializer.configuration.types.Configuration;
 import org.eclipse.serializer.configuration.types.ConfigurationBasedCreator;
 import org.eclipse.store.afs.blobstore.types.BlobStoreFileSystem;
@@ -25,27 +26,19 @@ public class RedisFileSystemCreator extends ConfigurationBasedCreator.Abstract<A
 {
 	public RedisFileSystemCreator()
 	{
-		super(AFileSystem.class);
+		super(AFileSystem.class, "redis");
 	}
 
 	@Override
-	public AFileSystem create(
-		final Configuration configuration
-	)
+	public AFileSystem create(final Configuration configuration)
 	{
-		final Configuration redisConfiguration = configuration.child("redis");
-		if(redisConfiguration == null)
-		{
-			return null;
-		}
-		
-		final String redisUri = redisConfiguration.get("uri");
+		final String redisUri = configuration.get("uri");
 		if(XChars.isEmpty(redisUri))
 		{
-			return null;
+			throw new ConfigurationException(configuration, "redis.uri cannot be empty");
 		}
 
-		final boolean        cache     = redisConfiguration.optBoolean("cache").orElse(true);
+		final boolean        cache     = configuration.optBoolean("cache").orElse(true);
 		final RedisConnector connector = cache
 			? RedisConnector.Caching(redisUri)
 			: RedisConnector.New(redisUri)

--- a/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorHana.java
+++ b/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorHana.java
@@ -28,11 +28,11 @@ public class SqlFileSystemCreatorHana extends SqlFileSystemCreator
 	
 	@Override
 	protected SqlProvider createSqlProvider(
-		final Configuration sqlConfiguration,
+		final Configuration configuration,
 		final DataSource    dataSource
 	)
 	{
-		final SqlProviderHana.StoreType storeType = sqlConfiguration.opt("store-type")
+		final SqlProviderHana.StoreType storeType = configuration.opt("store-type")
 			.map(name -> SqlProviderHana.StoreType.valueOf(name.toUpperCase()))
 			.orElse(SqlProviderHana.StoreType.ROW)
 		;

--- a/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorMariaDb.java
+++ b/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorMariaDb.java
@@ -28,13 +28,13 @@ public class SqlFileSystemCreatorMariaDb extends SqlFileSystemCreator
 	
 	@Override
 	protected SqlProvider createSqlProvider(
-		final Configuration sqlConfiguration,
+		final Configuration configuration,
 		final DataSource    dataSource
 	)
 	{
 		return SqlProviderMariaDb.New(
-			sqlConfiguration.get("catalog"),
-			sqlConfiguration.get("schema") ,
+			configuration.get("catalog"),
+			configuration.get("schema") ,
 			dataSource
 		);
 	}

--- a/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorOracle.java
+++ b/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorOracle.java
@@ -28,13 +28,13 @@ public class SqlFileSystemCreatorOracle extends SqlFileSystemCreator
 	
 	@Override
 	protected SqlProvider createSqlProvider(
-		final Configuration sqlConfiguration,
+		final Configuration configuration,
 		final DataSource    dataSource
 	)
 	{
 		return SqlProviderOracle.New(
-			sqlConfiguration.get("catalog"),
-			sqlConfiguration.get("schema") ,
+			configuration.get("catalog"),
+			configuration.get("schema") ,
 			dataSource
 		);
 	}

--- a/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorPostgres.java
+++ b/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorPostgres.java
@@ -28,13 +28,13 @@ public class SqlFileSystemCreatorPostgres extends SqlFileSystemCreator
 	
 	@Override
 	protected SqlProvider createSqlProvider(
-		final Configuration sqlConfiguration,
+		final Configuration configuration,
 		final DataSource    dataSource
 	)
 	{
 		return SqlProviderPostgres.New(
-			sqlConfiguration.get("catalog"),
-			sqlConfiguration.get("schema") ,
+			configuration.get("catalog"),
+			configuration.get("schema") ,
 			dataSource
 		);
 	}

--- a/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorSqlite.java
+++ b/afs/sql/src/main/java/org/eclipse/store/afs/sql/types/SqlFileSystemCreatorSqlite.java
@@ -28,13 +28,13 @@ public class SqlFileSystemCreatorSqlite extends SqlFileSystemCreator
 	
 	@Override
 	protected SqlProvider createSqlProvider(
-		final Configuration sqlConfiguration,
+		final Configuration configuration,
 		final DataSource    dataSource
 	)
 	{
 		return SqlProviderSqlite.New(
-			sqlConfiguration.get("catalog"),
-			sqlConfiguration.get("schema") ,
+			configuration.get("catalog"),
+			configuration.get("schema") ,
 			dataSource
 		);
 	}

--- a/docs/modules/storage/pages/storage-targets/blob-stores/aws-dynamodb.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/aws-dynamodb.adoc
@@ -29,6 +29,9 @@ When using xref:configuration/index.adoc#external-configuration[external configu
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=aws.dynamodb
+
 storage-filesystem.aws.dynamodb.credentials.type=static
 storage-filesystem.aws.dynamodb.credentials.access-key-id=my-access-key-id
 storage-filesystem.aws.dynamodb.credentials.secret-access-key=my-secret-access-key

--- a/docs/modules/storage/pages/storage-targets/blob-stores/aws-s3.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/aws-s3.adoc
@@ -40,6 +40,9 @@ When using xref:configuration/index.adoc#external-configuration[external configu
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=aws.s3
+
 storage-directory=bucket-name/folder/subfolder
 storage-filesystem.aws.s3.credentials.type=static
 storage-filesystem.aws.s3.credentials.access-key-id=my-access-key-id

--- a/docs/modules/storage/pages/storage-targets/blob-stores/azure-storage.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/azure-storage.adoc
@@ -30,6 +30,9 @@ When using xref:configuration/index.adoc#external-configuration[external configu
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=azure.storage
+
 storage-filesystem.azure.storage.credentials.type=basic
 storage-filesystem.azure.storage.credentials.username=user
 storage-filesystem.azure.storage.credentials.password=secret

--- a/docs/modules/storage/pages/storage-targets/blob-stores/google-cloud-firestore.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/google-cloud-firestore.adoc
@@ -29,6 +29,9 @@ When using xref:configuration/index.adoc#external-configuration[external configu
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=googlecloud.firestore
+
 storage-filesystem.googlecloud.firestore.credentials.type=default
 storage-filesystem.googlecloud.firestore.database-id=my-database-id
 storage-filesystem.googlecloud.firestore.project-id=my-project-id

--- a/docs/modules/storage/pages/storage-targets/blob-stores/kafka.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/kafka.adoc
@@ -33,7 +33,10 @@ When using xref:configuration/index.adoc#external-configuration[external configu
 
 [source, properties, title="eclipsestore.properties"]
 ----
-storage-filesystem.kafka-properties.bootstrap.servers=localhost:9093
+# optional, enforces checks
+storage-filesystem.target=kafka
+
+storage-filesystem.kafka.bootstrap.servers=localhost:9093
 ----
 
 == Supported properties

--- a/docs/modules/storage/pages/storage-targets/blob-stores/oracle-cloud-object-storage.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/oracle-cloud-object-storage.adoc
@@ -29,6 +29,9 @@ When using xref:configuration/index.adoc#external-configuration[external configu
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=oraclecloud.object-storage
+
 storage-filesystem.oraclecloud.object-storage.config-file.profile=production
 storage-filesystem.oraclecloud.object-storage.region=us-phoenix-1
 ----

--- a/docs/modules/storage/pages/storage-targets/blob-stores/redis.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/redis.adoc
@@ -29,6 +29,9 @@ When using xref:configuration/index.adoc#external-configuration[external configu
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=redis
+
 storage-filesystem.redis.uri=redis://localhost:6379/0
 ----
 

--- a/docs/modules/storage/pages/storage-targets/sql-databases/mariadb.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/mariadb.adoc
@@ -37,6 +37,9 @@ Please note that you have to define a data source provider.
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=sql.mariadb
+
 storage-filesystem.sql.mariadb.data-source-provider=com.sample.MyDataSourceProvider
 storage-filesystem.sql.mariadb.catalog=mycatalog
 storage-filesystem.sql.mariadb.schema=myschema

--- a/docs/modules/storage/pages/storage-targets/sql-databases/oracle.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/oracle.adoc
@@ -37,6 +37,9 @@ Please note that you have to define a data source provider.
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=sql.oracle
+
 storage-filesystem.sql.oracle.data-source-provider=com.sample.MyDataSourceProvider
 storage-filesystem.sql.oracle.catalog=mycatalog
 storage-filesystem.sql.oracle.schema=myschema

--- a/docs/modules/storage/pages/storage-targets/sql-databases/postgresql.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/postgresql.adoc
@@ -37,6 +37,9 @@ Please note that you have to define a data source provider.
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=sql.postgres
+
 storage-filesystem.sql.postgres.data-source-provider=com.sample.MyDataSourceProvider
 storage-filesystem.sql.postgres.catalog=mycatalog
 storage-filesystem.sql.postgres.schema=myschema

--- a/docs/modules/storage/pages/storage-targets/sql-databases/sqlite.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/sqlite.adoc
@@ -35,6 +35,9 @@ Please note that you have to define a data source provider.
 
 [source, properties, title="eclipsestore.properties"]
 ----
+# optional, enforces checks
+storage-filesystem.target=sql.sqlite
+
 storage-filesystem.sql.sqlite.data-source-provider=com.sample.MyDataSourceProvider
 storage-filesystem.sql.sqlite.catalog=mycatalog
 storage-filesystem.sql.sqlite.schema=myschema

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -42,7 +42,7 @@ public class EclipseStoreProperties
      */
     @NestedConfigurationProperty
     private StorageFilesystem storageFilesystem;
-
+    
     /**
      * If configured, the storage will not delete files. Instead of deleting a file it will be moved to this directory.
      */
@@ -538,20 +538,20 @@ public class EclipseStoreProperties
 
     public boolean isAutoCreateDefaultFoundation()
     {
-        return autoCreateDefaultFoundation;
+        return this.autoCreateDefaultFoundation;
     }
 
-    public void setAutoCreateDefaultFoundation(boolean autoCreateDefaultFoundation)
+    public void setAutoCreateDefaultFoundation(final boolean autoCreateDefaultFoundation)
     {
         this.autoCreateDefaultFoundation = autoCreateDefaultFoundation;
     }
 
     public boolean isAutoCreateDefaultStorage()
     {
-        return autoCreateDefaultStorage;
+        return this.autoCreateDefaultStorage;
     }
 
-    public void setAutoCreateDefaultStorage(boolean autoCreateDefaultStorage)
+    public void setAutoCreateDefaultStorage(final boolean autoCreateDefaultStorage)
     {
         this.autoCreateDefaultStorage = autoCreateDefaultStorage;
     }

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/StorageFilesystem.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/StorageFilesystem.java
@@ -25,100 +25,115 @@ import org.eclipse.store.integrations.spring.boot.types.configuration.redis.Redi
 import org.eclipse.store.integrations.spring.boot.types.configuration.sql.Sql;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
+
 public class StorageFilesystem
 {
+	/**
+	 * The target type of the file system
+	 */
+	private String target;
 
-    @NestedConfigurationProperty
-    private Sql sql;
-
-    @NestedConfigurationProperty
-    private Aws aws;
-
-    @NestedConfigurationProperty
-    private Azure azure;
-
-    /**
-     * Supported properties
-     * All supported properties of Kafka, see <a href="https://kafka.apache.org/documentation/">...</a>
-     */
-    private Map<String, String> kafkaProperties;
-
-    @NestedConfigurationProperty
-    private Oraclecloud oraclecloud;
-
-    @NestedConfigurationProperty
-    private Googlecloud googlecloud;
-
-    @NestedConfigurationProperty
-    private Redis redis;
-
-    public Sql getSql()
-    {
-        return this.sql;
-    }
-
-    public void setSql(final Sql sql)
-    {
-        this.sql = sql;
-    }
-
-    public Aws getAws()
-    {
-        return this.aws;
-    }
-
-    public void setAws(final Aws aws)
-    {
-        this.aws = aws;
-    }
-
-    public Map<String, String> getKafkaProperties()
-    {
-        return this.kafkaProperties;
-    }
-
-    public void setKafkaProperties(final Map<String, String> kafkaProperties)
-    {
-        this.kafkaProperties = kafkaProperties;
-    }
-
-    public Oraclecloud getOraclecloud()
-    {
-        return this.oraclecloud;
-    }
-
-    public void setOraclecloud(final Oraclecloud oraclecloud)
-    {
-        this.oraclecloud = oraclecloud;
-    }
-
-    public Redis getRedis()
-    {
-        return this.redis;
-    }
-
-    public void setRedis(final Redis redis)
-    {
-        this.redis = redis;
-    }
-
-    public Azure getAzure()
-    {
-        return this.azure;
-    }
-
-    public void setAzure(final Azure azure)
-    {
-        this.azure = azure;
-    }
-
-    public Googlecloud getGooglecloud()
-    {
-        return this.googlecloud;
-    }
-
-    public void setGooglecloud(final Googlecloud googlecloud)
-    {
-        this.googlecloud = googlecloud;
-    }
+	@NestedConfigurationProperty
+	private Sql sql;
+	
+	@NestedConfigurationProperty
+	private Aws aws;
+	
+	@NestedConfigurationProperty
+	private Azure azure;
+	
+	/**
+	 * Supported properties
+	 * All supported properties of Kafka, see <a href="https://kafka.apache.org/documentation/">...</a>
+	 */
+	private Map<String, String> kafkaProperties;
+	
+	@NestedConfigurationProperty
+	private Oraclecloud oraclecloud;
+	
+	@NestedConfigurationProperty
+	private Googlecloud googlecloud;
+	
+	@NestedConfigurationProperty
+	private Redis redis;
+	
+	public String getTarget()
+	{
+		return this.target;
+	}
+	
+	public void setTarget(final String target)
+	{
+		this.target = target;
+	}
+	
+	public Sql getSql()
+	{
+	    return this.sql;
+	}
+	
+	public void setSql(final Sql sql)
+	{
+	    this.sql = sql;
+	}
+	
+	public Aws getAws()
+	{
+	    return this.aws;
+	}
+	
+	public void setAws(final Aws aws)
+	{
+	    this.aws = aws;
+	}
+	
+	public Map<String, String> getKafkaProperties()
+	{
+	    return this.kafkaProperties;
+	}
+	
+	public void setKafkaProperties(final Map<String, String> kafkaProperties)
+	{
+	    this.kafkaProperties = kafkaProperties;
+	}
+	
+	public Oraclecloud getOraclecloud()
+	{
+	    return this.oraclecloud;
+	}
+	
+	public void setOraclecloud(final Oraclecloud oraclecloud)
+	{
+	    this.oraclecloud = oraclecloud;
+	}
+	
+	public Redis getRedis()
+	{
+	    return this.redis;
+	}
+	
+	public void setRedis(final Redis redis)
+	{
+	    this.redis = redis;
+	}
+	
+	public Azure getAzure()
+	{
+	    return this.azure;
+	}
+	
+	public void setAzure(final Azure azure)
+	{
+	    this.azure = azure;
+	}
+	
+	public Googlecloud getGooglecloud()
+	{
+	    return this.googlecloud;
+	}
+	
+	public void setGooglecloud(final Googlecloud googlecloud)
+	{
+	    this.googlecloud = googlecloud;
+	}
 }

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/ConfigKeys.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/ConfigKeys.java
@@ -31,6 +31,7 @@ public enum ConfigKeys
     
     // commons
     CACHE("cache"),
+    TARGET("target"),
     
     //aws
     AWS("aws"),

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -142,6 +142,13 @@ public class EclipseStoreConfigConverter
     private Map<String, String> prepareFileSystem(final StorageFilesystem properties, final String key)
     {
         final Map<String, String> values = new HashMap<>();
+        
+        final String target = properties.getTarget();
+        if(target != null)
+        {
+        	values.put(this.composeKey(key, ConfigKeys.TARGET.value()), target);
+        }
+        
         if (properties.getSql() != null)
         {
             values.putAll(this.prepareSql(properties.getSql(), this.composeKey(key, ConfigKeys.SQL.value())));

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -137,14 +137,30 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 			final Configuration configuration = this.configuration.child(configurationKey);
 			if(configuration != null)
 			{
+				final String  fileSystemTypeKey = this.configuration.opt(configurationKey + ".target").orElse(null);
+				final boolean fileSystemTypeSet = !XChars.isEmpty(fileSystemTypeKey);
 				for(final ConfigurationBasedCreator<AFileSystem> creator :
 					ConfigurationBasedCreator.registeredCreators(AFileSystem.class))
 				{
-					final AFileSystem fileSystem = creator.create(configuration);
-					if(fileSystem != null)
+					if(!fileSystemTypeSet || creator.key().equals(fileSystemTypeKey))
 					{
-						return fileSystem;
+						final Configuration child = configuration.child(creator.key());
+						if(child != null)
+						{
+							final AFileSystem fileSystem = creator.create(child);
+							if(fileSystem != null)
+							{
+								return fileSystem;
+							}
+						}
 					}
+				}
+				if(fileSystemTypeSet)
+				{
+					throw new IllegalStateException(
+						"No " + configurationKey + " provider found for '" + fileSystemTypeKey +
+						"'. Please ensure that all required dependencies are present."
+					);
 				}
 			}
 			


### PR DESCRIPTION
Add a property to enforce a certain file system provider to add checks like missing dependencies. This should prevent the accidental creation of the wrong provider.

`storage-filesystem.target=$provider`
`backup-filesystem.target=$provider`