### PR TITLE
chore: add license headers to Java files

### DIFF
--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/Address.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/Address.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import com.github.javafaker.Faker;
 
 public class Address

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/BasicExample.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/BasicExample.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import com.github.javafaker.Faker;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.GigaQuery;

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/Interest.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/Interest.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/Person.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/Person.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/PersonIndices.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/PersonIndices.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import java.time.LocalDate;
 
 import org.eclipse.store.gigamap.types.BinaryIndexer;

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/RandomGenerator.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/RandomGenerator.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
This pull request adds licensing information to several files in the `examples/gigamap` package. The changes involve including a standard header that specifies the Eclipse Public License 2.0 for each file.

### Licensing Information Updates:

* Added a license header specifying the Eclipse Public License 2.0 to the following files:
  - `Address.java`
  - `BasicExample.java`
  - `Interest.java`
  - `Person.java`
  - `PersonIndices.java`
  - `RandomGenerator.java`