### PR TITLE
chore: update Maven deployment commands to include production profile

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -55,17 +55,10 @@ jobs:
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
       - name: Maven change serializer version
         run:  mvn versions:set-property -Dproperty=eclipse.serializer.version -DnewVersion=${{ github.event.release.tag_name }}
-      - name: Build with java 17
-        run: |
-          mvn -pl integrations/spring-boot3 clean install -am -B
-          mvn -pl integrations/spring-boot3-console clean install -am -B          
-          mvn -P production -pl storage/rest/client-app clean install -am -B
-          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
-          mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl integrations/spring-boot3 clean deploy
-          mvn -Pdeploy -pl integrations/spring-boot3-console clean deploy
+          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy
+          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3-console clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -55,6 +55,13 @@ jobs:
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
       - name: Maven change serializer version
         run:  mvn versions:set-property -Dproperty=eclipse.serializer.version -DnewVersion=${{ github.event.release.tag_name }}
+      - name: Build with java 17
+        run: |
+          mvn -P production -pl integrations/spring-boot3 clean install -am -B
+          mvn -P production -pl integrations/spring-boot3-console clean install -am -B          
+          mvn -P production -pl storage/rest/client-app clean install -am -B
+          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
+          mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
           mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy


### PR DESCRIPTION
This pull request includes changes to the Maven release workflow configuration in the `.github/workflows/maven_release.yml` file. The changes focus on streamlining the build and deploy steps for Java 17.

Key changes:

* Removed the separate build steps for Java 17, consolidating them into the deploy step.
* Updated the deploy step to include the `production` profile for all modules.