### PR TITLE
chore: update jetty.version to 9.4.57.v20241219 in pom.xml

### DIFF
--- a/storage/rest/service-sparkjava/pom.xml
+++ b/storage/rest/service-sparkjava/pom.xml
@@ -21,7 +21,7 @@
 	
 	<properties>
 		<sparkjava.version>2.9.3</sparkjava.version>
-		<jetty.version>9.4.56.v20240826</jetty.version>
+		<jetty.version>9.4.57.v20241219</jetty.version>
 		<gson.version>2.8.9</gson.version>
 	</properties>
 


### PR DESCRIPTION
This pull request updates the `jetty.version` property in the `pom.xml` file to a newer version, ensuring compatibility with the latest Jetty release.

Dependency update:

* [`storage/rest/service-sparkjava/pom.xml`](diffhunk://#diff-69e75cb09be38aae2eb87e36b96e5748ec6e414870959bb31e809da74dbefb0aL24-R24): Updated `jetty.version` from `9.4.56.v20240826` to `9.4.57.v20241219` to incorporate the latest fixes and improvements.