### PR TITLE
fix: resolve redit vulnerability by updating dependency versions

### DIFF
--- a/afs/redis/pom.xml
+++ b/afs/redis/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>io.lettuce</groupId>
 			<artifactId>lettuce-core</artifactId>
-			<version>6.4.0.RELEASE</version>
+			<version>6.5.2.RELEASE</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
This pull request includes an update to the `afs/redis/pom.xml` file to upgrade the version of the `lettuce-core` dependency.

Dependency update:

* [`afs/redis/pom.xml`](diffhunk://#diff-da02e9170a0f4e51eed2142342940ec3aa5d778678849b34932c1f866349d83eL36-R36): Upgraded `lettuce-core` from version `6.4.0.RELEASE` to `6.5.2.RELEASE`.