### PR TITLE
test: add maxLongNotAllowedTest to validate Long.MAX_VALUE handling i…

### DIFF
--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerLongTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerLongTest.java
@@ -54,9 +54,6 @@ public class BinaryIndexerLongTest
             assertEquals(value, list.get(0).getLongValue());
         }
 
-        assertThrows(IllegalArgumentException.class, () ->
-            map.add(new LongBinaryIndexerPojo(Long.MAX_VALUE)));
-
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(map, tempDir)) {
 
         }
@@ -86,6 +83,19 @@ public class BinaryIndexerLongTest
             List<LongBinaryIndexerPojo> list1 = newMap2.query(indexer.not(100L)).toList();
             assertEquals(4, list1.size());
         }
+    }
+
+    @Test
+    void maxLongNotAllowedTest()
+    {
+        LongBinaryIndexer indexer = new LongBinaryIndexer();
+
+        GigaMap<LongBinaryIndexerPojo> map = GigaMap.<LongBinaryIndexerPojo>Builder()
+                .withBitmapIdentityIndex(indexer)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                map.add(new LongBinaryIndexerPojo(Long.MAX_VALUE)));
     }
 
     static class LongBinaryIndexer extends  BinaryIndexerLong.Abstract<LongBinaryIndexerPojo>


### PR DESCRIPTION
This pull request introduces a new unit test to clarify and isolate the behavior when attempting to add a `LongBinaryIndexerPojo` with `Long.MAX_VALUE` to a `GigaMap`. The previous assertion for this behavior was removed from the existing test, and a dedicated test method was added to improve test clarity and maintainability.

Testing improvements:

* Removed the inline assertion for `IllegalArgumentException` from `binaryIndexFloatTest()` to avoid mixing unrelated test concerns.
* Added a new test method `maxLongNotAllowedTest()` to explicitly verify that adding a `LongBinaryIndexerPojo` with `Long.MAX_VALUE` throws an `IllegalArgumentException`