### PR TITLE
chore: add sbom generation and upload workflow

### DIFF
--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -1,0 +1,79 @@
+name: Generate Maven SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    # Provide custom 'Version' input, to allow running the workflow for older
+    # git refs, where the workflow file did not exist yet. This is not possible
+    # with the builtin "Use workflow from" input field.
+    inputs:
+      version:
+        description: "Version"
+        default: "main"
+        required: true
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'temurin'
+  PLUGIN_VERSION: '2.9.1'
+  SBOM_TYPE: 'makeAggregateBom'
+  PROJECT_VERSION: "${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      # Make env var available in re-usuable workflow (see actions/runner#2372)
+      project-version: ${{ env.PROJECT_VERSION }}
+    steps:
+      - name: Checkout repository at '${{ env.PROJECT_VERSION }}'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ env.PROJECT_VERSION }}
+          persist-credentials: false
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate
+        run: |
+          # Patching version for tags only allows generating correct release
+          # SBOMs, and also to test SBOMs on arbitrary non-tag git refs, which
+          # the maven version plugin would otherwise choke on.
+
+          if git show-ref --tags --quiet --verify "refs/tags/${PROJECT_VERSION}"; then
+            mvn versions:set -DnewVersion=${PROJECT_VERSION} --batch-mode
+            mvn versions:set-property -Dproperty=eclipse.serializer.version \
+                -DnewVersion=${PROJECT_VERSION}
+          fi
+
+          # Generate SBOMs as per config in pom.xml. 'skipNotDeployed' is needed
+          # to generate an SBOM outside of the deployment phase.
+
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${PLUGIN_VERSION}:${SBOM_TYPE} \
+              -Dcyclonedx.skipNotDeployed=false
+
+      - name: Upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: target/sbom/Eclipse-Store-Sbom.json
+
+  # Store SBOM and metadata in a predefined format for otterdog to pick up
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'store'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'Eclipse-Store-Sbom.json'
+      parentProject: '0a48ad69-bb92-4881-b35e-450e4f7264dc'

--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -55,13 +55,13 @@ jobs:
                 -DnewVersion=${PROJECT_VERSION}
           fi
 
-          # Generate SBOMs as per config in pom.xml. 'skipNotDeployed' is needed
+          # Generate SBOMs. 'skipNotDeployed' is needed
           # to generate an SBOM outside of the deployment phase.
 
           mvn org.cyclonedx:cyclonedx-maven-plugin:${PLUGIN_VERSION}:${SBOM_TYPE} \
-              -Dcyclonedx.skipNotDeployed=false
-              -Dcyclonedx.outputName=Eclipse-Store-Sbom \
-              -Dcyclonedx.outputDirectory=target/sbom
+              -Dcyclonedx.skipNotDeployed=false \
+              -DoutputName=Eclipse-Store-Sbom \
+              -DoutputDirectory=target/sbom
 
       - name: Upload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -60,6 +60,8 @@ jobs:
 
           mvn org.cyclonedx:cyclonedx-maven-plugin:${PLUGIN_VERSION}:${SBOM_TYPE} \
               -Dcyclonedx.skipNotDeployed=false
+              -Dcyclonedx.outputName=Eclipse-Store-Sbom \
+              -Dcyclonedx.outputDirectory=target/sbom
 
       - name: Upload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ If you want to contribute to this project, please read our [guidelines](CONTRIBU
 - [Website](https://eclipsestore.io)
 - [Eclipse project page](https://projects.eclipse.org/projects/technology.store)
 - [Dev mailing list](https://accounts.eclipse.org/mailing-list/store-dev)
+
+## SBOM
+
+To enhance supply chain security and offer users clear insight into project
+components, Eclipse Store now generates a Software Bill of Materials (SBOM) for
+every release. These are published to the Eclipse Foundation SBOM registry,
+with access instructions and usage details available in this [documentation]
+(https://eclipse-csi.github.io/security-handbook/sbom/registry.html).

--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
                     </executions>
                     <configuration>
                         <projectType>library</projectType>
-                        <schemaVersion>1.4</schemaVersion>
+                        <schemaVersion>1.6</schemaVersion>
                         <includeBomSerialNumber>true</includeBomSerialNumber>
                         <includeCompileScope>true</includeCompileScope>
                         <includeProvidedScope>true</includeProvidedScope>

--- a/pom.xml
+++ b/pom.xml
@@ -358,34 +358,6 @@
                     <version>3.5.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.cyclonedx</groupId>
-                    <artifactId>cyclonedx-maven-plugin</artifactId>
-                    <version>2.8.1</version>
-                    <executions>
-                        <execution>
-                            <phase>prepare-package</phase>
-                            <goals>
-                                <goal>makeAggregateBom</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <projectType>library</projectType>
-                        <schemaVersion>1.6</schemaVersion>
-                        <includeBomSerialNumber>true</includeBomSerialNumber>
-                        <includeCompileScope>true</includeCompileScope>
-                        <includeProvidedScope>true</includeProvidedScope>
-                        <includeRuntimeScope>true</includeRuntimeScope>
-                        <includeSystemScope>true</includeSystemScope>
-                        <includeTestScope>false</includeTestScope>
-                        <includeLicenseText>false</includeLicenseText>
-                        <outputReactorProjects>true</outputReactorProjects>
-                        <outputFormat>all</outputFormat>
-                        <outputName>Eclipse-Store-Sbom</outputName>
-                        <outputDirectory>${project.build.directory}/sbom</outputDirectory>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
                     <version>0.8.0</version>
@@ -405,42 +377,6 @@
             <modules>
                 <module>examples</module>
             </modules>
-        </profile>
-        <profile>
-            <id>production</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.cyclonedx</groupId>
-                        <artifactId>cyclonedx-maven-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy-meta-inf-resources</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>copy-resources</goal>
-                                </goals>
-                                <configuration>
-                                    <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
-                                    <resources>
-                                        <resource>
-                                            <directory>${project.build.directory}/sbom/</directory>
-                                            <includes>
-                                                <include>*.json</include>
-                                                <include>*.xml</include>
-                                            </includes>
-                                        </resource>
-                                    </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>deploy</id>


### PR DESCRIPTION
This PR aims to bootstrap the EF Security Team initiative of generating and publishing SBOMs for project releases, with the goal of enhancing software supply chain security.

To not interfere with your existing release processes, this PR proposes a new workflow to generate and publish SBOMs autonomously, following GitHub releases of the **store** product. The workflow respects the existing SBOM plugin configuration in `pom.xml`, which is updated to use the latest SBOM schema version.[^1]

In addition to the release event, the workflow can be triggered manually to test SBOM generation, or to generate SBOMs for past releases.

Following a workflow run, the EF self-service system automatically publishes the SBOM on our DependencyTrack [instance](https://sbom.eclipse.org/), under the **Eclipse Store → store** entry. To view the uploaded results, you can log into DependencyTrack by using your EF account credentials.

If the PR is merged, we kindly ask you to run the workflow once, so that we can confirm a successful SBOM upload from your repository. You can find instructions to [trigger a workflow manually in the GitHub documentation](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow#running-a-workflow):

- The name of the workflow is "Generate Maven SBOM”
- Enter an existing release tag in the “Version” input field of the “Run workflow” UI, e.g. “3.0.0”

Also note that edits by maintainers are enabled for this PR, so feel free to update the workflow as you see fit, and do let us know if you have any questions!

More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html).

[^1]: We recommend removing the SBOM configuration from `pom.xml`, and defining necessary (non-default) options only in the new workflow to avoid surprising behaviour.