### PR TITLE
Fix race condition in LuceneIndex GraphDirectory during store

### DIFF
--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -599,7 +599,6 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 
         private int defaultMaxResults()
         {
-
 			return XMath.cap_int(this.gigaMap.size());
         }
 

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -599,20 +599,31 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 
         private int defaultMaxResults()
         {
-            return XMath.cap_int(this.gigaMap.size());
+
+			return XMath.cap_int(this.gigaMap.size());
         }
 
         private void lazyInit() throws IOException
         {
             if(this.directory == null)
             {
+                this.directory = this.createDirectory();
+                final IndexWriterConfig writerConfig = new IndexWriterConfig(
+                    this.analyzer = this.context.analyzerCreator().createAnalyzer()
+                );
+                if(this.usesGraphDirectory())
+                {
+                    // GraphDirectory stores index data in the persistent fileEntries map.
+                    // ConcurrentMergeScheduler would modify that map from background threads,
+                    // racing with GigaMap#store serialization. SerialMergeScheduler ensures
+                    // merges run on the caller's thread, which holds the GigaMap lock.
+                    writerConfig.setMergeScheduler(new SerialMergeScheduler());
+                }
                 this.searcher              = new IndexSearcher(
                     this.reader            = DirectoryReader.open(
                         this.writer        = new IndexWriter(
-                            this.directory = this.createDirectory(),
-                            new IndexWriterConfig(
-                                this.analyzer = this.context.analyzerCreator().createAnalyzer()
-                            )
+                            this.directory,
+                            writerConfig
                         )
                     )
                 );
@@ -630,12 +641,16 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
             }
         }
 
+		private boolean usesGraphDirectory()
+		{
+			return this.context.directoryCreator() == null;
+		}
+
 		private Directory createDirectory()
 		{
-			final DirectoryCreator creator = this.context.directoryCreator();
-			return creator != null
-				? creator.createDirectory()
-				: new GraphDirectory()
+			return this.usesGraphDirectory()
+				? new GraphDirectory()
+				: this.context.directoryCreator().createDirectory()
 			;
 		}
 


### PR DESCRIPTION
This pull request refactors the initialization logic for the Lucene index in `LuceneIndex.java`, primarily to improve clarity and ensure thread safety when using a `GraphDirectory`. The main changes involve extracting logic for determining directory type and configuring merge schedulers to prevent concurrency issues.

**Initialization and thread safety improvements:**

* Extracted the logic to detect if a `GraphDirectory` is used into a new `usesGraphDirectory()` method, improving readability and maintainability.
* Updated `createDirectory()` to use `usesGraphDirectory()`, clarifying the choice between `GraphDirectory` and a custom directory creator.
* In `lazyInit()`, when using a `GraphDirectory`, configured the `IndexWriterConfig` to use a `SerialMergeScheduler` instead of the default `ConcurrentMergeScheduler`, ensuring merges run on the caller's thread and preventing race conditions with GigaMap serialization.

These changes help ensure that Lucene index merges are handled safely in environments where background thread concurrency could cause data corruption or race conditions.