### PR TITLE
Refactor root handling in `StorageManager` and related systems

### DIFF
--- a/cache/cache/src/main/java/org/eclipse/store/cache/types/CacheStore.java
+++ b/cache/cache/src/main/java/org/eclipse/store/cache/types/CacheStore.java
@@ -67,13 +67,12 @@ public interface CacheStore<K, V> extends CacheLoader<K, V>, CacheWriter<K, V>
 				this.cacheKey = cacheKey;
 			}
 
-			@SuppressWarnings("unchecked")
 			@Override
 			public <K, V> XTable<K, Lazy<V>> provideTable(final StorageManager storage, final boolean create)
 			{
 				boolean                                  storeRoot = false;
 				XTable<String, Lazy<XTable<K, Lazy<V>>>> rootTable;
-				if((rootTable = (XTable<String, Lazy<XTable<K, Lazy<V>>>>)storage.root()) == null)
+				if((rootTable = storage.root()) == null)
 				{
 					storage.setRoot(rootTable = EqHashTable.New());
 					storeRoot = true;
@@ -110,7 +109,7 @@ public interface CacheStore<K, V> extends CacheLoader<K, V>, CacheWriter<K, V>
 			{
 				boolean                                  storeRoot = false;
 				XTable<String, Lazy<XTable<K, Lazy<V>>>> rootTable;
-				if((rootTable = (XTable<String, Lazy<XTable<K, Lazy<V>>>>)Lazy.get((Lazy)storage.root())) == null)
+				if((rootTable = Lazy.get(storage.root())) == null)
 				{
 					storage.setRoot(Lazy.Reference(rootTable = EqHashTable.New()));
 					storeRoot = true;

--- a/examples/blobs/src/main/java/org/eclipse/store/examples/blobs/Main.java
+++ b/examples/blobs/src/main/java/org/eclipse/store/examples/blobs/Main.java
@@ -59,7 +59,7 @@ public class Main
 			System.out.println("Existing Database found:");
 		}
 		
-		final MyRoot root = (MyRoot)storage.root();
+		final MyRoot root = storage.root();
 		for(final FileAsset fileAsset : root.getFileAssets())
 		{
 			System.out.println("File asset '" + fileAsset.getName() + "' file = "

--- a/examples/custom-legacy-type-handler/src/main/java/org/eclipse/store/examples/customlegacytypehandler/Main.java
+++ b/examples/custom-legacy-type-handler/src/main/java/org/eclipse/store/examples/customlegacytypehandler/Main.java
@@ -68,7 +68,7 @@ public class Main
 							.registerLegacyTypeHandler(new LegacyTypeHandlerNicePlace()))
 					.start();
 			
-			final NicePlace myPlace = (NicePlace)storage.root();
+			final NicePlace myPlace = storage.root();
 	
 			System.out.println("loaded legacy storage:");
 			System.out.println(ObjectToString(myPlace));

--- a/examples/deleting/src/main/java/org/eclipse/store/examples/deleting/Main.java
+++ b/examples/deleting/src/main/java/org/eclipse/store/examples/deleting/Main.java
@@ -58,7 +58,7 @@ public class Main
     	{
     		System.out.println("Existing Database found:");
     		
-    		final MyRoot root = (MyRoot) storage.root();
+    		final MyRoot root = storage.root();
     		root.myObjects.forEach(System.out::println);
     		
     		if(!root.myObjects.isEmpty())

--- a/examples/eager-storing/src/main/java/org/eclipse/store/examples/eagerstoring/Main.java
+++ b/examples/eager-storing/src/main/java/org/eclipse/store/examples/eagerstoring/Main.java
@@ -50,7 +50,7 @@ public class Main
 			}
 			else
 			{
-				final MyRoot root = (MyRoot)storage.root();
+				final MyRoot root = storage.root();
 				
 				/*
 				 * At each iteration you can see that the eager field (root#numbers) gets stored,

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/BasicExample.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/BasicExample.java
@@ -41,7 +41,7 @@ public class BasicExample
 	@SuppressWarnings("unchecked")
 	static GigaMap<Person> ensureGigaMap()
 	{
-		GigaMap<Person> gigaMap = (GigaMap<Person>)storageManager.root();
+		GigaMap<Person> gigaMap = storageManager.root();
 		if(gigaMap == null)
 		{
 			System.out.print("Creating random data ... ");

--- a/examples/items/src/main/java/org/eclipse/store/examples/items/Commands.java
+++ b/examples/items/src/main/java/org/eclipse/store/examples/items/Commands.java
@@ -48,7 +48,7 @@ public class Commands
 
 		DataRoot data()
 		{
-			return (DataRoot)this.storageManager.root();
+			return this.storageManager.root();
 		}
 
 		void print(final List<Item> items)

--- a/examples/lazy-loading/src/main/java/org/eclipse/store/examples/lazyLoading/Main.java
+++ b/examples/lazy-loading/src/main/java/org/eclipse/store/examples/lazyLoading/Main.java
@@ -55,7 +55,7 @@ public class Main
 	
 	private static void calcRevenue(final EmbeddedStorageManager storageManager)
 	{
-		final MyBusinessApp        root           = (MyBusinessApp)storageManager.root();
+		final MyBusinessApp        root           = storageManager.root();
 
 		final int                  startYear      = Year.now().getValue() - 3;
 		final long                 now            = System.currentTimeMillis();

--- a/examples/loading/src/main/java/org/eclipse/store/examples/loading/Main.java
+++ b/examples/loading/src/main/java/org/eclipse/store/examples/loading/Main.java
@@ -49,7 +49,7 @@ public class Main
     	{
     		System.out.println("Existing Database found:");
     		
-    		final MyRoot root = (MyRoot) storage.root();
+    		final MyRoot root = storage.root();
     		root.myObjects.forEach(System.out::println);
     	}
     	

--- a/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/JokesStorageImpl.java
+++ b/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/JokesStorageImpl.java
@@ -45,7 +45,7 @@ public class JokesStorageImpl implements JokesStorage
     public String oneJoke(Integer id)
     {
         String joke;
-        JokesRoot root = (JokesRoot) storageManager.root();
+        JokesRoot root = storageManager.root();
         if (id > root.getJokes().size())
         {
             throw new IllegalArgumentException("No jokes with this id");
@@ -58,7 +58,7 @@ public class JokesStorageImpl implements JokesStorage
     @Read
     public List<String> allJokes()
     {
-        JokesRoot root = (JokesRoot) storageManager.root();
+        JokesRoot root = storageManager.root();
         return new ArrayList<>(root.getJokes()); // Create new List... never return original one.
     }
 
@@ -66,7 +66,7 @@ public class JokesStorageImpl implements JokesStorage
     @Write
     public Integer addNewJoke(String joke)
     {
-        JokesRoot root = (JokesRoot) storageManager.root();
+        JokesRoot root = storageManager.root();
         root.getJokes().add(joke);
         storageManager.store(root.getJokes());
         return root.getJokes().size();
@@ -76,7 +76,7 @@ public class JokesStorageImpl implements JokesStorage
     @Write
     public void addJokes(List<String> jokes)
     {
-        JokesRoot root = (JokesRoot) storageManager.root();
+        JokesRoot root = storageManager.root();
         root.getJokes().addAll(jokes);
         storageManager.store(root.getJokes());
     }
@@ -85,7 +85,7 @@ public class JokesStorageImpl implements JokesStorage
     @Write
     public Integer saveAllJokes(List<String> jokes)
     {
-        JokesRoot root = (JokesRoot) storageManager.root();
+        JokesRoot root = storageManager.root();
         root.setJokes(jokes);
         Storer eagerStorer = storageManager.createEagerStorer();
         eagerStorer.store(root);

--- a/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/MuppetsStorageImpl.java
+++ b/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/MuppetsStorageImpl.java
@@ -43,7 +43,7 @@ public class MuppetsStorageImpl implements MuppetStorage
     @Read
     public String oneMuppet(Integer id)
     {
-        MuppetsRoot root = (MuppetsRoot) storageManager.root();
+        MuppetsRoot root = storageManager.root();
         if (id > root.getMuppets().size())
         {
             throw new IllegalArgumentException("No muppet with this id");
@@ -55,7 +55,7 @@ public class MuppetsStorageImpl implements MuppetStorage
     @Read
     public List<String> allMuppets()
     {
-        MuppetsRoot root = (MuppetsRoot) storageManager.root();
+        MuppetsRoot root = storageManager.root();
         return new ArrayList<>(root.getMuppets()); // Create new List... never return original one.
 
     }
@@ -64,7 +64,7 @@ public class MuppetsStorageImpl implements MuppetStorage
     @Write
     public int addMuppets(List<String> muppets)
     {
-        MuppetsRoot root = (MuppetsRoot) storageManager.root();
+        MuppetsRoot root = storageManager.root();
         root.setMuppets(muppets);
         Storer eagerStorer = storageManager.createEagerStorer();
         eagerStorer.store(root);

--- a/examples/spring-boot3-simple/src/main/java/org/microstream/spring/boot/example/simple/storage/JokesStorageImpl.java
+++ b/examples/spring-boot3-simple/src/main/java/org/microstream/spring/boot/example/simple/storage/JokesStorageImpl.java
@@ -41,7 +41,7 @@ public class JokesStorageImpl implements JokesStorage
     public String oneJoke(Integer id)
     {
         String joke;
-        Root root = (Root) storageManager.root();
+        Root root = storageManager.root();
         if (id > root.getJokes().size())
         {
             throw new IllegalArgumentException("No jokes with this id");
@@ -54,7 +54,7 @@ public class JokesStorageImpl implements JokesStorage
     @Read
     public List<String> allJokes()
     {
-        Root root = (Root) storageManager.root();
+        Root root = storageManager.root();
         return new ArrayList<>(root.getJokes()); // Create new List... never return original one.
     }
 
@@ -62,7 +62,7 @@ public class JokesStorageImpl implements JokesStorage
     @Write
     public Integer addNewJoke(String joke)
     {
-        Root root = (Root) storageManager.root();
+        Root root = storageManager.root();
         root.getJokes().add(joke);
         storageManager.store(root.getJokes());
         return root.getJokes().size();
@@ -72,7 +72,7 @@ public class JokesStorageImpl implements JokesStorage
     @Write
     public void addJokes(List<String> jokes)
     {
-        Root root = (Root) storageManager.root();
+        Root root = storageManager.root();
         root.getJokes().addAll(jokes);
         storageManager.store(root.getJokes());
     }
@@ -81,7 +81,7 @@ public class JokesStorageImpl implements JokesStorage
     @Write
     public Integer saveAllJokes(List<String> jokes)
     {
-        Root root = (Root) storageManager.root();
+        Root root = storageManager.root();
         root.setJokes(jokes);
         Storer eagerStorer = storageManager.createEagerStorer();
         eagerStorer.store(root);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/CustomConstraintsBuilderTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/CustomConstraintsBuilderTest.java
@@ -49,7 +49,7 @@ public class CustomConstraintsBuilderTest
         }
 
         try (EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir)) {
-            GigaMap<Entity> loadedMap = (GigaMap<Entity>) storage.root();
+            GigaMap<Entity> loadedMap = storage.root();
             assertThrows(
                     ConstraintViolationException.class,
                     () -> loadedMap.add(Entity.Random().setWord(CONSTRAINT_VIOLATION_WORD))

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/CrudTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/CrudTest.java
@@ -32,7 +32,6 @@ public class CrudTest
     Path tempDir;
 
 
-    @SuppressWarnings("unchecked")
 	@Test
     void addTestMap()
     {
@@ -48,7 +47,7 @@ public class CrudTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(this.tempDir)) {
-            final GigaMap<String> root = (GigaMap<String>) storageManager.root();
+            final GigaMap<String> root = storageManager.root();
             assertEquals(1000, root.size());
             root.add("1000");
             root.store();
@@ -56,7 +55,7 @@ public class CrudTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(this.tempDir)) {
-            final GigaMap<String> root = (GigaMap<String>) storageManager.root();
+            final GigaMap<String> root = storageManager.root();
             assertEquals(1001, root.size());
         }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapCombiTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapCombiTest.java
@@ -52,7 +52,7 @@ public class GigaMapCombiTest
         // Load the GigaMap from the storage
         GigaMap<GigaMap<String>> loadedGigaMap;
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-            loadedGigaMap = (GigaMap<GigaMap<String>>) storageManager.root();
+            loadedGigaMap = storageManager.root();
             assertEquals(gigaMap.size(), loadedGigaMap.size());
             // Verify that the loaded GigaMap is identical to the original one
             for (int i = 0; i < gigaMap.size(); i++) {

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapStoreTests.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapStoreTests.java
@@ -54,7 +54,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
             assertTrue(loaded.isEmpty());
 			assertEquals(0, loaded.size());
 		}
@@ -93,7 +93,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertEquals(2, loaded.size());
 			loaded.add(Entity.Random());
 			loaded.store();
@@ -132,7 +132,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertEquals(initialSize + 1, loaded.size());
 		}
 	}
@@ -148,7 +148,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertThrows(IllegalArgumentException.class, () -> loaded.add(null));
 		}
 	}
@@ -183,7 +183,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDirLocal)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertEquals(initialSize + add.size(), loaded.size());
 		}
 	}
@@ -227,7 +227,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertEquals(size + 1, loaded.size());
 		}
 	}
@@ -248,7 +248,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertEquals(initialSize - 1, loaded.size());
 		}
 	}
@@ -269,7 +269,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertEquals(initialSize - 1, loaded.size());
 		}
 	}
@@ -288,7 +288,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			final AtomicInteger     loadedCounter = new AtomicInteger();
 			loaded.iterate(element -> loadedCounter.incrementAndGet());
 			assertEquals(entryCount, loadedCounter.get());
@@ -311,7 +311,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			final LongSummaryStatistics loadedStats = new LongSummaryStatistics();
 			loaded.iterateIndexed((id, element) -> loadedStats.accept(id));
 			assertEquals(entryCount, loadedStats.getCount());
@@ -342,7 +342,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			final GigaQuery<Entity> loadedQuery = loaded.query(Entity.intValueIndex.is(0));
 			assertEquals(100, loadedQuery.count());
 		}
@@ -369,7 +369,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			final GigaQuery<Entity> loadedQuery = loaded.query(Entity.intValueIndex.is(searchFor));
 			assertEquals(expected.get(), loadedQuery.count());
 		}
@@ -400,7 +400,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			final GigaQuery<Entity> loadedQuery = loaded.query(Entity.intValueIndex.is(0));
 			final AtomicInteger     loadedForEachCounter  = new AtomicInteger();
 			final AtomicInteger     loadedIteratorCounter = new AtomicInteger();
@@ -426,7 +426,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			final GigaQuery<Entity> loadedQuery = loaded.query(Entity.wordIndex.not("red"));
 			loadedQuery.execute(entity -> assertNotNull(entity));
 		}
@@ -451,7 +451,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			final Entity loadedEntity = loaded.get(5);
 			assertEquals(newWord, loadedEntity.getWord());
 		}
@@ -471,7 +471,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertNull(loaded.peek(1)); // not loaded after start of storage manager
 			loaded.get(1);
 			assertNotNull(loaded.peek(1)); // loaded after get
@@ -494,7 +494,7 @@ public class GigaMapStoreTests
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir)) {
-			final GigaMap<Entity> loaded = (GigaMap<Entity>) manager.root();
+			final GigaMap<Entity> loaded = manager.root();
 			assertNotNull(loaded.index().bitmap().get(Integer.class, Entity.intValueIndex.name()));
 			assertNotNull(loaded.index().bitmap().get(Entity.wordIndex.name()));
 		}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapUnitTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapUnitTest.java
@@ -43,7 +43,7 @@ public class GigaMapUnitTest
             assertEquals("1000", gigaMap.get(0));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals("1000", gigaMap2.get(0));
         }
     }
@@ -57,7 +57,7 @@ public class GigaMapUnitTest
             assertEquals("1000", gigaMap.get(0));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals("1000", gigaMap2.get(0));
         }
     }
@@ -71,7 +71,7 @@ public class GigaMapUnitTest
             assertThrows(IllegalArgumentException.class, () -> gigaMap.add(null));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertThrows(IllegalArgumentException.class, () -> gigaMap2.add(null));
         }
     }
@@ -87,7 +87,7 @@ public class GigaMapUnitTest
             assertThrows(IllegalArgumentException.class, () -> gigaMap.add(null));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertThrows(IllegalArgumentException.class, () -> gigaMap2.replace(s, null));
         }
     }
@@ -103,7 +103,7 @@ public class GigaMapUnitTest
             assertThrows(IllegalArgumentException.class, () -> gigaMap.set(0, null));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertThrows(IllegalArgumentException.class, () -> gigaMap2.set(0, null));
         }
     }
@@ -117,7 +117,7 @@ public class GigaMapUnitTest
             assertEquals("1000", gigaMap.get(0));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals("1000", gigaMap2.get(0));
         }
     }
@@ -153,7 +153,7 @@ public class GigaMapUnitTest
             assertEquals("1000", gigaMap.get(0));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals("1000", gigaMap2.get(0));
         }
     }
@@ -180,7 +180,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals(10, gigaMap2.highestUsedId());
         }
     }
@@ -201,7 +201,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertFalse(gigaMap2.isEmpty());
         }
     }
@@ -229,7 +229,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals("1000", gigaMap2.get(0));
         }
 
@@ -246,7 +246,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertNull(gigaMap2.get(0));
         }
 
@@ -283,7 +283,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals(1004, gigaMap2.add("1000"));
         }
     }
@@ -324,7 +324,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals(2999, gigaMap2.addAll(values));
             assertEquals(3000, gigaMap2.size());
         }
@@ -368,7 +368,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             gigaMap2.addAll("1000", "1001", "1002", "1003", "1004", "1005", "1006", "1007", "1008", "1009");
             assertEquals(30, gigaMap2.size());
         }
@@ -390,7 +390,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertNull(gigaMap2.peek(0));
         }
     }
@@ -404,7 +404,7 @@ public class GigaMapUnitTest
             assertNull(gigaMap.peek(-1));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertNull(gigaMap2.peek(-1));
         }
     }
@@ -436,7 +436,7 @@ public class GigaMapUnitTest
             assertNull(gigaMap.removeById(9));
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertNull(gigaMap2.removeById(9));
         }
     }
@@ -520,7 +520,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertThrows(RuntimeException.class, () -> gigaMap2.remove("1000", indexer));
         }
     }
@@ -696,7 +696,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals(10, gigaMap2.size());
             gigaMap2.removeAll();
             assertEquals(0, gigaMap2.size());
@@ -705,7 +705,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals(0, gigaMap2.size());
         }
 
@@ -736,7 +736,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals(gigaMap.size(), gigaMap2.size());
 
             String s = gigaMap2.query(indexer.is("20")).findFirst().get();
@@ -749,7 +749,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals(0, gigaMap2.size());
         }
 
@@ -838,7 +838,7 @@ public class GigaMapUnitTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap2 = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap2 = manager.root();
             assertEquals("[1005, 1006]", gigaMap2.toString(5, 2));
         }
     }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/SetTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/SetTest.java
@@ -64,7 +64,7 @@ public class SetTest
 		
 		try(EmbeddedStorageManager storageManager = EmbeddedStorage.start(this.tempDir))
 		{
-			final GigaMap<Item> loadedGigaMap = (GigaMap<Item>)storageManager.root();
+			final GigaMap<Item> loadedGigaMap = storageManager.root();
 			//loadedGigaMap.forEach(System.out::println); // just for debugging
 			assertEquals(item5, loadedGigaMap.get(0)); // <=== is still Item4, Item2, Item3
 			

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/UpdateTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/UpdateTest.java
@@ -30,7 +30,7 @@ public class UpdateTest
 		{
 			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(Paths.get("target", "update_test")))
 			{
-				GigaMap<Entity> map = (GigaMap<Entity>)storage.root();
+				GigaMap<Entity> map = storage.root();
 				if(map == null)
 				{
 					map = GigaMap.New();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BinaryIndexerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BinaryIndexerTest.java
@@ -62,7 +62,7 @@ public class BinaryIndexerTest
 
         // Reload and compare results of both indexes
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
 
             BitmapIndex<LongEntity, Long> binary = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
             BitmapIndex<LongEntity, Long> normal = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongNormalIndexer");
@@ -163,7 +163,7 @@ public class BinaryIndexerTest
 
         // Reload and re-verify
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> reloadedMap = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> reloadedMap = storageManager.root();
             BitmapIndex<LongEntity, Long> index = reloadedMap.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
 
             assertEquals(10, reloadedMap.query(index.is(42L)).count());
@@ -189,7 +189,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
             LongEntity entity1 = map2.query(indexer.is(99L)).findFirst().orElse(null);
             assertNotNull(entity1);
             assertEquals(99L, entity1.value);
@@ -262,7 +262,7 @@ public class BinaryIndexerTest
 
         // Reload and verify correctness of queries
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
 
             BitmapIndex<LongEntity, Long> index = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
             for (LongEntity longEntity : list) {
@@ -300,7 +300,7 @@ public class BinaryIndexerTest
 
         // Reload and verify correctness of queries
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
 
             BitmapIndex<LongEntity, Long> index = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
             for (LongEntity longEntity : list) {
@@ -335,7 +335,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
 
             BitmapIndex<LongEntity, Long> index = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
             for (LongEntity longEntity : list) {
@@ -371,7 +371,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
 
             BitmapIndex<LongEntity, Long> index = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
             for (LongEntity longEntity : list) {
@@ -410,7 +410,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
             map2.add(new LongEntity(5L));
 //            map2.store();
 
@@ -419,7 +419,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
 
             LongEntity longEntity = map2.query(indexer.is(5L)).findFirst().orElse(null);
             assertNull(longEntity);
@@ -441,7 +441,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
             map2.add(new LongEntity(Long.MAX_VALUE));
 //            map2.store();
 
@@ -450,7 +450,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
 
             LongEntity longEntity = map2.query(indexer.is(Long.MAX_VALUE)).findFirst().orElse(null);
             assertNull(longEntity);
@@ -484,7 +484,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
             longEntity = map2.query(wrapped.is(1L)).findFirst().get();
             assertEquals(entity1.value, longEntity.value);
         }
@@ -519,7 +519,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
             BitmapIndex<LongEntity, Long> index = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
 
             longEntity = map2.query(index.is(1L)).findFirst().get();
@@ -532,7 +532,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
             BitmapIndex<LongEntity, Long> index = map2.index().bitmap().get(Long.class, "org.eclipse.store.gigamap.indexer.BinaryIndexerTest.LongIndexer");
 
             assertEquals(5000L, map2.query(index.is(5_000L)).findFirst().get().value);
@@ -567,7 +567,7 @@ public class BinaryIndexerTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<LongEntity> map2 = (GigaMap<LongEntity>) storageManager.root();
+            GigaMap<LongEntity> map2 = storageManager.root();
             longEntity = map2.query(wrapped.is(1L)).findFirst().get();
             assertEquals(entity1.value, longEntity.value);
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
@@ -43,7 +43,7 @@ public class BooleanIndexTest
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(map, tempDir)) {}
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BooleanPerson> newMap = (GigaMap<BooleanPerson>) storageManager.root();
+            GigaMap<BooleanPerson> newMap = storageManager.root();
             assertEquals(2, newMap.query(booleanPersonIndex.isTrue()).count());
             assertEquals(1, newMap.query(booleanPersonIndex.isFalse()).count());
             BooleanPerson booleanPerson = newMap.get(0);
@@ -66,7 +66,7 @@ public class BooleanIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BooleanPerson> newMap = (GigaMap<BooleanPerson>) manager.root();
+            GigaMap<BooleanPerson> newMap = manager.root();
             long count1 = newMap.query(booleanPersonIndex.isFalse()).count();
             assertEquals(1, count1);
             newMap.query(booleanPersonIndex.isFalse()).forEach(booleanPerson -> assertFalse(booleanPerson.isAdult()));
@@ -88,7 +88,7 @@ public class BooleanIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BooleanPerson> newMap = (GigaMap<BooleanPerson>) manager.root();
+            GigaMap<BooleanPerson> newMap = manager.root();
             long count1 = newMap.query(booleanPersonIndex.isTrue()).count();
             assertEquals(2, count1);
 
@@ -115,7 +115,7 @@ public class BooleanIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BooleanPerson> newMap = (GigaMap<BooleanPerson>) manager.root();
+            GigaMap<BooleanPerson> newMap = manager.root();
             newMap.query(booleanPersonIndex.is(true)).forEach(booleanPerson -> assertTrue(booleanPerson.isAdult()));
             newMap.query(booleanPersonIndex.is(false)).forEach(booleanPerson -> assertFalse(booleanPerson.isAdult()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BuilderWithIndicesTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BuilderWithIndicesTest.java
@@ -57,7 +57,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query().findFirst().get().value);
         }
     }
@@ -79,7 +79,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query().findFirst().get().value);
         }
     }
@@ -100,7 +100,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query().findFirst().get().value);
         }
     }
@@ -122,7 +122,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query().findFirst().get().value);
         }
     }
@@ -146,7 +146,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query().findFirst().get().value);
         }
     }
@@ -167,7 +167,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query().findFirst().get().value);
         }
     }
@@ -189,7 +189,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query(stringIndexer.is("1000")).findFirst().get().value);
         }
 
@@ -214,7 +214,7 @@ public class BuilderWithIndicesTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Entity> map2 = (GigaMap<Entity>) storageManager.root();
+            GigaMap<Entity> map2 = storageManager.root();
             assertEquals("1000", map2.query(stringIndexer.is("1000")).findFirst().get().value);
         }
     }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ByteIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ByteIndexTest.java
@@ -47,7 +47,7 @@ public class ByteIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.between((byte) 20, (byte) 30)).count();
             assertEquals(2, count);
             newMap.query(bytePersonIndex.between((byte) 20, (byte) 30)).forEach(bytePerson -> assertTrue(bytePerson.getAge() >= 20 && bytePerson.getAge() <= 30));
@@ -68,7 +68,7 @@ public class ByteIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.greaterThanEqual((byte) 20)).count();
             assertEquals(3, count);
             newMap.query(bytePersonIndex.greaterThanEqual((byte) 20)).forEach(bytePerson -> assertTrue(bytePerson.getAge() >= 20));
@@ -89,7 +89,7 @@ public class ByteIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.greaterThan((byte) 20)).count();
             assertEquals(2, count);
             newMap.query(bytePersonIndex.greaterThan((byte) 20)).forEach(bytePerson -> assertTrue(bytePerson.getAge() > 20));
@@ -110,7 +110,7 @@ public class ByteIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.lessThanEqual((byte) 30)).count();
             assertEquals(2, count);
             newMap.query(bytePersonIndex.lessThanEqual((byte) 30)).forEach(bytePerson -> assertTrue(bytePerson.getAge() <= 30));
@@ -131,7 +131,7 @@ public class ByteIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.lessThan((byte) 30)).count();
             assertEquals(1, count);
             newMap.query(bytePersonIndex.lessThan((byte) 30)).forEach(bytePerson -> assertTrue(bytePerson.getAge() < 30));
@@ -157,7 +157,7 @@ public class ByteIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             newMap.query(bytePersonIndex.is((byte) 20)).forEach(bytePerson -> assertEquals(20, bytePerson.getAge()));
             newMap.query(bytePersonIndex.is((byte) 30)).forEach(bytePerson -> assertEquals(30, bytePerson.getAge()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ByteNonPrimitiveIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ByteNonPrimitiveIndexTest.java
@@ -62,7 +62,7 @@ public class ByteNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.between((byte) 20, (byte) 30)).count();
             assertEquals(2, count);
             newMap.query(bytePersonIndex.between((byte) 20, (byte) 30)).forEach(bytePerson -> assertTrue(bytePerson.getAge() >= 20 && bytePerson.getAge() <= 30));
@@ -83,7 +83,7 @@ public class ByteNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.greaterThanEqual((byte) 20)).count();
             assertEquals(3, count);
             newMap.query(bytePersonIndex.greaterThanEqual((byte) 20)).forEach(bytePerson -> assertTrue(bytePerson.getAge() >= 20));
@@ -104,7 +104,7 @@ public class ByteNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.greaterThan((byte) 20)).count();
             assertEquals(2, count);
             newMap.query(bytePersonIndex.greaterThan((byte) 20)).forEach(bytePerson -> assertTrue(bytePerson.getAge() > 20));
@@ -125,7 +125,7 @@ public class ByteNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.lessThanEqual((byte) 30)).count();
             assertEquals(2, count);
             newMap.query(bytePersonIndex.lessThanEqual((byte) 30)).forEach(bytePerson -> assertTrue(bytePerson.getAge() <= 30));
@@ -146,7 +146,7 @@ public class ByteNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             long count = newMap.query(bytePersonIndex.lessThan((byte) 30)).count();
             assertEquals(1, count);
             newMap.query(bytePersonIndex.lessThan((byte) 30)).forEach(bytePerson -> assertTrue(bytePerson.getAge() < 30));
@@ -172,7 +172,7 @@ public class ByteNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<BytePerson> newMap = (GigaMap<BytePerson>) manager.root();
+            GigaMap<BytePerson> newMap = manager.root();
             newMap.query(bytePersonIndex.is((byte) 20)).forEach(bytePerson -> assertEquals((byte) 20, bytePerson.getAge()));
             newMap.query(bytePersonIndex.is((byte) 30)).forEach(bytePerson -> assertEquals((byte) 30, bytePerson.getAge()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CharacterIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CharacterIndexTest.java
@@ -46,7 +46,7 @@ public class CharacterIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<CharacterPerson> newMap = (GigaMap<CharacterPerson>) manager.root();
+            GigaMap<CharacterPerson> newMap = manager.root();
             CharacterPerson characterPerson = newMap.get(1);
             long count1 = newMap.query(characterPersonIndex.byExample(characterPerson)).count();
             assertEquals(1, count1);
@@ -66,7 +66,7 @@ public class CharacterIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<CharacterPerson> newMap = (GigaMap<CharacterPerson>) manager.root();
+            GigaMap<CharacterPerson> newMap = manager.root();
             long count = newMap.query(characterPersonIndex.in('A', 'B')).count();
             assertEquals(2, count);
             newMap.query(characterPersonIndex.in('A', 'B')).forEach(characterPerson -> assertTrue(characterPerson.getInitial() == 'A' || characterPerson.getInitial() == 'B'));
@@ -92,7 +92,7 @@ public class CharacterIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<CharacterPerson> newMap = (GigaMap<CharacterPerson>) manager.root();
+            GigaMap<CharacterPerson> newMap = manager.root();
             newMap.query(characterPersonIndex.is('A')).forEach(characterPerson -> assertEquals('A', characterPerson.getInitial()));
             newMap.query(characterPersonIndex.is('B')).forEach(characterPerson -> assertEquals('B', characterPerson.getInitial()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/DoubleIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/DoubleIndexTest.java
@@ -46,7 +46,7 @@ public class DoubleIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().between(20.0, 30.0)).count();
             assertEquals(2, count);
             newMap.query(new DoublePersonIndex().between(20.0, 30.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() >= 20.0 && doublePerson.getScore() <= 30.0));
@@ -67,7 +67,7 @@ public class DoubleIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().greaterThanEqual(20.0)).count();
             assertEquals(3, count);
             newMap.query(new DoublePersonIndex().greaterThanEqual(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() >= 20.0));
@@ -88,7 +88,7 @@ public class DoubleIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().greaterThan(20.0)).count();
             assertEquals(2, count);
             newMap.query(new DoublePersonIndex().greaterThan(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() > 20.0));
@@ -109,7 +109,7 @@ public class DoubleIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().lessThanEqual(20.0)).count();
             assertEquals(3, count);
             newMap.query(new DoublePersonIndex().lessThanEqual(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() <= 20.0));
@@ -130,7 +130,7 @@ public class DoubleIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().lessThan(20.0)).count();
             assertEquals(2, count);
             newMap.query(new DoublePersonIndex().lessThan(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() < 20.0));
@@ -166,7 +166,7 @@ public class DoubleIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             newMap.query(doublePersonIndex.is(20.0)).forEach(doublePerson -> assertEquals(20.0, doublePerson.getScore()));
             newMap.query(doublePersonIndex.is(30.0)).forEach(doublePerson -> assertEquals(30.0, doublePerson.getScore()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/DoubleNonPrimitiveIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/DoubleNonPrimitiveIndexTest.java
@@ -62,7 +62,7 @@ public class DoubleNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().between(20.0, 30.0)).count();
             assertEquals(2, count);
             newMap.query(new DoublePersonIndex().between(20.0, 30.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() >= 20.0 && doublePerson.getScore() <= 30.0));
@@ -83,7 +83,7 @@ public class DoubleNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().greaterThanEqual(20.0)).count();
             assertEquals(3, count);
             newMap.query(new DoublePersonIndex().greaterThanEqual(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() >= 20.0));
@@ -104,7 +104,7 @@ public class DoubleNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().greaterThan(20.0)).count();
             assertEquals(2, count);
             newMap.query(new DoublePersonIndex().greaterThan(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() > 20.0));
@@ -125,7 +125,7 @@ public class DoubleNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().lessThanEqual(20.0)).count();
             assertEquals(3, count);
             newMap.query(new DoublePersonIndex().lessThanEqual(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() <= 20.0));
@@ -146,7 +146,7 @@ public class DoubleNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             long count = newMap.query(new DoublePersonIndex().lessThan(20.0)).count();
             assertEquals(2, count);
             newMap.query(new DoublePersonIndex().lessThan(20.0)).forEach(doublePerson -> assertTrue(doublePerson.getScore() < 20.0));
@@ -182,7 +182,7 @@ public class DoubleNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<DoublePerson> newMap = (GigaMap<DoublePerson>) manager.root();
+            GigaMap<DoublePerson> newMap = manager.root();
             newMap.query(doublePersonIndex.is(20.0)).forEach(doublePerson -> assertEquals(20.0, doublePerson.getScore()));
             newMap.query(doublePersonIndex.is(30.0)).forEach(doublePerson -> assertEquals(30.0, doublePerson.getScore()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/FloatIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/FloatIndexTest.java
@@ -47,7 +47,7 @@ public class FloatIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.between(20.0f, 30.0f)).count();
             assertEquals(2, count);
             newMap.query(floatPersonIndex.between(20.0f, 30.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() >= 20.0f && floatPerson.getScore() <= 30.0f));
@@ -68,7 +68,7 @@ public class FloatIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.greaterThanEqual(20.0f)).count();
             assertEquals(3, count);
             newMap.query(floatPersonIndex.greaterThanEqual(20.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() >= 20.0f));
@@ -89,7 +89,7 @@ public class FloatIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.greaterThan(20.0f)).count();
             assertEquals(2, count);
             newMap.query(floatPersonIndex.greaterThan(20.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() > 20.0f));
@@ -110,7 +110,7 @@ public class FloatIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.lessThanEqual(30.0f)).count();
             assertEquals(2, count);
             newMap.query(floatPersonIndex.lessThanEqual(30.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() <= 30.0f));
@@ -131,7 +131,7 @@ public class FloatIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.lessThan(30.0f)).count();
             assertEquals(1, count);
             newMap.query(floatPersonIndex.lessThan(30.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() < 30.0f));
@@ -157,7 +157,7 @@ public class FloatIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             newMap.query(floatPersonIndex.is(20.0f)).forEach(floatPerson -> assertEquals(20.0f, floatPerson.getScore()));
             newMap.query(floatPersonIndex.is(30.0f)).forEach(floatPerson -> assertEquals(30.0f, floatPerson.getScore()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/FloatNonPrimitiveIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/FloatNonPrimitiveIndexTest.java
@@ -61,7 +61,7 @@ public class FloatNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.between(20.0f, 30.0f)).count();
             assertEquals(2, count);
             newMap.query(floatPersonIndex.between(20.0f, 30.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() >= 20.0f && floatPerson.getScore() <= 30.0f));
@@ -82,7 +82,7 @@ public class FloatNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.greaterThanEqual(20.0f)).count();
             assertEquals(3, count);
             newMap.query(floatPersonIndex.greaterThanEqual(20.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() >= 20.0f));
@@ -103,7 +103,7 @@ public class FloatNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.greaterThan(20.0f)).count();
             assertEquals(2, count);
             newMap.query(floatPersonIndex.greaterThan(20.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() > 20.0f));
@@ -124,7 +124,7 @@ public class FloatNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.lessThanEqual(30.0f)).count();
             assertEquals(2, count);
             newMap.query(floatPersonIndex.lessThanEqual(30.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() <= 30.0f));
@@ -145,7 +145,7 @@ public class FloatNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             long count = newMap.query(floatPersonIndex.lessThan(30.0f)).count();
             assertEquals(1, count);
             newMap.query(floatPersonIndex.lessThan(30.0f)).forEach(floatPerson -> assertTrue(floatPerson.getScore() < 30.0f));
@@ -171,7 +171,7 @@ public class FloatNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<FloatPerson> newMap = (GigaMap<FloatPerson>) manager.root();
+            GigaMap<FloatPerson> newMap = manager.root();
             newMap.query(floatPersonIndex.is(20.0f)).forEach(floatPerson -> assertEquals(20.0f, floatPerson.getScore()));
             newMap.query(floatPersonIndex.is(30.0f)).forEach(floatPerson -> assertEquals(30.0f, floatPerson.getScore()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/InstantIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/InstantIndexTest.java
@@ -69,7 +69,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.between(toInstant(2021, 1, 1, 12, 0, 0), toInstant(2021, 1, 1, 14, 0, 0))).count();
             assertEquals(3, count);
             long count1 = newMap.query(instantPersonIndex.between(toInstant(2021, 1, 1, 12, 0, 0), toInstant(2021, 1, 1, 14, 0, 0))).count();
@@ -92,7 +92,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.after(toInstant(2021, 1, 1, 12, 0, 0))).count();
             assertEquals(9, count);
             long count1 = newMap.query(instantPersonIndex.after(toInstant(2021, 1, 1, 13, 0, 0))).count();
@@ -113,7 +113,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.before(toInstant(2021, 1, 1, 12, 0, 1))).count();
             assertEquals(1, count);
             long count1 = newMap.query(instantPersonIndex.before(toInstant(2021, 1, 1, 13, 0, 0))).count();
@@ -132,7 +132,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isSecond(0)).count();
             assertEquals(10, count);
         }
@@ -149,7 +149,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isMinute(0)).count();
             assertEquals(10, count);
         }
@@ -166,7 +166,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isHour(12)).count();
             assertEquals(1, count);
         }
@@ -183,7 +183,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isTime(12, 0, 0)).count();
             assertEquals(1, count);
         }
@@ -200,7 +200,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isDay(1)).count();
             assertEquals(10, count);
         }
@@ -217,7 +217,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isMonth(1)).count();
             assertEquals(10, count);
         }
@@ -234,7 +234,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isYear(2021)).count();
             assertEquals(10, count);
         }
@@ -251,7 +251,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isDate(2021, 1, 1)).count();
             assertEquals(10, count);
         }
@@ -268,7 +268,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             long count = newMap.query(instantPersonIndex.isDateTime(2021, 1, 1, 12, 0, 0)).count();
             assertEquals(1, count);
         }
@@ -302,7 +302,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             newMap.query(instantPersonIndex.is(toInstant(2000, 1, 1, 0, 0, 0))).forEach(person -> assertEquals(toInstant(2000, 1, 1, 0, 0, 0), person.getTimestamp()));
             newMap.query(instantPersonIndex.is(toInstant(1990, 1, 1, 0, 0, 0))).forEach(person -> assertEquals(toInstant(1990, 1, 1, 0, 0, 0), person.getTimestamp()));
 
@@ -336,7 +336,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             List<InstantPerson> list1 = newMap.query(instantPersonIndex.beforeEqual(toInstant(1990, 1, 1, 0, 0, 0))).toList();
             assertEquals(2, list1.size());
             list1.forEach(person -> assertNotEquals("Alice", person.name));
@@ -364,7 +364,7 @@ public class InstantIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<InstantPerson> newMap = (GigaMap<InstantPerson>) manager.root();
+            GigaMap<InstantPerson> newMap = manager.root();
             List<InstantPerson> list1 = newMap.query(instantPersonIndex.afterEqual(toInstant(1990, 1, 1, 0, 0, 0))).toList();
             assertEquals(2, list1.size());
             list1.forEach(person -> assertNotEquals("Charlie", person.name));

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IntIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IntIndexTest.java
@@ -48,7 +48,7 @@ public class IntIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.isNull()).count();
             assertEquals(0, count);
         }
@@ -67,7 +67,7 @@ public class IntIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.between(5, 8)).count();
             assertEquals(4, count);
             long count1 = newMap.query(integerPersonIndex.between(4, 8)).count();
@@ -88,7 +88,7 @@ public class IntIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.greaterThanEqual(5)).count();
             assertEquals(6, count);
             long count1 = newMap.query(integerPersonIndex.greaterThanEqual(4)).count();
@@ -109,7 +109,7 @@ public class IntIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.greaterThan(5)).count();
             assertEquals(5, count);
             long count1 = newMap.query(integerPersonIndex.greaterThan(4)).count();
@@ -130,7 +130,7 @@ public class IntIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.lessThanEqual(5)).count();
             assertEquals(6, count);
             long count1 = newMap.query(integerPersonIndex.lessThanEqual(4)).count();
@@ -151,7 +151,7 @@ public class IntIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.lessThan(5)).count();
             assertEquals(5, count);
             long count1 = newMap.query(integerPersonIndex.lessThan(4)).count();
@@ -186,7 +186,7 @@ public class IntIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             newMap.query(integerPersonIndex.is(20)).forEach(integerPerson -> assertEquals(20, integerPerson.getAge()));
             newMap.query(integerPersonIndex.is(30)).forEach(integerPerson -> assertEquals(30, integerPerson.getAge()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IntegerIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IntegerIndexTest.java
@@ -54,7 +54,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.notIn(5, 6, 7)).count();
             assertEquals(8, count);
             long count1 = newMap.query(integerPersonIndex.notIn(5, 6, 7, 8)).count();
@@ -82,7 +82,7 @@ public class IntegerIndexTest
             assertEquals(6, count3);
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.in(5, 6, 7)).count();
             assertEquals(3, count);
             long count1 = newMap.query(integerPersonIndex.in(5, 6, 7, 8)).count();
@@ -106,7 +106,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.notByExample(integerPerson)).count();
             assertEquals(10, count1);
@@ -125,7 +125,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.byExample(integerPerson)).count();
             assertEquals(1, count1);
@@ -144,7 +144,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.unlike(integerPerson)).count();
             assertEquals(10, count1);
@@ -163,7 +163,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.like(integerPerson)).count();
             assertEquals(1, count1);
@@ -181,7 +181,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.notNull()).count();
             assertEquals(11, count);
 
@@ -201,7 +201,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.not(5)).count();
             assertEquals(10, count);
             long count2 = newMap.query(integerPersonIndex.not(15)).count();
@@ -221,7 +221,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.isNull()).count();
             assertEquals(0, count);
 
@@ -242,7 +242,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.between(5, 8)).count();
             assertEquals(4, count);
             long count1 = newMap.query(integerPersonIndex.between(4, 8)).count();
@@ -263,7 +263,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.greaterThanEqual(5)).count();
             assertEquals(6, count);
             long count1 = newMap.query(integerPersonIndex.greaterThanEqual(4)).count();
@@ -284,7 +284,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.greaterThan(5)).count();
             assertEquals(5, count);
             long count1 = newMap.query(integerPersonIndex.greaterThan(4)).count();
@@ -305,7 +305,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.lessThanEqual(5)).count();
             assertEquals(6, count);
             long count1 = newMap.query(integerPersonIndex.lessThanEqual(4)).count();
@@ -326,7 +326,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.lessThan(5)).count();
             assertEquals(5, count);
             long count1 = newMap.query(integerPersonIndex.lessThan(4)).count();
@@ -361,7 +361,7 @@ public class IntegerIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             newMap.query(integerPersonIndex.is(20)).forEach(integerPerson -> assertEquals(20, integerPerson.getAge()));
             newMap.query(integerPersonIndex.is(30)).forEach(integerPerson -> assertEquals(30, integerPerson.getAge()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IntegerNonPrimitiveIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IntegerNonPrimitiveIndexTest.java
@@ -68,7 +68,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.notIn(5, 6, 7)).count();
             assertEquals(9, count);
             long count1 = newMap.query(integerPersonIndex.notIn(5, 6, 7, 8)).count();
@@ -96,7 +96,7 @@ public class IntegerNonPrimitiveIndexTest
             assertEquals(6, count3);
         }
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.in(5, 6, 7)).count();
             assertEquals(3, count);
             long count1 = newMap.query(integerPersonIndex.in(5, 6, 7, 8)).count();
@@ -120,7 +120,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.notByExample(integerPerson)).count();
             assertEquals(11, count1);
@@ -139,7 +139,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.byExample(integerPerson)).count();
             assertEquals(1, count1);
@@ -158,7 +158,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.unlike(integerPerson)).count();
             assertEquals(11, count1);
@@ -177,7 +177,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             IntegerPerson integerPerson = newMap.get(1);
             long count1 = newMap.query(integerPersonIndex.like(integerPerson)).count();
             assertEquals(1, count1);
@@ -195,7 +195,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.notNull()).count();
             assertEquals(11, count);
 
@@ -219,7 +219,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.not(5)).count();
             assertEquals(11, count);
             long count2 = newMap.query(integerPersonIndex.not(15)).count();
@@ -239,7 +239,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.isNull()).count();
             assertEquals(1, count);
 
@@ -264,7 +264,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.between(5, 8)).count();
             assertEquals(4, count);
             long count1 = newMap.query(integerPersonIndex.between(4, 8)).count();
@@ -285,7 +285,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.greaterThanEqual(5)).count();
             assertEquals(6, count);
             long count1 = newMap.query(integerPersonIndex.greaterThanEqual(4)).count();
@@ -306,7 +306,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.greaterThan(5)).count();
             assertEquals(5, count);
             long count1 = newMap.query(integerPersonIndex.greaterThan(4)).count();
@@ -327,7 +327,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.lessThanEqual(5)).count();
             assertEquals(6, count);
             long count1 = newMap.query(integerPersonIndex.lessThanEqual(4)).count();
@@ -348,7 +348,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             long count = newMap.query(integerPersonIndex.lessThan(5)).count();
             assertEquals(5, count);
             long count1 = newMap.query(integerPersonIndex.lessThan(4)).count();
@@ -383,7 +383,7 @@ public class IntegerNonPrimitiveIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<IntegerPerson> newMap = (GigaMap<IntegerPerson>) manager.root();
+            GigaMap<IntegerPerson> newMap = manager.root();
             newMap.query(integerPersonIndex.is(20)).forEach(integerPerson -> assertEquals(20, integerPerson.getAge()));
             newMap.query(integerPersonIndex.is(30)).forEach(integerPerson -> assertEquals(30, integerPerson.getAge()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateIndexTest.java
@@ -65,7 +65,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count = newMap.query(localDatePersonIndex.between(LocalDate.of(1990, 1, 1), LocalDate.of(2000, 1, 1))).count();
             assertEquals(2, count);
             long count1 = newMap.query(localDatePersonIndex.between(LocalDate.of(1990, 1, 1), LocalDate.of(1990, 1, 1))).count();
@@ -86,7 +86,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count = newMap.query(localDatePersonIndex.after(LocalDate.of(1990, 1, 1))).count();
             assertEquals(1, count);
 //            long count1 = newMap.query(localDatePersonIndex.after(LocalDate.of(2000, 1, 1))).count();
@@ -107,7 +107,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count = newMap.query(localDatePersonIndex.before(LocalDate.of(2000, 1, 1))).count();
             assertEquals(2, count);
             long count1 = newMap.query(localDatePersonIndex.before(LocalDate.of(1990, 1, 1))).count();
@@ -128,7 +128,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count1 = newMap.query(localDatePersonIndex.isDay(1)).count();
             assertEquals(3, count1);
 //            long count2 = newMap.query(localDatePersonIndex.isDay(2)).count();
@@ -149,7 +149,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count1 = newMap.query(localDatePersonIndex.isMonth(1)).count();
             assertEquals(3, count1);
 //            long count2 = newMap.query(localDatePersonIndex.isMonth(2)).count();
@@ -170,7 +170,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count1 = newMap.query(localDatePersonIndex.isYear(2000)).count();
             assertEquals(1, count1);
             long count2 = newMap.query(localDatePersonIndex.isYear(1990)).count();
@@ -192,7 +192,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count1 = newMap.query(localDatePersonIndex.isDate(2000, 1, 1)).count();
             assertEquals(1, count1);
             long count2 = newMap.query(localDatePersonIndex.isDate(1990, 1, 1)).count();
@@ -218,7 +218,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             newMap.query(localDatePersonIndex.is(LocalDate.of(2000, 1, 1))).forEach(localDatePerson -> assertEquals(LocalDate.of(2000, 1, 1), localDatePerson.getBirthday()));
             newMap.query(localDatePersonIndex.is(LocalDate.of(1990, 1, 1))).forEach(localDatePerson -> assertEquals(LocalDate.of(1990, 1, 1), localDatePerson.getBirthday()));
 
@@ -254,7 +254,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count = newMap.query(localDatePersonIndex.beforeEqual(LocalDate.of(1990, 1, 1))).count();
             assertEquals(2, count);
             long count1 = newMap.query(localDatePersonIndex.beforeEqual(LocalDate.of(1980, 1, 1))).count();
@@ -275,7 +275,7 @@ public class LocalDateIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDatePerson> newMap = (GigaMap<LocalDatePerson>) manager.root();
+            GigaMap<LocalDatePerson> newMap = manager.root();
             long count = newMap.query(localDatePersonIndex.afterEqual(LocalDate.of(1990, 1, 1))).count();
             assertEquals(2, count);
             long count1 = newMap.query(localDatePersonIndex.afterEqual(LocalDate.of(2000, 1, 1))).count();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateTimeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateTimeIndexTest.java
@@ -67,7 +67,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.between(LocalDateTime.of(2021, 1, 1, 12, 0), LocalDateTime.of(2021, 1, 1, 14, 0))).count();
             assertEquals(3, count);
             long count1 = newMap.query(localDateTimePersonIndex.between(LocalDateTime.of(2021, 1, 1, 12, 0), LocalDateTime.of(2021, 1, 1, 14, 0))).count();
@@ -90,7 +90,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.after(LocalDateTime.of(2021, 1, 1, 12, 0))).count();
             assertEquals(9, count);
             long count1 = newMap.query(localDateTimePersonIndex.after(LocalDateTime.of(2021, 1, 1, 13, 0))).count();
@@ -111,7 +111,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.before(LocalDateTime.of(2021, 1, 1, 12, 1))).count();
             assertEquals(1, count);
             long count1 = newMap.query(localDateTimePersonIndex.before(LocalDateTime.of(2021, 1, 1, 13, 0))).count();
@@ -130,7 +130,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isSecond(0)).count();
             assertEquals(10, count);
         }
@@ -147,7 +147,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isMinute(0)).count();
             assertEquals(10, count);
         }
@@ -164,7 +164,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isHour(12)).count();
             assertEquals(1, count);
         }
@@ -181,7 +181,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isTime(12, 0, 0)).count();
             assertEquals(1, count);
         }
@@ -198,7 +198,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isDay(1)).count();
             assertEquals(10, count);
         }
@@ -215,7 +215,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isMonth(1)).count();
             assertEquals(10, count);
         }
@@ -232,7 +232,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isYear(2021)).count();
             assertEquals(10, count);
         }
@@ -249,7 +249,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isDate(2021, 1, 1)).count();
             assertEquals(10, count);
         }
@@ -266,7 +266,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             long count = newMap.query(localDateTimePersonIndex.isDateTime(2021, 1, 1, 12, 0,0)).count();
             assertEquals(1, count);
         }
@@ -300,7 +300,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             newMap.query(localDateTimePersonIndex.is(LocalDateTime.of(2000, 1, 1, 0, 0))).forEach(localDateTimePerson -> assertEquals(LocalDateTime.of(2000, 1, 1, 0, 0), localDateTimePerson.getBirthday()));
             newMap.query(localDateTimePersonIndex.is(LocalDateTime.of(1990, 1, 1, 0, 0))).forEach(localDateTimePerson -> assertEquals(LocalDateTime.of(1990, 1, 1, 0, 0), localDateTimePerson.getBirthday()));
 
@@ -334,7 +334,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             List<LocalDateTimePerson> list1 = newMap.query(localDateTimePersonIndex.beforeEqual(LocalDateTime.of(1990, 1, 1, 0, 0))).toList();
             assertEquals(2, list1.size());
             list1.forEach(localDateTimePerson -> assertNotEquals("Alice", localDateTimePerson.name));
@@ -362,7 +362,7 @@ public class LocalDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalDateTimePerson> newMap = (GigaMap<LocalDateTimePerson>) manager.root();
+            GigaMap<LocalDateTimePerson> newMap = manager.root();
             List<LocalDateTimePerson> list1 = newMap.query(localDateTimePersonIndex.afterEqual(LocalDateTime.of(1990, 1, 1, 0, 0))).toList();
             assertEquals(2, list1.size());
             list1.forEach(localDateTimePerson -> assertNotEquals("Charlie", localDateTimePerson.name));

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalTimeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalTimeIndexTest.java
@@ -79,7 +79,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.between(LocalTime.of(12, 0), LocalTime.of(14, 0))).count();
             assertEquals(3, count);
             long count1 = newMap.query(localTimePersonIndex.between(LocalTime.of(12, 0), LocalTime.of(14, 0))).count();
@@ -102,7 +102,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.after(LocalTime.of(12, 0))).count();
             assertEquals(2, count);
             long count1 = newMap.query(localTimePersonIndex.after(LocalTime.of(13, 0))).count();
@@ -123,7 +123,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.afterEqual(LocalTime.of(12, 0))).count();
             assertEquals(3, count);
             long count1 = newMap.query(localTimePersonIndex.afterEqual(LocalTime.of(13, 0))).count();
@@ -144,7 +144,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.before(LocalTime.of(13, 0))).count();
             assertEquals(1, count);
             long count1 = newMap.query(localTimePersonIndex.before(LocalTime.of(12, 0))).count();
@@ -165,7 +165,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.beforeEqual(LocalTime.of(13, 0))).count();
             assertEquals(2, count);
             long count1 = newMap.query(localTimePersonIndex.beforeEqual(LocalTime.of(12, 0))).count();
@@ -184,7 +184,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.isSecond(0)).count();
             assertEquals(3, count);
         }
@@ -201,7 +201,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.isMinute(0)).count();
             assertEquals(3, count);
         }
@@ -218,7 +218,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.isHour(12)).count();
             assertEquals(1, count);
         }
@@ -235,7 +235,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             long count = newMap.query(localTimePersonIndex.isTime(12, 0, 0)).count();
             assertEquals(1, count);
         }
@@ -259,7 +259,7 @@ public class LocalTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LocalTimePerson> newMap = (GigaMap<LocalTimePerson>) manager.root();
+            GigaMap<LocalTimePerson> newMap = manager.root();
             newMap.query(localTimePersonIndex.is(LocalTime.of(12, 0))).forEach(localTimePerson -> assertEquals(LocalTime.of(12, 0), localTimePerson.getLunchTime()));
             newMap.query(localTimePersonIndex.is(LocalTime.of(13, 0))).forEach(localTimePerson -> assertEquals(LocalTime.of(13, 0), localTimePerson.getLunchTime()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LongIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LongIndexTest.java
@@ -76,7 +76,7 @@ public class LongIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LongPerson> newMap = (GigaMap<LongPerson>) manager.root();
+            GigaMap<LongPerson> newMap = manager.root();
             long count = newMap.query(longPersonIndex.between(200L, 300L)).count();
             assertEquals(2, count);
             newMap.query(longPersonIndex.between(200L, 300L)).forEach(longPerson -> assertTrue(longPerson.getSalary() >= 200L && longPerson.getSalary() <= 300L));
@@ -106,7 +106,7 @@ public class LongIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LongPerson> newMap = (GigaMap<LongPerson>) manager.root();
+            GigaMap<LongPerson> newMap = manager.root();
             long count = newMap.query(longPersonIndex.greaterThanEqual(200L)).count();
             assertEquals(2, count);
             newMap.query(longPersonIndex.greaterThanEqual(200L)).forEach(longPerson -> assertTrue(longPerson.getSalary() >= 200L));
@@ -133,7 +133,7 @@ public class LongIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LongPerson> newMap = (GigaMap<LongPerson>) manager.root();
+            GigaMap<LongPerson> newMap = manager.root();
             long count = newMap.query(longPersonIndex.greaterThan(100L)).count();
             assertEquals(2, count);
             newMap.query(longPersonIndex.greaterThan(100L)).forEach(longPerson -> assertTrue(longPerson.getSalary() > 100L));
@@ -156,7 +156,7 @@ public class LongIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LongPerson> newMap = (GigaMap<LongPerson>) manager.root();
+            GigaMap<LongPerson> newMap = manager.root();
             long count = newMap.query(longPersonIndex.lessThanEqual(200L)).count();
             assertEquals(2, count);
             newMap.query(longPersonIndex.lessThanEqual(200L)).forEach(longPerson -> assertTrue(longPerson.getSalary() <= 200L));
@@ -181,7 +181,7 @@ public class LongIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LongPerson> newMap = (GigaMap<LongPerson>) manager.root();
+            GigaMap<LongPerson> newMap = manager.root();
             long count = newMap.query(longPersonIndex.lessThan(200L)).count();
             assertEquals(1, count);
             newMap.query(longPersonIndex.lessThan(200L)).forEach(longPerson -> assertTrue(longPerson.getSalary() < 200L));
@@ -207,7 +207,7 @@ public class LongIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<LongPerson> newMap = (GigaMap<LongPerson>) manager.root();
+            GigaMap<LongPerson> newMap = manager.root();
             newMap.query(longPersonIndex.is(100L)).forEach(longPerson -> assertEquals(100L, longPerson.getSalary()));
             newMap.query(longPersonIndex.is(200L)).forEach(longPerson -> assertEquals(200L, longPerson.getSalary()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ShortIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ShortIndexTest.java
@@ -66,7 +66,7 @@ public class ShortIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ShortPerson> newMap = (GigaMap<ShortPerson>) manager.root();
+            GigaMap<ShortPerson> newMap = manager.root();
             long count = map.query(shortPersonIndex.between((short) 20, (short) 30)).count();
             assertEquals(2, count);
             newMap.query(shortPersonIndex.between((short) 20, (short) 30)).forEach(shortPerson -> assertTrue(shortPerson.getAge() >= 20 && shortPerson.getAge() <= 30));
@@ -119,7 +119,7 @@ public class ShortIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ShortPerson> newMap = (GigaMap<ShortPerson>) manager.root();
+            GigaMap<ShortPerson> newMap = manager.root();
             long count = map.query(shortPersonIndex.greaterThanEqual((short) 20)).count();
             assertEquals(3, count);
             newMap.query(shortPersonIndex.greaterThanEqual((short) 20)).forEach(shortPerson -> assertTrue(shortPerson.getAge() >= 20));
@@ -140,7 +140,7 @@ public class ShortIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ShortPerson> newMap = (GigaMap<ShortPerson>) manager.root();
+            GigaMap<ShortPerson> newMap = manager.root();
             long count = map.query(shortPersonIndex.greaterThan((short) 20)).count();
             assertEquals(2, count);
             newMap.query(shortPersonIndex.greaterThan((short) 20)).forEach(shortPerson -> assertTrue(shortPerson.getAge() > 20));
@@ -161,7 +161,7 @@ public class ShortIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ShortPerson> newMap = (GigaMap<ShortPerson>) manager.root();
+            GigaMap<ShortPerson> newMap = manager.root();
             long count = map.query(shortPersonIndex.lessThanEqual((short) 30)).count();
             assertEquals(2, count);
             newMap.query(shortPersonIndex.lessThanEqual((short) 30)).forEach(shortPerson -> assertTrue(shortPerson.getAge() <= 30));
@@ -182,7 +182,7 @@ public class ShortIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ShortPerson> newMap = (GigaMap<ShortPerson>) manager.root();
+            GigaMap<ShortPerson> newMap = manager.root();
             long count = map.query(shortPersonIndex.lessThan((short) 30)).count();
             assertEquals(1, count);
             newMap.query(shortPersonIndex.lessThan((short) 30)).forEach(shortPerson -> assertTrue(shortPerson.getAge() < 30));
@@ -208,7 +208,7 @@ public class ShortIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ShortPerson> newMap = (GigaMap<ShortPerson>) manager.root();
+            GigaMap<ShortPerson> newMap = manager.root();
             newMap.query(shortPersonIndex.is((short) 20)).forEach(shortPerson -> assertEquals((short) 20, shortPerson.getAge()));
             newMap.query(shortPersonIndex.is((short) 30)).forEach(shortPerson -> assertEquals((short) 30, shortPerson.getAge()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/SpatialIndexerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/SpatialIndexerTest.java
@@ -274,8 +274,7 @@ public class SpatialIndexerTest
 
 		try(final EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir))
 		{
-			@SuppressWarnings("unchecked")
-			final GigaMap<Location> loaded = (GigaMap<Location>)manager.root();
+			final GigaMap<Location> loaded = manager.root();
 
 			assertEquals(3, loaded.query(this.locationIndex.latitudeBetween(0.0, 90.0)).count());
 			assertEquals(1, loaded.query(this.locationIndex.withinBox(35.0, 60.0, -10.0, 30.0)).count());
@@ -294,8 +293,7 @@ public class SpatialIndexerTest
 
 		try(final EmbeddedStorageManager manager = EmbeddedStorage.start(this.tempDir))
 		{
-			@SuppressWarnings("unchecked")
-			final GigaMap<Location> loaded = (GigaMap<Location>)manager.root();
+			final GigaMap<Location> loaded = manager.root();
 
 			assertEquals(1, loaded.query(this.locationIndex.at(40.7128, -74.0060)).count());
 		}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/StringIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/StringIndexTest.java
@@ -67,7 +67,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(1, newMap.query(profIndex.isBlank()).count());
         }
     }
@@ -84,7 +84,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(1, newMap.query(profIndex.isEmpty()).count());
         }
     }
@@ -103,7 +103,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(2, newMap.query(profIndex.endsWithIgnoreCase("eer")).count());
             newMap.query(profIndex.endsWithIgnoreCase("eer")).forEach(stringPerson -> assertEquals("Engineer", stringPerson.getProfession()));
             assertEquals(1, newMap.query(profIndex.endsWithIgnoreCase("tor")).count());
@@ -125,7 +125,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(2, newMap.query(profIndex.endsWith("eer")).count());
             newMap.query(profIndex.endsWith("eer")).forEach(stringPerson -> assertEquals("Engineer", stringPerson.getProfession()));
             assertEquals(1, newMap.query(profIndex.endsWith("tor")).count());
@@ -149,7 +149,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(2, newMap.query(profIndex.containsIgnoreCase("eng")).count());
             newMap.query(profIndex.containsIgnoreCase("eng")).forEach(stringPerson -> assertEquals("Engineer", stringPerson.getProfession()));
             assertEquals(1, newMap.query(profIndex.containsIgnoreCase("doc")).count());
@@ -174,7 +174,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(2, newMap.query(profIndex.contains("Eng")).count());
             newMap.query(profIndex.contains("Eng")).forEach(stringPerson -> assertEquals("Engineer", stringPerson.getProfession()));
             assertEquals(1, newMap.query(profIndex.contains("Doc")).count());
@@ -197,7 +197,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(2, newMap.query(profIndex.startsWith("Eng")).count());
             newMap.query(profIndex.startsWith("Eng")).forEach(stringPerson -> assertEquals("Engineer", stringPerson.getProfession()));
             assertEquals(1, newMap.query(profIndex.startsWith("Doc")).count());
@@ -219,7 +219,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             assertEquals(2, newMap.query(profIndex.startsWithIgnoreCase("eng")).count());
             newMap.query(profIndex.startsWithIgnoreCase("eng")).forEach(stringPerson -> assertEquals("Engineer", stringPerson.getProfession()));
             assertEquals(1, newMap.query(profIndex.startsWithIgnoreCase("doc")).count());
@@ -258,7 +258,7 @@ public class StringIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<StringPerson> newMap = (GigaMap<StringPerson>) manager.root();
+            GigaMap<StringPerson> newMap = manager.root();
             newMap.query(profIndex.is("Engineer")).forEach(stringPerson -> assertEquals("Engineer", stringPerson.getProfession()));
             newMap.query(profIndex.is("Doctor")).forEach(stringPerson -> assertEquals("Doctor", stringPerson.getProfession()));
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ZonedDateTimeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ZonedDateTimeIndexTest.java
@@ -70,7 +70,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.between(toUTC(2021, 1, 1, 12, 0, 0), toUTC(2021, 1, 1, 14, 0, 0))).count();
             assertEquals(3, count);
             long count1 = newMap.query(zonedDateTimePersonIndex.between(toUTC(2021, 1, 1, 12, 0, 0), toUTC(2021, 1, 1, 14, 0, 0))).count();
@@ -93,7 +93,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.after(toUTC(2021, 1, 1, 12, 0, 0))).count();
             assertEquals(9, count);
             long count1 = newMap.query(zonedDateTimePersonIndex.after(toUTC(2021, 1, 1, 13, 0, 0))).count();
@@ -114,7 +114,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.before(toUTC(2021, 1, 1, 12, 0, 1))).count();
             assertEquals(1, count);
             long count1 = newMap.query(zonedDateTimePersonIndex.before(toUTC(2021, 1, 1, 13, 0, 0))).count();
@@ -133,7 +133,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isSecond(0)).count();
             assertEquals(10, count);
         }
@@ -150,7 +150,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isMinute(0)).count();
             assertEquals(10, count);
         }
@@ -167,7 +167,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isHour(12)).count();
             assertEquals(1, count);
         }
@@ -184,7 +184,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isTime(12, 0, 0)).count();
             assertEquals(1, count);
         }
@@ -201,7 +201,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isDay(1)).count();
             assertEquals(10, count);
         }
@@ -218,7 +218,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isMonth(1)).count();
             assertEquals(10, count);
         }
@@ -235,7 +235,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isYear(2021)).count();
             assertEquals(10, count);
         }
@@ -252,7 +252,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isDate(2021, 1, 1)).count();
             assertEquals(10, count);
         }
@@ -269,7 +269,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             long count = newMap.query(zonedDateTimePersonIndex.isDateTime(2021, 1, 1, 12, 0, 0)).count();
             assertEquals(1, count);
         }
@@ -303,7 +303,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             newMap.query(zonedDateTimePersonIndex.is(toUTC(2000, 1, 1, 0, 0, 0))).forEach(person -> assertEquals(toUTC(2000, 1, 1, 0, 0, 0), person.getTimestamp()));
             newMap.query(zonedDateTimePersonIndex.is(toUTC(1990, 1, 1, 0, 0, 0))).forEach(person -> assertEquals(toUTC(1990, 1, 1, 0, 0, 0), person.getTimestamp()));
 
@@ -337,7 +337,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             List<ZonedDateTimePerson> list1 = newMap.query(zonedDateTimePersonIndex.beforeEqual(toUTC(1990, 1, 1, 0, 0, 0))).toList();
             assertEquals(2, list1.size());
             list1.forEach(person -> assertNotEquals("Alice", person.name));
@@ -365,7 +365,7 @@ public class ZonedDateTimeIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<ZonedDateTimePerson> newMap = (GigaMap<ZonedDateTimePerson>) manager.root();
+            GigaMap<ZonedDateTimePerson> newMap = manager.root();
             List<ZonedDateTimePerson> list1 = newMap.query(zonedDateTimePersonIndex.afterEqual(toUTC(1990, 1, 1, 0, 0, 0))).toList();
             assertEquals(2, list1.size());
             list1.forEach(person -> assertNotEquals("Charlie", person.name));

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/AllBaseTypeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/AllBaseTypeIndexTest.java
@@ -50,7 +50,7 @@ public class AllBaseTypeIndexTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(this.tempDir)) {
-            final GigaMap<AllIBaseTypeEntity> map2 = (GigaMap<AllIBaseTypeEntity>) storageManager.root();
+            final GigaMap<AllIBaseTypeEntity> map2 = storageManager.root();
 
             this.checkIndices(map2, map2.index().bitmap());
         }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/AllTypeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/AllTypeIndexTest.java
@@ -54,7 +54,7 @@ public class AllTypeIndexTest
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, tempDir)) {
         }
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<AllTypeEntity> map2 = (GigaMap<AllTypeEntity>) storageManager.root();
+            GigaMap<AllTypeEntity> map2 = storageManager.root();
 
             final IndexerString<AllTypeEntity> stringIndex = map2.index().bitmap().getIndexerString("stringField");
             List<AllTypeEntity> list = map2.query(stringIndex.isNull()).toList();
@@ -79,7 +79,7 @@ public class AllTypeIndexTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<AllTypeEntity> map2 = (GigaMap<AllTypeEntity>) storageManager.root();
+            GigaMap<AllTypeEntity> map2 = storageManager.root();
 
             checkIndices(map2, map2.index().bitmap());
         }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/binary/CarBinaryTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/binary/CarBinaryTest.java
@@ -68,7 +68,7 @@ public class CarBinaryTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<CarBinary> loadedVehicles = (GigaMap<CarBinary>) storageManager.root();
+            GigaMap<CarBinary> loadedVehicles = storageManager.root();
             BitmapIndex<CarBinary, Long> vehicleId1 = loadedVehicles.index().bitmap().get(Long.class, "vehicleId");
             CarBinary carBinary1 = loadedVehicles.query(vehicleId1.is(1L)).findFirst().orElse(null);
             assertNotNull(carBinary1);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/custom/CustomTypeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/custom/CustomTypeIndexTest.java
@@ -51,7 +51,7 @@ public class CustomTypeIndexTest
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(this.tempDir)) {
-            final GigaMap<CustomTypeEntity> map2 = (GigaMap<CustomTypeEntity>) storageManager.root();
+            final GigaMap<CustomTypeEntity> map2 = storageManager.root();
             this.checkIndices(map2, map2.index().bitmap());
         }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/unique/CarUniqueTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/unique/CarUniqueTest.java
@@ -51,7 +51,7 @@ public class CarUniqueTest
 
         // Load the vehicles from storage and check if the unique constraint is still enforced
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<Car> loadedVehicles = (GigaMap<Car>) storageManager.root();
+            GigaMap<Car> loadedVehicles = storageManager.root();
             UniqueConstraintViolationExceptionBitmap ex1 =
                     Assertions.assertThrows(UniqueConstraintViolationExceptionBitmap.class,
                             () -> loadedVehicles.add(car2)); //<-- No exception

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryUUIDIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryUUIDIndexTest.java
@@ -79,7 +79,7 @@ public class BinaryUUIDIndexTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<UUIDPerson> newMap = (GigaMap<UUIDPerson>) manager.root();
+            GigaMap<UUIDPerson> newMap = manager.root();
             newMap.query(uuidPersonIndex.is(uuid1)).forEach(uuidPerson -> assertEquals(uuid1, uuidPerson.getUuid()));
             newMap.query(uuidPersonIndex.is(uuid2)).forEach(uuidPerson -> assertEquals(uuid2, uuidPerson.getUuid()));
             newMap.query(uuidPersonIndex.is(zeroMsb)).forEach(uuidPerson -> assertEquals(zeroMsb, uuidPerson.getUuid()));

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/CustomComparableTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/CustomComparableTest.java
@@ -64,7 +64,7 @@ public class CustomComparableTest
 		}
 
 		try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-			GigaMap<PersonCustomComparable> loadedMap = (GigaMap<PersonCustomComparable>) storageManager.root();
+			GigaMap<PersonCustomComparable> loadedMap = storageManager.root();
 
 			IndexerComparing loadedIndexer = loadedMap.index().bitmap().getIndexer(IndexerComparing.class, "org.eclipse.store.gigamap.indexer.comparable.CustomComparableTest.PersonIndexerCompare");
 			Assertions.assertNotNull(loadedIndexer);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/StringComparableTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/comparable/StringComparableTest.java
@@ -67,7 +67,7 @@ public class StringComparableTest
 		}
 
 		try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-			GigaMap<PersonCompare> root = (GigaMap<PersonCompare>) manager.root();
+			GigaMap<PersonCompare> root = manager.root();
 
 			IndexerComparing loadedIndexer = root.index().bitmap().getIndexer(IndexerComparing.class, "org.eclipse.store.gigamap.indexer.comparable.StringComparableTest.PersonAgeIndexer");
 			assertNotNull(loadedIndexer);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/BoundaryTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/BoundaryTest.java
@@ -49,7 +49,7 @@ public class BoundaryTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<Item> loadedGigaMap = (GigaMap<Item>) manager.root();
+            GigaMap<Item> loadedGigaMap = manager.root();
             Item item = loadedGigaMap.query(idIndex.is(1024)).findFirst().get();
             assertEquals(1024, item.id());
         }
@@ -71,7 +71,7 @@ public class BoundaryTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<Item> loadedGigaMap = (GigaMap<Item>) manager.root();
+            GigaMap<Item> loadedGigaMap = manager.root();
             Item item = loadedGigaMap.query(idIndex.is(65536)).findFirst().get();
             assertEquals(65536, item.id());
         }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/InteratorIndexIdTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/InteratorIndexIdTest.java
@@ -70,7 +70,7 @@ public class InteratorIndexIdTest
         }
 
         try (EmbeddedStorageManager storage = EmbeddedStorage.start(guitars, tempDir) ) {
-            GigaMap<Guitar> loadedGuitars = (GigaMap<Guitar>) storage.root();
+            GigaMap<Guitar> loadedGuitars = storage.root();
             Map<Long, Guitar> loadedControlMap = new HashMap<>();
             loadedGuitars.query(brandIndexer.is("Gibson")).iterateIndexed(loadedControlMap::put);
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryVariableTests.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryVariableTests.java
@@ -90,7 +90,7 @@ public class QueryVariableTests
         }
 
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(workDir)) {
-            GigaMap<Person> map2 = (GigaMap<Person>) storageManager.root();
+            GigaMap<Person> map2 = storageManager.root();
 
             List<Person> collect2 = map2.query
                             (

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumInsideTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumInsideTest.java
@@ -47,7 +47,7 @@ public class StoreEnumInsideTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<Person> loadedGigaMap = (GigaMap<Person>) manager.root();
+            GigaMap<Person> loadedGigaMap = manager.root();
 
             List<Person> list = loadedGigaMap.query().toList();
             Assertions.assertEquals(3, list.size(), "There should be 3 persons in the GigaMap");

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/enumeration/StoreEnumTest.java
@@ -45,7 +45,7 @@ public class StoreEnumTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(workDir)) {
-            GigaMap<StoreEnum> loadedGigaMap = (GigaMap<StoreEnum>) manager.root();
+            GigaMap<StoreEnum> loadedGigaMap = manager.root();
 
             List<StoreEnum> expectedList = List.of(StoreEnum.VALUE, StoreEnum.SECOND, StoreEnum.THIRD);
             List<StoreEnum> loadedEnumList = loadedGigaMap.query().toList();
@@ -65,7 +65,7 @@ public class StoreEnumTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(workDir)) {
-            List<StoreEnum> loadedEnumList = (List<StoreEnum>) manager.root();
+            List<StoreEnum> loadedEnumList = manager.root();
 
             List<StoreEnum> expectedList = List.of(StoreEnum.VALUE, StoreEnum.SECOND, StoreEnum.THIRD);
             Assertions.assertIterableEquals(expectedList, loadedEnumList);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/inheritance/InheritanceIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/inheritance/InheritanceIndexTest.java
@@ -59,7 +59,7 @@ public class InheritanceIndexTest
 
         //load data test
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(workDir)) {
-            GigaMap<Employee> loadedEmployees = (GigaMap<Employee>) manager.root();
+            GigaMap<Employee> loadedEmployees = manager.root();
 
             assertEquals(1, loadedEmployees.query(employeeAgeIndexer.is(30)).count());
             assertEquals("Jane", loadedEmployees.query(employeeAgeIndexer.is(30)).findFirst().get().getName());

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/UpdateBinaryIndex462Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/UpdateBinaryIndex462Test.java
@@ -131,7 +131,7 @@ public class UpdateBinaryIndex462Test
 
 		//load from storage
 		try (var manager = EmbeddedStorage.start(workDir)) {
-			GigaMap<TestObject> loadedMap = (GigaMap<TestObject>) manager.root();
+			GigaMap<TestObject> loadedMap = manager.root();
 
 			var itemToUpdate = loadedMap.get(addedItemId);
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/EqualatorStoreTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/EqualatorStoreTest.java
@@ -64,7 +64,7 @@ public class EqualatorStoreTest
 
         try (EmbeddedStorageManager storage = EmbeddedStorage.start(storagePath))
         {
-            GigaMap<Item> loaded = (GigaMap<Item>) storage.root();
+            GigaMap<Item> loaded = storage.root();
             assertEquals(2, loaded.size());
             loaded.remove(item1);
             loaded.remove(item2);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/RestartFailed3000Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/RestartFailed3000Test.java
@@ -66,7 +66,7 @@ public class RestartFailed3000Test
 		
 		try(EmbeddedStorageManager manager = EmbeddedStorage.start(this.newDirectory))
 		{
-			final GigaMap<String> loadedMap = (GigaMap<String>)manager.root();
+			final GigaMap<String> loadedMap = manager.root();
 			assertEquals(3000, loadedMap.size());
 			assertEquals(AMOUNT * 3, loadedMap.size());
 			assertEquals("Hello0", loadedMap.get(0));

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/WriteReadTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/WriteReadTest.java
@@ -49,7 +49,7 @@ public class WriteReadTest
     void readAndCheckValuesTest()
     {
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<String> gigaMap = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap = manager.root();
             assertAll(
                     () -> assertEquals(3, gigaMap.size()),
                     () -> assertEquals("Hello", gigaMap.get(0)),

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/WriteReadTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/WriteReadTest.java
@@ -35,17 +35,8 @@ public class WriteReadTest
     @BeforeAll
     static void writeTest()
     {
-
-        GigaMap<String> gigaMap = GigaMap.New();
-
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            if (manager.root() == null) {
-                manager.setRoot(gigaMap);
-            } else {
-                gigaMap = (GigaMap<String>) manager.root();
-            }
-            manager.storeRoot();
-
+            GigaMap<String> gigaMap = manager.ensureRoot(GigaMap::New);
             gigaMap.add("Hello");
             gigaMap.add("ahoj");
             gigaMap.add("servus");

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/it/GigaMapTestBase.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/misc/it/GigaMapTestBase.java
@@ -95,13 +95,12 @@ public abstract class GigaMapTestBase<T>
 	}
 		
 	@AfterAll
-	@SuppressWarnings("unchecked")
 	protected void shutdown()
 	{
 		this.storage.shutdown();
 		
 		this.storage = this.startStorage();
-		this.gigaMap = (GigaMap<T>)this.storage.root();
+		this.gigaMap = this.storage.root();
 		
 		assertEquals(this.testDataAmount, this.gigaMap.size());
 		
@@ -123,10 +122,9 @@ public abstract class GigaMapTestBase<T>
 	}
 	
 	
-	@SuppressWarnings("unchecked")
 	private GigaMap<T> ensureRoot(final EmbeddedStorageManager storage)
 	{
-		GigaMap<T> gigaMap = (GigaMap<T>)storage.root();
+		GigaMap<T> gigaMap = storage.root();
 		if(gigaMap != null)
 		{
 			return gigaMap;

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/query/QueryInQueryTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/query/QueryInQueryTest.java
@@ -70,7 +70,7 @@ public class QueryInQueryTest
 
         //reload it and test again
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(workDir)) {
-            Root root2 = (Root) storageManager.root();
+            Root root2 = storageManager.root();
             GigaMap<Address> addressGigaMap1 = root2.getAddressGigaMap();
             GigaMap<Person> personGigaMap1 = root2.getPersonGigaMap();
             GigaQuery<Person> street1 = personGigaMap1.query(personStreetIndexer.in(addressGigaMap1.query(addressIndexer.is("street"))));

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AddTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AddTest.java
@@ -87,7 +87,7 @@ public class AddTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             root.add(new Customer("Updated Name", 100));
             root.store();
 
@@ -98,7 +98,7 @@ public class AddTest
 
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root2 = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root2 = manager.root();
 
             assertEquals(7, root2.size(), "Size of the map should be 7 after adding a new customer");
             assertEquals("Updated Name", root2.query(nameIndexer.is("Updated Name")).findFirst().get().getName());
@@ -110,7 +110,7 @@ public class AddTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root2 = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root2 = manager.root();
 
             assertEquals(8, root2.size(), "Size of the map should be 7 after adding a new customer");
             assertEquals("Updated Name second", root2.query(nameIndexer.is("Updated Name second")).findFirst().get().getName());

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AllTypesApplyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AllTypesApplyTest.java
@@ -270,7 +270,7 @@ public class AllTypesApplyTest
                 storageManager.setRoot(map);
                 storageManager.storeRoot();
             } else {
-                GigaMap<AllTypesPojo> map = (GigaMap<AllTypesPojo>) storageManager.root();
+                GigaMap<AllTypesPojo> map = storageManager.root();
                 AllTypesPojo pojo = getRandomPojo(map);
                 AllTypesPojo toReplacePojo = new AllTypesPojo();
                 toReplacePojo.generateRandomData();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AllTypesUpdateTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/AllTypesUpdateTest.java
@@ -191,7 +191,7 @@ public class AllTypesUpdateTest
                 storageManager.setRoot(map);
                 storageManager.storeRoot();
             } else {
-                GigaMap<AllTypesPojo> map = (GigaMap<AllTypesPojo>) storageManager.root();
+                GigaMap<AllTypesPojo> map = storageManager.root();
 
                 AllTypesPojo pojo = getRandomPojo(map);
                 map.update(pojo, operation);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/ApplyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/ApplyTest.java
@@ -54,7 +54,7 @@ public class ApplyTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             Optional<Customer> first = root.query().findFirst();
             if (first.isPresent()) {
                 Customer customer = first.get();
@@ -74,7 +74,7 @@ public class ApplyTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root2 = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root2 = manager.root();
 
             long count = root2.query(nameIndexer.startsWith("Upda")).count();
             assertEquals(1, count, "Count of customers with name starting with 'Upda' should be 1");

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/RemoveAllTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/RemoveAllTest.java
@@ -50,13 +50,13 @@ public class RemoveAllTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             root.removeAll();
             root.store();
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             assertEquals(0, root.size(), "Size of the map should be 0 after removing all elements");
 
             long count = root.query(nameIndexer.startsWith("John")).count();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/RemoveTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/RemoveTest.java
@@ -51,7 +51,7 @@ public class RemoveTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             Optional<Customer> first = root.query().findFirst();
             if (first.isPresent()) {
                 Customer customer = first.get();
@@ -61,7 +61,7 @@ public class RemoveTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             root.query().findFirst().ifPresent(customer -> {
                 assertEquals("Jane", customer.getName());
                 assertEquals(5, root.size());

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/ReplaceTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/ReplaceTest.java
@@ -54,7 +54,7 @@ public class ReplaceTest
         Customer newCustomer = new Customer("Updated Name", 100);
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             Optional<Customer> first = root.query().findFirst();
             if (first.isPresent()) {
                 Customer customer = first.get();
@@ -73,7 +73,7 @@ public class ReplaceTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root2 = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root2 = manager.root();
 
             long count = root2.query(nameIndexer.startsWith("Upda")).count();
             assertEquals(1, count, "Count of customers with name starting with 'Upda' should be 1");

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/SetTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/SetTest.java
@@ -54,7 +54,7 @@ public class SetTest
         Customer newCustomer = new Customer("Updated Name", 100);
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             root.set(0, newCustomer);
             root.store();
 
@@ -70,7 +70,7 @@ public class SetTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root2 = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root2 = manager.root();
 
             long count = root2.query(nameIndexer.startsWith("Upda")).count();
             assertEquals(1, count, "Count of customers with name starting with 'Upda' should be 1");

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/UpdateTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/UpdateTest.java
@@ -51,7 +51,7 @@ public class UpdateTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             Optional<Customer> first = root.query().findFirst();
             if (first.isPresent()) {
                 Customer customer = first.get();
@@ -61,7 +61,7 @@ public class UpdateTest
         }
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Customer> root = (GigaMap<Customer>) manager.root();
+            final GigaMap<Customer> root = manager.root();
             root.query().findFirst().ifPresent(customer -> {
                 assertEquals("John Doe", customer.getName());
                 assertEquals(6, root.size());

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadLoadTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadLoadTest.java
@@ -67,7 +67,7 @@ public class WriteReadLoadTest
     void readFromRepositoryTest()
     {
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<String> gigaMap = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap = manager.root();
             assertAll(
                     () -> assertEquals(AMOUNT * 3, gigaMap.size()),
                     () -> assertEquals("Hello0", gigaMap.get(0)),
@@ -84,7 +84,7 @@ public class WriteReadLoadTest
         final StringIndexer stringIndexer = new StringIndexer();
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<String> gigaMap = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap = manager.root();
             final BitmapIndices<String> register = gigaMap.index().bitmap();
             final BitmapIndex<String, String> stringIndexer1 = register.get("StringIndexer");
             if (stringIndexer1 == null) {

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadLoadTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadLoadTest.java
@@ -42,16 +42,9 @@ public class WriteReadLoadTest
     @BeforeAll
     static void writeTest()
     {
-
-        GigaMap<String> gigaMap = GigaMap.New();
-
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            if (manager.root() == null) {
-                manager.setRoot(gigaMap);
-                manager.storeRoot();
-            } else {
-                gigaMap = (GigaMap<String>) manager.root();
-            }
+
+            GigaMap<String> gigaMap = manager.ensureRoot(GigaMap::New);
 
             for (int i = 0; i < AMOUNT; i++) {
                 gigaMap.add("Hello" + i);
@@ -88,19 +81,10 @@ public class WriteReadLoadTest
     @Order(2)
     void addIndex()
     {
-
-        GigaMap<String> gigaMap = GigaMap.New();
-
         final StringIndexer stringIndexer = new StringIndexer();
 
-
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            if (manager.root() == null) {
-                manager.setRoot(gigaMap);
-            } else {
-                gigaMap = (GigaMap<String>) manager.root();
-            }
-
+            final GigaMap<String> gigaMap = (GigaMap<String>) manager.root();
             final BitmapIndices<String> register = gigaMap.index().bitmap();
             final BitmapIndex<String, String> stringIndexer1 = register.get("StringIndexer");
             if (stringIndexer1 == null) {

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadPersonTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadPersonTest.java
@@ -65,7 +65,7 @@ public class WriteReadPersonTest
     void readFromRepositoryTest()
     {
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            final GigaMap<Patient> gigaMap = (GigaMap<Patient>) manager.root();
+            final GigaMap<Patient> gigaMap = manager.root();
             assertEquals(AMOUNT + 2, gigaMap.size());
         }
     }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadPersonTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadPersonTest.java
@@ -43,15 +43,9 @@ public class WriteReadPersonTest
     @BeforeAll
     static void writeTest()
     {
-        GigaMap<Patient> gigaMap = GigaMap.New();
-
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            if (manager.root() == null) {
-                manager.setRoot(gigaMap);
-            } else {
-                gigaMap = (GigaMap<Patient>) manager.root();
-            }
-            manager.storeRoot();
+
+            GigaMap<Patient> gigaMap = manager.ensureRoot(GigaMap::New);
 
             for (int i = 0; i < AMOUNT; i++) {
                 gigaMap.add(Patient.createRandomPatient());
@@ -79,7 +73,6 @@ public class WriteReadPersonTest
     @Test
     void addIndex()
     {
-        GigaMap<Patient> gigaMap = GigaMap.New();
 
         final PatientIndexer patientIndexer = new PatientIndexer();
         final PatientIndexerFaxIndexer patientIndexerFaxIndexer = new PatientIndexerFaxIndexer();
@@ -87,11 +80,8 @@ public class WriteReadPersonTest
         final PatientAgeIndexer patientAgeIndexer = new PatientAgeIndexer();
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(newDirectory)) {
-            if (manager.root() == null) {
-                manager.setRoot(gigaMap);
-            } else {
-                gigaMap = (GigaMap<Patient>) manager.root();
-            }
+
+            GigaMap<Patient> gigaMap = manager.ensureRoot(GigaMap::New);
 
             final BitmapIndices<Patient>       register = gigaMap.index().bitmap();
             final BitmapIndex<Patient, String> indexer  = register.get("PatientIndexer");

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadTest.java
@@ -33,7 +33,6 @@ public class WriteReadTest
     @TempDir
     static Path tempDir;
 
-    @SuppressWarnings("unchecked")
     @Test
     @Order(1)
     void writeTest()
@@ -57,13 +56,12 @@ public class WriteReadTest
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     @Order(2)
     void name()
     {
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            final GigaMap<String> gigaMap = (GigaMap<String>) manager.root();
+            final GigaMap<String> gigaMap = manager.root();
             assertAll(
                     () -> assertEquals("Hello", gigaMap.get(0)),
                     () -> assertEquals("ahoj", gigaMap.get(1)),

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/WriteReadTest.java
@@ -38,15 +38,8 @@ public class WriteReadTest
     @Order(1)
     void writeTest()
     {
-        GigaMap<String> gigaMap = GigaMap.New();
-
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
-            if (manager.root() == null) {
-                manager.setRoot(gigaMap);
-                manager.storeRoot();
-            } else {
-                gigaMap = (GigaMap<String>) manager.root();
-            }
+            final GigaMap<String> gigaMap = manager.ensureRoot(GigaMap::New);
 
             gigaMap.add("Hello");
             gigaMap.store();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/update/SmallEVTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/update/SmallEVTest.java
@@ -33,16 +33,7 @@ public class SmallEVTest
     void testWithUpdateAndRestart()
     {
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempDir)) {
-            GigaMap<SmallEV> smallEVs;
-            if (storageManager.root() == null) {
-                smallEVs = generateData();
-                storageManager.setRoot(smallEVs);
-                storageManager.storeRoot();
-                //System.out.println("Stored to storage: " + smallEVs.size());
-            } else {
-                smallEVs = (GigaMap<SmallEV>) storageManager.root();
-                //System.out.println("Loaded from storage: " + smallEVs.size());
-            }
+            final GigaMap<SmallEV> smallEVs = storageManager.ensureRoot(this::generateData);
             SmallEV smallEV = smallEVs.get(0);
             smallEVs.update(smallEV, smallEV1 -> smallEV1.setElectric(false));
             storageManager.storeAll(smallEVs, smallEV);

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -253,7 +253,7 @@ import java.util.stream.IntStream;
  *
  * // Load
  * try (EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir)) {
- *     GigaMap<Document> gigaMap = (GigaMap<Document>) storage.root();
+ *     GigaMap<Document> gigaMap = storage.root();
  *     VectorIndices<Document> indices = gigaMap.index().get(VectorIndices.Category());
  *     VectorIndex<Document> index = indices.get("embeddings");
  *

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexBatchTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexBatchTest.java
@@ -346,8 +346,7 @@ class VectorIndexBatchTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 assertNotNull(gigaMap);
                 assertEquals(21, gigaMap.size());
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
@@ -203,8 +203,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(vectorCount, gigaMap.size());
@@ -238,8 +237,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(vectorCount + additionalCount, gigaMap.size());
@@ -408,8 +406,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(100, gigaMap.size());
@@ -433,8 +430,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(150, gigaMap.size());
@@ -590,8 +586,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(vectorCount, gigaMap.size());
@@ -997,8 +992,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(500, gigaMap.size());
@@ -1021,8 +1015,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(500, gigaMap.size());
@@ -1534,8 +1527,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(vectorCount, gigaMap.size());
@@ -2126,8 +2118,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(parallelStorageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(vectorCount, gigaMap.size());
@@ -2151,8 +2142,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(sequentialStorageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(vectorCount, gigaMap.size());
@@ -2497,8 +2487,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
 
@@ -2583,8 +2572,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
 
@@ -2660,8 +2648,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
 
@@ -2771,8 +2758,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
 
@@ -2804,8 +2790,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
 
@@ -2883,8 +2868,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
 
@@ -2946,8 +2930,7 @@ class VectorIndexDiskTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexTest.java
@@ -328,8 +328,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 assertNotNull(gigaMap);
 
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
@@ -445,8 +444,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 assertNotNull(gigaMap);
 
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
@@ -647,8 +645,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 // Search and compare results
@@ -806,8 +803,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(100, gigaMap.size(), "Should have 100 documents from phase 1");
@@ -838,8 +834,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(150, gigaMap.size(), "Should have 150 documents from phases 1+2");
@@ -866,8 +861,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(200, gigaMap.size(), "Should have all 200 documents");
@@ -930,8 +924,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 // Add 50 more vectors
@@ -951,8 +944,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(150, gigaMap.size());
@@ -968,8 +960,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 final VectorIndex<Document> index = vectorIndices.get("embeddings");
@@ -1025,8 +1016,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(200, gigaMap.size());
@@ -1057,8 +1047,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(300, gigaMap.size());
@@ -1123,8 +1112,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 assertEquals(500, gigaMap.size());
@@ -1146,8 +1134,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 // DON'T load graph - let it rebuild from entities
@@ -1204,8 +1191,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 final int expectedSize = 50 + (cycle - 1) * 10;
@@ -1230,8 +1216,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
 
                 // 50 initial + 10 cycles * 10 documents = 150 total
@@ -2136,8 +2121,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 assertNotNull(gigaMap);
 
                 assertEquals(90, gigaMap.size(), "Should still have 90 entities after restart");
@@ -2210,8 +2194,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 assertNotNull(gigaMap);
 
                 assertEquals(90, gigaMap.size(), "Should still have 90 entities after restart");
@@ -2284,8 +2267,7 @@ class VectorIndexTest
         {
             try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir))
             {
-                @SuppressWarnings("unchecked")
-                final GigaMap<Document> gigaMap = (GigaMap<Document>)storage.root();
+                final GigaMap<Document> gigaMap = storage.root();
                 assertNotNull(gigaMap);
 
                 assertEquals(30, gigaMap.size(), "Should have 30 new documents after restart");

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/BasicLuceneTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/BasicLuceneTest.java
@@ -263,7 +263,7 @@ public class BasicLuceneTest
 
         LuceneIndex<Article> luceneIndex2 = null;
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Article> gigaMap2 = (GigaMap<Article>) storageManager.root();
+            GigaMap<Article> gigaMap2 = storageManager.root();
             luceneIndex2 = gigaMap2.index().get(LuceneIndex.class);
 
             List<Article> result2 = new ArrayList<>();
@@ -350,7 +350,7 @@ public class BasicLuceneTest
 
         LuceneIndex<Article> luceneIndex2 = null;
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, storagePath)) {
-            GigaMap<Article> gigaMap2 = (GigaMap<Article>) storageManager.root();
+            GigaMap<Article> gigaMap2 = storageManager.root();
             luceneIndex2 = gigaMap2.index().get(LuceneIndex.class);
 
             List<Article> result2 = new ArrayList<>();

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
@@ -196,13 +196,13 @@ public class StorageManagerProxy extends UsageMarkable.Default implements Storag
     }
 
     @Override
-    public Object root()
+    public <R> R root()
     {
         return this.getStorageManager().root();
     }
 
     @Override
-    public Object setRoot(final Object newRoot)
+    public <R> R setRoot(final R newRoot)
     {
         return this.getStorageManager().setRoot(newRoot);
     }

--- a/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/RestartStorageBeanTest.java
+++ b/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/RestartStorageBeanTest.java
@@ -77,7 +77,7 @@ public class RestartStorageBeanTest
         final EmbeddedStorageFoundation<?> storageFoundation = this.foundationFactory.createStorageFoundation(this.myConfiguration, pair);
         try (EmbeddedStorageManager storage = storageFoundation.start())
         {
-            final RestartRoot rootFromStorage = (RestartRoot) storage.root();
+            final RestartRoot rootFromStorage = storage.root();
             assertEquals("hello", rootFromStorage.getValue());
         }
     }

--- a/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/advance/AdvanceRestartTest.java
+++ b/integrations/spring-boot3/src/test/java/test/eclipse/store/integrations/spring/boot/advance/AdvanceRestartTest.java
@@ -56,7 +56,7 @@ public class AdvanceRestartTest
     {
 
         manager.start();
-        AdvanceRestartRoot root = (AdvanceRestartRoot) manager.root();
+        AdvanceRestartRoot root = manager.root();
         root.setValue("hello");
         manager.storeRoot();
         manager.shutdown();
@@ -68,7 +68,7 @@ public class AdvanceRestartTest
         final EmbeddedStorageFoundation<?> storageFoundation = this.foundationFactory.createStorageFoundation(this.myConfiguration);
         try (EmbeddedStorageManager storage = storageFoundation.start())
         {
-            final AdvanceRestartRoot rootFromStorage = (AdvanceRestartRoot) storage.root();
+            final AdvanceRestartRoot rootFromStorage = storage.root();
             assertEquals("hello", rootFromStorage.getValue());
         }
     }

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
@@ -77,38 +77,6 @@ public interface EmbeddedStorageManager extends StorageManager
 	@Override
 	public EmbeddedStorageManager start();
 
-	/**
-	 * Ensures that the root object of the persistent object graph is initialized and available.
-	 * If the storage is not running, it starts the storage. If the root object is not set, it uses
-	 * the given supplier to provide the initial root and stores it. Throws an exception if the
-	 * initial root provided by the supplier is null.
-	 *
-	 * @param <R> the type of the root object
-	 * @param initialRootSupplier a supplier that provides the initial root object if it is not already set
-	 * @return the root object of the persistent object graph, cast to the specified type
-	 * @throws IllegalArgumentException if the supplied initial root is null
-	 */
-	@SuppressWarnings("unchecked")
-	public default <R> R ensureRoot(final Supplier<R> initialRootSupplier)
-	{
-		if (!this.isRunning())
-		{
-			this.start();
-		}
-
-		if (this.root() == null)
-		{
-			final R initialRoot = initialRootSupplier.get();
-			if(initialRoot == null)
-			{
-				throw new IllegalArgumentException("Initial root must not be null");
-			}
-			this.setRoot(initialRoot);
-			this.storeRoot();
-		}
-		return (R) this.root();
-	}
-
 	
 	
 	public static EmbeddedStorageManager.Default New(

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.eclipse.serializer.afs.types.AFile;
 import org.eclipse.serializer.collections.EqHashTable;
@@ -75,6 +76,38 @@ public interface EmbeddedStorageManager extends StorageManager
 {
 	@Override
 	public EmbeddedStorageManager start();
+
+	/**
+	 * Ensures that the root object of the persistent object graph is initialized and available.
+	 * If the storage is not running, it starts the storage. If the root object is not set, it uses
+	 * the given supplier to provide the initial root and stores it. Throws an exception if the
+	 * initial root provided by the supplier is null.
+	 *
+	 * @param <R> the type of the root object
+	 * @param initialRootSupplier a supplier that provides the initial root object if it is not already set
+	 * @return the root object of the persistent object graph, cast to the specified type
+	 * @throws IllegalArgumentException if the supplied initial root is null
+	 */
+	@SuppressWarnings("unchecked")
+	public default <R> R ensureRoot(final Supplier<R> initialRootSupplier)
+	{
+		if (!this.isRunning())
+		{
+			this.start();
+		}
+
+		if (this.root() == null)
+		{
+			final R initialRoot = initialRootSupplier.get();
+			if(initialRoot == null)
+			{
+				throw new IllegalArgumentException("Initial root must not be null");
+			}
+			this.setRoot(initialRoot);
+			this.storeRoot();
+		}
+		return (R) this.root();
+	}
 
 	
 	

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
@@ -21,7 +21,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import org.eclipse.serializer.afs.types.AFile;
 import org.eclipse.serializer.collections.EqHashTable;
@@ -163,14 +162,15 @@ public interface EmbeddedStorageManager extends StorageManager
 			return this.database;
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
-		public final Object root()
+		public final <R> R root()
 		{
-			return this.rootReference().get();
+			return (R)this.rootReference().get();
 		}
 		
 		@Override
-		public final Object setRoot(final Object newRoot)
+		public final <R> R setRoot(final R newRoot)
 		{
 			this.rootReference().setRoot(newRoot);
 			

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
@@ -18,6 +18,7 @@ import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
 import org.eclipse.serializer.persistence.types.PersistenceRootsView;
 import org.eclipse.serializer.persistence.types.Storer;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 
@@ -120,10 +121,13 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	 * @param <R> the type of the root object
 	 * @param initialRootSupplier a supplier that provides the initial root object if it is not already set
 	 * @return the root object of the persistent object graph, cast to the specified type
+	 * @throws NullPointerException if {@code initialRootSupplier} is null
 	 * @throws IllegalArgumentException if the supplied initial root is null
 	 */
 	public default <R> R ensureRoot(final Supplier<R> initialRootSupplier)
 	{
+		Objects.requireNonNull(initialRootSupplier, "initialRootSupplier must not be null");
+		
 		if (!this.isRunning())
 		{
 			this.start();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
@@ -18,6 +18,8 @@ import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
 import org.eclipse.serializer.persistence.types.PersistenceRootsView;
 import org.eclipse.serializer.persistence.types.Storer;
 
+import java.util.function.Supplier;
+
 
 /**
  * Central managing type for a native Java database's storage layer.
@@ -113,6 +115,38 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	 * @return the root instance's objectId.
 	 */
 	public long storeRoot();
+
+	/**
+	 * Ensures that the root object of the persistent object graph is initialized and available.
+	 * If the storage is not running, it starts the storage. If the root object is not set, it uses
+	 * the given supplier to provide the initial root and stores it. Throws an exception if the
+	 * initial root provided by the supplier is null.
+	 *
+	 * @param <R> the type of the root object
+	 * @param initialRootSupplier a supplier that provides the initial root object if it is not already set
+	 * @return the root object of the persistent object graph, cast to the specified type
+	 * @throws IllegalArgumentException if the supplied initial root is null
+	 */
+	@SuppressWarnings("unchecked")
+	public default <R> R ensureRoot(final Supplier<R> initialRootSupplier)
+	{
+		if (!this.isRunning())
+		{
+			this.start();
+		}
+
+		if (this.root() == null)
+		{
+			final R initialRoot = initialRootSupplier.get();
+			if(initialRoot == null)
+			{
+				throw new IllegalArgumentException("Initial root must not be null");
+			}
+			this.setRoot(initialRoot);
+			this.storeRoot();
+		}
+		return (R) this.root();
+	}
 	
 	/**
 	 * Returns a read-only view on all technical root instance registered in this {@link StorageManager} instance.<br>

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
@@ -127,7 +127,6 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	public default <R> R ensureRoot(final Supplier<R> initialRootSupplier)
 	{
 		Objects.requireNonNull(initialRootSupplier, "initialRootSupplier must not be null");
-		
 		if (!this.isRunning())
 		{
 			this.start();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
@@ -78,31 +78,26 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	 * @return a new {@link StorageConnection} instance.
 	 */
 	public StorageConnection createConnection();
-	
+
 	/**
-	 * Return the persistent object graph's root object, without specific typing.
-	 * <p>
-	 * If a specifically typed root instance reference is desired, it is preferable to hold a properly typed constant
-	 * reference to it and let the storage initialization use that instance as the root.<br>
-	 * See the following code snippet on how to do that:
-	 * <pre>{@code
-	 *static final MyAppRoot      ROOT    = new MyAppRoot();
-	 *static final StorageManager STORAGE = EmbeddedStorage.start(ROOT);
-	 * }</pre>
-	 * 
-	 * @return the persistent object graph's root object.
+	 * Returns the current root object of the persistent object graph managed by this instance.
+	 * The root object is the entry point for accessing the graph of persisted objects.
+	 *
+	 * @param <R> the type of the root object
+	 * @return the root object of the persistent object graph, or null if no root is currently set
 	 */
-	public Object root();
+	public <R> R root();
 	
 	/**
 	 * Sets the passed instance as the new root for the persistent object graph.<br>
 	 * Note that this will replace the old root instance, potentially resulting in wiping the whole database.
-	 * 
+	 *
+	 * @param <R> the type of the root object
 	 * @param newRoot the new root instance to be set.
 	 * 
 	 * @return the passed {@literal newRoot} to allow fluent usage of this method.
 	 */
-	public Object setRoot(Object newRoot);
+	public <R> R setRoot(R newRoot);
 	
 	/**
 	 * Stores the registered root instance (as returned by {@link #root()}) by using the default storing logic
@@ -127,7 +122,6 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	 * @return the root object of the persistent object graph, cast to the specified type
 	 * @throws IllegalArgumentException if the supplied initial root is null
 	 */
-	@SuppressWarnings("unchecked")
 	public default <R> R ensureRoot(final Supplier<R> initialRootSupplier)
 	{
 		if (!this.isRunning())
@@ -145,7 +139,7 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 			this.setRoot(initialRoot);
 			this.storeRoot();
 		}
-		return (R) this.root();
+		return this.root();
 	}
 	
 	/**


### PR DESCRIPTION
- [x] Validate `initialRootSupplier` with `Objects.requireNonNull` in `StorageManager.ensureRoot` to give a clear error instead of NPE on dereference
- [x] Update Javadoc to document `@throws NullPointerException` for null supplier
- [x] Remove extra blank line after null check for consistent formatting