### PR TITLE
chore: update build configurations to use JDK 17

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -14,18 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      #Build with java 11
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -P examples -B clean package --file pom.xml -U
-
-      #Build with java 17
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -14,18 +14,6 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      #Build with java 11
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -P examples -B clean package --file pom.xml -U
-
-      #Build with java 17
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3
@@ -35,3 +23,4 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -P examples -B clean package --file pom.xml -U
+

--- a/.github/workflows/maven_converter.yml
+++ b/.github/workflows/maven_converter.yml
@@ -14,12 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      #Build with java 11
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
     - name: Build with Maven
       run: mvn -B -Pconverter-standalone -pl storage/embedded-tools/storage-converter -am clean package --file pom.xml -U

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Snapshot Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
           server-id: ossrh
@@ -32,37 +32,3 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
           MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
 
-      #java 17 build
-  publish_java17:
-    if: github.repository == 'eclipse-store/store'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Java 17 for publishing to Maven Central Repository
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Build with java 17
-        run: |
-          mvn -P production -pl integrations/spring-boot3 clean install -am -B
-          mvn -P production -pl integrations/spring-boot3-console clean install -am -B
-          mvn -P production -pl storage/rest/client-app clean install -am -B
-          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
-          mvn -P production -pl storage/rest/service-springboot clean install -am -B
-      - name: Deploy module build with java 17
-        run: |
-          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy
-          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3-console clean deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Snapshot Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
           server-id: ossrh
@@ -52,58 +52,3 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
           MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
 
-
-        #java 17 build
-  publish_java17:
-    if: github.repository == 'eclipse-store/store'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Java for publishing to Maven Central Snapshot Repository
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Prepare suffix
-        run: |
-          suffix=$(echo -n "${GITHUB_REF#refs/heads/}" | tr '/' '_' | cut -c1-10)-$(echo -n "${GITHUB_REF#refs/heads/}" | md5sum | cut -c1-10)
-          echo "Suffix: $suffix"
-          echo "SUFFIX=$suffix" >> $GITHUB_ENV
-      - name: Update project version java 17
-        run: |
-          currentVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-          currentVersionWithoutSnapshot=${currentVersion%-SNAPSHOT}
-          newVersion="${currentVersionWithoutSnapshot}-$SUFFIX-SNAPSHOT"
-          mvn versions:set -DnewVersion=$newVersion --batch-mode
-          BRANCH_NAME=${{ github.ref }}
-          REPO_OWNER="eclipse-serializer"
-          REPO_NAME="serializer"
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/branches/$BRANCH_NAME)
-          if [ $RESPONSE -eq 200 ]; then
-            mvn versions:set-property -Dproperty=eclipse.serializer.version -DnewVersion=$newVersion
-          else
-            echo "Branch does not exist in serializer repository, skipping serializer version change"          
-          fi
-      - name: Make a snapshot java 17
-        run: |
-          mvn -P production -pl integrations/spring-boot3 clean install -am -B
-          mvn -P production -pl integrations/spring-boot3-console clean install -am -B          
-          mvn -P production -pl storage/rest/client-app clean install -am -B
-          mvn -P production -pl storage/rest/client-app-standalone-assembly clean install -am -B
-          mvn -P production -pl storage/rest/service-springboot clean install -am -B
-      - name: Deploy module build with java 17
-        run: |
-          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3 clean deploy
-          mvn -Pdeploy -Pproduction -pl integrations/spring-boot3-console clean deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app clean deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/client-app-standalone-assembly clean deploy
-          mvn -Pdeploy -Pproduction -pl storage/rest/service-springboot clean deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY: ${{ secrets.ORG_GPG_PRIVATE_KEY }}

--- a/integrations/itest/pom.xml
+++ b/integrations/itest/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <org.springframework.boot.version>3.2.2</org.springframework.boot.version>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -18,39 +18,10 @@
 
     <modules>
         <module>cdi4</module>
+        <module>spring-boot3</module>
+        <module>spring-boot3-console</module>
+        <!-- This module exists in order to run real itests with dependencies provided by the application -->
+        <module>itest</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>from_java_17</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <modules>
-                <module>spring-boot3</module>
-                <module>spring-boot3-console</module>
-                <!-- This module exists in order to run real itests with dependencies provided by the application -->
-                <module>itest</module>
-            </modules>
-            <properties>
-                <maven.compiler.source>17</maven.compiler.source>
-                <maven.compiler.target>17</maven.compiler.target>
-                <java.version>17</java.version>
-            </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <source>17</source>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/integrations/spring-boot3-console/pom.xml
+++ b/integrations/spring-boot3-console/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <org.springframework.boot.version>3.4.5</org.springframework.boot.version>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3/pom.xml
+++ b/integrations/spring-boot3/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <org.springframework.boot.version>3.4.5</org.springframework.boot.version>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.compilerId>javac</maven.compiler.compilerId>
         <maven.version.minimum>3.8.1</maven.version.minimum>
         <maven.java.version.minimum>11</maven.java.version.minimum>

--- a/storage/rest/client-app-standalone-assembly/pom.xml
+++ b/storage/rest/client-app-standalone-assembly/pom.xml
@@ -21,6 +21,7 @@
 	<properties>
 		<vaadin.version>24.2.6</vaadin.version>
 		<spring.boot.version>3.2.0</spring.boot.version>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencyManagement>

--- a/storage/rest/client-app/pom.xml
+++ b/storage/rest/client-app/pom.xml
@@ -22,6 +22,7 @@
 	<properties>
 		<vaadin.version>24.2.6</vaadin.version>
 		<spring.boot.version>3.2.0</spring.boot.version>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencyManagement>

--- a/storage/rest/pom.xml
+++ b/storage/rest/pom.xml
@@ -26,39 +26,9 @@
         <module>client-jersey</module>
         <module>service</module>
         <module>service-sparkjava</module>
+        <module>service-springboot</module>
+        <module>client-app</module>
+        <module>client-app-standalone-assembly</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>from_java_17</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.source>17</maven.compiler.source>
-                <maven.compiler.target>17</maven.compiler.target>
-                <java.version>17</java.version>
-            </properties>
-            <modules>
-                <module>service-springboot</module>
-                <module>client-app</module>
-                <module>client-app-standalone-assembly</module>
-            </modules>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <source>17</source>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-
-        </profile>
-    </profiles>
 
 </project>

--- a/storage/rest/service-springboot/pom.xml
+++ b/storage/rest/service-springboot/pom.xml
@@ -21,6 +21,7 @@
 
 	<properties>
 		<spring-boot.version>3.2.2</spring-boot.version>
+		<maven.compiler.release>17</maven.compiler.release>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
This pull request updates the Maven build configurations and project files to standardize Java version usage across workflows and modules. The most significant changes involve removing Java 11 configurations, consolidating builds to Java 17, and simplifying Maven profiles and properties.

### Workflow Changes:
* [`.github/workflows/maven_build.yml`](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L17-L28): Removed Java 11 build steps, retaining only Java 17 build configurations.
* [`.github/workflows/maven_build_win.yml`](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L17-L28): Similar to the Ubuntu workflow, removed Java 11 build steps while keeping Java 17 configurations. [[1]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L17-L28) [[2]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259R26)
* [`.github/workflows/maven_converter.yml`](diffhunk://#diff-78ec4836e8c0653030b3d3a7cf36ff43c53aeecd17784becf8fb1453033d15a6L17-R21): Updated Java version from 11 to 17 for the Maven converter workflow.
* `.github/workflows/maven_deploy_snapshot.yml` and `.github/workflows/maven_deploy_snapshot_dev.yml`: Standardized Java version to 17 and removed redundant Java 17-specific build profiles. [[1]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L21-R21) [[2]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L35-L68) [[3]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L21-R21) [[4]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L55-L109)

### Maven Project Changes:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R39): Replaced `maven.compiler.source` and `maven.compiler.target` with `maven.compiler.release` for Java 11.
* Module-specific `pom.xml` files (e.g., `integrations/itest/pom.xml`, `integrations/spring-boot3-console/pom.xml`, `storage/rest/service-springboot/pom.xml`): Added `maven.compiler.release` set to 17, aligning with the updated workflows. [[1]](diffhunk://#diff-bc38a1cf1fe655a64667a489957faedfb6ff967fdb1f6921ee207d8b30196bebR20) [[2]](diffhunk://#diff-edb745cc289cf9d279366e508f6468114761d00e2e79f7ec98ef6d977ef109cfR20) [[3]](diffhunk://#diff-c8e69b25567ade5703935720998482dec95ab8f6f631dbaeea972a5099fd20e1R24)
* `integrations/pom.xml` and `storage/rest/pom.xml`: Removed Java 17-specific profiles and consolidated module definitions. [[1]](diffhunk://#diff-6649974da27e83f63f17f080c1340a08d00d734e1dd12285fad97395e1338e7fL21-L54) [[2]](diffhunk://#diff-a3a688ff5535d018144bf06b5051461cf3f89088ae72ee040a4f75ee6e1622f3L29-L62)