### PR TITLE
Zj/oci update 030225

### DIFF
--- a/afs/oraclecloud/objectstorage/src/main/java/module-info.java
+++ b/afs/oraclecloud/objectstorage/src/main/java/module-info.java
@@ -24,4 +24,5 @@ module org.eclipse.store.afs.oraclecloud.objectstorage
 	requires transitive oci.java.sdk.common;
 	requires transitive oci.java.sdk.objectstorage.extensions;
 	requires transitive oci.java.sdk.objectstorage.generated;
+    requires oci.java.sdk.common.httpclient;
 }

--- a/afs/oraclecloud/objectstorage/src/main/java/module-info.java
+++ b/afs/oraclecloud/objectstorage/src/main/java/module-info.java
@@ -24,5 +24,5 @@ module org.eclipse.store.afs.oraclecloud.objectstorage
 	requires transitive oci.java.sdk.common;
 	requires transitive oci.java.sdk.objectstorage.extensions;
 	requires transitive oci.java.sdk.objectstorage.generated;
-    requires oci.java.sdk.common.httpclient;
+	requires oci.java.sdk.common.httpclient;
 }

--- a/afs/oraclecloud/objectstorage/src/main/java/org/eclipse/store/afs/oraclecloud/objectstorage/types/OracleCloudObjectStorageConnector.java
+++ b/afs/oraclecloud/objectstorage/src/main/java/org/eclipse/store/afs/oraclecloud/objectstorage/types/OracleCloudObjectStorageConnector.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import com.oracle.bmc.io.DuplicatableInputStream;
+import com.oracle.bmc.http.client.io.DuplicatableInputStream;
 import com.oracle.bmc.model.Range;
 import com.oracle.bmc.objectstorage.ObjectStorageClient;
 import com.oracle.bmc.objectstorage.model.ObjectSummary;

--- a/afs/oraclecloud/pom.xml
+++ b/afs/oraclecloud/pom.xml
@@ -29,7 +29,7 @@
 			<dependency>
 				<groupId>com.oracle.oci.sdk</groupId>
 				<artifactId>oci-java-sdk-bom</artifactId>
-				<version>2.73.0</version>
+				<version>3.44.4</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/docs/modules/storage/pages/storage-targets/blob-stores/oracle-cloud-object-storage.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/oracle-cloud-object-storage.adoc
@@ -10,7 +10,12 @@
 <dependency>
 	<groupId>com.oracle.oci.sdk</groupId>
 	<artifactId>oci-java-sdk-objectstorage</artifactId>
-	<version>2.21.0</version>
+	<version>3.44.4</version>
+</dependency>
+<dependency>
+	<groupId>com.oracle.oci.sdk</groupId>
+	<artifactId>oci-java-sdk-common-httpclient-jersey</artifactId>
+	<version>3.44.4</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Update OCI
fix issue:
https://github.com/eclipse-store/store/issues/368

This pull request includes several updates to dependencies and imports in the Oracle Cloud Object Storage module. The most important changes include adding a new required module, updating import statements to use the correct package, and updating dependency versions in both the `pom.xml` and documentation.

Dependency updates:

* [`afs/oraclecloud/objectstorage/src/main/java/module-info.java`](diffhunk://#diff-1713ecba8fc25dff7a2c03d134738fb97e2b6f705a031ee9632298ae76070916R27): Added `oci.java.sdk.common.httpclient` as a required module.
* [`afs/oraclecloud/pom.xml`](diffhunk://#diff-f8a02ff18fea4f685deab511a3890bedb0fdb619992dea79fe172013e84e01c3L32-R32): Updated the version of `oci-java-sdk-bom` dependency from `2.73.0` to `3.44.4`.
* [`docs/modules/storage/pages/storage-targets/blob-stores/oracle-cloud-object-storage.adoc`](diffhunk://#diff-62fbcf17a27bfa24a358bf5c5b964f20a15f81f2147db4b564a52a39a19c3e5fL13-R18): Updated the version of `oci-java-sdk-objectstorage` from `2.21.0` to `3.44.4` and added a new dependency for `oci-java-sdk-common-httpclient-jersey`.

Import corrections:

* [`afs/oraclecloud/objectstorage/src/main/java/org/eclipse/store/afs/oraclecloud/objectstorage/types/OracleCloudObjectStorageConnector.java`](diffhunk://#diff-306660d1880849205a6cef89f12a7b0b959911d22b10bb030c21564a19061edeL30-R30): Changed import statement from `com.oracle.bmc.io.DuplicatableInputStream` to `com.oracle.bmc.http.client.io.DuplicatableInputStream`.