### PR TITLE
Store size limit #319 #321

### DIFF
--- a/afs/redis/pom.xml
+++ b/afs/redis/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>io.lettuce</groupId>
 			<artifactId>lettuce-core</artifactId>
-			<version>6.4.0.RELEASE</version>
+			<version>6.5.2.RELEASE</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionCommitSizeExceeded.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionCommitSizeExceeded.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.storage.exceptions;
 
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 @SuppressWarnings("serial")
 public class StorageExceptionCommitSizeExceeded extends StorageException
 {

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionCommitSizeExceeded.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionCommitSizeExceeded.java
@@ -1,0 +1,17 @@
+package org.eclipse.store.storage.exceptions;
+
+@SuppressWarnings("serial")
+public class StorageExceptionCommitSizeExceeded extends StorageException
+{
+
+	public StorageExceptionCommitSizeExceeded(String message)
+	{
+		super(message);
+	}
+
+	public StorageExceptionCommitSizeExceeded(int channelIndex, long commitSize)
+	{
+		super("Cannel " + channelIndex + " store size " + commitSize  + " bytes exceeds technical limit of 2^31 bytes");
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.persistence.binary.types.BinaryEntityRawDataIterator;
-import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionCommitSizeExceeded;
+import org.eclipse.store.storage.exceptions.StorageExceptionCommitSizeExceeded;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
 
 
@@ -355,7 +355,7 @@ public interface StorageDataChunkValidator
 								
 				if(commitSize >= Integer.MAX_VALUE)
 				{
-					throw new PersistenceExceptionCommitSizeExceeded(channelIndex, commitSize);
+					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize);
 				}
 				
 			}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -32,13 +32,13 @@ import org.eclipse.serializer.collections.XSort;
 import org.eclipse.serializer.collections.types.XGettingSequence;
 import org.eclipse.serializer.exceptions.MultiCauseException;
 import org.eclipse.serializer.memory.XMemory;
-import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionCommitSizeExceeded;
 import org.eclipse.serializer.typing.Disposable;
 import org.eclipse.serializer.typing.XTypes;
 import org.eclipse.serializer.util.BufferSizeProvider;
 import org.eclipse.serializer.util.X;
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageException;
+import org.eclipse.store.storage.exceptions.StorageExceptionCommitSizeExceeded;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
 import org.eclipse.store.storage.exceptions.StorageExceptionIoReading;
 import org.eclipse.store.storage.exceptions.StorageExceptionIoWriting;
@@ -612,7 +612,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 					//Should never be reached, this case should be alreay handled by
 					//org.eclipse.store.storage.types.StorageDataChunkValidator.MaxFileSize.
 					//But keep exception to have secound guard as the validator might be replaced.
-					throw new PersistenceExceptionCommitSizeExceeded(this.channelIndex(), commitSize);
+					throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), commitSize);
 				}
 				if(commitSize + this.headFile.totalLength() > Integer.MAX_VALUE)
 				{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -32,6 +32,7 @@ import org.eclipse.serializer.collections.XSort;
 import org.eclipse.serializer.collections.types.XGettingSequence;
 import org.eclipse.serializer.exceptions.MultiCauseException;
 import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionCommitSizeExceeded;
 import org.eclipse.serializer.typing.Disposable;
 import org.eclipse.serializer.typing.XTypes;
 import org.eclipse.serializer.util.BufferSizeProvider;
@@ -594,6 +595,32 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			
 			return physicalLength;
 		}
+		
+		private void ensureHeadFileLoadableSize(final ByteBuffer[] dataBuffers)
+		{
+			//Must ensure that a filesize never exceeds 2^31 bytes size.
+			//If that size is exceeded the storage is corrupted and can't be loaded any more because
+			//the current implementation use only one byte buffer to load a file.
+			//This buffer size is limited to an Integer.MAX_VALUE value.
+			
+			long commitSize = 0;
+			for(int i = 0; i < dataBuffers.length; i++)
+			{
+				commitSize += dataBuffers[i].limit();
+				if(commitSize > Integer.MAX_VALUE)
+				{
+					//Should never be reached, this case should be alreay handled by
+					//org.eclipse.store.storage.types.StorageDataChunkValidator.MaxFileSize.
+					//But keep exception to have secound guard as the validator might be replaced.
+					throw new PersistenceExceptionCommitSizeExceeded(this.channelIndex(), commitSize);
+				}
+				if(commitSize + this.headFile.totalLength() > Integer.MAX_VALUE)
+				{
+					logger.debug("creating new storage file because appending would exceed the file size limit of 2^31 bytes");
+					this.createNextStorageFile();
+				}
+			}
+		}
 
 		@Override
 		public final long[] storeChunks(final long timestamp, final ByteBuffer[] dataBuffers)
@@ -605,6 +632,8 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			}
 			
 			this.checkForNewFile();
+			this.ensureHeadFileLoadableSize(dataBuffers);
+				
 			final long   oldTotalLength   = this.ensureHeadFileTotalLength();
 			final long[] storagePositions = allChunksStoragePositions(dataBuffers, oldTotalLength);
 			final long   writeCount       = this.writer.writeStore(this.headFile, X.ArrayView(dataBuffers));

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
@@ -973,7 +973,7 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 
 		protected StorageDataChunkValidator.Provider2 ensureDataChunkValidatorProvider2()
 		{
-			return new StorageDataChunkValidator.NoOp();
+			return new StorageDataChunkValidator.MaxFileSize();
 		}
 
 		protected StorageChannelsCreator ensureChannelCreator()


### PR DESCRIPTION
Prevent storage corruption if storage files become lager than 2GB.
see #319 and  #321.

This fix throws a PersistenceExceptionCommitSizeExceeded exception if a single channels commit size is to large before data is written or it creates a new storage file if appending to the current head file would exceed the size limit.