### PR TITLE
Zj/vaadin update 131025

### DIFF
--- a/storage/rest/client-app/pom.xml
+++ b/storage/rest/client-app/pom.xml
@@ -20,7 +20,7 @@
 	<url>https://projects.eclipse.org/projects/technology.store</url>
 
 	<properties>
-		<vaadin.version>24.3.20</vaadin.version>
+		<vaadin.version>24.8.10</vaadin.version>
 		<spring.boot.version>3.5.6</spring.boot.version>
 	</properties>
 

--- a/storage/rest/client-app/src/main/java/org/eclipse/store/storage/restclient/app/ui/AppShell.java
+++ b/storage/rest/client-app/src/main/java/org/eclipse/store/storage/restclient/app/ui/AppShell.java
@@ -1,0 +1,29 @@
+package org.eclipse.store.storage.restclient.app.ui;
+
+/*-
+ * #%L
+ * EclipseStore Storage REST Client App
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@Push
+@Theme(themeClass = Lumo.class, variant = Lumo.DARK)
+@CssImport("./styles/shared-styles.css")
+public final class AppShell implements AppShellConfigurator
+{
+
+}

--- a/storage/rest/client-app/src/main/java/org/eclipse/store/storage/restclient/app/ui/RootLayout.java
+++ b/storage/rest/client-app/src/main/java/org/eclipse/store/storage/restclient/app/ui/RootLayout.java
@@ -33,11 +33,9 @@ import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;
 
 
-@Push
-@Theme(themeClass = Lumo.class, variant = Lumo.DARK)
-@CssImport("./styles/shared-styles.css")
+
 public class RootLayout extends VerticalLayout
-	implements RouterLayout, BeforeEnterObserver, AppShellConfigurator
+	implements RouterLayout, BeforeEnterObserver
 {
 	public final static String PAGE_TITLE = "Eclipse Store Client";
 	


### PR DESCRIPTION
This pull request updates the Vaadin framework version and introduces a new `AppShell` class to manage global UI configuration for the client app. It also refactors the `RootLayout` class to remove UI configuration annotations, delegating them to the new `AppShell`.

Framework and dependency updates:
* Upgraded Vaadin version from `24.2.6` to `24.8.10` in the Maven project configuration to ensure access to the latest features and fixes.

UI configuration refactoring:
* Added a new `AppShell` class that implements `AppShellConfigurator` and applies global UI settings, such as enabling push support, setting the Lumo dark theme, and importing shared CSS styles.
* Removed UI configuration annotations (`@Push`, `@Theme`, `@CssImport`) from the `RootLayout` class, so that these settings are now centralized in the new `AppShell`.