### PR TITLE
Zj/update jetty 100125

### DIFF
--- a/storage/rest/service-sparkjava/pom.xml
+++ b/storage/rest/service-sparkjava/pom.xml
@@ -21,7 +21,7 @@
 	
 	<properties>
 		<sparkjava.version>2.9.3</sparkjava.version>
-		<jetty.version>	9.4.46.v20220331</jetty.version>
+		<jetty.version>	9.4.56.v20240826</jetty.version>
 		<gson.version>2.8.9</gson.version>
 	</properties>
 

--- a/storage/rest/service-sparkjava/pom.xml
+++ b/storage/rest/service-sparkjava/pom.xml
@@ -21,7 +21,7 @@
 	
 	<properties>
 		<sparkjava.version>2.9.3</sparkjava.version>
-		<jetty.version>	9.4.56.v20240826</jetty.version>
+		<jetty.version>9.4.56.v20240826</jetty.version>
 		<gson.version>2.8.9</gson.version>
 	</properties>
 


### PR DESCRIPTION
This pull request includes an update to the `jetty.version` in the `storage/rest/service-sparkjava/pom.xml` file to ensure compatibility with the latest version.

Dependency update:

* [`storage/rest/service-sparkjava/pom.xml`](diffhunk://#diff-69e75cb09be38aae2eb87e36b96e5748ec6e414870959bb31e809da74dbefb0aL24-R24): Updated `jetty.version` from `9.4.46.v20220331` to `9.4.56.v20240826` to maintain compatibility with the latest version.