### PR TITLE
chore: update GitHub Actions to use latest versions of checkout and s…

### DIFF
--- a/.github/workflows/maven_converter.yml
+++ b/.github/workflows/maven_converter.yml
@@ -15,18 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       #Build with java 11
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: mvn -B -Pconverter-standalone -pl storage/embedded-tools/storage-converter -am clean package --file pom.xml -U
 


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration for the Maven converter. The changes primarily focus on updating the action versions and removing the caching step.

Key changes:

* Updated `actions/checkout` from version 2 to version 3 in `.github/workflows/maven_converter.yml`.
* Updated `actions/setup-java` from version 2 to version 3 in `.github/workflows/maven_converter.yml`.
* Removed the Maven packages caching step from the workflow.…etup-java