### PR TITLE
chore: update minimum Java version in pom.xml to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.compilerId>javac</maven.compiler.compilerId>
         <java.version>17</java.version>
         <maven.version.minimum>3.8.1</maven.version.minimum>
-        <maven.java.version.minimum>11</maven.java.version.minimum>
+        <maven.java.version.minimum>17</maven.java.version.minimum>
         <org.eclipse.jdt.ecj.version>3.29.0</org.eclipse.jdt.ecj.version>
         <license.inceptionYear>2023</license.inceptionYear>
         <license.licenseName>epl_only_v2</license.licenseName>


### PR DESCRIPTION
This pull request updates the minimum required Java version for the project. The `maven.java.version.minimum` property in the `pom.xml` file has been updated from Java 11 to Java 17.

- [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L43-R43): Updated the `maven.java.version.minimum` property to require Java 17 instead of Java 11.