### PR TITLE
Clarify synchronization requirements in documentation

### DIFF
--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -22,11 +22,13 @@ GigaMap<Entity> gigaMap = GigaMap.New(
 
 == Locking
 
-The GigaMap employs internal read-write locking, making it thread-safe.
+The GigaMap employs internal read-write locking, making it thread-safe for its own operations (`add`, `remove`, `update`, `get`, etc.).
 
 However, all reading operations must be closed at the end to determine when the read locks should be released.
 
 Most of the default reading methods, like `get`, are atomic read operations that are closed by default internally. Only when using iterators should you remember to close them, best by using a try-with-resources block.
+
+NOTE: The internal locking covers GigaMap operations, but *not* the store operation when using `storageManager.store(gigaMap)`. Use `gigaMap.store()` instead, which acquires the internal lock during storing. See xref:persistence.adoc#_why_not_storagemanager_store_gigamap[Persistence] for details.
 
 == Creating and Adding Entities
 

--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -8,19 +8,14 @@ The loading process is fully automatic, as usual. Even the lazy loading is handl
 
 == Storing
 
-After updating the contents of the GigaMap, simply call `store`, just like usual.
-
-[source, java]
-----
-storageManager.store(gigaMap);
-----
-
-or this way:
+After updating the contents of the GigaMap, call `gigaMap.store()` to persist the changes:
 
 [source, java]
 ----
 gigaMap.store();
 ----
+
+This is the *recommended* way to store. `gigaMap.store()` is synchronized internally — it acquires the GigaMap's lock, ensuring that no other thread can modify the GigaMap while the store operation is running.
 
 The GigaMap monitors changes internally, ensuring that only the modified parts are written to the storage.
 
@@ -39,15 +34,17 @@ gigaMap.store();
 
 NOTE: Changes made to entities directly (outside of `update` or `apply`) are not tracked by the GigaMap and must be stored manually.
 
-== Concurrency
+=== Why not `storageManager.store(gigaMap)`?
 
-When using GigaMap in a multi-threaded environment, it is important to understand how storing interacts with the GigaMap's internal locking.
+[IMPORTANT]
+====
+Storing the GigaMap through `storageManager.store(gigaMap)` or `storageConnection.storeAll(...)` does *not* acquire the GigaMap's internal lock.
+This means other threads can modify the GigaMap (e.g. by calling `add`, `remove`, or `update`) while it is being serialized, leading to errors such as `BinaryPersistenceException: Inconsistent element count`.
 
-`gigaMap.store()` is the *recommended* way to store. It is synchronized on the GigaMap instance, which guarantees that no other thread can modify the GigaMap while the store operation is running.
+Always prefer `gigaMap.store()`.
+====
 
-Storing the GigaMap through any other path, such as `storageManager.store(gigaMap)` or `storageConnection.storeAll(...)`, does *not* acquire the GigaMap's lock. If another thread modifies the GigaMap concurrently (e.g. by calling `add`, `remove`, or `update`), the internal data structures can be modified while they are being serialized, leading to errors such as `BinaryPersistenceException: Inconsistent element count`.
-
-If you need to store the GigaMap through an external path, you must synchronize on the GigaMap instance yourself:
+If you must store the GigaMap through an external path, you need to synchronize on the GigaMap instance yourself:
 
 [source, java]
 ----
@@ -57,3 +54,11 @@ synchronized (gigaMap) {
 ----
 
 This is the same principle as the classic problem with synchronized JDK collections like `Vector`: synchronizing individual methods is not sufficient when multiple operations need to be atomic. In this case, the entire store traversal must be protected from concurrent modifications.
+
+== Concurrency
+
+As with any {product-name} application, modifying the object graph and storing the changes *must be done under the same lock*.
+The `gigaMap.store()` method handles this for you by acquiring the GigaMap's internal lock.
+
+However, if your application modifies other parts of the object graph alongside the GigaMap, you are responsible for synchronizing those modifications and their corresponding `store()` calls as well.
+See xref:misc:locking/index.adoc[Locking] for details on application-level synchronization strategies.

--- a/docs/modules/misc/pages/integrations/spring-boot.adoc
+++ b/docs/modules/misc/pages/integrations/spring-boot.adoc
@@ -174,7 +174,14 @@ org.eclipse.store.second.root=org.eclipse.store.integrations.spring.boot.types.s
 ----
 
 == Mutex Locking
-{product-name} supports mutex locking. This is useful if you have multiple processes that need to access the same objects. Easiest way to use it is to use the annotation `@read` and `@write` on the methods that need to be locked. The annotation @read is used for methods that only read data and @write is used for methods that modify data.
+{product-name} supports mutex locking. This is useful if you have multiple processes that need to access the same objects. Easiest way to use it is to use the annotation `@Read` and `@Write` on the methods that need to be locked. The annotation `@Read` is used for methods that only read data and `@Write` is used for methods that modify data.
+
+[IMPORTANT]
+====
+A `@Write` method *must* contain both the object graph modification and the corresponding `store()` call.
+If the mutation and the store happen in separate methods (or outside the lock), other threads may observe inconsistent state.
+This is the same principle described in xref:misc:locking/index.adoc[Locking]: modifying the object graph and storing the changes must always be done under the same lock.
+====
 
 To activate  mutex locking, you need to add the following dependency to Maven pom.xml of your SpringBoot application:
 
@@ -202,7 +209,9 @@ public class SomeStorageImpl implements SomeStorage
     @Write
     public void addSomething(String something)
     {
-        // Add something to the storage
+        // Modify the object graph AND store — both inside the @Write method
+        this.root.getSomethings().add(something);
+        this.storageManager.store(this.root.getSomethings());
     }
 }
 ----

--- a/docs/modules/misc/pages/locking/index.adoc
+++ b/docs/modules/misc/pages/locking/index.adoc
@@ -4,6 +4,14 @@
 
 Therefore, the application must handle concurrency if it is multi-threaded.
 
+[IMPORTANT]
+====
+Modifying the object graph and storing the changes *must always be done under the same lock*.
+{product-name} cannot provide this synchronization on the application level — it is the application's responsibility.
+If the modification and the `store()` call are not protected by the same lock, other threads may read partially modified state or the persisted data may become inconsistent with the in-memory object graph.
+See the examples below for how to achieve this.
+====
+
 The easiest way is to synchronize all affected code, but this makes your application effectively single-threaded.
 This is not advisable if performance is important.
 

--- a/docs/modules/storage/pages/deleting-data.adoc
+++ b/docs/modules/storage/pages/deleting-data.adoc
@@ -4,6 +4,8 @@ Deleting data does not require performing explicit deleting actions like `DELETE
 If a stored object is not reachable anymore its data will be deleted from the storage later.
 This behavior is comparable to Java's garbage collector.
 
+NOTE: In a multi-threaded application, removing references and calling `store()` *must be done under the same lock* to prevent other threads from observing inconsistent state. This is the application's responsibility. See xref:misc:locking/index.adoc[Locking] for details.
+
 == Basic Deletion
 
 Remove the reference to the object and store the parent:

--- a/docs/modules/storage/pages/faq/data-management.adoc
+++ b/docs/modules/storage/pages/faq/data-management.adoc
@@ -36,6 +36,11 @@ However, *your application code is responsible for synchronizing access to the s
 Since {product-name} stores plain Java objects that live in memory, the same concurrency rules apply as for any shared mutable data in Java.
 Without proper synchronization, concurrent reads and writes to the same objects can cause race conditions and inconsistent state — just like with any in-memory data structure.
 
+In particular, modifying the object graph and calling `store()` *must be done under the same lock*.
+{product-name} cannot enforce this on the application level.
+If the modification and the store call are not in the same synchronized scope, other threads may read intermediate state or the persisted data may diverge from what is in memory.
+See xref:misc:locking/index.adoc[Locking] for details.
+
 Use xref:misc:locking/index.adoc[locking] or other synchronization strategies to protect your data during concurrent access.
 
 [IMPORTANT]

--- a/docs/modules/storage/pages/faq/miscellaneous.adoc
+++ b/docs/modules/storage/pages/faq/miscellaneous.adoc
@@ -10,8 +10,17 @@ Any problem during the IO-operation causes the whole block to be deleted (rolled
 == Is {product-name} multi-threaded?
 
 Yes.
-The storing and loading process can be parallelized by using multiple threads and thus be strongly accelerated.
-There is no limitation on how many threads can be used, apart from the mathematical constraint that the thread count must be a power of 2 (1, 2, 4, 8, 16, etc.).
+Internally, {product-name} uses multiple threads (called _channels_) to parallelize its own storing and loading operations, which can strongly accelerate IO performance.
+The number of channels must be a power of 2 (1, 2, 4, 8, 16, etc.).
+See xref:configuration/using-channels.adoc[Using Channels] for configuration details.
+
+[IMPORTANT]
+====
+This internal multi-threading does *not* protect your application's access to the shared object graph.
+In a multi-threaded application, modifying the object graph and storing the changes *must be done under the same lock*.
+{product-name} cannot provide this synchronization on the application level — it is the application's responsibility.
+See xref:misc:locking/index.adoc[Locking] for details.
+====
 
 == Does {product-name} support a backup strategy?
 

--- a/docs/modules/storage/pages/root-instances.adoc
+++ b/docs/modules/storage/pages/root-instances.adoc
@@ -63,6 +63,14 @@ If you are working with {product-name} technology in a multi-threaded environmen
 ==== Synchronize access to shared mutable data
 When using standard frameworks, you often work in a multi-threaded environment. If you are using the older JDBC approach, you create a copy of your data that you work with within a single thread, modify the data, and then save it back in a database trace. {product-name} works with data directly, allowing it to achieve significantly better performance parameters. However, for developers, this means that any reading and writing to this shared object graph must be synchronized.
 
+[IMPORTANT]
+====
+Modifying the object graph and storing the changes *must be done under the same lock*.
+{product-name} cannot provide this synchronization on the application level — it is the application's responsibility to ensure that the mutation and the corresponding `store()` call are executed atomically with respect to other threads.
+If they are not protected by the same lock, other threads may observe a partially modified object graph, or the stored data may not reflect the intended change.
+See xref:misc:locking/index.adoc[Locking] for details.
+====
+
 To make it easier to use within your application, we have prepared a simple way for you to do so.
 [source, java]
 ----
@@ -72,11 +80,13 @@ XThreads.executeSynchronized(() -> {
 });
 ----
 
+Note that both the modification (`changeData()`) and the `store()` call are inside the same synchronized block. This is essential — *never* modify the object graph outside the lock or defer the `store()` to a later, unsynchronized point.
+
 This approach will immediately provide you with several benefits:
 
 . Any changes to your object graph will be synchronized, every other thread will see the current value.
 . Avoid Deadlocks
-. In principle, you prevent the object graph from being modified at the same time it is saved.
+. The object graph cannot be modified by another thread while it is being saved.
 
 [TIP]
 ====

--- a/docs/modules/storage/pages/storing-data/index.adoc
+++ b/docs/modules/storage/pages/storing-data/index.adoc
@@ -8,6 +8,14 @@ While storing your data most of the work {product-name} performs for you.
 You only need to call the store method on the correct object.
 The rule is: "The Object that has been modified has to be stored!".
 
+[IMPORTANT]
+====
+In a multi-threaded application, modifying the object graph and storing the changes *must be done under the same lock*.
+{product-name} cannot enforce this on the application level — it is *your responsibility* to ensure that no other thread can read or modify the affected objects between the mutation and the corresponding `store()` call.
+Without this guarantee, other threads may observe inconsistent in-memory state or the stored data may not reflect the intended change.
+See xref:misc:locking/index.adoc[Locking] for details.
+====
+
 Storing objects that are not part of an object graph is most likely pointless.
 
 == Storing Root Instances

--- a/docs/modules/storage/pages/storing-data/transactions.adoc
+++ b/docs/modules/storage/pages/storing-data/transactions.adoc
@@ -45,3 +45,12 @@ If the store call is successful all data is written to the storage.
 Otherwise no data is persisted.
 Partially persisted data will be reverted.
 ====
+
+[IMPORTANT]
+====
+While each `store()` call is atomic at the persistence level, {product-name} does *not* synchronize the in-memory object graph for you.
+In a multi-threaded application, the modification of the object graph and the corresponding `store()` call *must be done under the same lock*.
+This is the application's responsibility.
+Without this guarantee, another thread could read or modify the object graph between your mutation and the `store()`, leading to inconsistent in-memory or persisted state.
+See xref:misc:locking/index.adoc[Locking] for details.
+====


### PR DESCRIPTION
Provide detailed guidance on synchronization needs for multi-threaded applications, ensuring developers understand best practices for thread safety.