### PR TITLE
Zj/vaadin app optimize 260226

### DIFF
--- a/storage/rest/client-app-standalone-assembly/pom.xml
+++ b/storage/rest/client-app-standalone-assembly/pom.xml
@@ -39,6 +39,20 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Override root POM's JUnit 5.8.2 — incompatible with Spring Boot 3.5.6
+			     which manages junit-platform-commons 1.12.2 -->
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>5.12.2</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-api</artifactId>
+				<version>5.12.2</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -92,7 +106,6 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.10.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/storage/rest/client-app/pom.xml
+++ b/storage/rest/client-app/pom.xml
@@ -68,12 +68,6 @@
 					<groupId>com.vaadin</groupId>
 					<artifactId>collaboration-engine</artifactId>
 				</exclusion>
-				<!-- Vaadin dev tools — not needed at runtime, saves ~7 MB
-				     (removes javaparser, jna, oshi, nimbus-jose-jwt, copilot) -->
-				<exclusion>
-					<groupId>com.vaadin</groupId>
-					<artifactId>vaadin-dev</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This pull request updates dependencies and streamlines the dependency tree for the standalone and main client app modules. The main goals are to upgrade to the latest Vaadin and Spring Boot versions, ensure compatibility with JUnit, and remove unused or unnecessary dependencies to reduce the build size and avoid pulling in unwanted transitive dependencies.

**Dependency version upgrades and management:**

- Upgraded `vaadin.version` to `24.8.10` and `spring.boot.version` to `3.5.6` in `storage/rest/client-app-standalone-assembly/pom.xml`, and added the `vaadin-bom` for better dependency management. JUnit dependencies are overridden to version `5.12.2` for compatibility with Spring Boot 3.5.6.
- Removed explicit version from the `junit-jupiter-engine` dependency in favor of dependency management.

**Exclusion of unused dependencies (to minimize footprint and avoid unnecessary code):**

- In `storage/rest/client-app-standalone-assembly/pom.xml`, excluded unused dependencies such as Hilla, Vaadin dev tools, Collaboration Engine, Spring Data Commons, and Spring Security from the `storage-restclient-app` dependency.
- In `storage/rest/client-app/pom.xml`, excluded Hilla, Collaboration Engine, Spring Data Commons, and Spring Security from both `vaadin-core` and `vaadin-spring-boot-starter` dependencies to reduce the size and remove unused features.