### PR TITLE
chore: remove bom from afs connectors.

### DIFF
--- a/afs/aws/aws/pom.xml
+++ b/afs/aws/aws/pom.xml
@@ -33,11 +33,13 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>auth</artifactId>
+            <version>${aws.sdk.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>aws-core</artifactId>
+            <version>${aws.sdk.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/aws/dynamodb/pom.xml
+++ b/afs/aws/dynamodb/pom.xml
@@ -28,6 +28,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>dynamodb</artifactId>
+            <version>${aws.sdk.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/aws/pom.xml
+++ b/afs/aws/pom.xml
@@ -20,22 +20,14 @@
 	<description>EclipseStore File System Abstraction for AWS</description>
 	<url>https://projects.eclipse.org/projects/technology.store</url>
 
+    <properties>
+        <aws.sdk.version>2.35.5</aws.sdk.version>
+    </properties>
+
 	<modules>
 		<module>aws</module>
 		<module>dynamodb</module>
 		<module>s3</module>
 	</modules>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>bom</artifactId>
-				<version>2.35.2</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 </project>

--- a/afs/aws/s3/pom.xml
+++ b/afs/aws/s3/pom.xml
@@ -28,6 +28,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
+            <version>${aws.sdk.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/azure/pom.xml
+++ b/afs/azure/pom.xml
@@ -24,16 +24,4 @@
 		<module>storage</module>
 	</modules>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.azure</groupId>
-				<artifactId>azure-sdk-bom</artifactId>
-				<version>1.3.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 </project>

--- a/afs/azure/storage/pom.xml
+++ b/afs/azure/storage/pom.xml
@@ -31,6 +31,7 @@
 		<dependency>
 			<groupId>com.azure</groupId>
 			<artifactId>azure-storage-blob</artifactId>
+            <version>12.31.3</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/googlecloud/firestore/pom.xml
+++ b/afs/googlecloud/firestore/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-firestore</artifactId>
+            <version>3.33.2</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/googlecloud/pom.xml
+++ b/afs/googlecloud/pom.xml
@@ -23,18 +23,6 @@
 	<modules>
 		<module>firestore</module>
 	</modules>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.google.cloud</groupId>
-				<artifactId>libraries-bom</artifactId>
-				<version>26.69.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	
 	<dependencies>
 		<dependency>

--- a/afs/oraclecloud/objectstorage/pom.xml
+++ b/afs/oraclecloud/objectstorage/pom.xml
@@ -33,6 +33,7 @@
 		<dependency>
 			<groupId>com.oracle.oci.sdk</groupId>
 			<artifactId>oci-java-sdk-objectstorage</artifactId>
+            <version>3.74.2</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/oraclecloud/pom.xml
+++ b/afs/oraclecloud/pom.xml
@@ -24,16 +24,4 @@
 		<module>objectstorage</module>
 	</modules>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.oracle.oci.sdk</groupId>
-				<artifactId>oci-java-sdk-bom</artifactId>
-				<version>3.74.2</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 </project>


### PR DESCRIPTION
This pull request updates dependency management for several cloud provider modules by removing BOM (Bill of Materials) imports from parent `pom.xml` files and specifying explicit dependency versions in module-level `pom.xml` files. 

Using a BOM import is recommended for end projects, but not for libraries.

Dependency management refactoring:

* Removed `<dependencyManagement>` sections (BOM imports) from parent `pom.xml` files in `afs/aws/pom.xml`, `afs/azure/pom.xml`, `afs/googlecloud/pom.xml`, and `afs/oraclecloud/pom.xml`, shifting version control to individual module dependencies. [[1]](diffhunk://#diff-40d72cea7951b268d0e9b7b9a9368dcd660eb5ed6a7df0fc4d35acec741b029dR23-L40) [[2]](diffhunk://#diff-c13a51d60474a33f2633e2dd9dd21eab7588721285bbc454f74fc9393758d551L27-L38) [[3]](diffhunk://#diff-70007d6e39a539389ae1f9656d873ab29812382cb9f43386afaff6f74e879d58L27-L38) [[4]](diffhunk://#diff-f8a02ff18fea4f685deab511a3890bedb0fdb619992dea79fe172013e84e01c3L27-L38)
* Introduced a new `<aws.sdk.version>` property in `afs/aws/pom.xml` to centralize AWS SDK versioning.

Explicit dependency versioning:

* Added explicit version properties to AWS SDK dependencies in `afs/aws/aws/pom.xml`, `afs/aws/dynamodb/pom.xml`, and `afs/aws/s3/pom.xml` using the `${aws.sdk.version}` property. [[1]](diffhunk://#diff-7633bae35adb5cb03fe460b65e6f4366fd0665a9ea098334d120116803e27cb1R36-R42) [[2]](diffhunk://#diff-b4f97b96a249fc91f780ddb69cc7b69c6eabe42a29ea180907cb1585356c098fR31) [[3]](diffhunk://#diff-75210f37d433c2e57587fa9208c65cde7c35006bb240854ccaedc956d2708e2eR31)
* Set explicit versions for Azure, Google Cloud, and Oracle Cloud dependencies in their respective module `pom.xml` files: `afs/azure/storage/pom.xml` (`azure-storage-blob`), `afs/googlecloud/firestore/pom.xml` (`google-cloud-firestore`), and `afs/oraclecloud/objectstorage/pom.xml` (`oci-java-sdk-objectstorage`). [[1]](diffhunk://#diff-da866016f8739cea46f87413fa9aa319a57fe5ca7fdb09aa87451f1288e7f882R34) [[2]](diffhunk://#diff-70d018efeab81296dcba6bf4d384a78415a44065d94e6b23af5830481efe7244R26) [[3]](diffhunk://#diff-e79f8de06007685956c13ec913034a94c3a13f686a5da9884c8646d5cb87d174R36)