### PR TITLE
Add test coverage for PQ-compressed disk index search and fix needle vector determinism

### DIFF
--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexTest.java
@@ -746,17 +746,10 @@ class VectorIndexTest
             gigaMap.add(new Document("random_" + i, randomVector(random, dimension)));
         }
 
-        // Add a specific "needle" vector
+        // Add a one-hot "needle" vector that randomVector() cannot produce,
+        // since randomVector() populates all dimensions with non-zero values.
         final float[] needleVector = new float[dimension];
-        for(int i = 0; i < dimension; i++)
-        {
-            needleVector[i] = (i % 2 == 0) ? 0.1f : -0.1f;
-        }
-        // Normalize
-        float norm = 0;
-        for(float v : needleVector) norm += v * v;
-        norm = (float)Math.sqrt(norm);
-        for(int i = 0; i < dimension; i++) needleVector[i] /= norm;
+        needleVector[0] = 1.0f;
 
         gigaMap.add(new Document("needle", needleVector));
 


### PR DESCRIPTION
- Add 10 new tests covering search operations on disk-based vector indexes with Product Quantization (PQ) compression enabled, an area that previously had minimal coverage (only basic "returns N results" checks)
- Fix needle vectors in search quality tests to use a one-hot vector [1,0,...,0] instead of an alternating ±0.1 pattern, making the assertion deterministic rather than relying on probabilistic separation from         
  randomVector() output 