### PR TITLE
Gigamap fix 449 tests 230226

### DIFF
--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IterationThreadProviderTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IterationThreadProviderTest.java
@@ -53,8 +53,8 @@ public class IterationThreadProviderTest
     @Test
     void testAdaptiveThreadCountProvider_validation()
     {
-        assertThrows(RuntimeException.class, () -> ThreadCountProvider.Adaptive(-5));
-        assertThrows(RuntimeException.class, () -> ThreadCountProvider.Adaptive(0));
+        assertThrows(NumberRangeException.class, () -> ThreadCountProvider.Adaptive(-5));
+        assertThrows(NumberRangeException.class, () -> ThreadCountProvider.Adaptive(0));
     }
 
     @Test


### PR DESCRIPTION
This pull request adds unit tests for thread count provider validation and usage in the `IterationThreadProviderTest` class. 

Validation tests for thread count providers:

* Added tests to verify that `ThreadCountProvider.Fixed` and `ThreadCountProvider.Adaptive` throw `NumberRangeException` when provided with invalid values (negative or zero).

Integration tests for thread count providers:

* Added tests to check correct behavior of `IterationThreadProvider` when used with both fixed and adaptive thread count providers, ensuring the thread count is set and used as expected during queries.
* Added a test to confirm that `ThreadCountProvider.Adaptive` provides a thread count not exceeding the number of available processors.
