### PR TITLE
Update DefaultEclipseStoreConfiguration

### DIFF
--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/DefaultEclipseStoreConfiguration.java
@@ -26,10 +26,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @AutoConfigureAfter(EclipseStoreSpringBoot.class)
+@ComponentScan("org.eclipse.store.integrations.spring.boot.types.concurrent")
 public class DefaultEclipseStoreConfiguration
 {
 


### PR DESCRIPTION
Add a `@ComponentScan` annotation so that spring will register `LockAspect` as a bean. I have tested this along with an alternative approach which would create the bean explicitly using `@ConditionalOnMissingBean`. But since the `LockAspect` class does not need configuration this seemed unnecessary.
