### PR TITLE
docs: add Lazy Instance Storage Binding section to index and lazy-col…

### DIFF
--- a/docs/modules/storage/pages/loading-data/lazy-loading/index.adoc
+++ b/docs/modules/storage/pages/loading-data/lazy-loading/index.adoc
@@ -180,3 +180,7 @@ You want to be able to write anything you want and you want full insight and con
 
 All this can be done with the tiny Lazy Interim Reference class.
 No restrictions, no incomprehensible "magic" under the hood (proxy instances and stuff) and also usable for individual instances.
+
+== Lazy Instance Storage Binding
+
+When a lazy instance is stored in a storage, it becomes permanently bound to that storage for the duration of the program's runtime. It is not possible to persist the same lazy instance to a different storage instance while the program is running. Any attempt to do so will result in an error.

--- a/docs/modules/storage/pages/loading-data/lazy-loading/lazy-collections.adoc
+++ b/docs/modules/storage/pages/loading-data/lazy-loading/lazy-collections.adoc
@@ -41,3 +41,6 @@ Some aspects of the implementations
 The _size_ property is cached, so calling for the amount of data in the collection doesn't need to load the segments.
 
 Accessing the `LazyHashMap` by a key value will load at maximum log2(n) segments when the implementation uses n segments since the search is implemented as btree.
+
+== Lazy Instance Storage Binding
+Collections are bound to specific storage instances upon their first persistence. Once they have been persisted, they can no longer be stored in different storage instances. Attempting to do so will result in an `IllegalStateException`.


### PR DESCRIPTION
This pull request includes updates to the documentation for lazy loading in storage modules. The most important changes involve adding new sections on the binding behavior of lazy instances and collections to storage.

Documentation updates:

* [`docs/modules/storage/pages/loading-data/lazy-loading/index.adoc`](diffhunk://#diff-7aa5aed501b1e9e84efe8aba3e80940b1a9d6f8dd0700598bd033dcdad5ee309R183-R186): Added a section explaining that a lazy instance becomes permanently bound to the storage it is stored in for the duration of the program's runtime, and cannot be persisted to a different storage instance.
* [`docs/modules/storage/pages/loading-data/lazy-loading/lazy-collections.adoc`](diffhunk://#diff-333f40987d2bbc3ad21d2cbfd48abbe80f08e309bfdd092508f64befe22a85f8R44-R46): Added a section detailing that collections are bound to specific storage instances upon their first persistence and cannot be stored in different storage instances afterward.…lections documentation