### PR TITLE
Storer enhancements

### DIFF
--- a/examples/extension-wrapper/src/main/java/org/eclipse/store/examples/extensionwrapper/PersistenceStorerWrapper.java
+++ b/examples/extension-wrapper/src/main/java/org/eclipse/store/examples/extensionwrapper/PersistenceStorerWrapper.java
@@ -16,7 +16,6 @@ package org.eclipse.store.examples.extensionwrapper;
 
 import org.eclipse.serializer.persistence.types.PersistenceCommitListener;
 import org.eclipse.serializer.persistence.types.PersistenceStorer;
-import org.eclipse.serializer.persistence.types.Storer;
 
 /**
  * Wrapper for {@link PersistenceStorer}, used as base for extensions
@@ -126,12 +125,6 @@ public class PersistenceStorerWrapper implements PersistenceStorer
 	public void registerCommitListener(final PersistenceCommitListener listener)
 	{
 		this.delegate.registerCommitListener(listener);
-	}
-	
-	@Override
-	public boolean registerSubStorer(final Storer subStorer)
-	{
-		return this.delegate.registerSubStorer(subStorer);
 	}
 	
 	

--- a/examples/extension-wrapper/src/main/java/org/eclipse/store/examples/extensionwrapper/PersistenceStorerWrapper.java
+++ b/examples/extension-wrapper/src/main/java/org/eclipse/store/examples/extensionwrapper/PersistenceStorerWrapper.java
@@ -16,6 +16,7 @@ package org.eclipse.store.examples.extensionwrapper;
 
 import org.eclipse.serializer.persistence.types.PersistenceCommitListener;
 import org.eclipse.serializer.persistence.types.PersistenceStorer;
+import org.eclipse.serializer.persistence.types.Storer;
 
 /**
  * Wrapper for {@link PersistenceStorer}, used as base for extensions
@@ -125,6 +126,12 @@ public class PersistenceStorerWrapper implements PersistenceStorer
 	public void registerCommitListener(final PersistenceCommitListener listener)
 	{
 		this.delegate.registerCommitListener(listener);
+	}
+	
+	@Override
+	public boolean registerSubStorer(final Storer subStorer)
+	{
+		return this.delegate.registerSubStorer(subStorer);
 	}
 	
 	

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
@@ -19,7 +19,6 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import jakarta.enterprise.inject.spi.CDI;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.serializer.afs.types.AFile;
 import org.eclipse.serializer.collections.types.XGettingEnum;
@@ -28,12 +27,25 @@ import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.persistence.types.PersistenceManager;
 import org.eclipse.serializer.persistence.types.PersistenceRootsView;
 import org.eclipse.serializer.persistence.types.PersistenceTypeDictionaryExporter;
+import org.eclipse.serializer.reference.UsageMarkable;
 import org.eclipse.store.integrations.cdi.ConfigurationCoreProperties;
 import org.eclipse.store.storage.embedded.configuration.types.EmbeddedStorageConfiguration;
 import org.eclipse.store.storage.embedded.configuration.types.EmbeddedStorageConfigurationBuilder;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
-import org.eclipse.store.storage.types.*;
+import org.eclipse.store.storage.types.Database;
+import org.eclipse.store.storage.types.StorageConfiguration;
+import org.eclipse.store.storage.types.StorageConnection;
+import org.eclipse.store.storage.types.StorageEntityCacheEvaluator;
+import org.eclipse.store.storage.types.StorageEntityTypeExportFileProvider;
+import org.eclipse.store.storage.types.StorageEntityTypeExportStatistics;
+import org.eclipse.store.storage.types.StorageEntityTypeHandler;
+import org.eclipse.store.storage.types.StorageLiveFileProvider;
+import org.eclipse.store.storage.types.StorageManager;
+import org.eclipse.store.storage.types.StorageRawFileStatistics;
+import org.eclipse.store.storage.types.StorageTypeDictionary;
+
+import jakarta.enterprise.inject.spi.CDI;
 
 
 /**
@@ -43,7 +55,7 @@ import org.eclipse.store.storage.types.*;
  * And to avoid the creating of the StorageManager at deployment time, we have this proxy that
  * delays the creation of the StorageManager until first use.
  */
-public class StorageManagerProxy implements StorageManager
+public class StorageManagerProxy extends UsageMarkable.Default implements StorageManager
 {
 
     private static final Object LOCK = new Object();

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
@@ -38,6 +38,7 @@ import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.serializer.persistence.types.Unpersistable;
 import org.eclipse.serializer.reference.LazyReferenceManager;
 import org.eclipse.serializer.reference.Swizzling;
+import org.eclipse.serializer.reference.UsageMarkable;
 import org.eclipse.serializer.typing.KeyValue;
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
@@ -92,7 +93,9 @@ public interface EmbeddedStorageManager extends StorageManager
 	}
 
 
-	public final class Default implements EmbeddedStorageManager, Unpersistable, LazyReferenceManager.Controller
+	public final class Default
+	extends UsageMarkable.Default
+	implements EmbeddedStorageManager, Unpersistable, LazyReferenceManager.Controller
 	{
 		private final static Logger logger = Logging.getLogger(EmbeddedStorageManager.class);
 		
@@ -318,7 +321,7 @@ public interface EmbeddedStorageManager extends StorageManager
 			final EqHashTable<String, Object> loadedEntries  = normalize(loadedRoots.entries());
 			final EqHashTable<String, Object> definedEntries = normalize(this.rootsProvider.provideRoots().entries());
 			
-			final boolean match = loadedEntries.equalsContent(definedEntries, Default::isEqualRootEntry);
+			final boolean match = loadedEntries.equalsContent(definedEntries, EmbeddedStorageManager.Default::isEqualRootEntry);
 			if(!match)
 			{
 				// change detected. Entries of loadedRoots must be updated/replaced

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
@@ -29,6 +29,7 @@ import org.eclipse.serializer.persistence.types.PersistenceTypeDictionaryFileHan
 import org.eclipse.serializer.persistence.types.Persister;
 import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.serializer.persistence.types.Unpersistable;
+import org.eclipse.serializer.reference.UsageMarkable;
 import org.eclipse.store.storage.exceptions.StorageExceptionBackupFullBackupTargetNotEmpty;
 
 
@@ -40,7 +41,7 @@ import org.eclipse.store.storage.exceptions.StorageExceptionBackupFullBackupTarg
  * Since {@link StorageManager} implements this interface, is normally sufficient to use just that.
  *
  */
-public interface StorageConnection extends Persister
+public interface StorageConnection extends UsageMarkable, Persister
 {
 	/* (11.05.2014 TM)TODO: Proper InterruptedException handling
 	 *  just returning, especially returning null (see below) seems quite dangerous.
@@ -469,7 +470,7 @@ public interface StorageConnection extends Persister
 	}
 	
 
-	public final class Default implements StorageConnection, Unpersistable
+	public final class Default extends UsageMarkable.Default implements StorageConnection, Unpersistable
 	{
 		///////////////////////////////////////////////////////////////////////////
 		// instance fields //


### PR DESCRIPTION
UsageMarkable concept: To prevent Lazy references from being cleared despite having unstored changes, they can now be marked for being used for certain instances. A lazy reference can only get cleared if it has 0 usage marks.

See https://github.com/eclipse-serializer/serializer/pull/143 