### PR TITLE
Fix NPE in empty BitmapIndices

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -701,6 +701,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public void internalPrepareIndicesUpdate(final E replacedEntity)
 		{
+			if(this.bitmapIndices.isEmpty())
+			{
+				// no-op
+				return;
+			}
+
 			// Derive state handlers for the state of the replaced entity.
 			this.createChangeHandlers(this.cachedPrevChangeHandlers, replacedEntity);
 		}
@@ -708,6 +714,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public void internalFinishIndicesUpdate()
 		{
+			if(this.bitmapIndices.isEmpty())
+			{
+				// no-op
+				return;
+			}
+
 			this.clearCachedChangeHandlers();
 		}
 		
@@ -719,6 +731,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			final CustomConstraints<? super E> customConstraints
 		)
 		{
+			if(this.bitmapIndices.isEmpty())
+			{
+				// no-op
+				return;
+			}
+
 			try
 			{
 				// Derive state handlers for the new, potentially changed state

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BasicIndexerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BasicIndexerTest.java
@@ -288,6 +288,14 @@ public class BasicIndexerTest
 	}
 
 	@Test
+	void setWithNoIndex()
+	{
+		final GigaMap<String> map = GigaMap.New();
+		final long id = map.add("foo");
+		assertEquals("foo", map.set(id, "bar"));
+	}
+
+	@Test
 	void bulk()
 	{
 		final LongIndexer indexer = new LongIndexer();


### PR DESCRIPTION
Resolves a NullPointerException occurring in BitmapIndices when they are empty.

Occured when calling `GigaMap#set(id, E)` with no defined BitmapIndex.