### PR TITLE
chore: update slf4j-api version to 2.0.17 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.9</version>
+                <version>2.0.17</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
This pull request updates a dependency version in the project's build configuration to ensure compatibility and access to the latest fixes.

Dependency update:

* Upgraded the `slf4j-api` dependency from version `2.0.9` to `2.0.17` in `pom.xml` to include the latest improvements and bug fixes.