### PR TITLE
chore: add license header check workflow and enforce header requireme…

### DIFF
--- a/.github/workflows/maven_licence_check.yml
+++ b/.github/workflows/maven_licence_check.yml
@@ -1,0 +1,28 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Licence header check
+
+on:
+  push:
+    branches: 
+      - '**'
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      #Build with java 17
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -B clean license:check-file-header --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
                             <include>**/*.java</include>
                         </includes>
                         <ignoreNoFileToScan>true</ignoreNoFileToScan>
+                        <failOnMissingHeader>true</failOnMissingHeader>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Add a check to ensure that all Java files contain a license header.