### PR TITLE
chore: update Maven deployment commands to include production profile - dev build

### DIFF
--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -49,17 +49,10 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: PASSPHRASE
-      - name: Build with java 17
-        run: |
-          mvn -pl integrations/spring-boot3 clean install -am -B
-          mvn -pl integrations/spring-boot3-console clean install -am -B
-          mvn -P production -pl storage/rest/client-app clean install -am -B
-          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
-          mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl integrations/spring-boot3 clean deploy
-          mvn -Pdeploy -pl integrations/spring-boot3-console clean deploy
+          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy
+          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3-console clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -49,6 +49,13 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: PASSPHRASE
+      - name: Build with java 17
+        run: |
+          mvn -P production -pl integrations/spring-boot3 clean install -am -B
+          mvn -P production -pl integrations/spring-boot3-console clean install -am -B
+          mvn -P production -pl storage/rest/client-app clean install -am -B
+          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
+          mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
           mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -111,6 +111,13 @@ jobs:
           else
             echo "Branch does not exist in serializer repository, skipping serializer version change"          
           fi
+      - name: Make a snapshot java 17
+        run: |
+          mvn -P production -pl integrations/spring-boot3 clean install -am -B
+          mvn -P production -pl integrations/spring-boot3-console clean install -am -B          
+          mvn -P production -pl storage/rest/client-app clean install -am -B
+          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
+          mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
           mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -111,17 +111,10 @@ jobs:
           else
             echo "Branch does not exist in serializer repository, skipping serializer version change"          
           fi
-      - name: Make a snapshot java 17
-        run: |
-          mvn -pl integrations/spring-boot3 clean install -am -B
-          mvn -pl integrations/spring-boot3-console clean install -am -B          
-          mvn -P production -pl storage/rest/client-app clean install -am -B
-          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
-          mvn -P production -pl storage/rest/service-springboot clean install -am -B
       - name: Deploy module build with java 17
         run: |
-          mvn -Pdeploy -pl integrations/spring-boot3 clean deploy
-          mvn -Pdeploy -pl integrations/spring-boot3-console clean deploy
+          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy
+          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3-console clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
           mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy


### PR DESCRIPTION
This pull request includes changes to the Maven deployment workflows to streamline the build and deployment process. The most important changes involve removing redundant build steps and ensuring that all deployments use the production profile.

Improvements to Maven deployment workflows:

* [`.github/workflows/maven_deploy_snapshot.yml`](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L52-R55): Removed redundant build steps and added the `production` profile to the deployment commands.
* [`.github/workflows/maven_deploy_snapshot_dev.yml`](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L114-R117): Removed redundant build steps and added the `production` profile to the deployment commands.