### PR TITLE
update OCI to 3.57.1

### DIFF
--- a/afs/oraclecloud/pom.xml
+++ b/afs/oraclecloud/pom.xml
@@ -29,7 +29,7 @@
 			<dependency>
 				<groupId>com.oracle.oci.sdk</groupId>
 				<artifactId>oci-java-sdk-bom</artifactId>
-				<version>3.44.4</version>
+				<version>3.57.1</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
This pull request includes an update to the Oracle Cloud SDK dependency version in the `afs/oraclecloud/pom.xml` file. The version has been upgraded from `3.44.4` to `3.57.1`.

Dependency update:

* [`afs/oraclecloud/pom.xml`](diffhunk://#diff-f8a02ff18fea4f685deab511a3890bedb0fdb619992dea79fe172013e84e01c3L32-R32): Updated the `oci-java-sdk-bom` dependency version from `3.44.4` to `3.57.1` to ensure the latest features and fixes are included.