### PR TITLE
427 no sub keys for googlecloudfirestore for googlecloudfirestorefilesystemcreator found

### DIFF
--- a/afs/googlecloud/firestore/src/main/java/org/eclipse/store/afs/googlecloud/firestore/types/GoogleCloudFirestoreFileSystemCreator.java
+++ b/afs/googlecloud/firestore/src/main/java/org/eclipse/store/afs/googlecloud/firestore/types/GoogleCloudFirestoreFileSystemCreator.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import com.google.cloud.NoCredentials;
 import org.eclipse.serializer.afs.types.AFileSystem;
 import org.eclipse.serializer.chars.XChars;
 import org.eclipse.serializer.configuration.exceptions.ConfigurationException;
@@ -95,7 +96,7 @@ public class GoogleCloudFirestoreFileSystemCreator extends ConfigurationBasedCre
 			{
 				case "none":
 				{
-					optionsBuilder.setCredentialsProvider(NoCredentialsProvider.create());
+					optionsBuilder.setCredentialsProvider(NoCredentials::getInstance);
 				}
 				break;
 

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/ConfigKeys.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/ConfigKeys.java
@@ -69,6 +69,15 @@ public enum ConfigKeys
     ORACLECLOUD_REGION("object-storage.region"),
     ORACLECLOUD_ENDPOINT("object-storage.endpoint"),
 
+    // Google Cloud
+    GOOGLECLOUD("googlecloud"),
+    GOOGLECLOUD_FIRESTORE_DATABASE_ID("firestore.database-id"),
+    GOOGLECLOUD_FIRESTORE_EMULATOR_HOST("firestore.emulator-host"),
+    GOOGLECLOUD_FIRESTORE_HOST("firestore.host"),
+    GOOGLECLOUD_FIRESTORE_PROJECT_ID("firestore.project-id"),
+    GOOGLECLOUD_FIRESTORE_QUOTA_PROJECT_ID("firestore.quota-project-id"),
+    GOOGLECLOUD_FIRESTORE_CREDENTIALS_TYPE("firestore.credentials.type"),
+
     //Coherence
     COHERENCE("coherence"),
     COHERENCE_CACHE_NAME("cache-name"),

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -24,6 +24,7 @@ import org.eclipse.store.integrations.spring.boot.types.configuration.aws.Abstra
 import org.eclipse.store.integrations.spring.boot.types.configuration.aws.Aws;
 import org.eclipse.store.integrations.spring.boot.types.configuration.aws.S3;
 import org.eclipse.store.integrations.spring.boot.types.configuration.azure.Azure;
+import org.eclipse.store.integrations.spring.boot.types.configuration.googlecloud.Googlecloud;
 import org.eclipse.store.integrations.spring.boot.types.configuration.oraclecloud.Oraclecloud;
 import org.eclipse.store.integrations.spring.boot.types.configuration.sql.AbstractSqlConfiguration;
 import org.eclipse.store.integrations.spring.boot.types.configuration.sql.Sql;
@@ -169,8 +170,27 @@ public class EclipseStoreConfigConverter
         {
             values.put(ConfigKeys.REDIS_URI.value(), properties.getRedis().getUri());
         }
+        if (properties.getGooglecloud() != null)
+        {
+            values.putAll(this.prepareGoogleCloud(properties.getGooglecloud(), this.composeKey(key, ConfigKeys.GOOGLECLOUD.value())));
+        }
 
 
+        return values;
+    }
+
+    private Map<String, String> prepareGoogleCloud(final Googlecloud googlecloud, final String key)
+    {
+        final Map<String, String> values = new HashMap<>();
+        values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_DATABASE_ID.value()), googlecloud.getFirestore().getDatabaseId());
+        values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_EMULATOR_HOST.value()), googlecloud.getFirestore().getEmulatorHost());
+        values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_HOST.value()), googlecloud.getFirestore().getHost());
+        values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_PROJECT_ID.value()), googlecloud.getFirestore().getProjectId());
+        values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_QUOTA_PROJECT_ID.value()), googlecloud.getFirestore().getQuotaProjectId());
+        if (googlecloud.getFirestore().getCredentials() != null)
+        {
+            values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_CREDENTIALS_TYPE.value()), googlecloud.getFirestore().getCredentials().getType());
+        }
         return values;
     }
 

--- a/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java
+++ b/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.configuration.StorageFilesystem;
+import org.eclipse.store.integrations.spring.boot.types.configuration.googlecloud.Googlecloud;
+import org.eclipse.store.integrations.spring.boot.types.configuration.googlecloud.firestore.Firestore;
 import org.eclipse.store.integrations.spring.boot.types.configuration.sql.Mariadb;
 import org.eclipse.store.integrations.spring.boot.types.configuration.sql.Sql;
 import org.junit.jupiter.api.Test;
@@ -105,5 +107,27 @@ class EclipseStoreConfigConverterTest
     {
         final String result = this.converter.composeKey("prefix", "suffix");
         assertEquals("prefix.suffix", result);
+    }
+
+    @Test
+    void testGoogleCloudConversion()
+    {
+        final EclipseStoreProperties properties = new EclipseStoreProperties();
+        Firestore firestore = new Firestore();
+        Googlecloud googlecloud = new Googlecloud();
+        googlecloud.setFirestore(firestore);
+        StorageFilesystem storageFilesystem = new StorageFilesystem();
+        storageFilesystem.setGooglecloud(googlecloud);
+        properties.setStorageFilesystem(storageFilesystem);
+        properties.getStorageFilesystem().getGooglecloud().getFirestore().setDatabaseId("firestore_es_db");
+
+        final EclipseStoreConfigConverter converter = new EclipseStoreConfigConverter();
+        final Map<String, String> valuesMap = converter.convertConfigurationToMap(properties);
+
+        assertNotNull(valuesMap);
+        assertEquals(1, valuesMap.size());
+        Map.Entry<String, String> next = valuesMap.entrySet().iterator().next();
+        assertEquals("storage-filesystem.googlecloud.firestore.database-id", next.getKey());
+        assertEquals("firestore_es_db", next.getValue());
     }
 }


### PR DESCRIPTION
This pull request introduces support for Google Cloud Firestore configuration in the project, including updates to the configuration keys, conversion logic, and associated tests. The most important changes include adding Firestore-specific configuration keys, implementing logic to handle Firestore properties, and adding a test to validate the new functionality.

### Google Cloud Firestore Configuration Support:

* Added Firestore-specific configuration keys to the `ConfigKeys` enum, enabling support for properties like `database-id`, `emulator-host`, `host`, `project-id`, `quota-project-id`, and `credentials.type` (`integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/ConfigKeys.java`).

* Updated the `EclipseStoreConfigConverter` to handle Firestore configuration by adding a `prepareGoogleCloud` method, which maps Firestore properties to their corresponding configuration keys (`integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java`).

### Code Updates for Google Cloud Firestore:

* Replaced the use of `NoCredentialsProvider.create()` with `NoCredentials::getInstance` in the `GoogleCloudFirestoreFileSystemCreator` to simplify the credentials setup (`afs/googlecloud/firestore/src/main/java/org/eclipse/store/afs/googlecloud/firestore/types/GoogleCloudFirestoreFileSystemCreator.java`).

* Added necessary imports for Google Cloud Firestore configuration in both the `EclipseStoreConfigConverter` and its test class (`integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java`, `integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java`) [[1]](diffhunk://#diff-f46d4ee485650ec97bdb2ec16778c60e90aaf08f8086f5e4fbbf5a6501befc36R27) [[2]](diffhunk://#diff-be6f6a61486f97b832c3764e163db6c1596f397136a6afdef68cf1c71c959a07R26-R27).

### Testing:

* Added a test method, `testGoogleCloudConversion`, to validate the conversion of Firestore properties into a configuration map. This ensures the new functionality works as expected (`integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java`).