### PR TITLE
Disallow certain characters in JVector index names

### DIFF
--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
@@ -367,6 +367,11 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
                 throw new IllegalArgumentException("Index name may not be empty.");
             }
 
+            if(indexName.contains("/") || indexName.contains("\\"))
+            {
+                throw new IllegalArgumentException("Index name may not contain '/' or '\\' characters.");
+            }
+
             if(indexName.length() > 200)
             {
                 throw new IllegalArgumentException(


### PR DESCRIPTION
---

### Description

This pull request introduces validation for index names in JVector to ensure they do not contain the `/` or `\` characters. This helps maintain consistency and prevents potential errors caused by unsupported characters.