### PR TITLE
Remove unnecessary synchronization in housekeeping methods

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
@@ -613,7 +613,7 @@ public interface StorageHousekeepingController
 		// methods //
 		////////////
 		
-		private synchronized void reset()
+		private void reset()
 		{
 			this.lastFinishedGCCycle = this.lastIncrease = System.currentTimeMillis();
 			if(this.currentIncreaseNs != 0)
@@ -623,7 +623,7 @@ public interface StorageHousekeepingController
 			}
 		}
 		
-		private synchronized long increaseNs()
+		private long increaseNs()
 		{
 			if(this.monitorSupplier.get().isComplete())
 			{


### PR DESCRIPTION
### Description
This pull request removes the `synchronized` keyword from the `reset` and `increaseNs` methods. The operations within these methods are either inherently thread-safe or already externally guarded. This simplification reduces code complexity and may improve performance by eliminating unnecessary locking overhead.

This fixes potential deadlocks in multi-channel applications.

### Relevant Changes
- `reset`: Removed `synchronized` as it is no longer needed for thread safety.
- `increaseNs`: Simplified by removing `synchronized`, relying on existing thread-safety guarantees.