### PR TITLE
chore: update Maven release workflow to remove GPG key installation a…

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -12,11 +12,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - id: install-secret-key
-        name: Install gpg secret key
-        run: |
-          cat <(echo -e "${{ secrets.ORG_GPG_PRIVATE_KEY }}") | gpg --batch --import
-          gpg --list-secret-keys --keyid-format LONG
       - uses: actions/checkout@v3
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v3
@@ -27,7 +22,6 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-passphrase: PASSPHRASE
       - name: Maven change version
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
       - name: Maven change serializer version
@@ -37,7 +31,8 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
 
       #java 17 build
       - uses: actions/checkout@v3
@@ -50,7 +45,6 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-passphrase: PASSPHRASE
       - name: Maven change version
         run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }} --batch-mode
       - name: Maven change serializer version
@@ -72,5 +66,6 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
 


### PR DESCRIPTION
This pull request includes changes to the `maven_release.yml` workflow file to improve the handling of GPG keys and passphrases for Maven Central Repository publishing. The most important changes include removing the step to install the GPG secret key, renaming environment variables, and updating the corresponding references.

Improvements to GPG key handling:

* Removed the step to install the GPG secret key (`install-secret-key`).
* Renamed the `PASSPHRASE` environment variable to `MAVEN_GPG_PASSPHRASE` and added `MAVEN_GPG_KEY` for the GPG private key. [[1]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L40-R35) [[2]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L75-R70)
* Updated the Maven server configuration to remove the `gpg-passphrase` reference. [[1]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L30) [[2]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L53)…nd adjust environment variable names