### PR TITLE
Fix: prevent leaking non-matching IDs in composite conditions

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
@@ -36,8 +36,7 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 	// constants //
 	//////////////
 	
-	private static final BitmapResult[] EMPTY_RESULT       = new BitmapResult[0];
-	private static final BitmapResult   EMPTY_RESULT_SINGLE = new BitmapResult.Empty();
+	private static final BitmapResult[] NO_MATCH = new BitmapResult[0];
 	
 	
 	
@@ -326,11 +325,11 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 	public BitmapResult internalQuery(final long key)
 	{
 		final BitmapResult[] results = this.internalQueryResults(key);
-		if(results == EMPTY_RESULT)
+		if(results == NO_MATCH)
 		{
 			// key cannot be contained (required bit positions have no entries), so the result must be the Empty singleton,
 			// not a ChainAnd wrapping an empty array (which would vacuously match every id via its -1L bitmap value).
-			return EMPTY_RESULT_SINGLE;
+			return EMPTY_RESULT;
 		}
 		return new BitmapResult.ChainAnd(results);
 	}
@@ -340,7 +339,7 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 		if(!this.fitsInEntries(keys))
 		{
 			// if the keys value's 1-bits don't fit in the entry range, the key cannot be contained.
-			return EMPTY_RESULT;
+			return NO_MATCH;
 		}
 		
 		final BitmapResult[] results = new BitmapResult[this.entriesCount];
@@ -353,7 +352,7 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 				// if the key demands a 1 bit at index i, but the index doesn't even have an entry for i, the key CANNOT be contained.
 				if(this.entries[i] == null)
 				{
-					return EMPTY_RESULT;
+					return NO_MATCH;
 				}
 				
 				// add condition for index i to filter for 1-bits.
@@ -375,7 +374,7 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 		// never return null since it is perfectly valid to query for a key that does not exist.
 		if(r == 0)
 		{
-			return EMPTY_RESULT;
+			return NO_MATCH;
 		}
 		
 		XSort.insertionsort(results, BitmapResult::andOptimize, 0, r);
@@ -416,7 +415,7 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 		}
 		
 		final BitmapResult[] results = this.internalQueryResults(keys);
-		if(results == EMPTY_RESULT)
+		if(results == NO_MATCH)
 		{
 			return false;
 		}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
@@ -36,7 +36,8 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 	// constants //
 	//////////////
 	
-	private static final BitmapResult[] EMPTY_RESULT = new BitmapResult[0];
+	private static final BitmapResult[] EMPTY_RESULT       = new BitmapResult[0];
+	private static final BitmapResult   EMPTY_RESULT_SINGLE = new BitmapResult.Empty();
 	
 	
 	
@@ -324,7 +325,14 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 	
 	public BitmapResult internalQuery(final long key)
 	{
-		return new BitmapResult.ChainAnd(this.internalQueryResults(key));
+		final BitmapResult[] results = this.internalQueryResults(key);
+		if(results == EMPTY_RESULT)
+		{
+			// key cannot be contained (required bit positions have no entries), so the result must be the Empty singleton,
+			// not a ChainAnd wrapping an empty array (which would vacuously match every id via its -1L bitmap value).
+			return EMPTY_RESULT_SINGLE;
+		}
+		return new BitmapResult.ChainAnd(results);
 	}
 	
 	public final BitmapResult[] internalQueryResults(final long keys)

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCompositeConditionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCompositeConditionTest.java
@@ -4,7 +4,7 @@ package org.eclipse.store.gigamap.indexer.binary;
  * #%L
  * EclipseStore GigaMap
  * %%
- * Copyright (C) 2023 - 2025 MicroStream Software
+ * Copyright (C) 2023 - 2026 MicroStream Software
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCompositeConditionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCompositeConditionTest.java
@@ -1,0 +1,479 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * https://github.com/eclipse-store/store/issues/641
+ */
+
+/// Reproduces a bug in EclipseStore GigaMap where [Condition.And] and
+/// [Condition.Or] combined with [BinaryBitmapIndex] (created by
+/// [GigaMap.Builder#withBitmapIndex]) return entities that match only a
+/// **subset** of the conjuncts, instead of requiring **all** conjuncts to match.
+///
+/// ## Setup
+///
+/// We create a GigaMap with three [BinaryIndexerLong] bitmap indexes and insert
+/// six entities.  Some share individual fields (e.g. `groupId` or `roleId`) but
+/// no two share the full `(actorId, groupId, roleId)` triple:
+///
+/// | id | actorId | groupId | roleId |
+/// |----|---------|---------|--------|
+/// | 10 | 100     | 1000    | 10000  |
+/// | 20 | 200     | 1000    | 10000  |
+/// | 30 | 300     | 2000    | 10000  |
+/// | 40 | 400     | 2000    | 20000  |
+/// | 50 | 500     | 1000    | 20000  |
+/// | 60 | 600     | 2000    | 30000  |
+///
+/// ## The Bug
+///
+/// ### Manifestation 1 — nested `And`
+///
+/// When we query for the **non-existent** tuple `(actorId=999, groupId=2000, roleId=20000)`
+/// using a nested `Condition.And` (the exact nesting order from production code):
+///
+/// ```java
+/// var condition = GROUP_INDEX.is(2000L)
+///         .and(ROLE_INDEX.is(20000L)
+///                 .and(ACTOR_INDEX.is(999L)));
+/// var results = gigaMap.query(condition).toList();
+/// ```
+///
+/// The expected result is **empty** (no entity has `actorId=999`).
+///
+/// The actual result is entity `40` `(actorId=400, groupId=2000, roleId=20000)` —
+/// an entity that matches `groupId` and `roleId` but **not** `actorId`.  The
+/// `And` evaluator returned a partial match instead of a strict intersection.
+///
+/// ### Manifestation 2 — `Or` wrapping `And`
+///
+/// When the `And` is wrapped in an `Or`:
+///
+/// ```java
+/// var condition = ID_INDEX.is(999L)
+///         .or(ACTOR_INDEX.is(999L)
+///                 .and(GROUP_INDEX.is(2000L))
+///                 .and(ROLE_INDEX.is(20000L)));
+/// ```
+///
+/// The query returns **all entities in the map** instead of an empty list.
+///
+/// ## Root Cause Analysis
+///
+/// [BinaryIndexer] stores values in a [BinaryBitmapIndex] (a bitmap-backed index
+/// optimised for high-cardinality `long` values). When a query receives a
+/// composite [Condition.And] or [Condition.Or] tree, the evaluator is supposed
+/// to intersect (for `And`) or union (for `Or`) the bitmaps from each
+/// sub-condition.
+///
+/// Instead, the evaluator appears to:
+/// 1. Mis-resolve bitmap segments during intersection/union (possibly due to
+///    improper offset arithmetic when combining multiple `BinaryBitmapIndex`
+///    bitsets).
+/// 2. Or short-circuit and return the first entity found in **any** sub-index
+///    bitmap without completing the full conjunction.
+///
+/// This means composite conditions are effectively treated as broken
+/// partial-matches instead of strict set operations.
+///
+/// ## Workaround
+///
+/// Avoid composing [Condition.And] or [Condition.Or] trees manually and passing
+/// them to `gigaMap.query(...)`. Instead, apply conditions sequentially via
+/// `GigaQuery.and(Condition)`:
+///
+/// ```java
+/// var query = gigaMap.query();
+/// query.and(ACTOR_INDEX.is(999L));
+/// query.and(GROUP_INDEX.is(2000L));
+/// query.and(ROLE_INDEX.is(20000L));
+/// var results = query.toList(); // correct — empty
+/// ```
+///
+/// The [GigaQueryBuilder] abstraction in the `peruncs` stack already implements
+/// this workaround by maintaining a list of standalone conditions and applying
+/// them one-by-one in its `create()` method.
+///
+/// ## Affected Versions
+///
+/// Observed on EclipseStore 3.1.0. The same bug likely affects any version that
+/// uses the `BinaryBitmapIndex` condition-evaluation path for composite
+/// conditions.
+///
+/// ## Related
+///
+/// - [GigaQueryBuilder] — documents the same workaround:
+///   `WORKAROUND: This builder avoids using [Condition#and(Condition)] internally`
+/// - [BinaryIndexBug] — related reproduction for `And` with mixed indexers
+public class BinaryIndexerCompositeConditionTest
+{
+
+	/// Simple entity with three independently-indexed `long` fields.
+	/// Mirrors the `(actor, group, role)` tuple pattern used in RBAC stores.
+	record Assignment(long id, long actorId, long groupId, long roleId)
+	{
+	}
+
+	static final BinaryIndexerLong<Assignment> ID_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(Assignment a)
+		{
+			return a.id();
+		}
+	};
+
+	static final BinaryIndexerLong<Assignment> ACTOR_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(Assignment a)
+		{
+			return a.actorId();
+		}
+	};
+
+	static final BinaryIndexerLong<Assignment> GROUP_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(Assignment a)
+		{
+			return a.groupId();
+		}
+	};
+
+	static final BinaryIndexerLong<Assignment> ROLE_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(Assignment a)
+		{
+			return a.roleId();
+		}
+	};
+
+	private GigaMap<Assignment> gigaMap;
+
+	@BeforeEach
+	void setUp()
+	{
+		gigaMap = GigaMap.<Assignment>Builder()
+			.withBitmapIdentityIndex(ID_INDEX)
+			.withBitmapIndex(ACTOR_INDEX)
+			.withBitmapIndex(GROUP_INDEX)
+			.withBitmapIndex(ROLE_INDEX)
+			.build();
+
+		// Six entities with overlapping but distinct (actorId, groupId, roleId) tuples.
+		// Some share individual fields (e.g. groupId or roleId) but no two share the
+		// full triple.  This mirrors the AGR pattern in the production store.
+		gigaMap.add(new Assignment(10L, 100L, 1000L, 10000L));
+		gigaMap.add(new Assignment(20L, 200L, 1000L, 10000L));
+		gigaMap.add(new Assignment(30L, 300L, 2000L, 10000L));
+		gigaMap.add(new Assignment(40L, 400L, 2000L, 20000L));
+		gigaMap.add(new Assignment(50L, 500L, 1000L, 20000L));
+		gigaMap.add(new Assignment(60L, 600L, 2000L, 30000L));
+
+		assertEquals(6, gigaMap.size(), "Setup: expected 6 entities in map");
+	}
+
+	/// Demonstrates that a single-index `is()` query works correctly.
+	@Test
+	void singleIndexQueryWorks()
+	{
+		var results = gigaMap.query(ACTOR_INDEX.is(200L)).toList();
+		assertEquals(1, results.size());
+		assertEquals(20L, results.get(0).id());
+	}
+
+	/// Demonstrates that a two-index `And` query works correctly.
+	@Test
+	void twoIndexAndQueryWorks()
+	{
+		var condition = ACTOR_INDEX.is(200L).and(GROUP_INDEX.is(1000L));
+		var results = gigaMap.query(condition).toList();
+		assertEquals(1, results.size());
+		assertEquals(20L, results.get(0).id());
+	}
+
+	/// A three-index `And` query for a non-existent tuple should return empty.
+	///
+	/// We query for `(actorId=999, groupId=2000, roleId=20000)`.
+	/// No entity in the store has `actorId=999`, so the result should be empty.
+	///
+	/// **Note:** With `BinaryIndexerLong` and small values this test currently
+	/// passes.  The bug was originally observed with `BinaryIndexerTsid` using
+	/// `Tsid.fast()` values (large pseudo-random longs) where the standalone
+	/// `And` also returned wrong entities.  The `Or` wrapping `And` variant
+	/// below fails reliably with both indexer types.
+	@Test
+	void threeIndexAndQueryForNonExistentTupleShouldBeEmpty()
+	{
+		var condition = ACTOR_INDEX.is(999L)
+			.and(GROUP_INDEX.is(2000L))
+			.and(ROLE_INDEX.is(20000L));
+
+		var results = gigaMap.query(condition).toList();
+
+		assertTrue(
+			results.isEmpty(),
+			() -> "Expected empty result for non-existent tuple (actor=999, group=2000, role=20000), "
+				+ "but got: " + results.stream()
+				.map(r -> "(id=%d, actor=%d, group=%d, role=%d)".formatted(
+					r.id(), r.actorId(), r.groupId(), r.roleId()))
+				.toList()
+		);
+	}
+
+	/// Same three-index `And` but with the nesting order used in the original
+	/// `ActorGroupRole.Store` code: `group.and(role.and(actor))`.
+	@Test
+	void threeIndexAndWithNestedGroupingShouldBeEmpty()
+	{
+		var condition = GROUP_INDEX.is(2000L)
+			.and(ROLE_INDEX.is(20000L)
+				.and(ACTOR_INDEX.is(999L)));
+
+		var results = gigaMap.query(condition).toList();
+
+		assertTrue(
+			results.isEmpty(),
+			() -> "Expected empty result for nested And (group=2000, role=20000, actor=999), "
+				+ "but got: " + results.stream()
+				.map(r -> "(id=%d, actor=%d, group=%d, role=%d)".formatted(
+					r.id(), r.actorId(), r.groupId(), r.roleId()))
+				.toList()
+		);
+	}
+
+	/// Another angle: querying for a tuple that matches `groupId` and `roleId`
+	/// but **not** `actorId` should also be empty.
+	@Test
+	void andQueryWithWrongActorShouldBeEmpty()
+	{
+		var condition = ACTOR_INDEX.is(300L) // entity 30 has actor=300
+			.and(GROUP_INDEX.is(2000L))   // entity 30 has group=2000 ✓
+			.and(ROLE_INDEX.is(20000L));  // entity 30 has role=10000 ✗
+
+		var results = gigaMap.query(condition).toList();
+
+		assertTrue(
+			results.isEmpty(),
+			() -> "Expected empty result because no entity has (actor=300, group=2000, role=20000), "
+				+ "but got: " + results.stream()
+				.map(r -> "(id=%d, actor=%d, group=%d, role=%d)".formatted(
+					r.id(), r.actorId(), r.groupId(), r.roleId()))
+				.toList()
+		);
+	}
+
+	/// Shows that the **workaround** (sequential `GigaQuery.and()`) produces
+	/// the correct empty result.
+	@Test
+	void sequentialAndQueryProducesCorrectResult()
+	{
+		var query = gigaMap.query();
+		query.and(ACTOR_INDEX.is(999L));
+		query.and(GROUP_INDEX.is(2000L));
+		query.and(ROLE_INDEX.is(20000L));
+
+		var results = query.toList();
+
+		assertTrue(results.isEmpty(),
+			"Sequential GigaQuery.and() should correctly intersect bitmaps");
+	}
+
+	/// **THE BUG:** An `Or` wrapping an `And` returns **all entities** instead
+	/// of an empty list.
+	///
+	/// We query for `id=999 OR (actor=999 AND group=2000 AND role=20000)`.
+	/// Neither branch matches any entity, so the result should be empty.
+	///
+	/// The bug causes the query to return every entity in the store.
+	@Test
+	void orWrappingAndForNonExistentIdShouldBeEmpty()
+	{
+		Condition<Assignment> idMatch = ID_INDEX.is(999L);
+		Condition<Assignment> tupleMatch = ACTOR_INDEX.is(999L)
+			.and(GROUP_INDEX.is(2000L))
+			.and(ROLE_INDEX.is(20000L));
+
+		var results = gigaMap.query(idMatch.or(tupleMatch)).toList();
+
+		assertTrue(
+			results.isEmpty(),
+			() -> "Expected empty result for id=999 OR non-existent tuple, but got: "
+				+ results.stream()
+				.map(r -> "(id=%d, actor=%d, group=%d, role=%d)".formatted(
+					r.id(), r.actorId(), r.groupId(), r.roleId()))
+				.toList()
+		);
+	}
+
+	/// Variant using [UUID]-derived long values — uses only standard JDK types.
+	///
+	/// The fixed UUIDs encode their distinguishing bits in the least-significant
+	/// 64 bits, so [UUID#getLeastSignificantBits] is used to extract distinct
+	/// long values per entity.  This exercises the same composite `And`/`Or`
+	/// code path with a second, independent set of keys.
+	@Nested
+	class UuidVariantTests
+	{
+
+		record UuidAssignment(UUID id, UUID actorId, UUID groupId, UUID roleId)
+		{
+		}
+
+		static final BinaryIndexerLong<UuidAssignment> UUID_ID_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(UuidAssignment a)
+			{
+				return a.id().getLeastSignificantBits();
+			}
+		};
+
+		static final BinaryIndexerLong<UuidAssignment> UUID_ACTOR_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(UuidAssignment a)
+			{
+				return a.actorId().getLeastSignificantBits();
+			}
+		};
+
+		static final BinaryIndexerLong<UuidAssignment> UUID_GROUP_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(UuidAssignment a)
+			{
+				return a.groupId().getLeastSignificantBits();
+			}
+		};
+
+		static final BinaryIndexerLong<UuidAssignment> UUID_ROLE_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(UuidAssignment a)
+			{
+				return a.roleId().getLeastSignificantBits();
+			}
+		};
+
+		private GigaMap<UuidAssignment> uuidMap;
+
+		@BeforeEach
+		void setUpUuid()
+		{
+			uuidMap = GigaMap.<UuidAssignment>Builder()
+				.withBitmapIdentityIndex(UUID_ID_INDEX)
+				.withBitmapIndex(UUID_ACTOR_INDEX)
+				.withBitmapIndex(UUID_GROUP_INDEX)
+				.withBitmapIndex(UUID_ROLE_INDEX)
+				.build();
+
+			// Distinct tuples using fixed UUIDs for reproducibility
+			uuidMap.add(new UuidAssignment(
+				UUID.fromString("00000000-0000-0000-0000-00000000000a"),
+				UUID.fromString("00000000-0000-0000-0000-000000000064"),
+				UUID.fromString("00000000-0000-0000-0000-0000000003e8"),
+				UUID.fromString("00000000-0000-0000-0000-000000002710")));
+			uuidMap.add(new UuidAssignment(
+				UUID.fromString("00000000-0000-0000-0000-000000000014"),
+				UUID.fromString("00000000-0000-0000-0000-0000000000c8"),
+				UUID.fromString("00000000-0000-0000-0000-0000000003e8"),
+				UUID.fromString("00000000-0000-0000-0000-000000002710")));
+			uuidMap.add(new UuidAssignment(
+				UUID.fromString("00000000-0000-0000-0000-00000000001e"),
+				UUID.fromString("00000000-0000-0000-0000-00000000012c"),
+				UUID.fromString("00000000-0000-0000-0000-0000000007d0"),
+				UUID.fromString("00000000-0000-0000-0000-000000002710")));
+			uuidMap.add(new UuidAssignment(
+				UUID.fromString("00000000-0000-0000-0000-000000000028"),
+				UUID.fromString("00000000-0000-0000-0000-000000000190"),
+				UUID.fromString("00000000-0000-0000-0000-0000000007d0"),
+				UUID.fromString("00000000-0000-0000-0000-000000004e20")));
+
+			assertEquals(4, uuidMap.size(), "Setup: expected 4 entities in UUID map");
+		}
+
+		/// Three-index `And` with UUID-derived long values.
+		///
+		/// Queries for a non-existent actor while matching group and role that
+		/// exist together in entity 4.
+		@Test
+		void threeIndexAndQueryForNonExistentTupleShouldBeEmpty()
+		{
+			var condition = UUID_ACTOR_INDEX.is(
+					UUID.fromString("00000000-0000-0000-0000-0000000003e7")
+						.getLeastSignificantBits())
+				.and(UUID_GROUP_INDEX.is(
+					UUID.fromString("00000000-0000-0000-0000-0000000007d0")
+						.getLeastSignificantBits()))
+				.and(UUID_ROLE_INDEX.is(
+					UUID.fromString("00000000-0000-0000-0000-000000004e20")
+						.getLeastSignificantBits()));
+
+			var results = uuidMap.query(condition).toList();
+
+			assertTrue(
+				results.isEmpty(),
+				() -> "Expected empty result for non-existent UUID tuple, but got: "
+					+ results.stream()
+					.map(r -> "(id=%s, actor=%s, group=%s, role=%s)".formatted(
+						r.id(), r.actorId(), r.groupId(), r.roleId()))
+					.toList()
+			);
+		}
+
+		/// `Or` wrapping a three-index `And` with UUID-derived long values.
+		@Test
+		void orWrappingAndForNonExistentIdShouldBeEmpty()
+		{
+			Condition<UuidAssignment> idMatch = UUID_ID_INDEX.is(
+				UUID.fromString("00000000-0000-0000-0000-0000000003e7")
+					.getLeastSignificantBits());
+			Condition<UuidAssignment> tupleMatch = UUID_ACTOR_INDEX.is(
+					UUID.fromString("00000000-0000-0000-0000-0000000003e7")
+						.getLeastSignificantBits())
+				.and(UUID_GROUP_INDEX.is(
+					UUID.fromString("00000000-0000-0000-0000-0000000007d0")
+						.getLeastSignificantBits()))
+				.and(UUID_ROLE_INDEX.is(
+					UUID.fromString("00000000-0000-0000-0000-000000004e20")
+						.getLeastSignificantBits()));
+
+			var results = uuidMap.query(idMatch.or(tupleMatch)).toList();
+
+			assertTrue(
+				results.isEmpty(),
+				() -> "Expected empty result for id=999 OR non-existent UUID tuple, but got: "
+					+ results.stream()
+					.map(r -> "(id=%s, actor=%s, group=%s, role=%s)".formatted(
+						r.id(), r.actorId(), r.groupId(), r.roleId()))
+					.toList()
+			);
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCompositeConditionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCompositeConditionTest.java
@@ -28,111 +28,126 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * https://github.com/eclipse-store/store/issues/641
  */
 
-/// Reproduces a bug in EclipseStore GigaMap where [Condition.And] and
-/// [Condition.Or] combined with [BinaryBitmapIndex] (created by
-/// [GigaMap.Builder#withBitmapIndex]) return entities that match only a
-/// **subset** of the conjuncts, instead of requiring **all** conjuncts to match.
-///
-/// ## Setup
-///
-/// We create a GigaMap with three [BinaryIndexerLong] bitmap indexes and insert
-/// six entities.  Some share individual fields (e.g. `groupId` or `roleId`) but
-/// no two share the full `(actorId, groupId, roleId)` triple:
-///
-/// | id | actorId | groupId | roleId |
-/// |----|---------|---------|--------|
-/// | 10 | 100     | 1000    | 10000  |
-/// | 20 | 200     | 1000    | 10000  |
-/// | 30 | 300     | 2000    | 10000  |
-/// | 40 | 400     | 2000    | 20000  |
-/// | 50 | 500     | 1000    | 20000  |
-/// | 60 | 600     | 2000    | 30000  |
-///
-/// ## The Bug
-///
-/// ### Manifestation 1 — nested `And`
-///
-/// When we query for the **non-existent** tuple `(actorId=999, groupId=2000, roleId=20000)`
-/// using a nested `Condition.And` (the exact nesting order from production code):
-///
-/// ```java
-/// var condition = GROUP_INDEX.is(2000L)
-///         .and(ROLE_INDEX.is(20000L)
-///                 .and(ACTOR_INDEX.is(999L)));
-/// var results = gigaMap.query(condition).toList();
-/// ```
-///
-/// The expected result is **empty** (no entity has `actorId=999`).
-///
-/// The actual result is entity `40` `(actorId=400, groupId=2000, roleId=20000)` —
-/// an entity that matches `groupId` and `roleId` but **not** `actorId`.  The
-/// `And` evaluator returned a partial match instead of a strict intersection.
-///
-/// ### Manifestation 2 — `Or` wrapping `And`
-///
-/// When the `And` is wrapped in an `Or`:
-///
-/// ```java
-/// var condition = ID_INDEX.is(999L)
-///         .or(ACTOR_INDEX.is(999L)
-///                 .and(GROUP_INDEX.is(2000L))
-///                 .and(ROLE_INDEX.is(20000L)));
-/// ```
-///
-/// The query returns **all entities in the map** instead of an empty list.
-///
-/// ## Root Cause Analysis
-///
-/// [BinaryIndexer] stores values in a [BinaryBitmapIndex] (a bitmap-backed index
-/// optimised for high-cardinality `long` values). When a query receives a
-/// composite [Condition.And] or [Condition.Or] tree, the evaluator is supposed
-/// to intersect (for `And`) or union (for `Or`) the bitmaps from each
-/// sub-condition.
-///
-/// Instead, the evaluator appears to:
-/// 1. Mis-resolve bitmap segments during intersection/union (possibly due to
-///    improper offset arithmetic when combining multiple `BinaryBitmapIndex`
-///    bitsets).
-/// 2. Or short-circuit and return the first entity found in **any** sub-index
-///    bitmap without completing the full conjunction.
-///
-/// This means composite conditions are effectively treated as broken
-/// partial-matches instead of strict set operations.
-///
-/// ## Workaround
-///
-/// Avoid composing [Condition.And] or [Condition.Or] trees manually and passing
-/// them to `gigaMap.query(...)`. Instead, apply conditions sequentially via
-/// `GigaQuery.and(Condition)`:
-///
-/// ```java
-/// var query = gigaMap.query();
-/// query.and(ACTOR_INDEX.is(999L));
-/// query.and(GROUP_INDEX.is(2000L));
-/// query.and(ROLE_INDEX.is(20000L));
-/// var results = query.toList(); // correct — empty
-/// ```
-///
-/// The [GigaQueryBuilder] abstraction in the `peruncs` stack already implements
-/// this workaround by maintaining a list of standalone conditions and applying
-/// them one-by-one in its `create()` method.
-///
-/// ## Affected Versions
-///
-/// Observed on EclipseStore 3.1.0. The same bug likely affects any version that
-/// uses the `BinaryBitmapIndex` condition-evaluation path for composite
-/// conditions.
-///
-/// ## Related
-///
-/// - [GigaQueryBuilder] — documents the same workaround:
-///   `WORKAROUND: This builder avoids using [Condition#and(Condition)] internally`
-/// - [BinaryIndexBug] — related reproduction for `And` with mixed indexers
+/**
+ * Reproduces a bug in EclipseStore GigaMap where {@link Condition.And} and
+ * {@link Condition.Or} combined with {@link BinaryBitmapIndex} (created by
+ * {@link GigaMap.Builder#withBitmapIndex}) return entities that match only a
+ * <b>subset</b> of the conjuncts, instead of requiring <b>all</b> conjuncts to match.
+ *
+ * <h2>Setup</h2>
+ *
+ * We create a GigaMap with three {@link BinaryIndexerLong} bitmap indexes and
+ * insert six entities. Some share individual fields (e.g. {@code groupId} or
+ * {@code roleId}) but no two share the full {@code (actorId, groupId, roleId)}
+ * triple:
+ * <pre>
+ * | id | actorId | groupId | roleId |
+ * |----|---------|---------|--------|
+ * | 10 | 100     | 1000    | 10000  |
+ * | 20 | 200     | 1000    | 10000  |
+ * | 30 | 300     | 2000    | 10000  |
+ * | 40 | 400     | 2000    | 20000  |
+ * | 50 | 500     | 1000    | 20000  |
+ * | 60 | 600     | 2000    | 30000  |
+ * </pre>
+ *
+ * <h2>The Bug</h2>
+ *
+ * <h3>Manifestation 1 &mdash; nested {@code And}</h3>
+ *
+ * When we query for the <b>non-existent</b> tuple
+ * {@code (actorId=999, groupId=2000, roleId=20000)} using a nested
+ * {@link Condition.And} (the exact nesting order from production code):
+ * <pre>{@code
+ * var condition = GROUP_INDEX.is(2000L)
+ *         .and(ROLE_INDEX.is(20000L)
+ *                 .and(ACTOR_INDEX.is(999L)));
+ * var results = gigaMap.query(condition).toList();
+ * }</pre>
+ *
+ * The expected result is <b>empty</b> (no entity has {@code actorId=999}).
+ *
+ * <p>The actual result is entity {@code 40} ({@code actorId=400, groupId=2000,
+ * roleId=20000}) &mdash; an entity that matches {@code groupId} and
+ * {@code roleId} but <b>not</b> {@code actorId}. The {@code And} evaluator
+ * returned a partial match instead of a strict intersection.
+ *
+ * <h3>Manifestation 2 &mdash; {@code Or} wrapping {@code And}</h3>
+ *
+ * When the {@code And} is wrapped in an {@code Or}:
+ * <pre>{@code
+ * var condition = ID_INDEX.is(999L)
+ *         .or(ACTOR_INDEX.is(999L)
+ *                 .and(GROUP_INDEX.is(2000L))
+ *                 .and(ROLE_INDEX.is(20000L)));
+ * }</pre>
+ *
+ * The query returns <b>all entities in the map</b> instead of an empty list.
+ *
+ * <h2>Root Cause</h2>
+ *
+ * When a {@link BinaryBitmapIndex} query cannot possibly match (a required bit
+ * position has no index entry), {@code internalQuery} returned
+ * {@code new BitmapResult.ChainAnd(EMPTY_RESULT)} &mdash; an <b>empty</b>
+ * {@code ChainAnd}.
+ *
+ * <p>An empty {@code ChainAnd} reports {@code -1L} (all-1s) from
+ * {@code getCurrentLevel1BitmapValue} because its AND-reduction starts at
+ * {@code -1L} and has no elements to reduce with. When that empty
+ * {@code ChainAnd} was nested inside another {@code ChainAnd} alongside a
+ * non-empty sibling, the level-1 AND at the driver couldn't filter it out:
+ * {@code non_empty & -1L = non_empty}. The non-matching sub-condition
+ * effectively vanished from the intersection, and any entity matching the
+ * other conjuncts was returned.
+ *
+ * <p>For {@code Or} wrapping {@code And}, the same empty {@code ChainAnd}
+ * fell through the {@code Or}-branch's {@code And} and made its bitmap match
+ * every id, blowing the overall query up to the full entity set.
+ *
+ * <p>The fix is to return the {@code BitmapResult.Empty} singleton (which
+ * correctly reports {@code 0L}/{@code false}) instead of wrapping the empty
+ * array in a {@code ChainAnd}, mirroring how
+ * {@code AbstractBitmapIndexHashing} already handles the no-match case.
+ *
+ * <h2>Workaround</h2>
+ *
+ * Avoid composing {@link Condition.And} or {@link Condition.Or} trees
+ * manually and passing them to {@code gigaMap.query(...)}. Instead, apply
+ * conditions sequentially via {@code GigaQuery.and(Condition)}:
+ * <pre>{@code
+ * var query = gigaMap.query();
+ * query.and(ACTOR_INDEX.is(999L));
+ * query.and(GROUP_INDEX.is(2000L));
+ * query.and(ROLE_INDEX.is(20000L));
+ * var results = query.toList(); // correct - empty
+ * }</pre>
+ *
+ * The {@code GigaQueryBuilder} abstraction in the {@code peruncs} stack
+ * already implements this workaround by maintaining a list of standalone
+ * conditions and applying them one-by-one in its {@code create()} method.
+ *
+ * <h2>Affected Versions</h2>
+ *
+ * Observed on EclipseStore 3.1.0. The same bug likely affects any version
+ * that uses the {@code BinaryBitmapIndex} condition-evaluation path for
+ * composite conditions.
+ *
+ * <h2>Related</h2>
+ * <ul>
+ *     <li>{@code GigaQueryBuilder} &mdash; documents the same workaround:
+ *         {@code WORKAROUND: This builder avoids using
+ *         [Condition#and(Condition)] internally}</li>
+ *     <li>{@code BinaryIndexBug} &mdash; related reproduction for {@code And}
+ *         with mixed indexers</li>
+ * </ul>
+ */
 public class BinaryIndexerCompositeConditionTest
 {
 
-	/// Simple entity with three independently-indexed `long` fields.
-	/// Mirrors the `(actor, group, role)` tuple pattern used in RBAC stores.
+	/**
+	 * Simple entity with three independently-indexed {@code long} fields.
+	 * Mirrors the {@code (actor, group, role)} tuple pattern used in RBAC stores.
+	 */
 	record Assignment(long id, long actorId, long groupId, long roleId)
 	{
 	}
@@ -198,7 +213,9 @@ public class BinaryIndexerCompositeConditionTest
 		assertEquals(6, gigaMap.size(), "Setup: expected 6 entities in map");
 	}
 
-	/// Demonstrates that a single-index `is()` query works correctly.
+	/**
+	 * Demonstrates that a single-index {@code is()} query works correctly.
+	 */
 	@Test
 	void singleIndexQueryWorks()
 	{
@@ -207,7 +224,9 @@ public class BinaryIndexerCompositeConditionTest
 		assertEquals(20L, results.get(0).id());
 	}
 
-	/// Demonstrates that a two-index `And` query works correctly.
+	/**
+	 * Demonstrates that a two-index {@code And} query works correctly.
+	 */
 	@Test
 	void twoIndexAndQueryWorks()
 	{
@@ -217,16 +236,19 @@ public class BinaryIndexerCompositeConditionTest
 		assertEquals(20L, results.get(0).id());
 	}
 
-	/// A three-index `And` query for a non-existent tuple should return empty.
-	///
-	/// We query for `(actorId=999, groupId=2000, roleId=20000)`.
-	/// No entity in the store has `actorId=999`, so the result should be empty.
-	///
-	/// **Note:** With `BinaryIndexerLong` and small values this test currently
-	/// passes.  The bug was originally observed with `BinaryIndexerTsid` using
-	/// `Tsid.fast()` values (large pseudo-random longs) where the standalone
-	/// `And` also returned wrong entities.  The `Or` wrapping `And` variant
-	/// below fails reliably with both indexer types.
+	/**
+	 * A three-index {@code And} query for a non-existent tuple should return empty.
+	 *
+	 * <p>We query for {@code (actorId=999, groupId=2000, roleId=20000)}.
+	 * No entity in the store has {@code actorId=999}, so the result should be empty.
+	 *
+	 * <p><b>Note:</b> With {@code BinaryIndexerLong} and small values this test
+	 * currently passes. The bug was originally observed with
+	 * {@code BinaryIndexerTsid} using {@code Tsid.fast()} values (large
+	 * pseudo-random longs) where the standalone {@code And} also returned
+	 * wrong entities. The {@code Or} wrapping {@code And} variant below fails
+	 * reliably with both indexer types.
+	 */
 	@Test
 	void threeIndexAndQueryForNonExistentTupleShouldBeEmpty()
 	{
@@ -246,8 +268,10 @@ public class BinaryIndexerCompositeConditionTest
 		);
 	}
 
-	/// Same three-index `And` but with the nesting order used in the original
-	/// `ActorGroupRole.Store` code: `group.and(role.and(actor))`.
+	/**
+	 * Same three-index {@code And} but with the nesting order used in the original
+	 * {@code ActorGroupRole.Store} code: {@code group.and(role.and(actor))}.
+	 */
 	@Test
 	void threeIndexAndWithNestedGroupingShouldBeEmpty()
 	{
@@ -267,12 +291,15 @@ public class BinaryIndexerCompositeConditionTest
 		);
 	}
 
-	/// Another angle: querying for a tuple that matches `groupId` and `roleId`
-	/// but **not** `actorId` should also be empty.
+	/**
+	 * Another angle: querying a tuple whose {@code actorId} and {@code groupId}
+	 * match entity 30 but whose {@code roleId} does <b>not</b> (entity 30's
+	 * roleId is 10000, the query asks for 20000). The result must be empty.
+	 */
 	@Test
-	void andQueryWithWrongActorShouldBeEmpty()
+	void andQueryWithWrongRoleShouldBeEmpty()
 	{
-		var condition = ACTOR_INDEX.is(300L) // entity 30 has actor=300
+		var condition = ACTOR_INDEX.is(300L)  // entity 30 has actor=300 ✓
 			.and(GROUP_INDEX.is(2000L))   // entity 30 has group=2000 ✓
 			.and(ROLE_INDEX.is(20000L));  // entity 30 has role=10000 ✗
 
@@ -280,7 +307,7 @@ public class BinaryIndexerCompositeConditionTest
 
 		assertTrue(
 			results.isEmpty(),
-			() -> "Expected empty result because no entity has (actor=300, group=2000, role=20000), "
+			() -> "Expected empty result because entity 30 (actor=300, group=2000) has role=10000, not 20000, "
 				+ "but got: " + results.stream()
 				.map(r -> "(id=%d, actor=%d, group=%d, role=%d)".formatted(
 					r.id(), r.actorId(), r.groupId(), r.roleId()))
@@ -288,8 +315,10 @@ public class BinaryIndexerCompositeConditionTest
 		);
 	}
 
-	/// Shows that the **workaround** (sequential `GigaQuery.and()`) produces
-	/// the correct empty result.
+	/**
+	 * Shows that the <b>workaround</b> (sequential {@code GigaQuery.and()})
+	 * produces the correct empty result.
+	 */
 	@Test
 	void sequentialAndQueryProducesCorrectResult()
 	{
@@ -304,13 +333,15 @@ public class BinaryIndexerCompositeConditionTest
 			"Sequential GigaQuery.and() should correctly intersect bitmaps");
 	}
 
-	/// **THE BUG:** An `Or` wrapping an `And` returns **all entities** instead
-	/// of an empty list.
-	///
-	/// We query for `id=999 OR (actor=999 AND group=2000 AND role=20000)`.
-	/// Neither branch matches any entity, so the result should be empty.
-	///
-	/// The bug causes the query to return every entity in the store.
+	/**
+	 * <b>THE BUG:</b> An {@code Or} wrapping an {@code And} returns
+	 * <b>all entities</b> instead of an empty list.
+	 *
+	 * <p>We query for {@code id=999 OR (actor=999 AND group=2000 AND role=20000)}.
+	 * Neither branch matches any entity, so the result should be empty.
+	 *
+	 * <p>The bug causes the query to return every entity in the store.
+	 */
 	@Test
 	void orWrappingAndForNonExistentIdShouldBeEmpty()
 	{
@@ -331,12 +362,16 @@ public class BinaryIndexerCompositeConditionTest
 		);
 	}
 
-	/// Variant using [UUID]-derived long values — uses only standard JDK types.
-	///
-	/// The fixed UUIDs encode their distinguishing bits in the least-significant
-	/// 64 bits, so [UUID#getLeastSignificantBits] is used to extract distinct
-	/// long values per entity.  This exercises the same composite `And`/`Or`
-	/// code path with a second, independent set of keys.
+	/**
+	 * Variant using {@link UUID}-derived long values &mdash; uses only standard
+	 * JDK types.
+	 *
+	 * <p>The fixed UUIDs encode their distinguishing bits in the
+	 * least-significant 64 bits, so {@link UUID#getLeastSignificantBits} is
+	 * used to extract distinct long values per entity. This exercises the same
+	 * composite {@code And}/{@code Or} code path with a second, independent set
+	 * of keys.
+	 */
 	@Nested
 	class UuidVariantTests
 	{
@@ -418,10 +453,12 @@ public class BinaryIndexerCompositeConditionTest
 			assertEquals(4, uuidMap.size(), "Setup: expected 4 entities in UUID map");
 		}
 
-		/// Three-index `And` with UUID-derived long values.
-		///
-		/// Queries for a non-existent actor while matching group and role that
-		/// exist together in entity 4.
+		/**
+		 * Three-index {@code And} with UUID-derived long values.
+		 *
+		 * <p>Queries for a non-existent actor while matching group and role
+		 * that exist together in entity 4.
+		 */
 		@Test
 		void threeIndexAndQueryForNonExistentTupleShouldBeEmpty()
 		{
@@ -447,7 +484,10 @@ public class BinaryIndexerCompositeConditionTest
 			);
 		}
 
-		/// `Or` wrapping a three-index `And` with UUID-derived long values.
+		/**
+		 * {@code Or} wrapping a three-index {@code And} with UUID-derived long
+		 * values.
+		 */
 		@Test
 		void orWrappingAndForNonExistentIdShouldBeEmpty()
 		{

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCrudTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerCrudTest.java
@@ -1,0 +1,256 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for CRUD operations (add, remove, update) with {@link BinaryIndexerLong}:
+ * verifies that the index is correctly maintained after each mutation.
+ */
+public class BinaryIndexerCrudTest
+{
+	static class Item
+	{
+		long typeId;
+		long ownerId;
+		String name;
+
+		Item(final long typeId, final long ownerId, final String name)
+		{
+			this.typeId  = typeId;
+			this.ownerId = ownerId;
+			this.name    = name;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Item{typeId=" + typeId + ", ownerId=" + ownerId + ", name=" + name + "}";
+		}
+	}
+
+	static final BinaryIndexerLong<Item> TYPE_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Item item) { return item.typeId; }
+	};
+
+	static final BinaryIndexerLong<Item> OWNER_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Item item) { return item.ownerId; }
+	};
+
+	private GigaMap<Item> map;
+	private Item itemA; // typeId=1, ownerId=10
+	private Item itemB; // typeId=1, ownerId=20
+	private Item itemC; // typeId=2, ownerId=10
+
+	@BeforeEach
+	void setUp()
+	{
+		map = GigaMap.<Item>Builder()
+			.withBitmapIndex(TYPE_INDEX)
+			.withBitmapIndex(OWNER_INDEX)
+			.build();
+
+		itemA = new Item(1L, 10L, "Alpha");
+		itemB = new Item(1L, 20L, "Beta");
+		itemC = new Item(2L, 10L, "Gamma");
+
+		map.add(itemA);
+		map.add(itemB);
+		map.add(itemC);
+	}
+
+	// -----------------------------------------------------------------------
+	// Add
+	// -----------------------------------------------------------------------
+
+	@Test
+	void addedEntityIsImmediatelyQueryable()
+	{
+		final Item newItem = new Item(3L, 30L, "Delta");
+		map.add(newItem);
+
+		final List<Item> results = map.query(TYPE_INDEX.is(3L)).toList();
+		assertEquals(1, results.size());
+		assertEquals("Delta", results.get(0).name);
+	}
+
+	@Test
+	void addIncreasesMapSize()
+	{
+		assertEquals(3, map.size());
+		map.add(new Item(4L, 40L, "Epsilon"));
+		assertEquals(4, map.size());
+	}
+
+	@Test
+	void addDuplicateKeyValueIncreasesResultCount()
+	{
+		assertEquals(2, map.query(TYPE_INDEX.is(1L)).count());
+		map.add(new Item(1L, 30L, "Zeta"));
+		assertEquals(3, map.query(TYPE_INDEX.is(1L)).count());
+	}
+
+	// -----------------------------------------------------------------------
+	// Remove
+	// -----------------------------------------------------------------------
+
+	@Test
+	void removedEntityIsNoLongerReturnedByQuery()
+	{
+		map.remove(itemA);
+
+		final List<Item> results = map.query(TYPE_INDEX.is(1L)).toList();
+		assertEquals(1, results.size());
+		assertEquals("Beta", results.get(0).name);
+	}
+
+	@Test
+	void removeDecreasesMapSize()
+	{
+		assertEquals(3, map.size());
+		map.remove(itemC);
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	void removeOneOfSeveralWithSameKeyLeavesOthersIntact()
+	{
+		// typeId=1 has itemA and itemB — remove itemA, itemB must still be found
+		map.remove(itemA);
+
+		final List<Item> remaining = map.query(TYPE_INDEX.is(1L)).toList();
+		assertEquals(1, remaining.size());
+		assertEquals("Beta", remaining.get(0).name);
+	}
+
+	@Test
+	void removeByIndexHintWorksCorrectly()
+	{
+		// remove itemC using TYPE_INDEX as hint
+		final long removedId = map.remove(itemC, TYPE_INDEX);
+		assertNotEquals(-1L, removedId, "remove() should return the entity's id, not -1");
+
+		assertTrue(map.query(TYPE_INDEX.is(2L)).toList().isEmpty());
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	void removeAllOfOneKeyLeavesOtherKeysIntact()
+	{
+		map.remove(itemA);
+		map.remove(itemB);
+
+		assertTrue(map.query(TYPE_INDEX.is(1L)).toList().isEmpty());
+		assertEquals(1, map.query(TYPE_INDEX.is(2L)).count());
+	}
+
+	// -----------------------------------------------------------------------
+	// Update
+	// -----------------------------------------------------------------------
+
+	@Test
+	void updateIndexedFieldIsReflectedInQueryResults()
+	{
+		// Change itemA's typeId from 1 → 5
+		map.update(itemA, item -> item.typeId = 5L);
+
+		// Old value no longer returns itemA
+		final List<Item> oldResults = map.query(TYPE_INDEX.is(1L)).toList();
+		assertEquals(1, oldResults.size());
+		assertEquals("Beta", oldResults.get(0).name);
+
+		// New value returns itemA
+		final List<Item> newResults = map.query(TYPE_INDEX.is(5L)).toList();
+		assertEquals(1, newResults.size());
+		assertEquals("Alpha", newResults.get(0).name);
+	}
+
+	@Test
+	void updateNonIndexedFieldDoesNotAffectQueryResults()
+	{
+		// Change only the name (not indexed)
+		map.update(itemA, item -> item.name = "AlphaRenamed");
+
+		// Index query still finds the entity under typeId=1
+		final List<Item> results = map.query(TYPE_INDEX.is(1L)).toList();
+		assertEquals(2, results.size());
+		assertTrue(results.stream().anyMatch(i -> "AlphaRenamed".equals(i.name)));
+	}
+
+	@Test
+	void updateBothIndexedFieldsKeepsConsistency()
+	{
+		// Move itemC from (type=2, owner=10) to (type=3, owner=30)
+		map.update(itemC, item ->
+		{
+			item.typeId  = 3L;
+			item.ownerId = 30L;
+		});
+
+		assertTrue(map.query(TYPE_INDEX.is(2L)).toList().isEmpty());
+		assertTrue(map.query(OWNER_INDEX.is(10L)).toList().stream()
+			.noneMatch(i -> "Gamma".equals(i.name)));
+
+		assertEquals(1, map.query(TYPE_INDEX.is(3L)).count());
+		assertEquals(1, map.query(OWNER_INDEX.is(30L)).count());
+	}
+
+	@Test
+	void sizeRemainsConstantAfterUpdate()
+	{
+		assertEquals(3, map.size());
+		map.update(itemB, item -> item.typeId = 99L);
+		assertEquals(3, map.size());
+	}
+
+	// -----------------------------------------------------------------------
+	// Combined CRUD
+	// -----------------------------------------------------------------------
+
+	@Test
+	void addThenRemoveLeavesMapInOriginalState()
+	{
+		final Item temp = new Item(9L, 90L, "Temp");
+		map.add(temp);
+		assertEquals(4, map.size());
+
+		map.remove(temp);
+		assertEquals(3, map.size());
+		assertTrue(map.query(TYPE_INDEX.is(9L)).toList().isEmpty());
+	}
+
+	@Test
+	void updateThenRemoveIsClean()
+	{
+		map.update(itemA, item -> item.typeId = 7L);
+		assertEquals(1, map.query(TYPE_INDEX.is(7L)).count());
+
+		map.remove(itemA);
+		assertTrue(map.query(TYPE_INDEX.is(7L)).toList().isEmpty());
+		assertEquals(2, map.size());
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerMixedIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerMixedIndexTest.java
@@ -1,0 +1,1069 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.BinaryIndexerUUID;
+import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.GigaQuery;
+import org.eclipse.store.gigamap.types.IndexerInteger;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests combining {@link BinaryIndexerLong} (and {@link BinaryIndexerUUID}) with regular
+ * bitmap indexes ({@link IndexerString}, {@link IndexerInteger}) in the same {@link GigaMap}.
+ * Covers AND/OR/NOT conditions, sequential {@code GigaQuery.and()}, and more complex combos.
+ */
+public class BinaryIndexerMixedIndexTest
+{
+	// -----------------------------------------------------------------------
+	// Section 1: BinaryIndexerLong + IndexerString + IndexerInteger
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Event entity:
+	 *   typeId  → BinaryIndexerLong  (binary bitmap)
+	 *   region  → IndexerString      (regular bitmap)
+	 *   priority→ IndexerInteger     (regular bitmap)
+	 *
+	 * Dataset (6 events, 0-indexed by insertion order):
+	 *   typeId=1, region="EU",   priority=1  (Aardvark)
+	 *   typeId=1, region="US",   priority=2  (Bear)
+	 *   typeId=2, region="EU",   priority=1  (Cheetah)
+	 *   typeId=2, region="US",   priority=3  (Dolphin)
+	 *   typeId=3, region="EU",   priority=2  (Elephant)
+	 *   typeId=3, region="APAC", priority=1  (Fox)
+	 */
+	@Nested
+	class LongStringInteger
+	{
+		record Event(long typeId, String region, int priority, String name) {}
+
+		static final BinaryIndexerLong<Event> TYPE_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(final Event e) { return e.typeId(); }
+		};
+
+		static final IndexerString<Event> REGION_INDEX = new IndexerString.Abstract<>()
+		{
+			@Override
+			protected String getString(final Event e) { return e.region(); }
+		};
+
+		static final IndexerInteger<Event> PRIORITY_INDEX = new IndexerInteger.Abstract<>()
+		{
+			@Override
+			protected Integer getInteger(final Event e) { return e.priority(); }
+		};
+
+		private GigaMap<Event> map;
+		private Event aardvark, bear, cheetah, dolphin, elephant, fox;
+
+		@BeforeEach
+		void setUp()
+		{
+			map = GigaMap.<Event>Builder()
+				.withBitmapIndex(TYPE_INDEX)
+				.withBitmapIndex(REGION_INDEX)
+				.withBitmapIndex(PRIORITY_INDEX)
+				.build();
+
+			aardvark = new Event(1L, "EU",   1, "Aardvark");
+			bear     = new Event(1L, "US",   2, "Bear");
+			cheetah  = new Event(2L, "EU",   1, "Cheetah");
+			dolphin  = new Event(2L, "US",   3, "Dolphin");
+			elephant = new Event(3L, "EU",   2, "Elephant");
+			fox      = new Event(3L, "APAC", 1, "Fox");
+
+			map.addAll(aardvark, bear, cheetah, dolphin, elephant, fox);
+		}
+
+		// -----------------------------------------------------------------------
+		// Sequential GigaQuery.and()
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryAndStringViaSequentialAnd()
+		{
+			final GigaQuery<Event> q = map.query();
+			q.and(TYPE_INDEX.is(1L));
+			q.and(REGION_INDEX.is("EU"));
+
+			final List<Event> results = q.toList();
+			assertEquals(1, results.size());
+			assertEquals("Aardvark", results.get(0).name());
+		}
+
+		@Test
+		void binaryAndIntegerViaSequentialAnd()
+		{
+			final GigaQuery<Event> q = map.query();
+			q.and(TYPE_INDEX.is(3L));
+			q.and(PRIORITY_INDEX.is(2));
+
+			final List<Event> results = q.toList();
+			assertEquals(1, results.size());
+			assertEquals("Elephant", results.get(0).name());
+		}
+
+		@Test
+		void threeWayAndBinaryStringInteger()
+		{
+			final GigaQuery<Event> q = map.query();
+			q.and(TYPE_INDEX.is(2L));
+			q.and(REGION_INDEX.is("EU"));
+			q.and(PRIORITY_INDEX.is(1));
+
+			final List<Event> results = q.toList();
+			assertEquals(1, results.size());
+			assertEquals("Cheetah", results.get(0).name());
+		}
+
+		@Test
+		void sequentialAndReturnsEmptyWhenNoOverlap()
+		{
+			final GigaQuery<Event> q = map.query();
+			q.and(TYPE_INDEX.is(1L));
+			q.and(REGION_INDEX.is("APAC")); // type=1 has no APAC entries
+
+			assertTrue(q.toList().isEmpty());
+		}
+
+		// -----------------------------------------------------------------------
+		// Condition.and()
+		// -----------------------------------------------------------------------
+
+		@Test
+		void conditionAndBinaryAndString()
+		{
+			final Condition<Event> cond = TYPE_INDEX.is(2L).and(REGION_INDEX.is("US"));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Dolphin", results.get(0).name());
+		}
+
+		@Test
+		void conditionAndBinaryAndInteger()
+		{
+			final Condition<Event> cond = TYPE_INDEX.is(1L).and(PRIORITY_INDEX.is(2));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Bear", results.get(0).name());
+		}
+
+		@Test
+		void conditionAndStringAndBinary()
+		{
+			// Same as above but condition order reversed (string AND binary)
+			final Condition<Event> cond = REGION_INDEX.is("EU").and(TYPE_INDEX.is(3L));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Elephant", results.get(0).name());
+		}
+
+		@Test
+		void conditionAndIntegerAndBinary()
+		{
+			final Condition<Event> cond = PRIORITY_INDEX.is(1).and(TYPE_INDEX.is(2L));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Cheetah", results.get(0).name());
+		}
+
+		@Test
+		void conditionAndAllThreeIndexes()
+		{
+			final Condition<Event> cond = TYPE_INDEX.is(3L)
+				.and(REGION_INDEX.is("APAC"))
+				.and(PRIORITY_INDEX.is(1));
+
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Fox", results.get(0).name());
+		}
+
+		// -----------------------------------------------------------------------
+		// Condition.or()
+		// -----------------------------------------------------------------------
+
+		@Test
+		void conditionOrBinaryAndString()
+		{
+			// type=1 → Aardvark, Bear; region="APAC" → Fox → union = 3
+			final Condition<Event> cond = TYPE_INDEX.is(1L).or(REGION_INDEX.is("APAC"));
+			assertEquals(3, map.query(cond).count());
+		}
+
+		@Test
+		void conditionOrBinaryAndInteger()
+		{
+			// type=3 → Elephant, Fox; priority=3 → Dolphin → union = 3
+			final Condition<Event> cond = TYPE_INDEX.is(3L).or(PRIORITY_INDEX.is(3));
+			assertEquals(3, map.query(cond).count());
+		}
+
+		@Test
+		void conditionOrStringAndBinary()
+		{
+			// region="US" → Bear, Dolphin; type=3 → Elephant, Fox → union = 4
+			final Condition<Event> cond = REGION_INDEX.is("US").or(TYPE_INDEX.is(3L));
+			assertEquals(4, map.query(cond).count());
+		}
+
+		@Test
+		void conditionOrWithOverlap()
+		{
+			// type=1 → Aardvark, Bear; priority=2 → Bear, Elephant → union = 3
+			final Condition<Event> cond = TYPE_INDEX.is(1L).or(PRIORITY_INDEX.is(2));
+			assertEquals(3, map.query(cond).count());
+		}
+
+		// -----------------------------------------------------------------------
+		// NOT conditions mixed
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryNotAndString()
+		{
+			// type != 1 → Cheetah, Dolphin, Elephant, Fox; AND region="EU" → Cheetah, Elephant
+			final Condition<Event> cond = TYPE_INDEX.not(1L).and(REGION_INDEX.is("EU"));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(2, results.size());
+			assertTrue(results.stream().noneMatch(e -> e.typeId() == 1L));
+			assertTrue(results.stream().allMatch(e -> "EU".equals(e.region())));
+		}
+
+		@Test
+		void stringNotAndBinary()
+		{
+			// region != "EU" → Bear, Dolphin, Fox; AND type=3 → Fox
+			final Condition<Event> cond = REGION_INDEX.not("EU").and(TYPE_INDEX.is(3L));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Fox", results.get(0).name());
+		}
+
+		// -----------------------------------------------------------------------
+		// notIn on binary combined with regular index
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryNotInAndString()
+		{
+			// type not in {1, 2} → Elephant, Fox; AND region="EU" → Elephant
+			final Condition<Event> cond = TYPE_INDEX.notIn(1L, 2L).and(REGION_INDEX.is("EU"));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Elephant", results.get(0).name());
+		}
+
+		@Test
+		void binaryInAndInteger()
+		{
+			// type in {1, 3} → Aardvark, Bear, Elephant, Fox; AND priority=1 → Aardvark, Fox
+			final Condition<Event> cond = TYPE_INDEX.in(1L, 3L).and(PRIORITY_INDEX.is(1));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(2, results.size());
+			assertTrue(results.stream().allMatch(e -> e.priority() == 1));
+			assertTrue(results.stream().noneMatch(e -> e.typeId() == 2L));
+		}
+
+		// -----------------------------------------------------------------------
+		// Size consistency
+		// -----------------------------------------------------------------------
+
+		@Test
+		void sizeRemainsUnaffectedByQuerying()
+		{
+			assertEquals(6, map.size());
+			map.query(TYPE_INDEX.is(1L).and(REGION_INDEX.is("EU"))).toList();
+			assertEquals(6, map.size());
+		}
+
+		// -----------------------------------------------------------------------
+		// CRUD: add/remove verify both indexes stay consistent
+		// -----------------------------------------------------------------------
+
+		@Test
+		void afterAddBothIndexesReflectNewEntity()
+		{
+			final Event newEvent = new Event(4L, "LATAM", 5, "Gorilla");
+			map.add(newEvent);
+
+			assertEquals(7, map.size());
+
+			// Both binary and string indexes must find the new entity
+			final Condition<Event> cond = TYPE_INDEX.is(4L).and(REGION_INDEX.is("LATAM"));
+			final List<Event> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Gorilla", results.get(0).name());
+		}
+
+		@Test
+		void afterRemoveBothIndexesNoLongerFindEntity()
+		{
+			map.remove(aardvark);
+			assertEquals(5, map.size());
+
+			// Neither binary nor string query should return Aardvark
+			assertTrue(map.query(TYPE_INDEX.is(1L).and(REGION_INDEX.is("EU"))).toList().isEmpty());
+		}
+
+		@Test
+		void noOpUpdateDoesNotCorruptIndexes()
+		{
+			// Event is a record (immutable) so the update body is a no-op.
+			// Verify that a no-op update leaves both indexes in the correct state.
+			map.update(aardvark, e -> {});
+
+			// type=1 → Aardvark, Bear (still 2)
+			assertEquals(2, map.query(TYPE_INDEX.is(1L)).count());
+			// region="EU" AND type=1 → only Aardvark (1)
+			assertEquals(1, map.query(REGION_INDEX.is("EU").and(TYPE_INDEX.is(1L))).count());
+			// region="EU" → Aardvark, Cheetah, Elephant (still 3)
+			assertEquals(3, map.query(REGION_INDEX.is("EU")).count());
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Section 2: BinaryIndexerUUID (composite binary) + IndexerString
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Combines {@link BinaryIndexerUUID} (a composite binary index encoding two longs)
+	 * with a regular {@link IndexerString} index on the same entity.
+	 */
+	@Nested
+	class UuidAndString
+	{
+		static class Asset
+		{
+			final UUID   id;
+			      String category;
+			      String name;
+
+			Asset(final UUID id, final String category, final String name)
+			{
+				this.id       = id;
+				this.category = category;
+				this.name     = name;
+			}
+		}
+
+		static final BinaryIndexerUUID<Asset> UUID_INDEX = new BinaryIndexerUUID.Abstract<>()
+		{
+			@Override
+			protected UUID getUUID(final Asset a) { return a.id; }
+		};
+
+		static final IndexerString<Asset> CATEGORY_INDEX = new IndexerString.Abstract<>()
+		{
+			@Override
+			protected String getString(final Asset a) { return a.category; }
+		};
+
+		private final UUID idA = UUID.randomUUID();
+		private final UUID idB = UUID.randomUUID();
+		private final UUID idC = UUID.randomUUID();
+
+		private GigaMap<Asset> map;
+		private Asset assetA, assetB, assetC, assetD;
+
+		@BeforeEach
+		void setUp()
+		{
+			map = GigaMap.<Asset>Builder()
+				.withBitmapIndex(UUID_INDEX)
+				.withBitmapIndex(CATEGORY_INDEX)
+				.build();
+
+			assetA = new Asset(idA, "hardware", "GPU");
+			assetB = new Asset(idB, "software", "IDE");
+			assetC = new Asset(idC, "hardware", "CPU");
+			assetD = new Asset(idA, "software", "Driver"); // same UUID as assetA, different category
+
+			map.addAll(assetA, assetB, assetC, assetD);
+		}
+
+		@Test
+		void uuidAndCategoryBothMatching()
+		{
+			// Only assetA has idA AND "hardware"
+			final Condition<Asset> cond = UUID_INDEX.is(idA).and(CATEGORY_INDEX.is("hardware"));
+			final List<Asset> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("GPU", results.get(0).name);
+		}
+
+		@Test
+		void uuidAndCategoryNoOverlap()
+		{
+			// idB is software (Bear), not hardware
+			final Condition<Asset> cond = UUID_INDEX.is(idB).and(CATEGORY_INDEX.is("hardware"));
+			assertTrue(map.query(cond).toList().isEmpty());
+		}
+
+		@Test
+		void uuidOrCategory()
+		{
+			// idA → assetA, assetD (2); "hardware" → assetA, assetC (2); union = assetA, assetC, assetD = 3
+			final Condition<Asset> cond = UUID_INDEX.is(idA).or(CATEGORY_INDEX.is("hardware"));
+			assertEquals(3, map.query(cond).count());
+		}
+
+		@Test
+		void categoryAndUuidViaSequentialAnd()
+		{
+			final GigaQuery<Asset> q = map.query();
+			q.and(CATEGORY_INDEX.is("software"));
+			q.and(UUID_INDEX.is(idA));
+
+			// assetD has idA AND software
+			final List<Asset> results = q.toList();
+			assertEquals(1, results.size());
+			assertEquals("Driver", results.get(0).name);
+		}
+
+		@Test
+		void uuidAndCategoryThreeWayOr()
+		{
+			// idA → assetA, assetD; idC → assetC; union OR category="software" → assetA, assetB, assetC, assetD = 4
+			final Condition<Asset> cond = UUID_INDEX.is(idA).or(UUID_INDEX.is(idC)).or(CATEGORY_INDEX.is("software"));
+			assertEquals(4, map.query(cond).count());
+		}
+
+		@Test
+		void uuidQueryReturnsAllAssetsWithSameId()
+		{
+			// Both assetA and assetD share idA
+			final List<Asset> results = map.query(UUID_INDEX.is(idA)).toList();
+			assertEquals(2, results.size());
+			assertTrue(results.stream().allMatch(a -> idA.equals(a.id)));
+		}
+
+		@Test
+		void afterRemoveUuidIndexIsUpdated()
+		{
+			map.remove(assetA);
+			// idA still has assetD
+			final List<Asset> results = map.query(UUID_INDEX.is(idA)).toList();
+			assertEquals(1, results.size());
+			assertEquals("Driver", results.get(0).name);
+		}
+
+		@Test
+		void afterRemoveLastWithUuidQueryReturnsEmpty()
+		{
+			map.remove(assetB);
+			assertTrue(map.query(UUID_INDEX.is(idB)).toList().isEmpty());
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Section 3: Two BinaryIndexerLong + IndexerInteger (3-index map)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Tests a GigaMap with two separate {@link BinaryIndexerLong} indexes and one
+	 * regular {@link IndexerInteger} index, verifying complex AND/OR chains
+	 * across all three indexes simultaneously.
+	 */
+	@Nested
+	class TwoBinaryPlusInteger
+	{
+		record Ticket(long typeId, long ownerId, int severity, String title) {}
+
+		static final BinaryIndexerLong<Ticket> TYPE_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(final Ticket t) { return t.typeId(); }
+		};
+
+		static final BinaryIndexerLong<Ticket> OWNER_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(final Ticket t) { return t.ownerId(); }
+		};
+
+		static final IndexerInteger<Ticket> SEVERITY_INDEX = new IndexerInteger.Abstract<>()
+		{
+			@Override
+			protected Integer getInteger(final Ticket t) { return t.severity(); }
+		};
+
+		private GigaMap<Ticket> map;
+
+		// Dataset:
+		// type=1, owner=10, sev=1 → "Alpha"
+		// type=1, owner=20, sev=2 → "Beta"
+		// type=2, owner=10, sev=1 → "Gamma"
+		// type=2, owner=20, sev=3 → "Delta"
+		// type=3, owner=30, sev=2 → "Epsilon"
+		@BeforeEach
+		void setUp()
+		{
+			map = GigaMap.<Ticket>Builder()
+				.withBitmapIndex(TYPE_INDEX)
+				.withBitmapIndex(OWNER_INDEX)
+				.withBitmapIndex(SEVERITY_INDEX)
+				.build();
+
+			map.addAll(
+				new Ticket(1L, 10L, 1, "Alpha"),
+				new Ticket(1L, 20L, 2, "Beta"),
+				new Ticket(2L, 10L, 1, "Gamma"),
+				new Ticket(2L, 20L, 3, "Delta"),
+				new Ticket(3L, 30L, 2, "Epsilon")
+			);
+		}
+
+		@Test
+		void twoBinaryAndIntegerAllMatch()
+		{
+			// type=1, owner=10, sev=1 → Alpha only
+			final Condition<Ticket> cond = TYPE_INDEX.is(1L)
+				.and(OWNER_INDEX.is(10L))
+				.and(SEVERITY_INDEX.is(1));
+
+			final List<Ticket> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Alpha", results.get(0).title());
+		}
+
+		@Test
+		void twoBinaryAndIntegerNoMatch()
+		{
+			// type=1 AND owner=10 AND sev=2 → no such ticket
+			final Condition<Ticket> cond = TYPE_INDEX.is(1L)
+				.and(OWNER_INDEX.is(10L))
+				.and(SEVERITY_INDEX.is(2));
+
+			assertTrue(map.query(cond).toList().isEmpty());
+		}
+
+		@Test
+		void twoBinaryOrOneInteger()
+		{
+			// (type=3 OR owner=20) → Beta, Delta, Epsilon (3 tickets)
+			final Condition<Ticket> cond = TYPE_INDEX.is(3L).or(OWNER_INDEX.is(20L));
+			assertEquals(3, map.query(cond).count());
+		}
+
+		@Test
+		void binaryAndIntegerOrBinary()
+		{
+			// (sev=1 AND type=1) OR owner=30 → Alpha, Epsilon
+			final Condition<Ticket> cond =
+				SEVERITY_INDEX.is(1).and(TYPE_INDEX.is(1L))
+				.or(OWNER_INDEX.is(30L));
+
+			assertEquals(2, map.query(cond).count());
+		}
+
+		@Test
+		void integerAndTwoBinaryViaSequentialAnd()
+		{
+			final GigaQuery<Ticket> q = map.query();
+			q.and(SEVERITY_INDEX.is(2));
+			q.and(TYPE_INDEX.is(1L));
+			q.and(OWNER_INDEX.is(20L));
+
+			final List<Ticket> results = q.toList();
+			assertEquals(1, results.size());
+			assertEquals("Beta", results.get(0).title());
+		}
+
+		@Test
+		void binaryNotCombinedWithIntegerAndBinary()
+		{
+			// type != 1 → Gamma, Delta, Epsilon; AND sev=1 → Gamma; AND owner=10 → Gamma
+			final Condition<Ticket> cond = TYPE_INDEX.not(1L)
+				.and(SEVERITY_INDEX.is(1))
+				.and(OWNER_INDEX.is(10L));
+
+			final List<Ticket> results = map.query(cond).toList();
+			assertEquals(1, results.size());
+			assertEquals("Gamma", results.get(0).title());
+		}
+
+		@Test
+		void countIsConsistentAcrossAllThreeIndexes()
+		{
+			// sev=2 → Beta, Epsilon (2 tickets)
+			assertEquals(2, map.query(SEVERITY_INDEX.is(2)).count());
+
+			// After adding more tickets this count should update correctly
+			map.add(new Ticket(4L, 40L, 2, "Zeta"));
+			assertEquals(3, map.query(SEVERITY_INDEX.is(2)).count());
+
+			// The binary index should also reflect the new ticket
+			assertEquals(1, map.query(TYPE_INDEX.is(4L)).count());
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Section 4 (slow): 100 000 records — exact count and content verification
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Large-scale stress test with 100 000 entities indexed by four indexes simultaneously:
+	 * <ul>
+	 *   <li>{@code typeId}    – {@link BinaryIndexerLong}  (5 values, 20 000 each)</li>
+	 *   <li>{@code status}    – {@link IndexerString}       (4 values, 25 000 each)</li>
+	 *   <li>{@code priority}  – {@link IndexerInteger}      (3 values: 33 334 / 33 333 / 33 333)</li>
+	 *   <li>{@code customerId}– {@link BinaryIndexerUUID}   (10 distinct UUIDs, 10 000 each)</li>
+	 * </ul>
+	 *
+	 * <p>Data layout (orderId 0..99 999):
+	 * <pre>
+	 *   typeId     = (orderId % 5) + 1          → {1..5}
+	 *   status     = STATUSES[orderId % 4]       → {"OPEN","CLOSED","PENDING","SHIPPED"}
+	 *   priority   = (orderId % 3) + 1           → {1,2,3}
+	 *   customerId = CUSTOMER_UUIDS[orderId % 10]→ 10 distinct UUIDs
+	 * </pre>
+	 *
+	 * <p>Expected combined counts derived via LCM / Chinese Remainder Theorem:
+	 * <pre>
+	 *   type=1 AND open                → lcm(5,4)=20   → 100 000/20  =  5 000
+	 *   type=1 OR open                 → 20 000+25 000−5 000         = 40 000
+	 *   type=1 AND priority=1          → lcm(5,3)=15   → 6 667
+	 *   open AND priority=1            → lcm(4,3)=12   → 8 334
+	 *   type=1 AND open AND priority=1 → lcm(5,4,3)=60 → 1 667
+	 *   customer[0] AND open           → lcm(10,4)=20  → 5 000
+	 *   all four (type=1, open, prio=1, customer[0]) → lcm(5,4,3,10)=60 → 1 667
+	 *   type in {1,3} AND open         → 5 000+5 000                 = 10 000
+	 *   type notIn {1,2}               → 3×20 000                    = 60 000
+	 * </pre>
+	 */
+	@Nested
+	@Tag("slow")
+	class LargeDataset
+	{
+		static final int COUNT = 100_000;
+
+		static final String[] STATUSES = {"OPEN", "CLOSED", "PENDING", "SHIPPED"};
+
+		// 10 deterministic, non-zero UUIDs (BinaryIndexerUUID treats 0L halves specially).
+		static final UUID[] CUSTOMER_UUIDS;
+		static
+		{
+			CUSTOMER_UUIDS = new UUID[10];
+			for(int i = 0; i < 10; i++)
+			{
+				CUSTOMER_UUIDS[i] = new UUID(1_000L + i, 2_000L + i);
+			}
+		}
+
+		record Order(long typeId, String status, int priority, UUID customerId) {}
+
+		static final BinaryIndexerLong<Order> TYPE_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(final Order o) { return o.typeId(); }
+		};
+
+		static final IndexerString<Order> STATUS_INDEX = new IndexerString.Abstract<>()
+		{
+			@Override
+			protected String getString(final Order o) { return o.status(); }
+		};
+
+		static final IndexerInteger<Order> PRIORITY_INDEX = new IndexerInteger.Abstract<>()
+		{
+			@Override
+			protected Integer getInteger(final Order o) { return o.priority(); }
+		};
+
+		static final BinaryIndexerUUID<Order> CUSTOMER_INDEX = new BinaryIndexerUUID.Abstract<>()
+		{
+			@Override
+			protected UUID getUUID(final Order o) { return o.customerId(); }
+		};
+
+		private GigaMap<Order> map;
+
+		@BeforeEach
+		void setUp()
+		{
+			map = GigaMap.<Order>Builder()
+				.withBitmapIndex(TYPE_INDEX)
+				.withBitmapIndex(STATUS_INDEX)
+				.withBitmapIndex(PRIORITY_INDEX)
+				.withBitmapIndex(CUSTOMER_INDEX)
+				.build();
+
+			for(int i = 0; i < COUNT; i++)
+			{
+				map.add(new Order(
+					(i % 5) + 1L,
+					STATUSES[i % 4],
+					(i % 3) + 1,
+					CUSTOMER_UUIDS[i % 10]
+				));
+			}
+		}
+
+		// -----------------------------------------------------------------------
+		// Basic single-index counts
+		// -----------------------------------------------------------------------
+
+		@Test
+		void sizeIsExact()
+		{
+			assertEquals(COUNT, map.size());
+		}
+
+		@Test
+		void singleBinaryIndexCounts()
+		{
+			assertEquals(20_000, map.query(TYPE_INDEX.is(1L)).count());
+			assertEquals(20_000, map.query(TYPE_INDEX.is(2L)).count());
+			assertEquals(20_000, map.query(TYPE_INDEX.is(3L)).count());
+			assertEquals(20_000, map.query(TYPE_INDEX.is(4L)).count());
+			assertEquals(20_000, map.query(TYPE_INDEX.is(5L)).count());
+		}
+
+		@Test
+		void singleStringIndexCounts()
+		{
+			assertEquals(25_000, map.query(STATUS_INDEX.is("OPEN")).count());
+			assertEquals(25_000, map.query(STATUS_INDEX.is("CLOSED")).count());
+			assertEquals(25_000, map.query(STATUS_INDEX.is("PENDING")).count());
+			assertEquals(25_000, map.query(STATUS_INDEX.is("SHIPPED")).count());
+		}
+
+		@Test
+		void singleIntegerIndexCounts()
+		{
+			// orderId%3==0: 0,3,...,99999 → 33 334; orderId%3==1 / ==2 → 33 333 each
+			assertEquals(33_334, map.query(PRIORITY_INDEX.is(1)).count());
+			assertEquals(33_333, map.query(PRIORITY_INDEX.is(2)).count());
+			assertEquals(33_333, map.query(PRIORITY_INDEX.is(3)).count());
+		}
+
+		@Test
+		void singleUuidIndexCounts()
+		{
+			for(int i = 0; i < 10; i++)
+			{
+				assertEquals(10_000, map.query(CUSTOMER_INDEX.is(CUSTOMER_UUIDS[i])).count(),
+					"UUID[" + i + "] should match exactly 10 000 orders");
+			}
+		}
+
+		// -----------------------------------------------------------------------
+		// Binary AND String
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryAndStringCount()
+		{
+			// orderId%5==0 AND orderId%4==0 → orderId%20==0 → 5 000
+			assertEquals(5_000, map.query(TYPE_INDEX.is(1L).and(STATUS_INDEX.is("OPEN"))).count());
+		}
+
+		@Test
+		void binaryAndStringAllResultsHaveCorrectValues()
+		{
+			final List<Order> results = map.query(TYPE_INDEX.is(1L).and(STATUS_INDEX.is("OPEN"))).toList();
+			assertEquals(5_000, results.size());
+			assertTrue(results.stream().allMatch(o -> o.typeId() == 1L && "OPEN".equals(o.status())));
+		}
+
+		@Test
+		void stringAndBinaryCountEqualsReversedOrder()
+		{
+			// AND is commutative — both orderings must give the same count
+			final long ab = map.query(TYPE_INDEX.is(1L).and(STATUS_INDEX.is("OPEN"))).count();
+			final long ba = map.query(STATUS_INDEX.is("OPEN").and(TYPE_INDEX.is(1L))).count();
+			assertEquals(ab, ba);
+			assertEquals(5_000, ab);
+		}
+
+		// -----------------------------------------------------------------------
+		// Binary OR String
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryOrStringCount()
+		{
+			// |type=1| + |open| - |type=1 AND open| = 20000 + 25000 - 5000 = 40 000
+			assertEquals(40_000, map.query(TYPE_INDEX.is(1L).or(STATUS_INDEX.is("OPEN"))).count());
+		}
+
+		@Test
+		void stringOrStringCount()
+		{
+			assertEquals(50_000, map.query(STATUS_INDEX.is("OPEN").or(STATUS_INDEX.is("CLOSED"))).count());
+		}
+
+		// -----------------------------------------------------------------------
+		// Binary AND Integer
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryAndIntegerCount()
+		{
+			// orderId%5==0 AND orderId%3==0 → orderId%15==0 → 6 667
+			assertEquals(6_667, map.query(TYPE_INDEX.is(1L).and(PRIORITY_INDEX.is(1))).count());
+		}
+
+		@Test
+		void integerAndBinaryAllResultsHaveCorrectValues()
+		{
+			final List<Order> results = map.query(PRIORITY_INDEX.is(1).and(TYPE_INDEX.is(2L))).toList();
+			// type=2: orderId%5==1, priority=1: orderId%3==0 → lcm(5,3)=15, orderId≡1(mod5)∧orderId≡0(mod3)
+			// CRT: orderId≡6(mod 15) → 100000/15=6666.7 → floor(99999/15−6/15)+1 counted from 6:
+			// Actually: orderId=6,21,36,...,99996 → (99996-6)/15+1=6661 ... hmm, let me recalculate.
+			// orderId%5==1 AND orderId%3==0: orderId=6,21,36,...
+			// First: 6. Last ≤ 99999: 6+15*k ≤ 99999 → k ≤ 6666.2 → k=6666 → last=6+15*6666=99996
+			// Count: 6667
+			assertEquals(6_667, results.size());
+			assertTrue(results.stream().allMatch(o -> o.typeId() == 2L && o.priority() == 1));
+		}
+
+		// -----------------------------------------------------------------------
+		// String AND Integer
+		// -----------------------------------------------------------------------
+
+		@Test
+		void stringAndIntegerCount()
+		{
+			// orderId%4==0 AND orderId%3==0 → orderId%12==0 → 8 334
+			assertEquals(8_334, map.query(STATUS_INDEX.is("OPEN").and(PRIORITY_INDEX.is(1))).count());
+		}
+
+		// -----------------------------------------------------------------------
+		// Three-way AND: binary + string + integer
+		// -----------------------------------------------------------------------
+
+		@Test
+		void threeWayAndCount()
+		{
+			// orderId%5==0 AND orderId%4==0 AND orderId%3==0 → orderId%60==0 → 1 667
+			assertEquals(1_667, map.query(
+				TYPE_INDEX.is(1L).and(STATUS_INDEX.is("OPEN")).and(PRIORITY_INDEX.is(1))
+			).count());
+		}
+
+		@Test
+		void threeWayAndViaSequentialQuery()
+		{
+			final GigaQuery<Order> q = map.query();
+			q.and(STATUS_INDEX.is("OPEN"));
+			q.and(TYPE_INDEX.is(1L));
+			q.and(PRIORITY_INDEX.is(1));
+			assertEquals(1_667, q.count());
+		}
+
+		@Test
+		void threeWayAndAllResultsHaveCorrectValues()
+		{
+			final List<Order> results = map.query(
+				TYPE_INDEX.is(1L).and(STATUS_INDEX.is("OPEN")).and(PRIORITY_INDEX.is(1))
+			).toList();
+			assertEquals(1_667, results.size());
+			assertTrue(results.stream().allMatch(o ->
+				o.typeId() == 1L && "OPEN".equals(o.status()) && o.priority() == 1
+			));
+		}
+
+		// -----------------------------------------------------------------------
+		// UUID combined with string and binary
+		// -----------------------------------------------------------------------
+
+		@Test
+		void uuidAndStringCount()
+		{
+			// orderId%10==0 AND orderId%4==0 → orderId%20==0 → 5 000
+			assertEquals(5_000, map.query(
+				CUSTOMER_INDEX.is(CUSTOMER_UUIDS[0]).and(STATUS_INDEX.is("OPEN"))
+			).count());
+		}
+
+		@Test
+		void uuidAndStringAllResultsHaveCorrectValues()
+		{
+			final List<Order> results = map.query(
+				CUSTOMER_INDEX.is(CUSTOMER_UUIDS[0]).and(STATUS_INDEX.is("OPEN"))
+			).toList();
+			assertEquals(5_000, results.size());
+			assertTrue(results.stream().allMatch(o ->
+				CUSTOMER_UUIDS[0].equals(o.customerId()) && "OPEN".equals(o.status())
+			));
+		}
+
+		@Test
+		void uuidAndBinaryCount()
+		{
+			// orderId%10==0 ⊆ orderId%5==0 (every multiple of 10 is a multiple of 5)
+			// → type=1 AND customer[0] = customer[0] = 10 000
+			assertEquals(10_000, map.query(
+				TYPE_INDEX.is(1L).and(CUSTOMER_INDEX.is(CUSTOMER_UUIDS[0]))
+			).count());
+		}
+
+		// -----------------------------------------------------------------------
+		// Four-way AND: all four indexes together
+		// -----------------------------------------------------------------------
+
+		@Test
+		void fourWayAndCount()
+		{
+			// lcm(5,4,3,10)=60 → 1 667 (orderId%60==0 implies orderId%10==0 since 60=6×10)
+			assertEquals(1_667, map.query(
+				TYPE_INDEX.is(1L)
+					.and(STATUS_INDEX.is("OPEN"))
+					.and(PRIORITY_INDEX.is(1))
+					.and(CUSTOMER_INDEX.is(CUSTOMER_UUIDS[0]))
+			).count());
+		}
+
+		@Test
+		void fourWayAndAllResultsHaveCorrectValues()
+		{
+			final List<Order> results = map.query(
+				TYPE_INDEX.is(1L)
+					.and(STATUS_INDEX.is("OPEN"))
+					.and(PRIORITY_INDEX.is(1))
+					.and(CUSTOMER_INDEX.is(CUSTOMER_UUIDS[0]))
+			).toList();
+			assertEquals(1_667, results.size());
+			assertTrue(results.stream().allMatch(o ->
+				o.typeId() == 1L
+				&& "OPEN".equals(o.status())
+				&& o.priority() == 1
+				&& CUSTOMER_UUIDS[0].equals(o.customerId())
+			));
+		}
+
+		// -----------------------------------------------------------------------
+		// NOT and notIn
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryNotCount()
+		{
+			assertEquals(80_000, map.query(TYPE_INDEX.not(1L)).count());
+		}
+
+		@Test
+		void binaryNotAndStringCount()
+		{
+			// type != 1 AND open: (open=25000) − (type=1 AND open=5000) = 20 000
+			assertEquals(20_000, map.query(TYPE_INDEX.not(1L).and(STATUS_INDEX.is("OPEN"))).count());
+		}
+
+		@Test
+		void binaryNotInCount()
+		{
+			// type not in {1,2} → types {3,4,5} → 3 × 20 000 = 60 000
+			assertEquals(60_000, map.query(TYPE_INDEX.notIn(1L, 2L)).count());
+		}
+
+		@Test
+		void binaryNotInAndStringAllResultsHaveCorrectValues()
+		{
+			final List<Order> results = map.query(
+				TYPE_INDEX.notIn(1L, 2L).and(STATUS_INDEX.is("OPEN"))
+			).toList();
+			// type in {3,4,5}: 60 000 entities; AND open: 60000*(25000/100000)=15000
+			// type=3 AND open: orderId%5==2 AND orderId%4==0 → orderId≡12(mod 20) → 5000
+			// type=4 AND open: orderId%5==3 AND orderId%4==0 → CRT orderId≡8(mod 20) → 5000
+			// type=5 AND open: orderId%5==4 AND orderId%4==0 → CRT orderId≡4(mod 20)? 4%5=4✓,4%4=0✓ → 5000
+			assertEquals(15_000, results.size());
+			assertTrue(results.stream().allMatch(o -> o.typeId() >= 3 && "OPEN".equals(o.status())));
+		}
+
+		// -----------------------------------------------------------------------
+		// in()
+		// -----------------------------------------------------------------------
+
+		@Test
+		void binaryInCount()
+		{
+			// type in {1,3} → 2 × 20 000 = 40 000
+			assertEquals(40_000, map.query(TYPE_INDEX.in(1L, 3L)).count());
+		}
+
+		@Test
+		void binaryInAndStringCount()
+		{
+			// type=1 AND open: 5 000; type=3 AND open (orderId%5==2 AND %4==0 → orderId≡12 mod 20): 5 000
+			assertEquals(10_000, map.query(TYPE_INDEX.in(1L, 3L).and(STATUS_INDEX.is("OPEN"))).count());
+		}
+
+		@Test
+		void binaryInAndStringAllResultsHaveCorrectValues()
+		{
+			final List<Order> results = map.query(
+				TYPE_INDEX.in(1L, 3L).and(STATUS_INDEX.is("OPEN"))
+			).toList();
+			assertEquals(10_000, results.size());
+			assertTrue(results.stream().allMatch(o ->
+				(o.typeId() == 1L || o.typeId() == 3L) && "OPEN".equals(o.status())
+			));
+		}
+
+		// -----------------------------------------------------------------------
+		// CRUD on large dataset
+		// -----------------------------------------------------------------------
+
+		@Test
+		void addOneAndBothIndexesReflectIt()
+		{
+			final UUID freshId = new UUID(9_999L, 9_999L);
+			map.add(new Order(9L, "OPEN", 1, freshId));
+
+			// Size increases
+			assertEquals(COUNT + 1, map.size());
+			// Binary index finds the new entity under its unique typeId
+			assertEquals(1, map.query(TYPE_INDEX.is(9L)).count());
+			// String index still finds it when combined
+			assertEquals(1, map.query(TYPE_INDEX.is(9L).and(STATUS_INDEX.is("OPEN"))).count());
+			// UUID index finds it
+			assertEquals(1, map.query(CUSTOMER_INDEX.is(freshId)).count());
+		}
+
+		@Test
+		void removeOneAndAllIndexesDecreaseCounts()
+		{
+			// Grab an entity we know matches type=1 AND open
+			final Order victim = map.query(TYPE_INDEX.is(1L).and(STATUS_INDEX.is("OPEN")))
+				.findFirst()
+				.orElseThrow();
+
+			map.remove(victim);
+
+			assertEquals(COUNT - 1, map.size());
+			assertEquals(4_999, map.query(TYPE_INDEX.is(1L).and(STATUS_INDEX.is("OPEN"))).count());
+			// type=1 alone lost one entry as well
+			assertEquals(19_999, map.query(TYPE_INDEX.is(1L)).count());
+			// open alone lost one entry as well
+			assertEquals(24_999, map.query(STATUS_INDEX.is("OPEN")).count());
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerMultiFieldTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerMultiFieldTest.java
@@ -1,0 +1,286 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.GigaQuery;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for multi-field queries with {@link BinaryIndexerLong}:
+ * sequential {@code GigaQuery.and()}, {@code Condition.and/or},
+ * nested AND grouping, {@code idStart}/{@code idBound}, and
+ * mixing binary indexes with a regular bitmap index.
+ */
+public class BinaryIndexerMultiFieldTest
+{
+	// Task(id, categoryId, statusId, title)
+	// categoryId: 10, 20, 30
+	// statusId:    1 (open), 2 (closed)
+	record Task(long id, long categoryId, long statusId, String title) {}
+
+	static final BinaryIndexerLong<Task> CATEGORY_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Task t) { return t.categoryId(); }
+	};
+
+	static final BinaryIndexerLong<Task> STATUS_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Task t) { return t.statusId(); }
+	};
+
+	static final IndexerString<Task> TITLE_INDEX = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Task t) { return t.title(); }
+	};
+
+	private GigaMap<Task> map;
+
+	// Dataset:
+	// id=0  cat=10 status=1  "Aardvark"
+	// id=1  cat=10 status=2  "Bear"
+	// id=2  cat=20 status=1  "Cheetah"
+	// id=3  cat=20 status=2  "Dolphin"
+	// id=4  cat=30 status=1  "Elephant"
+	// id=5  cat=30 status=2  "Fox"
+	@BeforeEach
+	void setUp()
+	{
+		map = GigaMap.<Task>Builder()
+			.withBitmapIndex(CATEGORY_INDEX)
+			.withBitmapIndex(STATUS_INDEX)
+			.withBitmapIndex(TITLE_INDEX)
+			.build();
+
+		map.add(new Task(0L, 10L, 1L, "Aardvark"));
+		map.add(new Task(0L, 10L, 2L, "Bear"));
+		map.add(new Task(0L, 20L, 1L, "Cheetah"));
+		map.add(new Task(0L, 20L, 2L, "Dolphin"));
+		map.add(new Task(0L, 30L, 1L, "Elephant"));
+		map.add(new Task(0L, 30L, 2L, "Fox"));
+	}
+
+	// -----------------------------------------------------------------------
+	// Sequential GigaQuery.and()
+	// -----------------------------------------------------------------------
+
+	@Test
+	void sequentialAndIntersectsTwoBinaryIndexes()
+	{
+		final GigaQuery<Task> q = map.query();
+		q.and(CATEGORY_INDEX.is(10L));
+		q.and(STATUS_INDEX.is(1L));
+
+		final List<Task> results = q.toList();
+		assertEquals(1, results.size());
+		assertEquals("Aardvark", results.get(0).title());
+	}
+
+	@Test
+	void sequentialAndReturnsEmptyWhenNoOverlap()
+	{
+		// cat=10 has ids 0,1 — none with status=99
+		final GigaQuery<Task> q = map.query();
+		q.and(CATEGORY_INDEX.is(10L));
+		q.and(STATUS_INDEX.is(99L));
+
+		assertTrue(q.toList().isEmpty());
+	}
+
+	@Test
+	void sequentialAndWithThreeConditions()
+	{
+		final GigaQuery<Task> q = map.query();
+		q.and(CATEGORY_INDEX.is(20L));
+		q.and(STATUS_INDEX.is(1L));
+		q.and(TITLE_INDEX.is("Cheetah"));
+
+		final List<Task> results = q.toList();
+		assertEquals(1, results.size());
+		assertEquals("Cheetah", results.get(0).title());
+	}
+
+	// -----------------------------------------------------------------------
+	// Condition.and / Condition.or
+	// -----------------------------------------------------------------------
+
+	@Test
+	void conditionAndIntersectsTwoBinaryIndexes()
+	{
+		final Condition<Task> cond = CATEGORY_INDEX.is(20L).and(STATUS_INDEX.is(2L));
+		final List<Task> results = map.query(cond).toList();
+		assertEquals(1, results.size());
+		assertEquals("Dolphin", results.get(0).title());
+	}
+
+	@Test
+	void conditionAndWithNonExistentKeyReturnsEmpty()
+	{
+		final Condition<Task> cond = CATEGORY_INDEX.is(10L).and(STATUS_INDEX.is(99L));
+		assertTrue(map.query(cond).toList().isEmpty());
+	}
+
+	@Test
+	void conditionOrUnitesTwoBinaryIndexes()
+	{
+		// cat=10 → Aardvark, Bear; status=2 → Bear, Dolphin, Fox
+		// union = Aardvark, Bear, Dolphin, Fox (4 distinct)
+		final Condition<Task> cond = CATEGORY_INDEX.is(10L).or(STATUS_INDEX.is(2L));
+		final long count = map.query(cond).count();
+		assertEquals(4, count);
+	}
+
+	@Test
+	void conditionOrWithBothMatchingReturnsUnion()
+	{
+		// cat=10 OR cat=30 → 4 tasks
+		final Condition<Task> cond = CATEGORY_INDEX.is(10L).or(CATEGORY_INDEX.is(30L));
+		assertEquals(4, map.query(cond).count());
+	}
+
+	@Test
+	void conditionOrWithNeitherMatchingReturnsEmpty()
+	{
+		final Condition<Task> cond = CATEGORY_INDEX.is(99L).or(STATUS_INDEX.is(99L));
+		assertTrue(map.query(cond).toList().isEmpty());
+	}
+
+	@Test
+	void nestedAndGrouping()
+	{
+		// cat=30 AND (status=1 AND title="Elephant") — nested form
+		final Condition<Task> cond = CATEGORY_INDEX.is(30L)
+			.and(STATUS_INDEX.is(1L)
+				.and(TITLE_INDEX.is("Elephant")));
+
+		final List<Task> results = map.query(cond).toList();
+		assertEquals(1, results.size());
+		assertEquals("Elephant", results.get(0).title());
+	}
+
+	@Test
+	void nestedAndGroupingWithNonExistentValueReturnsEmpty()
+	{
+		// cat=30 AND (status=1 AND title="Fox") — Fox has status=2, not 1
+		final Condition<Task> cond = CATEGORY_INDEX.is(30L)
+			.and(STATUS_INDEX.is(1L)
+				.and(TITLE_INDEX.is("Fox")));
+
+		assertTrue(map.query(cond).toList().isEmpty());
+	}
+
+	// -----------------------------------------------------------------------
+	// idStart / idBound
+	// -----------------------------------------------------------------------
+
+	@Test
+	void idBoundLimitsResults()
+	{
+		// status=1 has 3 results (ids 0, 2, 4); bound to first 2 ids
+		final List<Long> allIds = new ArrayList<>();
+		map.query(STATUS_INDEX.is(1L)).iterateIndexed((id, e) -> allIds.add(id));
+		assertEquals(3, allIds.size());
+
+		// Restrict to the first two by using idBound = allIds.get(2)
+		final List<Long> boundIds = new ArrayList<>();
+		map.query(STATUS_INDEX.is(1L))
+			.idBound(allIds.get(2))
+			.iterateIndexed((id, e) -> boundIds.add(id));
+
+		assertEquals(2, boundIds.size());
+		assertFalse(boundIds.contains(allIds.get(2)));
+	}
+
+	@Test
+	void idStartSkipsEarlierResults()
+	{
+		final List<Long> allIds = new ArrayList<>();
+		map.query(STATUS_INDEX.is(1L)).iterateIndexed((id, e) -> allIds.add(id));
+		assertEquals(3, allIds.size());
+
+		// Start from the second id
+		final List<Long> startIds = new ArrayList<>();
+		map.query(STATUS_INDEX.is(1L))
+			.idStart(allIds.get(1))
+			.iterateIndexed((id, e) -> startIds.add(id));
+
+		assertEquals(2, startIds.size());
+		assertFalse(startIds.contains(allIds.get(0)));
+	}
+
+	@Test
+	void idStartAndIdBoundTogetherReturnSubrange()
+	{
+		final List<Long> allIds = new ArrayList<>();
+		map.query(STATUS_INDEX.is(1L)).iterateIndexed((id, e) -> allIds.add(id));
+		assertEquals(3, allIds.size());
+
+		final List<Long> subIds = new ArrayList<>();
+		map.query(STATUS_INDEX.is(1L))
+			.idStart(allIds.get(1))
+			.idBound(allIds.get(2))
+			.iterateIndexed((id, e) -> subIds.add(id));
+
+		assertEquals(1, subIds.size());
+		assertEquals(allIds.get(1), subIds.get(0));
+	}
+
+	// -----------------------------------------------------------------------
+	// Mixed binary + regular bitmap index
+	// -----------------------------------------------------------------------
+
+	@Test
+	void binaryAndRegularIndexCombinedViaSequentialAnd()
+	{
+		// cat=20 AND title="Cheetah"
+		final GigaQuery<Task> q = map.query();
+		q.and(CATEGORY_INDEX.is(20L));
+		q.and(TITLE_INDEX.is("Cheetah"));
+
+		final List<Task> results = q.toList();
+		assertEquals(1, results.size());
+		assertEquals(20L, results.get(0).categoryId());
+	}
+
+	@Test
+	void binaryAndRegularIndexCombinedViaConditionAnd()
+	{
+		// cat=30 AND title="Fox"
+		final Condition<Task> cond = CATEGORY_INDEX.is(30L).and(TITLE_INDEX.is("Fox"));
+		final List<Task> results = map.query(cond).toList();
+		assertEquals(1, results.size());
+		assertEquals("Fox", results.get(0).title());
+	}
+
+	@Test
+	void binaryAndRegularIndexOrCombined()
+	{
+		// title="Aardvark" OR cat=30 → Aardvark + Elephant + Fox = 3 entities
+		final Condition<Task> cond = TITLE_INDEX.is("Aardvark").or(CATEGORY_INDEX.is(30L));
+		assertEquals(3, map.query(cond).count());
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerQueryTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerQueryTest.java
@@ -1,0 +1,186 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for basic query operations on {@link BinaryIndexerLong}:
+ * {@code is}, {@code not}, {@code in}, {@code notIn}, {@code count},
+ * {@code toList}, {@code forEach}, {@code iterateIndexed}, and
+ * duplicate-value handling.
+ */
+public class BinaryIndexerQueryTest
+{
+	record Product(long categoryId, String name) {}
+
+	static final BinaryIndexerLong<Product> CATEGORY_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Product p)
+		{
+			return p.categoryId();
+		}
+	};
+
+	private GigaMap<Product> map;
+
+	// categoryId distribution:
+	//   1L → "Alpha", "Beta"           (2 products)
+	//   2L → "Gamma"                    (1 product)
+	//   3L → "Delta", "Epsilon", "Zeta" (3 products)
+	@BeforeEach
+	void setUp()
+	{
+		map = GigaMap.<Product>Builder()
+			.withBitmapIndex(CATEGORY_INDEX)
+			.build();
+
+		map.add(new Product(1L, "Alpha"));
+		map.add(new Product(1L, "Beta"));
+		map.add(new Product(2L, "Gamma"));
+		map.add(new Product(3L, "Delta"));
+		map.add(new Product(3L, "Epsilon"));
+		map.add(new Product(3L, "Zeta"));
+	}
+
+	@Test
+	void isReturnsExactMatch()
+	{
+		final List<Product> results = map.query(CATEGORY_INDEX.is(2L)).toList();
+		assertEquals(1, results.size());
+		assertEquals("Gamma", results.get(0).name());
+	}
+
+	@Test
+	void isReturnsMultipleMatchesForSharedKey()
+	{
+		final List<Product> results = map.query(CATEGORY_INDEX.is(1L)).toList();
+		assertEquals(2, results.size());
+		assertTrue(results.stream().allMatch(p -> p.categoryId() == 1L));
+	}
+
+	@Test
+	void isReturnsEmptyForNonExistentKey()
+	{
+		final List<Product> results = map.query(CATEGORY_INDEX.is(99L)).toList();
+		assertTrue(results.isEmpty());
+	}
+
+	@Test
+	void notExcludesSingleValue()
+	{
+		final List<Product> results = map.query(CATEGORY_INDEX.not(2L)).toList();
+		assertEquals(5, results.size());
+		assertTrue(results.stream().noneMatch(p -> p.categoryId() == 2L));
+	}
+
+	@Test
+	void notExcludesAllWhenEveryEntityMatchesKey()
+	{
+		// All 6 products have categoryId != 99, so not(99) returns all
+		assertEquals(6, map.query(CATEGORY_INDEX.not(99L)).count());
+	}
+
+	@Test
+	void inMatchesAnyOfSeveralKeys()
+	{
+		final List<Product> results = map.query(CATEGORY_INDEX.in(1L, 2L)).toList();
+		assertEquals(3, results.size());
+		assertTrue(results.stream().allMatch(p -> p.categoryId() == 1L || p.categoryId() == 2L));
+	}
+
+	@Test
+	void inWithSingleKeyBehavesLikeIs()
+	{
+		final List<Product> via_in = map.query(CATEGORY_INDEX.in(3L)).toList();
+		final List<Product> via_is = map.query(CATEGORY_INDEX.is(3L)).toList();
+		assertEquals(via_is.size(), via_in.size());
+	}
+
+	@Test
+	void inWithNoMatchReturnsEmpty()
+	{
+		assertTrue(map.query(CATEGORY_INDEX.in(88L, 99L)).toList().isEmpty());
+	}
+
+	@Test
+	void notInExcludesAll()
+	{
+		final List<Product> results = map.query(CATEGORY_INDEX.notIn(1L, 3L)).toList();
+		assertEquals(1, results.size());
+		assertEquals(2L, results.get(0).categoryId());
+	}
+
+	@Test
+	void notInWithNonExistentKeysReturnsAll()
+	{
+		assertEquals(6, map.query(CATEGORY_INDEX.notIn(88L, 99L)).count());
+	}
+
+	@Test
+	void countMatchesListSize()
+	{
+		assertEquals(
+			map.query(CATEGORY_INDEX.is(3L)).toList().size(),
+			map.query(CATEGORY_INDEX.is(3L)).count()
+		);
+	}
+
+	@Test
+	void forEachVisitsAllMatchingEntities()
+	{
+		final List<Product> visited = new ArrayList<>();
+		map.query(CATEGORY_INDEX.is(3L)).forEach(visited::add);
+		assertEquals(3, visited.size());
+		assertTrue(visited.stream().allMatch(p -> p.categoryId() == 3L));
+	}
+
+	@Test
+	void iterateIndexedProvidesEntityIdAndEntity()
+	{
+		final List<Long> ids = new ArrayList<>();
+		final List<Product> entities = new ArrayList<>();
+
+		map.query(CATEGORY_INDEX.is(1L)).iterateIndexed((id, entity) ->
+		{
+			ids.add(id);
+			entities.add(entity);
+		});
+
+		assertEquals(2, ids.size());
+		assertEquals(2, entities.size());
+		// IDs must be non-negative and distinct
+		assertTrue(ids.stream().allMatch(id -> id >= 0));
+		assertEquals(ids.size(), ids.stream().distinct().count());
+		assertTrue(entities.stream().allMatch(p -> p.categoryId() == 1L));
+	}
+
+	@Test
+	void iterateIndexedOnEmptyResultCallsConsumerZeroTimes()
+	{
+		final List<Long> ids = new ArrayList<>();
+		map.query(CATEGORY_INDEX.is(99L)).iterateIndexed((id, entity) -> ids.add(id));
+		assertTrue(ids.isEmpty());
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/query/MixedIndexCompositeConditionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/query/MixedIndexCompositeConditionTest.java
@@ -1,0 +1,418 @@
+package org.eclipse.store.gigamap.query;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.GigaQuery;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Composite {@code And}/{@code Or}/{@code Not} coverage for GigaMaps that mix
+ * a hashing {@code BitmapIndex} (e.g. {@link IndexerString}) with a
+ * {@code BinaryBitmapIndex} (e.g. {@link BinaryIndexerLong}) on the same map.
+ *
+ * <p>Complements
+ * {@code org.eclipse.store.gigamap.indexer.binary.BinaryIndexerCompositeConditionTest}
+ * (issue #641): the original bug was that a binary-index query with no match
+ * produced an empty {@code ChainAnd} whose vacuous {@code -1L} bitmap leaked
+ * through cross-index intersections. These tests lock down the mixed-family
+ * case, which had no prior coverage.
+ *
+ * <h2>Score values are deliberately sparse</h2>
+ *
+ * Scores are powers of two (4, 8, 256), leaving large gaps in the binary
+ * index's bit-entry array (bit positions 0, 1, 4-7 are never populated).
+ * Queries for a non-existent key like {@code SCORE.is(1L)} therefore hit the
+ * "required bit position has no entry" path in
+ * {@code AbstractBitmapIndexBinary#internalQueryResults}, which is the path
+ * that originally produced the buggy empty {@code ChainAnd}. Using dense bit
+ * patterns (e.g. 10, 20, 999) would miss this path entirely.
+ */
+public class MixedIndexCompositeConditionTest
+{
+	record Item(String tag, long score)
+	{
+	}
+
+	static final IndexerString<Item> TAG = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item i)
+		{
+			return i.tag();
+		}
+	};
+
+	static final BinaryIndexerLong<Item> SCORE = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Item i)
+		{
+			return i.score();
+		}
+	};
+
+	/**
+	 * A score value that cannot be contained: bit 0 is required, but no
+	 * indexed entity ever sets bit 0 (all scores are even powers of two),
+	 * so the binary index has no entry at bit position 0.
+	 */
+	private static final long SCORE_NONE = 1L;
+
+	private GigaMap<Item> map;
+
+	@BeforeEach
+	void setUp()
+	{
+		this.map = GigaMap.<Item>Builder()
+			.withBitmapIndex(TAG)
+			.withBitmapIndex(SCORE)
+			.build();
+
+		this.map.add(new Item("A", 4L));    // id 0
+		this.map.add(new Item("A", 8L));    // id 1
+		this.map.add(new Item("B", 4L));    // id 2
+		this.map.add(new Item("B", 8L));    // id 3
+		this.map.add(new Item("C", 256L));  // id 4 — unique tag, unique high-bit score
+
+		assertEquals(5, this.map.size(), "Setup: expected 5 entities");
+	}
+
+	private Set<Long> scoresOf(final Condition<Item> condition)
+	{
+		return this.map.query(condition).toList().stream()
+			.map(Item::score)
+			.collect(Collectors.toSet());
+	}
+
+	// ----- sanity: individual queries --------------------------------------
+
+	@Test
+	void singleHashingQueryMatches()
+	{
+		assertEquals(Set.of(4L, 8L), this.scoresOf(TAG.is("A")));
+	}
+
+	@Test
+	void singleBinaryQueryMatches()
+	{
+		assertEquals(Set.of(4L), this.scoresOf(SCORE.is(4L)));
+	}
+
+	@Test
+	void singleBinaryQueryForNonExistentIsEmpty()
+	{
+		assertTrue(this.scoresOf(SCORE.is(SCORE_NONE)).isEmpty());
+	}
+
+	// ----- 2-way AND across index families ---------------------------------
+
+	@Test
+	void hashingAndBinaryBothMatch()
+	{
+		assertEquals(Set.of(4L), this.scoresOf(TAG.is("A").and(SCORE.is(4L))));
+	}
+
+	/**
+	 * Regression for issue #641, cross-family: the binary side has no match
+	 * ({@code SCORE_NONE} requires a bit position with no entry) while the
+	 * hashing side matches two entities. The AND must be empty.
+	 */
+	@Test
+	void hashingMatchAndBinaryNoMatchIsEmpty()
+	{
+		assertTrue(this.scoresOf(TAG.is("A").and(SCORE.is(SCORE_NONE))).isEmpty());
+	}
+
+	@Test
+	void hashingNoMatchAndBinaryMatchIsEmpty()
+	{
+		assertTrue(this.scoresOf(TAG.is("Z").and(SCORE.is(4L))).isEmpty());
+	}
+
+	@Test
+	void bothNoMatchIsEmpty()
+	{
+		assertTrue(this.scoresOf(TAG.is("Z").and(SCORE.is(SCORE_NONE))).isEmpty());
+	}
+
+	/**
+	 * Swapping hashing and binary operand positions must not change AND
+	 * semantics.
+	 */
+	@Test
+	void reversedChainOrderSameResult()
+	{
+		assertEquals(
+			this.scoresOf(TAG.is("A").and(SCORE.is(4L))),
+			this.scoresOf(SCORE.is(4L).and(TAG.is("A")))
+		);
+	}
+
+	/**
+	 * Same as above, but for the empty-binary case.
+	 */
+	@Test
+	void reversedChainOrderSameResultWithBinaryNoMatch()
+	{
+		assertEquals(
+			this.scoresOf(TAG.is("A").and(SCORE.is(SCORE_NONE))),
+			this.scoresOf(SCORE.is(SCORE_NONE).and(TAG.is("A")))
+		);
+	}
+
+	// ----- 3-way AND alternating index families ----------------------------
+
+	@Test
+	void threeWayAlternatingChainHashingBinaryHashing()
+	{
+		// tag=A AND score=8 AND tag=A  →  id 1
+		assertEquals(
+			Set.of(8L),
+			this.scoresOf(TAG.is("A").and(SCORE.is(8L)).and(TAG.is("A")))
+		);
+	}
+
+	@Test
+	void threeWayAlternatingChainBinaryHashingBinary()
+	{
+		// score=4 AND tag=B AND score=4  →  id 2
+		assertEquals(
+			Set.of(4L),
+			this.scoresOf(SCORE.is(4L).and(TAG.is("B")).and(SCORE.is(4L)))
+		);
+	}
+
+	@Test
+	void threeWayAlternatingChainWithContradiction()
+	{
+		// tag=A AND score=8 AND tag=B  →  empty (A and B are mutually exclusive)
+		assertTrue(
+			this.scoresOf(TAG.is("A").and(SCORE.is(8L)).and(TAG.is("B"))).isEmpty()
+		);
+	}
+
+	@Test
+	void threeWayNonMatchInTheMiddle()
+	{
+		// tag=A AND score=1 (no match) AND tag=B  →  empty; the binary no-match
+		// must short-circuit the intersection even sandwiched between hashing
+		// conditions. Before the #641 fix this returned entities that matched
+		// only the outer tag conditions.
+		assertTrue(
+			this.scoresOf(TAG.is("A").and(SCORE.is(SCORE_NONE)).and(TAG.is("B"))).isEmpty()
+		);
+	}
+
+	// ----- nested composites (the shape that historically leaked in #641) --
+
+	/**
+	 * Non-flattened nesting: the empty binary {@code ChainAnd} sits
+	 * <b>inside</b> another {@code ChainAnd}, alongside a non-empty sibling.
+	 * This is the exact shape that leaked in issue #641 (before the fix, the
+	 * sibling's bitmap won the AND because the empty {@code ChainAnd}
+	 * contributed {@code -1L}).
+	 */
+	@Test
+	void nestedAndWithBinaryNoMatchIsEmpty()
+	{
+		final Condition<Item> condition =
+			TAG.is("A").and(TAG.is("A").and(SCORE.is(SCORE_NONE)));
+
+		assertTrue(this.scoresOf(condition).isEmpty());
+	}
+
+	/**
+	 * Same nesting shape, but with the outer condition being binary and
+	 * the empty binary sitting deeper inside.
+	 */
+	@Test
+	void nestedAndWithBinaryNoMatchReversedIsEmpty()
+	{
+		final Condition<Item> condition =
+			SCORE.is(4L).and(TAG.is("A").and(SCORE.is(SCORE_NONE)));
+
+		assertTrue(this.scoresOf(condition).isEmpty());
+	}
+
+	// ----- OR across / wrapping mixed ANDs ---------------------------------
+
+	@Test
+	void orAcrossIndexTypes()
+	{
+		// tag=C OR score=4  →  ids 0, 2 (score=4) and 4 (tag=C)
+		assertEquals(
+			Set.of(4L, 256L),
+			this.scoresOf(TAG.is("C").or(SCORE.is(4L)))
+		);
+	}
+
+	@Test
+	void orWrappingAndAcrossIndexTypes()
+	{
+		// tag=Z  OR  (tag=A AND score=8)  →  id 1
+		final Condition<Item> idMatch    = TAG.is("Z");
+		final Condition<Item> tupleMatch = TAG.is("A").and(SCORE.is(8L));
+		assertEquals(Set.of(8L), this.scoresOf(idMatch.or(tupleMatch)));
+	}
+
+	/**
+	 * The "Or wrapping And" variant of issue #641, cross-family: neither
+	 * branch can match, so the overall result must be empty. Before the fix
+	 * the empty binary {@code ChainAnd} made the {@code And} branch vacuously
+	 * match every id, which flowed through the {@code Or} and returned the
+	 * whole map.
+	 */
+	@Test
+	void orWrappingAndWhereBothSidesAreEmpty()
+	{
+		final Condition<Item> lhs = SCORE.is(SCORE_NONE);
+		final Condition<Item> rhs = TAG.is("Z").and(SCORE.is(4L));
+		assertTrue(this.scoresOf(lhs.or(rhs)).isEmpty());
+	}
+
+	/**
+	 * OR branch whose AND includes an empty binary condition &mdash; the AND
+	 * side must contribute nothing, leaving only the OR's hashing branch.
+	 */
+	@Test
+	void orBranchWithBinaryNoMatchDoesNotLeakIntoResult()
+	{
+		// tag=C  OR  (tag=A AND score=1)   →  just tag=C (id 4)
+		final Condition<Item> lhs = TAG.is("C");
+		final Condition<Item> rhs = TAG.is("A").and(SCORE.is(SCORE_NONE));
+		assertEquals(Set.of(256L), this.scoresOf(lhs.or(rhs)));
+	}
+
+	// ----- NOT across mixed composites -------------------------------------
+
+	@Test
+	void notOnBinarySideOfMixedAnd()
+	{
+		// tag=A AND score != 4  →  id 1 (tag=A, score=8)
+		assertEquals(Set.of(8L), this.scoresOf(TAG.is("A").and(SCORE.not(4L))));
+	}
+
+	@Test
+	void notOnHashingSideOfMixedAnd()
+	{
+		// tag != A AND score=4  →  id 2 (tag=B, score=4)
+		assertEquals(Set.of(4L), this.scoresOf(TAG.not("A").and(SCORE.is(4L))));
+	}
+
+	// ----- composed vs. sequential ----------------------------------------
+
+	/**
+	 * Sequential {@code GigaQuery.and(Condition)} and composed
+	 * {@code Condition.and(Condition)} must produce identical results,
+	 * including when one condition resolves to "no match". This is the
+	 * workaround path documented in the #641 reproducer.
+	 */
+	@Test
+	void sequentialAndMatchesComposed()
+	{
+		final List<Item> composed   = this.map.query(TAG.is("A").and(SCORE.is(SCORE_NONE))).toList();
+		final List<Item> sequential = this.map.query()
+			.and(TAG.is("A"))
+			.and(SCORE.is(SCORE_NONE))
+			.toList();
+
+		assertEquals(composed, sequential);
+		assertTrue(sequential.isEmpty());
+	}
+
+	// ----- sub-query composition across mixed index types ------------------
+
+	/**
+	 * Closes the sub-query coverage gap &mdash; {@link SubQueryCompositionTest}
+	 * only exercises hashing indexes.
+	 */
+	@Nested
+	class SubQueryComposition
+	{
+		@Test
+		void primaryHashingWithBinarySubQuery()
+		{
+			// tag=A AND (sub-query: score=8)  →  id 1
+			final GigaQuery<Item> sub =
+				MixedIndexCompositeConditionTest.this.map.query(SCORE.is(8L));
+
+			final Set<Long> result =
+				MixedIndexCompositeConditionTest.this.map.query(TAG).is("A")
+					.and(sub)
+					.toList().stream().map(Item::score).collect(Collectors.toSet());
+
+			assertEquals(Set.of(8L), result);
+		}
+
+		@Test
+		void primaryBinaryWithHashingSubQuery()
+		{
+			// score=4 AND (sub-query: tag=A)  →  id 0
+			final GigaQuery<Item> sub =
+				MixedIndexCompositeConditionTest.this.map.query(TAG.is("A"));
+
+			final Set<Long> result =
+				MixedIndexCompositeConditionTest.this.map.query(SCORE).is(4L)
+					.and(sub)
+					.toList().stream().map(Item::score).collect(Collectors.toSet());
+
+			assertEquals(Set.of(4L), result);
+		}
+
+		@Test
+		void binarySubQueryRejectingEverythingProducesEmpty()
+		{
+			// Binary sub-query has no match, so the AND must be empty even
+			// though the hashing primary matches two entities.
+			final GigaQuery<Item> rejecting =
+				MixedIndexCompositeConditionTest.this.map.query(SCORE.is(SCORE_NONE));
+
+			final long count =
+				MixedIndexCompositeConditionTest.this.map.query(TAG).is("A")
+					.and(rejecting)
+					.count();
+
+			assertEquals(0L, count);
+		}
+
+		@Test
+		void hashingSubQueryRejectingEverythingProducesEmpty()
+		{
+			// Symmetric: binary primary, hashing sub-query rejects everything.
+			final GigaQuery<Item> rejecting =
+				MixedIndexCompositeConditionTest.this.map.query(TAG.is("Z"));
+
+			final long count =
+				MixedIndexCompositeConditionTest.this.map.query(SCORE).is(4L)
+					.and(rejecting)
+					.count();
+
+			assertEquals(0L, count);
+		}
+	}
+}


### PR DESCRIPTION
### Description

This pull request resolves an issue in `AbstractBitmapIndexBinary.internalQuery`, where non-matching IDs were incorrectly passed through composite conditions, leading to erroneous query results. The fix ensures that the BitmapResult.Empty singleton is returned when no match is possible, aligning behavior with `AbstractBitmapIndexHashing.internalQuery`.

### Summary of changes

- Fixed `AbstractBitmapIndexBinary.internalQuery` to return `BitmapResult.Empty` instead of an empty `ChainAnd` for non-matching keys.
- Added a regression test (`BinaryIndexerCompositeConditionTest`) to verify the fix and prevent future issues.
