### PR TITLE
chore: update kafka-clients version to 3.9.1 in pom.xml

### DIFF
--- a/afs/kafka/pom.xml
+++ b/afs/kafka/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>3.9.0</version>
+			<version>3.9.1</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
This pull request makes a minor dependency update to the Kafka client library in the `afs/kafka/pom.xml` file, upgrading it from version 3.9.0 to 3.9.1.

- Upgraded the `kafka-clients` dependency from version 3.9.0 to 3.9.1 in `afs/kafka/pom.xml` to include the latest bug fixes and improvements.