### PR TITLE
fix: update namespace reference from javax to jakarta in CDI document…

### DIFF
--- a/docs/modules/misc/pages/integrations/cdi.adoc
+++ b/docs/modules/misc/pages/integrations/cdi.adoc
@@ -15,7 +15,7 @@ It is available within this artifact:
 </dependencies>
 ----
 
-The integration requires the _javax_ namespace and requires a https://jakarta.ee/specifications/cdi/[CDI] 4.0 implementation
+The integration requires the _jakarta_ namespace and requires a https://jakarta.ee/specifications/cdi/[CDI] 4.0 implementation
 and an https://github.com/eclipse/microprofile-config[Eclipse MicroProfile Config] 2.0 implementation.
 
 


### PR DESCRIPTION
This pull request makes a minor documentation update to clarify the namespace requirement for CDI integration.

- Documentation update:
  * Updated the documentation in `docs/modules/misc/pages/integrations/cdi.adoc` to specify that the integration requires the `jakarta` namespace instead of the outdated `javax` namespace