### PR TITLE
update plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -229,7 +229,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.10.0</version>
                     <configuration>
                         <doclint>none</doclint>
                         <failOnError>${javadoc.failed.on.error}</failOnError>
@@ -276,7 +276,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.4</version>
+                    <version>3.2.6</version>
                     <executions>
                         <execution>
                             <id>sign-artifacts</id>
@@ -341,17 +341,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M13</version>
+                    <version>4.0.0-M16</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.cyclonedx</groupId>
                     <artifactId>cyclonedx-maven-plugin</artifactId>
-                    <version>2.7.11</version>
+                    <version>2.8.1</version>
                     <executions>
                         <execution>
                             <phase>prepare-package</phase>


### PR DESCRIPTION
This pull request includes updates to several Maven plugin versions in the `pom.xml` file. These updates ensure that the project uses the latest versions of the plugins, which may include bug fixes, performance improvements, and new features.

Updates to Maven plugin versions:

* Updated `maven-dependency-plugin` to version 3.8.0.
* Updated `maven-javadoc-plugin` to version 3.10.0.
* Updated `maven-gpg-plugin` to version 3.2.6.
* Updated `maven-site-plugin` to version 4.0.0-M16.
* Updated `maven-surefire-plugin` to version 3.5.0 and `cyclonedx-maven-plugin` to version 2.8.1.