### PR TITLE
Zj/spring configuration plugin enable direct 200426

### DIFF
--- a/examples/spring-boot3-advanced/pom.xml
+++ b/examples/spring-boot3-advanced/pom.xml
@@ -15,10 +15,9 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.5.6</spring.boot.version>
+        <spring.boot.version>3.5.13</spring.boot.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/spring-boot3-simple/pom.xml
+++ b/examples/spring-boot3-simple/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.5.6</spring.boot.version>
+        <spring.boot.version>3.5.13</spring.boot.version>
     </properties>
 
 

--- a/integrations/itest/pom.xml
+++ b/integrations/itest/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.2.2</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.13</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3-console/pom.xml
+++ b/integrations/spring-boot3-console/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.5.6</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.13</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3/pom.xml
+++ b/integrations/spring-boot3/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.5.6</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.13</org.springframework.boot.version>
     </properties>
 
     <dependencies>
@@ -91,6 +91,19 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${org.springframework.boot.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
This pull request updates the Spring Boot dependencies across multiple Maven project files to version 3.5.13 and makes related improvements to the build configuration. The most significant changes include version upgrades for consistency and security, as well as enhancements to the Maven compiler plugin configuration.

**Spring Boot version upgrades:**

* Updated the Spring Boot version to 3.5.13 in the following `pom.xml` files for consistency and to incorporate the latest fixes:
  * `examples/spring-boot3-advanced/pom.xml` (`spring.boot.version`)
  * `examples/spring-boot3-simple/pom.xml` (`spring.boot.version`)
  * `integrations/itest/pom.xml` (`org.springframework.boot.version`)
  * `integrations/spring-boot3-console/pom.xml` (`org.springframework.boot.version`)
  * `integrations/spring-boot3/pom.xml` (`org.springframework.boot.version`)

**Build configuration improvements:**

* Switched from specifying `maven.compiler.source` and `maven.compiler.target` to using `maven.compiler.release` for Java 17 in `examples/spring-boot3-advanced/pom.xml`, simplifying and modernizing the Java version configuration.
* Added explicit configuration for the `maven-compiler-plugin` in `integrations/spring-boot3/pom.xml` to include the `spring-boot-configuration-processor` as an annotation processor, improving build-time configuration metadata generation.