### PR TITLE
chore: update Spring Boot version to 3.5.6

### DIFF
--- a/examples/spring-boot3-advanced/pom.xml
+++ b/examples/spring-boot3-advanced/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.4.5</spring.boot.version>
+        <spring.boot.version>3.5.6</spring.boot.version>
     </properties>
 
     <dependencyManagement>
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.14.0</version>
             </plugin>
         </plugins>
     </build>

--- a/examples/spring-boot3-simple/pom.xml
+++ b/examples/spring-boot3-simple/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.4.5</spring.boot.version>
+        <spring.boot.version>3.5.6</spring.boot.version>
     </properties>
 
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.2.0</version>
+            <version>2.8.13</version>
         </dependency>
 
         <dependency>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.14.0</version>
             </plugin>
         </plugins>
     </build>

--- a/integrations/spring-boot3-console/pom.xml
+++ b/integrations/spring-boot3-console/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.4.5</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.6</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3/pom.xml
+++ b/integrations/spring-boot3/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.4.5</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.6</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/storage/rest/client-app/pom.xml
+++ b/storage/rest/client-app/pom.xml
@@ -21,7 +21,7 @@
 
 	<properties>
 		<vaadin.version>24.2.6</vaadin.version>
-		<spring.boot.version>3.2.0</spring.boot.version>
+		<spring.boot.version>3.5.6</spring.boot.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
This pull request updates several Maven project files to use newer versions of Spring Boot and related dependencies, ensuring all modules are aligned with the latest stable releases. The changes also include upgrades to the Maven Compiler Plugin and the Springdoc OpenAPI dependency for improved compatibility and features.

**Dependency version updates:**

* Upgraded `spring.boot.version` (or `org.springframework.boot.version`) from `3.4.5` or `3.2.0` to `3.5.6` in `examples/spring-boot3-advanced/pom.xml`, `examples/spring-boot3-simple/pom.xml`, `integrations/spring-boot3-console/pom.xml`, `integrations/spring-boot3/pom.xml`, and `storage/rest/client-app/pom.xml` for consistent use of the latest Spring Boot release. [[1]](diffhunk://#diff-3d878e0c0b66f01e7bdea2254ba1440c7b658e35a8d8ad4141e0d1165899f983L21-R21) [[2]](diffhunk://#diff-804ca3fe8bab5d865dba840ea1ea85d471729c6838b8e6de0daa171d2a127b7cL19-R19) [[3]](diffhunk://#diff-edb745cc289cf9d279366e508f6468114761d00e2e79f7ec98ef6d977ef109cfL19-R19) [[4]](diffhunk://#diff-8f4b084553286c4f43a0b984055b14d03d602925fd2497cd0e52c2d8289424ecL19-R19) [[5]](diffhunk://#diff-b565920d3f75b6a5319ca9921e3eb2384935750f5767ec7d6f39eb89f7baaa09L24-R24)

* Upgraded `springdoc-openapi-starter-webmvc-ui` dependency from version `2.2.0` to `2.8.13` in `examples/spring-boot3-simple/pom.xml` to benefit from bug fixes and new features.

**Build tool updates:**

* Upgraded `maven-compiler-plugin` from version `3.11.0` to `3.14.0` in `examples/spring-boot3-advanced/pom.xml` and `examples/spring-boot3-simple/pom.xml` for improved Java compilation support. [[1]](diffhunk://#diff-3d878e0c0b66f01e7bdea2254ba1440c7b658e35a8d8ad4141e0d1165899f983L78-R78) [[2]](diffhunk://#diff-804ca3fe8bab5d865dba840ea1ea85d471729c6838b8e6de0daa171d2a127b7cL83-R83)