### PR TITLE
fix docu (brakets in code)

### DIFF
--- a/docs/modules/storage/pages/loading-data/lazy-loading/clearing-lazy-references.adoc
+++ b/docs/modules/storage/pages/loading-data/lazy-loading/clearing-lazy-references.adoc
@@ -33,7 +33,7 @@ LazyReferenceManager.set(LazyReferenceManager.New(
 		Duration.ofMinutes(30).toMillis(), // timeout of lazy access
 		0.75                               // memory quota
 	)
-);
+));
 ----
 
 The timeout of lazy references is set to 30 minutes, meaning references which haven't been touched for this time are cleared.


### PR DESCRIPTION
This pull request includes a minor change to the `docs/modules/storage/pages/loading-data/lazy-loading/clearing-lazy-references.adoc` file. The change corrects the syntax of the `LazyReferenceManager.set` method call by adding an extra closing parenthesis.

* [`docs/modules/storage/pages/loading-data/lazy-loading/clearing-lazy-references.adoc`](diffhunk://#diff-0db7c1d0a5e6c0b2bb0c97441b857470a81d5eec6e99b39f4d9167d467decbceL36-R36): Corrected the syntax of the `LazyReferenceManager.set` method call by adding an extra closing parenthesis.