### PR TITLE
add test for LockAspect bean exists.

### DIFF
--- a/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/LockAspectTest.java
+++ b/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/LockAspectTest.java
@@ -1,0 +1,26 @@
+package test.eclipse.store.integrations.spring.boot;
+
+import org.eclipse.store.integrations.spring.boot.types.concurrent.LockAspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@TestPropertySource("classpath:application-test.properties")
+class LockAspectTest
+{
+
+    @Autowired
+    ApplicationContext context;
+
+    @Test
+    void isLockAspectBeanExists()
+    {
+        LockAspect bean = context.getBean(LockAspect.class);
+        assertNotNull(bean);
+    }
+}


### PR DESCRIPTION
This pull request includes a new test class to verify the existence of the `LockAspect` bean in the Spring Boot application context.

Addition of a new test class:

* [`integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/LockAspectTest.java`](diffhunk://#diff-720f1726fc5c9382e5bbde32ea4df10747e119b8c4e6ee01e2904429068fd5ffR1-R26): Added a new test class `LockAspectTest` to check if the `LockAspect` bean is present in the application context. This includes importing necessary dependencies, setting up the test context, and writing a test method `isLockAspectBeanExists` to assert the presence of the `LockAspect` bean.