### PR TITLE
Add override methods to BinaryIndexerLong interface

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerLong.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerLong.java
@@ -23,6 +23,14 @@ package org.eclipse.store.gigamap.types;
  */
 public interface BinaryIndexerLong<E> extends BinaryIndexerNumber<E, Long>
 {
+	@Override
+	public <S extends E> Condition<S> is(Long key);
+	
+	@Override
+	public <S extends E> Condition<S> in(Long... keys);
+		
+	
+	
 	public abstract class Abstract<E> extends BinaryIndexerNumber.Abstract<E, Long> implements BinaryIndexerLong<E>
 	{
 		protected Abstract()


### PR DESCRIPTION
The pull request adds override methods `is` and `in` to the `BinaryIndexerLong` interface. This resolves an issue where the Eclipse compiler displays an error due to non-compliance with the JLS.