### PR TITLE
fix: add license headers to multiple Java files + check

### DIFF
--- a/.github/workflows/maven_licence_check.yml
+++ b/.github/workflows/maven_licence_check.yml
@@ -25,4 +25,4 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     - name: Build with Maven
-      run: mvn -B clean license:check-file-header --file pom.xml
+      run: mvn -B -P examples clean license:check-file-header --file pom.xml

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/Category.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/Category.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap.vector;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 public enum Category
 {
     ELECTRONICS,

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/Product.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/Product.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap.vector;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 /**
  * Product with embedded vector.
  * <p>

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductIndices.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductIndices.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap.vector;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import org.eclipse.store.gigamap.types.BinaryIndexerString;
 
 public class ProductIndices

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductLoader.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductLoader.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap.vector;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductRecommendationSystem.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductRecommendationSystem.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap.vector;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import org.eclipse.store.gigamap.jvector.*;
 import org.eclipse.store.gigamap.types.GigaMap;
 

--- a/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductVectorizer.java
+++ b/examples/gigamap/src/main/java/org/eclipse/store/examples/gigamap/vector/ProductVectorizer.java
@@ -1,5 +1,19 @@
 package org.eclipse.store.examples.gigamap.vector;
 
+/*-
+ * #%L
+ * EclipseStore Example GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
 import org.eclipse.store.gigamap.jvector.Vectorizer;
 
 public class ProductVectorizer extends Vectorizer<Product>


### PR DESCRIPTION
This pull request primarily adds standardized license headers to all Java source files in the `examples/gigamap/vector` package and updates the Maven build process to ensure the license check includes the `examples` profile. These changes help maintain compliance with open source licensing requirements and ensure that example code is properly checked during automated builds.

**License compliance improvements:**

* Added Eclipse Public License 2.0 headers to all Java files in the `examples/gigamap/vector` package, including `Category.java`, `Product.java`, `ProductIndices.java`, `ProductLoader.java`, `ProductRecommendationSystem.java`, and `ProductVectorizer.java`. [[1]](diffhunk://#diff-97c98862e66fb279b23832846e521151abe80179b1f39e4991ed94193bef5711R3-R16) [[2]](diffhunk://#diff-489baf51e95e45de67247d507c522e5509546fe08dc31698ec8c8d1713ca42d9R3-R16) [[3]](diffhunk://#diff-ba9ae0c1d4497da1918b06511886dd358f005661005eb664491b6cab8df5eff3R3-R16) [[4]](diffhunk://#diff-e88fb1d4a214194a706780163523b508e5e0955e9d2e810856f6c6fb6e3cdc31R3-R16) [[5]](diffhunk://#diff-207edfafe81910aa797b052169236a2292817dfbbd5f08fe3b1b4303dddc4d74R3-R16) [[6]](diffhunk://#diff-1a74c052cd1c6891ee45a0c928279bbd6cf23e74f5e00fece4be8ca5c906b62fR3-R16)

**Build process adjustments:**

* Updated the Maven workflow in `.github/workflows/maven_licence_check.yml` to run the license check with the `examples` profile enabled, ensuring that license headers are verified for the example code as well.