### PR TITLE
chore: update Spring Boot version to 3.4.5 in pom.xml

### DIFF
--- a/examples/spring-boot3-advanced/pom.xml
+++ b/examples/spring-boot3-advanced/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.2.2</spring.boot.version>
+        <spring.boot.version>3.4.5</spring.boot.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/spring-boot3-simple/pom.xml
+++ b/examples/spring-boot3-simple/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.2.2</spring.boot.version>
+        <spring.boot.version>3.4.5</spring.boot.version>
     </properties>
 
 

--- a/integrations/spring-boot3-console/pom.xml
+++ b/integrations/spring-boot3-console/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.2.0</org.springframework.boot.version>
+        <org.springframework.boot.version>3.4.5</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3/pom.xml
+++ b/integrations/spring-boot3/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.2.2</org.springframework.boot.version>
+        <org.springframework.boot.version>3.4.5</org.springframework.boot.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request updates the Spring Boot version across multiple `pom.xml` files to ensure consistency and take advantage of the latest features and fixes provided in version 3.4.5.

Version updates:

* [`examples/spring-boot3-advanced/pom.xml`](diffhunk://#diff-3d878e0c0b66f01e7bdea2254ba1440c7b658e35a8d8ad4141e0d1165899f983L21-R21): Updated `<spring.boot.version>` from `3.2.2` to `3.4.5`.
* [`examples/spring-boot3-simple/pom.xml`](diffhunk://#diff-804ca3fe8bab5d865dba840ea1ea85d471729c6838b8e6de0daa171d2a127b7cL21-R21): Updated `<spring.boot.version>` from `3.2.2` to `3.4.5`.
* [`integrations/spring-boot3-console/pom.xml`](diffhunk://#diff-edb745cc289cf9d279366e508f6468114761d00e2e79f7ec98ef6d977ef109cfL19-R19): Updated `<org.springframework.boot.version>` from `3.2.0` to `3.4.5`.
* [`integrations/spring-boot3/pom.xml`](diffhunk://#diff-8f4b084553286c4f43a0b984055b14d03d602925fd2497cd0e52c2d8289424ecL19-R19): Updated `<org.springframework.boot.version>` from `3.2.2` to `3.4.5`.