### PR TITLE
refactor: update Maven build commands to use 'clean' before 'package'…

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -23,7 +23,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P examples -B package --file pom.xml -U
+      run: mvn -P examples -B clean package --file pom.xml -U
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -34,4 +34,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P examples -B package --file pom.xml -U
+      run: mvn -P examples -B clean package --file pom.xml -U

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -23,7 +23,7 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P examples -B package --file pom.xml -U
+      run: mvn -P examples -B clean package --file pom.xml -U
 
       #Build with java 17
     - uses: actions/checkout@v3
@@ -34,4 +34,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P examples -B package --file pom.xml -U
+      run: mvn -P examples -B clean package --file pom.xml -U

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -58,11 +58,11 @@ jobs:
           mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl integrations/spring-boot3 deploy
-          mvn -Pdeploy -pl integrations/spring-boot3-console deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot deploy
+          mvn -Pdeploy -pl integrations/spring-boot3 clean deploy
+          mvn -Pdeploy -pl integrations/spring-boot3-console clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -120,11 +120,11 @@ jobs:
           mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl integrations/spring-boot3 deploy
-          mvn -Pdeploy -pl integrations/spring-boot3-console deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot deploy
+          mvn -Pdeploy -pl integrations/spring-boot3 clean deploy
+          mvn -Pdeploy -pl integrations/spring-boot3-console clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -23,4 +23,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -P examples -P javadoc-check -B package --file pom.xml -U
+      run: mvn -P examples -P javadoc-check -B clean package --file pom.xml -U

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -64,11 +64,11 @@ jobs:
           mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl integrations/spring-boot3 deploy
-          mvn -Pdeploy -pl integrations/spring-boot3-console deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot deploy
+          mvn -Pdeploy -pl integrations/spring-boot3 clean deploy
+          mvn -Pdeploy -pl integrations/spring-boot3-console clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
+          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/LockAspectTest.java
+++ b/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/LockAspectTest.java
@@ -1,5 +1,19 @@
 package test.eclipse.store.integrations.spring.boot;
 
+/*-
+ * #%L
+ * EclipseStore Integrations SpringBoot
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import org.eclipse.store.integrations.spring.boot.types.concurrent.LockAspect;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
This pull request includes changes to several GitHub Actions workflows and adds a license header to a test file. The most important changes focus on ensuring that Maven builds and deployments include a clean step.

Changes to GitHub Actions workflows:

* [`.github/workflows/maven_build.yml`](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L26-R26): Modified the Maven build command to include the `clean` step. [[1]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L26-R26) [[2]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L37-R37)
* [`.github/workflows/maven_build_win.yml`](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L26-R26): Updated the Maven build command to include the `clean` step. [[1]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L26-R26) [[2]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L37-R37)
* [`.github/workflows/maven_deploy_snapshot.yml`](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L61-R65): Added the `clean` step to the Maven deploy commands.
* [`.github/workflows/maven_deploy_snapshot_dev.yml`](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L123-R127): Included the `clean` step in the Maven deploy commands.
* [`.github/workflows/maven_javadoc.yml`](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L26-R26): Updated the Maven build command to include the `clean` step.
* [`.github/workflows/maven_release.yml`](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L67-R71): Added the `clean` step to the Maven deploy commands.

Other changes:

* [`integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/LockAspectTest.java`](diffhunk://#diff-720f1726fc5c9382e5bbde32ea4df10747e119b8c4e6ee01e2904429068fd5ffR3-R16): Added a license header to the test file.… and 'deploy'