### PR TITLE
chore: switch Java distribution from AdoptOpenJDK to Temurin in maven…

### DIFF
--- a/.github/workflows/maven_converter.yml
+++ b/.github/workflows/maven_converter.yml
@@ -20,6 +20,6 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B -Pconverter-standalone -pl storage/embedded-tools/storage-converter -am clean package --file pom.xml -U

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskExportAdjacencyData.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskExportAdjacencyData.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.storage.types;
 
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;


### PR DESCRIPTION
This pull request includes updates to the build configuration and licensing information in the codebase. The most important changes involve switching the Java distribution used in the GitHub Actions workflow and adding a license header to a Java source file.

### Build configuration updates:
* [`.github/workflows/maven_converter.yml`](diffhunk://#diff-78ec4836e8c0653030b3d3a7cf36ff43c53aeecd17784becf8fb1453033d15a6L23-R23): Updated the Java distribution from `adopt` to `temurin` in the GitHub Actions workflow to align with the current recommended distribution for Java 17.

### Licensing updates:
* [`storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskExportAdjacencyData.java`](diffhunk://#diff-c1280e14bec281ca44418fe7aa1920d9ac2bd94da12b2c22e99cdd40c2bdac8dR3-R16): Added a license header to comply with the Eclipse Public License 2.0.…_converter.yml