### PR TITLE
feat: add scheduled build workflow for Maven project

### DIFF
--- a/.github/workflows/maven_scheduled_build.yml
+++ b/.github/workflows/maven_scheduled_build.yml
@@ -1,0 +1,24 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Scheduled build
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      #Build with java 17
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -P examples -B clean package --file pom.xml -U
+
+


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate scheduled builds for the Java project using Maven. The workflow ensures that the project is regularly built and tested with JDK 17 on a daily schedule.

Continuous integration improvements:

* Added `.github/workflows/maven_scheduled_build.yml` to run a scheduled Maven build every day at 2:00 AM UTC using JDK 17 and the `examples` profile.

2 UTC is now 3 CEST