### PR TITLE
chore: remove println statements from test files

### DIFF
--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/RemovalAllMemoryTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/RemovalAllMemoryTest.java
@@ -141,7 +141,7 @@ public class RemovalAllMemoryTest
 	@Order(0)
 	void testNoIndexer() throws IOException
 	{
-		System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
+//		System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
 		System.out.println("Memory usage: " + memoryUsage() + " MB");
 		
 		final GigaMap<Customer> gigaMap = GigaMap.New();
@@ -153,7 +153,7 @@ public class RemovalAllMemoryTest
 	@Order(1)
 	void testOneIndexer() throws IOException
 	{
-		System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
+//		System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
 		System.out.println("Memory usage: " + memoryUsage() + " MB");
 		
 		final GigaMap<Customer> gigaMap = GigaMap.New();
@@ -167,7 +167,7 @@ public class RemovalAllMemoryTest
 	@Order(2)
 	void testTwoIndexer() throws IOException
 	{
-		System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
+		//System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
 		System.out.println("Memory usage: " + memoryUsage() + " MB");
 		
 		final GigaMap<Customer> gigaMap = GigaMap.New();
@@ -183,7 +183,7 @@ public class RemovalAllMemoryTest
 	@Order(3)
 	void testThreeIndexer() throws IOException
 	{
-		System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
+//		System.out.println(this.newDirectory.toAbsolutePath()); // for debugging
 		System.out.println("Memory usage: " + memoryUsage() + " MB");
 		
 		final GigaMap<Customer> gigaMap = GigaMap.New();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/SetTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/SetTest.java
@@ -65,7 +65,7 @@ public class SetTest
 		try(EmbeddedStorageManager storageManager = EmbeddedStorage.start(this.tempDir))
 		{
 			final GigaMap<Item> loadedGigaMap = (GigaMap<Item>)storageManager.root();
-			loadedGigaMap.forEach(System.out::println); // just for debugging
+			//loadedGigaMap.forEach(System.out::println); // just for debugging
 			assertEquals(item5, loadedGigaMap.get(0)); // <=== is still Item4, Item2, Item3
 			
 		}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/experimental/ThreadCountProviderTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/experimental/ThreadCountProviderTest.java
@@ -32,7 +32,7 @@ public class ThreadCountProviderTest
 
 
     @Test
-    @Disabled("https://github.com/microstream-one/gigamap/issues/118")
+    @Disabled("https://github.com/eclipse-store/store/issues/449")
     void threadProviderTest()
     {
         GigaMap<ThreadEntity> gigaMap           = GigaMap.New();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IterationThreadProviderTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IterationThreadProviderTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 public class IterationThreadProviderTest
 {
     @Test
-    @Disabled("https://github.com/microstream-one/gigamap/issues/118")
+    @Disabled("https://github.com/eclipse-store/store/issues/449")
     void iterationThreadProviderTest()
     {
         GigaMap<Person> map = GigaMap.New();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryUUIDIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryUUIDIndexTest.java
@@ -55,8 +55,6 @@ public class BinaryUUIDIndexTest
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(map, tempDir)) {
             
-            map.forEach(p -> System.out.println(p));
-            
             assertEquals(uuid1, map.query(uuidPersonIndex.is(uuid1)).findFirst().get().uuid);
             assertEquals(uuid2, map.query(uuidPersonIndex.is(uuid2)).findFirst().get().uuid);
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryVariableTests.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryVariableTests.java
@@ -43,7 +43,7 @@ public class QueryVariableTests
     Condition<Person> firstSubQuery = nameIndexer.is("Alice").and(ageIndexer.is(30));
 
     @Test
-    @Disabled("https://github.com/microstream-one/gigamap/issues/103")
+    @Disabled("https://github.com/eclipse-store/store/issues/450")
     void queryTest()
     {
         GigaMap<Person> map = GigaMap.New();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumInsideTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumInsideTest.java
@@ -1,0 +1,99 @@
+package org.eclipse.store.gigamap.indexer.enumeration;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class StoreEnumInsideTest
+{
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @Disabled("https://github.com/eclipse-store/store/issues/448")
+    void storeEnumInsideTest()
+    {
+        Person person = new Person("John", 30, StoreEnum.VALUE);
+        Person person2 = new Person("John", 30, StoreEnum.SECOND);
+        Person person3 = new Person("John", 30, StoreEnum.THIRD);
+
+        GigaMap<Person> gigaMap = GigaMap.New();
+        gigaMap.add(person);
+        gigaMap.add(person2);
+        gigaMap.add(person3);
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(gigaMap, tempDir)) {
+        }
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
+            GigaMap<Person> loadedGigaMap = (GigaMap<Person>) manager.root();
+
+            //TODO check after fix
+            List<Person> list = loadedGigaMap.query().toList();
+            Assertions.assertEquals(3, list.size(), "There should be 3 persons in the GigaMap");
+        }
+
+    }
+
+    private static class Person
+    {
+        private String name;
+        private int age;
+        private Address address;
+
+        public Person(String name, int age, StoreEnum address)
+        {
+            this.name = name;
+            this.age = age;
+            this.address = new Address(address);
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public int getAge()
+        {
+            return age;
+        }
+
+        public Address getAddress()
+        {
+            return address;
+        }
+
+    }
+
+    private static class Address
+    {
+        StoreEnum address;
+
+        public Address(StoreEnum address)
+        {
+            this.address = address;
+        }
+    }
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumTest.java
@@ -17,6 +17,7 @@ package org.eclipse.store.gigamap.indexer.enumeration;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,7 +33,7 @@ public class StoreEnumTest
     Path workDir;
 
     @Test
-    @Disabled("https://github.com/microstream-one/gigamap/issues/71")
+    @Disabled("https://github.com/eclipse-store/store/issues/448")
     void enumTest()
     {
         GigaMap<StoreEnum> gigaMap = GigaMap.New();
@@ -47,7 +48,10 @@ public class StoreEnumTest
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(workDir)) {
             GigaMap<StoreEnum> loadedGigaMap = (GigaMap<StoreEnum>) manager.root();
 
-            loadedGigaMap.forEach(System.out::println);
+            //TODO check after fix
+            List<StoreEnum> expectedList = List.of(StoreEnum.VALUE, StoreEnum.SECOND, StoreEnum.THIRD);
+            List<StoreEnum> loadedEnumList = loadedGigaMap.query().toList();
+            Assertions.assertIterableEquals(expectedList, loadedEnumList);
         }
     }
 
@@ -65,7 +69,8 @@ public class StoreEnumTest
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(workDir)) {
             List<StoreEnum> loadedEnumList = (List<StoreEnum>) manager.root();
 
-            loadedEnumList.forEach(System.out::println);
+            List<StoreEnum> expectedList = List.of(StoreEnum.VALUE, StoreEnum.SECOND, StoreEnum.THIRD);
+            Assertions.assertIterableEquals(expectedList, loadedEnumList);
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/query/NumberSearchTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/query/NumberSearchTest.java
@@ -43,7 +43,7 @@ public class NumberSearchTest
         final long seconds = duration.toSecondsPart();
         final long millis = duration.toMillisPart();
         final long nanos = duration.toNanosPart();
-        System.out.printf("Time taken for %s: %dm %ds %dms %dns%n", actionDescription, minutes, seconds, millis, nanos);
+        System.out.printf("Time taken for: | %-28s | %dm | %ds | %-2dms | %-10dns |%n", actionDescription, minutes, seconds, millis, nanos);
     }
 
     @Test
@@ -57,22 +57,18 @@ public class NumberSearchTest
         final FloatIndexer floatIndexer = new FloatIndexer();
         indices.add(floatIndexer);
 
-        final Instant start, finish;
-
-        final int count = 0;
-
         measureTime(() ->
                 gigaMap.query(valueIndexer.is(integer -> (20 < integer) && (integer < 5000)))
                         .execute((Consumer<? super IntegerObject>) integerObject -> {}), "Between query");
 
         measureTime(() ->
                 gigaMap.query(valueIndexer.is(20))
-                        .execute((Consumer<? super IntegerObject>) System.out::println), "Exact value query");
+                        .execute((Consumer<? super IntegerObject>) integerObject -> {}), "Exact value query");
         measureTime(() ->
             gigaMap.query(valueIndexer.is(20).or(valueIndexer.is(30)).or(valueIndexer.is(40)).or(valueIndexer.is(50)))
-                    .execute((Consumer<? super IntegerObject>) System.out::println), "Exact multiple value query");
+                    .execute((Consumer<? super IntegerObject>) SintegerObject -> {}), "Exact multiple value query");
         measureTime(() ->
-            gigaMap.query(floatIndexer.is(20f)).execute((Consumer<? super IntegerObject>) System.out::println), "Exact float value query");
+            gigaMap.query(floatIndexer.is(20f)).execute((Consumer<? super IntegerObject>) integerObject -> {}), "Exact float value query");
 
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AddTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AddTest.java
@@ -152,9 +152,6 @@ public class AddTest
             gm2.index().bitmap().add(ageIndexer);
             assertTrue(gm2.query(ageIndexer.is(100)).toList().isEmpty());
 
-            gm2.forEach(System.out::println);
-            System.out.println("Size of the map: " + gm2.size());
-
             assertEquals(gm2.size() , gigaMap.size(), "Size of the map should be equal to the size of the giga map");
         }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/update/SmallEVTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/update/SmallEVTest.java
@@ -38,10 +38,10 @@ public class SmallEVTest
                 smallEVs = generateData();
                 storageManager.setRoot(smallEVs);
                 storageManager.storeRoot();
-                System.out.println("Stored to storage: " + smallEVs.size());
+                //System.out.println("Stored to storage: " + smallEVs.size());
             } else {
                 smallEVs = (GigaMap<SmallEV>) storageManager.root();
-                System.out.println("Loaded from storage: " + smallEVs.size());
+                //System.out.println("Loaded from storage: " + smallEVs.size());
             }
             SmallEV smallEV = smallEVs.get(0);
             smallEVs.update(smallEV, smallEV1 -> smallEV1.setElectric(false));


### PR DESCRIPTION
This pull request primarily updates tests in the `gigamap` module by cleaning up debugging output and improving test assertions, as well as updating references to issue trackers. It also adds a new test for storing enums inside objects. These changes help make the test suite cleaner and more maintainable.

**Test assertion improvements:**

* Enhanced assertions in `StoreEnumTest.java` to check for correct enum list contents after loading from storage, replacing print statements with `Assertions.assertIterableEquals`. [[1]](diffhunk://#diff-5d7d77145e6afb8e00623074f0f72cfe1ac463f1b5724b23a904814ecd7bb242L50-R54) [[2]](diffhunk://#diff-5d7d77145e6afb8e00623074f0f72cfe1ac463f1b5724b23a904814ecd7bb242L68-R73)
* Added a new test `StoreEnumInsideTest.java` to verify storing enums inside nested objects in a `GigaMap`, including proper assertions for the expected object count.

**Debugging output cleanup:**

* Commented out or removed `System.out.println` statements used for debugging in several test files, including `RemovalAllMemoryTest.java`, `SetTest.java`, `BinaryUUIDIndexTest.java`, `AddTest.java`, and `SmallEVTest.java`. [[1]](diffhunk://#diff-309a81d067ca19f107d213575921713052a1fe7488c4aae35dd0a71e942d70b9L144-R144) [[2]](diffhunk://#diff-309a81d067ca19f107d213575921713052a1fe7488c4aae35dd0a71e942d70b9L156-R156) [[3]](diffhunk://#diff-309a81d067ca19f107d213575921713052a1fe7488c4aae35dd0a71e942d70b9L170-R170) [[4]](diffhunk://#diff-309a81d067ca19f107d213575921713052a1fe7488c4aae35dd0a71e942d70b9L186-R186) [[5]](diffhunk://#diff-d36a73f54b87e29f319bd71fd4214dd89222682d11d04b9ea1da79f6143181cfL68-R68) [[6]](diffhunk://#diff-0531e3a3c621930c895966a0b36886a6089510ca3a97754d2d7f6f93635ffa22L58-L59) [[7]](diffhunk://#diff-7dde1200a15eaa8a1c9893f5bd817834f5ea6663aeaab92b0a689ea0e1c9a8b7L155-L157) [[8]](diffhunk://#diff-d14690b044f85fdb079cfa40bc60a4a527ae78d6d40e71a6b0372c6565ac0c5eL41-R44)

**Issue tracker reference updates:**

* Updated `@Disabled` test annotations to reference the new `eclipse-store/store` issue tracker instead of the old `microstream-one/gigamap` repository in multiple test files. [[1]](diffhunk://#diff-eff7fa082d99623eb81b703623e8994b6d35fd20274ace159a7063f93e656114L35-R35) [[2]](diffhunk://#diff-3101f9b7bacf0ffda849f8c99ee0a17ff8ffb2665b78e72903f4d894b403948bL26-R26) [[3]](diffhunk://#diff-7a80475363c70977b461dcaaeb09b31944d019c5c9bcad2774fae09590681f25L46-R46) [[4]](diffhunk://#diff-5d7d77145e6afb8e00623074f0f72cfe1ac463f1b5724b23a904814ecd7bb242L35-R36)

**Minor output formatting and code cleanup:**

* Improved the time measurement output format in `NumberSearchTest.java` for better readability.
* Removed unused variables and replaced printing with empty consumers in query tests to reduce unnecessary output.move issue to public