### PR TITLE
Docu:  add JDK17 Handlers to serializer foundation

### DIFF
--- a/docs/modules/storage/pages/addendum/specialized-type-handlers.adoc
+++ b/docs/modules/storage/pages/addendum/specialized-type-handlers.adoc
@@ -131,3 +131,10 @@ foundation.onConnectionFoundation(BinaryHandlersJDK8::registerJDK8TypeHandlers);
 final EmbeddedStorageFoundation<?> foundation = EmbeddedStorage.Foundation();
 foundation.onConnectionFoundation(BinaryHandlersJDK17::registerJDK17TypeHandlers);
 ----
+
+For serializer:
+[source, java]
+----
+final SerializerFoundation<?> foundation = SerializerFoundation.New();
+BinaryHandlersJDK17.registerJDK17TypeHandlers(foundation);
+----


### PR DESCRIPTION
This pull request includes an update to the documentation in `docs/modules/storage/pages/addendum/specialized-type-handlers.adoc` to include instructions for using a new serializer foundation with JDK 17 type handlers.

Documentation update:

* [`docs/modules/storage/pages/addendum/specialized-type-handlers.adoc`](diffhunk://#diff-866045d705a4203fbc90906166e8bd8c8f804990ba5bedcf35c6b719c0b14fd0R134-R140): Added instructions for using `SerializerFoundation` with `BinaryHandlersJDK17` to register JDK 17 type handlers.