### PR TITLE
Zj/afs update 040225

### DIFF
--- a/afs/aws/pom.xml
+++ b/afs/aws/pom.xml
@@ -31,7 +31,7 @@
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>bom</artifactId>
-				<version>2.27.24</version>
+				<version>2.30.11</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/afs/azure/pom.xml
+++ b/afs/azure/pom.xml
@@ -29,7 +29,7 @@
 			<dependency>
 				<groupId>com.azure</groupId>
 				<artifactId>azure-sdk-bom</artifactId>
-				<version>1.2.27</version>
+				<version>1.2.31</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/afs/googlecloud/pom.xml
+++ b/afs/googlecloud/pom.xml
@@ -29,7 +29,7 @@
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>libraries-bom</artifactId>
-				<version>26.45.0</version>
+				<version>26.53.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/afs/kafka/pom.xml
+++ b/afs/kafka/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.8.0</version>
+			<version>3.9.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/redis/pom.xml
+++ b/afs/redis/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>io.lettuce</groupId>
 			<artifactId>lettuce-core</artifactId>
-			<version>6.5.2.RELEASE</version>
+			<version>6.5.3.RELEASE</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/docs/modules/storage/pages/storage-targets/blob-stores/aws-dynamodb.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/aws-dynamodb.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>software.amazon.awssdk</groupId>
 	<artifactId>dynamodb</artifactId>
-	<version>2.17.272</version>
+	<version>2.30.11</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/blob-stores/aws-s3.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/aws-s3.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>software.amazon.awssdk</groupId>
 	<artifactId>s3</artifactId>
-	<version>2.26.14</version>
+	<version>2.30.11</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/blob-stores/azure-storage.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/azure-storage.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>com.azure</groupId>
 	<artifactId>azure-storage-blob</artifactId>
-	<version>12.10.0</version>
+	<version>12.29.0</version>
 </dependency>
 	
 ----

--- a/docs/modules/storage/pages/storage-targets/blob-stores/google-cloud-firestore.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/google-cloud-firestore.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>com.google.cloud</groupId>
 	<artifactId>google-cloud-firestore</artifactId>
-	<version>3.0.17</version>
+	<version>3.30.6</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/blob-stores/kafka.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/kafka.adoc
@@ -10,7 +10,7 @@
 <dependency>
     <groupId>org.apache.kafka</groupId>
     <artifactId>kafka-clients</artifactId>
-    <version>3.1.2</version>
+    <version>3.9.0</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/blob-stores/redis.adoc
+++ b/docs/modules/storage/pages/storage-targets/blob-stores/redis.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>io.lettuce</groupId>
 	<artifactId>lettuce-core</artifactId>
-	<version>6.2.6.RELEASE</version>
+	<version>6.5.3.RELEASE</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/sql-databases/mariadb.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/mariadb.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>org.mariadb.jdbc</groupId>
 	<artifactId>mariadb-java-client</artifactId>
-	<version>2.7.1</version>
+	<version>3.5.1</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/sql-databases/oracle.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/oracle.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>com.oracle.database.jdbc</groupId>
 	<artifactId>ojdbc8</artifactId>
-	<version>19.7.0.0</version>
+	<version>23.3.0.23.09</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/sql-databases/postgresql.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/postgresql.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>org.postgresql</groupId>
 	<artifactId>postgresql</artifactId>
-	<version>42.2.14</version>
+	<version>42.7.5</version>
 </dependency>
 ----
 

--- a/docs/modules/storage/pages/storage-targets/sql-databases/sqlite.adoc
+++ b/docs/modules/storage/pages/storage-targets/sql-databases/sqlite.adoc
@@ -10,7 +10,7 @@
 <dependency>
 	<groupId>org.xerial</groupId>
 	<artifactId>sqlite-jdbc</artifactId>
-	<version>3.32.3</version>
+	<version>3.48.0.0</version>
 </dependency>
 ----
 


### PR DESCRIPTION
This pull request includes multiple updates to dependency versions across various `pom.xml` files and corresponding documentation files. These updates ensure that the project uses the latest versions of these dependencies.

Dependency updates:

* [`afs/aws/pom.xml`](diffhunk://#diff-40d72cea7951b268d0e9b7b9a9368dcd660eb5ed6a7df0fc4d35acec741b029dL34-R34): Updated `software.amazon.awssdk:bom` from version `2.27.24` to `2.30.11`.
* [`afs/azure/pom.xml`](diffhunk://#diff-c13a51d60474a33f2633e2dd9dd21eab7588721285bbc454f74fc9393758d551L32-R32): Updated `com.azure:azure-sdk-bom` from version `1.2.27` to `1.2.31`.
* [`afs/googlecloud/pom.xml`](diffhunk://#diff-70007d6e39a539389ae1f9656d873ab29812382cb9f43386afaff6f74e879d58L32-R32): Updated `com.google.cloud:libraries-bom` from version `26.45.0` to `26.53.0`.
* [`afs/kafka/pom.xml`](diffhunk://#diff-50a9fcc7b4029187b01cc72bd31c48c19eb467c4cfcc09e8b9d504dd4290262bL34-R34): Updated `org.apache.kafka:kafka-clients` from version `3.8.0` to `3.9.0`.
* [`afs/redis/pom.xml`](diffhunk://#diff-da02e9170a0f4e51eed2142342940ec3aa5d778678849b34932c1f866349d83eL36-R36): Updated `io.lettuce:lettuce-core` from version `6.5.2.RELEASE` to `6.5.3.RELEASE`.

Documentation updates:

* [`docs/modules/storage/pages/storage-targets/blob-stores/aws-dynamodb.adoc`](diffhunk://#diff-deb2d0e54b2ada47870de446bfd7f00cfc6eadcd306a1f94586f8f5baf066adcL13-R13): Updated `software.amazon.awssdk:dynamodb` from version `2.17.272` to `2.30.11`.
* [`docs/modules/storage/pages/storage-targets/blob-stores/aws-s3.adoc`](diffhunk://#diff-406a515ab9d757773ee1440ccbee0c801400ada173cf5846eee76e8090fa7329L13-R13): Updated `software.amazon.awssdk:s3` from version `2.26.14` to `2.30.11`.
* [`docs/modules/storage/pages/storage-targets/blob-stores/azure-storage.adoc`](diffhunk://#diff-1928b017ba5984c8a1089fac7de418a9dffd7d55f510709236f0739026b4f9efL13-R13): Updated `com.azure:azure-storage-blob` from version `12.10.0` to `12.29.0`.
* [`docs/modules/storage/pages/storage-targets/blob-stores/google-cloud-firestore.adoc`](diffhunk://#diff-cf8c6aa3f767bc1acee1e0e86a14c0ed94b655fcb2e7f2f990a407d55dfdff67L13-R13): Updated `com.google.cloud:google-cloud-firestore` from version `3.0.17` to `3.30.6`.
* [`docs/modules/storage/pages/storage-targets/blob-stores/kafka.adoc`](diffhunk://#diff-1390e1354b088916ec12f12ec5fca5c12515312589750ad1572600e5348a802fL13-R13): Updated `org.apache.kafka:kafka-clients` from version `3.1.2` to `3.9.0`.
* [`docs/modules/storage/pages/storage-targets/blob-stores/redis.adoc`](diffhunk://#diff-698422c1b86b5dac89f97bb3939a3c8e4db916805db7d047f7cb254c22c0bff2L13-R13): Updated `io.lettuce:lettuce-core` from version `6.2.6.RELEASE` to `6.5.3.RELEASE`.
* [`docs/modules/storage/pages/storage-targets/sql-databases/mariadb.adoc`](diffhunk://#diff-c27b69135c52d29028996dd7f8f62f6f7bfbc875616dfc6acf487da825cb8218L13-R13): Updated `org.mariadb.jdbc:mariadb-java-client` from version `2.7.1` to `3.5.1`.
* [`docs/modules/storage/pages/storage-targets/sql-databases/oracle.adoc`](diffhunk://#diff-450d428da66120b2a37a3ee443066972a247fd6d9a8ee78f4a9d4799989f5c2fL13-R13): Updated `com.oracle.database.jdbc:ojdbc8` from version `19.7.0.0` to `23.3.0.23.09`.
* [`docs/modules/storage/pages/storage-targets/sql-databases/postgresql.adoc`](diffhunk://#diff-0c4b26d17357909b69d22e9cc303631ec8ab197ad7098184911ec72e115883c5L13-R13): Updated `org.postgresql:postgresql` from version `42.2.14` to `42.7.5`.
* [`docs/modules/storage/pages/storage-targets/sql-databases/sqlite.adoc`](diffhunk://#diff-573e263341fac0d56bb3ce7bdb0a9795e43f1c12188a08f481a92f07a72aad82L13-R13): Updated `org.xerial:sqlite-jdbc` from version `3.32.3` to `3.48.0.0`.