### PR TITLE
chore: update GitHub Actions workflows to use actions/checkout@v4 and…

### DIFF
--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -14,9 +14,9 @@ jobs:
     if: github.repository == 'eclipse-store/store'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Java for publishing to Maven Central Snapshot Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -33,6 +33,10 @@ jobs:
           MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
 
       #java 17 build
+  publish_java17:
+    if: github.repository == 'eclipse-store/store'
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v3
       - name: Set up Java 17 for publishing to Maven Central Repository
         uses: actions/setup-java@v3

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -14,9 +14,9 @@ jobs:
     if: github.repository == 'eclipse-store/store'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Java for publishing to Maven Central Snapshot Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -26,18 +26,7 @@ jobs:
           server-password: MAVEN_PASSWORD
       - name: Prepare suffix
         run: |
-          function prepareSuffix() {
-            local branch=$1
-            local result=${branch//\//_}
-            result=${result//#/}
-            local maxLength=10
-            if (( ${#result} > maxLength )); then
-              result=${result:0:maxLength}
-            fi
-            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
-            echo "${result}-${hashFromContent:0:10}"
-          }
-          suffix=$(prepareSuffix ${GITHUB_REF#refs/heads/})
+          suffix=$(echo -n "${GITHUB_REF#refs/heads/}" | tr '/' '_' | cut -c1-10)-$(echo -n "${GITHUB_REF#refs/heads/}" | md5sum | cut -c1-10)
           echo "Suffix: $suffix"
           echo "SUFFIX=$suffix" >> $GITHUB_ENV
       - name: Update project version
@@ -65,9 +54,13 @@ jobs:
 
 
         #java 17 build
-      - uses: actions/checkout@v3
+  publish_java17:
+    if: github.repository == 'eclipse-store/store'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Set up Java for publishing to Maven Central Snapshot Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -77,18 +70,7 @@ jobs:
           server-password: MAVEN_PASSWORD
       - name: Prepare suffix
         run: |
-          function prepareSuffix() {
-            local branch=$1
-            local result=${branch//\//_}
-            result=${result//#/}
-            local maxLength=10
-            if (( ${#result} > maxLength )); then
-              result=${result:0:maxLength}
-            fi
-            local hashFromContent=$(echo -n "$branch" | md5sum | cut -f1 -d" ")
-            echo "${result}-${hashFromContent:0:10}"
-          }          
-          suffix=$(prepareSuffix ${GITHUB_REF#refs/heads/})
+          suffix=$(echo -n "${GITHUB_REF#refs/heads/}" | tr '/' '_' | cut -c1-10)-$(echo -n "${GITHUB_REF#refs/heads/}" | md5sum | cut -c1-10)
           echo "Suffix: $suffix"
           echo "SUFFIX=$suffix" >> $GITHUB_ENV
       - name: Update project version java 17


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for deploying Maven snapshots. The changes primarily focus on updating action versions and adding support for publishing with Java 17.

### Workflow updates:

* [`.github/workflows/maven_deploy_snapshot.yml`](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L17-R19): Updated `actions/checkout` and `actions/setup-java` to version 4.
* [`.github/workflows/maven_deploy_snapshot.yml`](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0R36-R39): Added a new job for publishing with Java 17.
* [`.github/workflows/maven_deploy_snapshot_dev.yml`](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L17-R19): Updated `actions/checkout` and `actions/setup-java` to version 4.
* [`.github/workflows/maven_deploy_snapshot_dev.yml`](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L29-R29): Simplified the `prepareSuffix` function to a one-liner. [[1]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L29-R29) [[2]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L80-R73)
* [`.github/workflows/maven_deploy_snapshot_dev.yml`](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L68-R63): Added a new job for publishing with Java 17.… actions/setup-java@v4
[Copilot is generating a summary...]