### PR TITLE
test: add custom comparable tests for GigaMap indexing

### DIFF
--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/CustomComparableTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/CustomComparableTest.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.gigamap.indexer.comparable;
 
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Path;

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/StringComparableTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/StringComparableTest.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.gigamap.indexer.comparable;
 
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 


### PR DESCRIPTION
This pull request adds new unit tests to improve coverage for custom Comparable implementations and indexers within the GigaMap framework. The new tests verify the correct behavior of custom comparison logic and bitmap indexers, both in-memory and after storage round-trips.

**New test coverage for custom comparables and indexers:**

* Added `CustomComparableTest` to test a custom `Comparable` implementation (`PersonCustomComparable`) and a corresponding `IndexerComparing` for GigaMap, including queries using `between`, `greaterThan`, `lessThan`, and `is`, as well as persistence and retrieval from storage.
* Added `StringComparableTest` to test an `IndexerComparing` that indexes by an integer field (`age`) of a `PersonCompare` class, verifying correct query results and persistence.