### PR TITLE
Implemented cleanUp in ConstantSizedBufferProvider

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileItemIterator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileItemIterator.java
@@ -139,6 +139,11 @@ public interface StorageDataFileItemIterator
 				return this.buffer;
 			}
 
+			@Override
+			public void cleanUp()
+			{
+				XMemory.deallocateDirectByteBuffer(this.buffer);
+			}
 		}
 
 	}


### PR DESCRIPTION
Implement cleanUp() in StorageDataFileItemIterator's buffer wrapper to explicitly deallocate the direct ByteBuffer via XMemory.deallocateDirectByteBuffer(this.buffer), preventing native memory leaks.