### PR TITLE
feat: add jackson-databind dependency to pom.xml

### DIFF
--- a/storage/rest/service-javalin/pom.xml
+++ b/storage/rest/service-javalin/pom.xml
@@ -31,6 +31,11 @@
             <version>6.7.0</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
This pull request adds a new dependency to the `storage/rest/service-javalin/pom.xml` file. The change introduces the Jackson Databind library, which is commonly used for JSON serialization and deserialization in Java applications.

Dependency management:

* Added the `jackson-databind` library (version 2.17.2) to the project dependencies in `pom.xml`, enabling support for JSON processing.