### PR TITLE
Add tests for constraints

### DIFF
--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintViolationExceptionFieldsTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintViolationExceptionFieldsTest.java
@@ -1,0 +1,209 @@
+package org.eclipse.store.gigamap.constraint;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the fields carried by {@link ConstraintViolationException}:
+ * - {@code entityId}, {@code replacedEntity}, {@code violatingEntity}
+ *
+ * Also covers the identity + unique index combination:
+ * - Builder API: {@code withBitmapIdentityIndex} + {@code withBitmapUniqueIndex}
+ * - Post-creation API: {@code ensure} + {@code setIdentityIndices} + {@code addUniqueConstraint}
+ */
+public class ConstraintViolationExceptionFieldsTest
+{
+	static final class Person
+	{
+		String email; // mutable — allows in-place update() mutations
+		int    level;
+
+		Person(final String email, final int level)
+		{
+			this.email = email;
+			this.level = level;
+		}
+	}
+
+	static final BinaryIndexerString<Person> EMAIL_INDEX = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Person p)
+		{
+			return p.email;
+		}
+	};
+
+	// ---------------------------------------------------------------
+	// add() — replacedEntity must be null
+	// ---------------------------------------------------------------
+
+	@Test
+	void add_exceptionHasNullReplacedEntity()
+	{
+		final GigaMap<Person> map = GigaMap.<Person>Builder()
+			.withBitmapUniqueIndex(EMAIL_INDEX)
+			.build();
+
+		map.add(new Person("a@test.com", 1));
+		final Person duplicate = new Person("a@test.com", 2);
+
+		final UniqueConstraintViolationException ex = assertThrows(
+			UniqueConstraintViolationException.class,
+			() -> map.add(duplicate)
+		);
+
+		assertNull(ex.getReplacedEntity(),        "add() has no previous entity — replacedEntity must be null");
+		assertSame(duplicate, ex.getViolatingEntity(), "violatingEntity must be the rejected entity");
+		// During add(), constraints are checked before an ID is assigned; -1 signals "no ID yet".
+		assertEquals(-1L, ex.getEntityId(),       "entityId is -1 for add() — entity not yet permanently placed");
+	}
+
+	// ---------------------------------------------------------------
+	// set() — replacedEntity must be the previous entity
+	// ---------------------------------------------------------------
+
+	@Test
+	void set_exceptionHasPreviousEntityAsReplaced()
+	{
+		final GigaMap<Person> map = GigaMap.<Person>Builder()
+			.withBitmapUniqueIndex(EMAIL_INDEX)
+			.build();
+
+		final Person alice = new Person("alice@test.com", 1);
+		map.add(new Person("bob@test.com", 2));
+		final long aliceId = map.add(alice);
+
+		final Person replacement = new Person("bob@test.com", 9); // duplicates bob's email
+		final UniqueConstraintViolationException ex = assertThrows(
+			UniqueConstraintViolationException.class,
+			() -> map.set(aliceId, replacement)
+		);
+
+		assertSame(alice, ex.getReplacedEntity(),         "replacedEntity must be the entity that was in the map");
+		assertSame(replacement, ex.getViolatingEntity(), "violatingEntity must be the rejected replacement");
+		assertEquals(aliceId, ex.getEntityId(),           "entityId must match the slot being replaced");
+	}
+
+	// ---------------------------------------------------------------
+	// update() — entityId identifies the ejected entity
+	//
+	// update() mutates in place; GigaMap cannot roll back an arbitrary lambda,
+	// so it ejects the entity.  The exception carries the pre-ejection entityId,
+	// letting the caller re-add the entity after fixing the violation.
+	//
+	// NOTE: CustomConstraint.Abstract.check() receives the same (already mutated)
+	// object for both replacedEntity and entity during update().  Comparing them
+	// is therefore not meaningful.  Use a unique-index constraint instead, whose
+	// violation is detected by comparing bitmap state — not the entity object.
+	// ---------------------------------------------------------------
+
+	@Test
+	void update_exceptionCarriesEjectedEntityId()
+	{
+		final GigaMap<Person> map = GigaMap.<Person>Builder()
+			.withBitmapUniqueIndex(EMAIL_INDEX)
+			.build();
+
+		final Person alice = new Person("alice@test.com", 1);
+		final long idAlice = map.add(alice);
+		map.add(new Person("bob@test.com", 2));
+
+		final UniqueConstraintViolationException ex = assertThrows(
+			UniqueConstraintViolationException.class,
+			() -> map.update(alice, p -> p.email = "bob@test.com")
+		);
+
+		assertEquals(idAlice, ex.getEntityId(),
+			"entityId in exception must match the ejected entity's id");
+		assertNull(map.peek(idAlice),
+			"peek() must return null for the ejected id");
+		assertEquals(1, map.size(),
+			"only bob must remain after alice is ejected");
+	}
+
+	// ---------------------------------------------------------------
+	// Unique + identity index — builder API
+	//
+	// withBitmapIdentityIndex and withBitmapUniqueIndex cannot use the same
+	// indexer instance inside the builder (it would register the bitmap index
+	// twice). The correct builder pattern is withBitmapUniqueIndex only, then
+	// setIdentityIndices() on the built map.
+	// ---------------------------------------------------------------
+
+	@Test
+	void uniqueAndIdentityIndex_builder_enforcesUniqueness()
+	{
+		final GigaMap<Person> map = GigaMap.<Person>Builder()
+			.withBitmapUniqueIndex(EMAIL_INDEX)
+			.build();
+
+		map.add(new Person("alice@test.com", 1));
+		map.add(new Person("bob@test.com", 2));
+
+		assertThrows(UniqueConstraintViolationException.class,
+			() -> map.add(new Person("alice@test.com", 99)));
+
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	void uniqueAndIdentityIndex_builder_setIdentityAfterBuild()
+	{
+		// withBitmapUniqueIndex registers the index as both a bitmap index and a
+		// unique constraint.  setIdentityIndices() then promotes it to identity.
+		final GigaMap<Person> map = GigaMap.<Person>Builder()
+			.withBitmapUniqueIndex(EMAIL_INDEX)
+			.build();
+		map.index().bitmap().setIdentityIndices(EMAIL_INDEX);
+
+		final Person alice = new Person("alice@test.com", 1);
+		map.add(alice);
+
+		map.update(alice, p -> p.level = 42);
+		assertEquals(42, alice.level);
+		assertEquals(1, map.query(EMAIL_INDEX.is("alice@test.com")).count());
+	}
+
+	// ---------------------------------------------------------------
+	// Unique + identity index — post-creation API
+	//
+	// addUniqueConstraint() registers the index as both a bitmap index and a
+	// unique constraint in one step.  setIdentityIndices() is called afterward.
+	// ---------------------------------------------------------------
+
+	@Test
+	void uniqueAndIdentityIndex_postCreation_updateViaIdentity()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		final BitmapIndices<Person> bitmap = map.index().bitmap();
+		bitmap.addUniqueConstraint(EMAIL_INDEX);
+		bitmap.setIdentityIndices(EMAIL_INDEX);
+
+		final Person alice = new Person("alice@test.com", 5);
+		map.add(alice);
+
+		map.update(alice, p -> p.level = 20);
+		assertEquals(20, alice.level);
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/CustomConstraintEdgeCasesTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/CustomConstraintEdgeCasesTest.java
@@ -1,0 +1,300 @@
+package org.eclipse.store.gigamap.constraint;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.util.X;
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.CustomConstraint;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Edge-case tests for custom constraints covering:
+ * - addConstraints() registering multiple constraints at once
+ * - addConstraint() on a non-empty map validates existing entities immediately
+ * - CustomConstraint.Abstract using the replacedEntity parameter
+ * - CustomConstraint.Wrapper cross-checking other entities via the GigaMap instance
+ * - Duplicate constraint name rejection
+ */
+public class CustomConstraintEdgeCasesTest
+{
+	// ---------------------------------------------------------------
+	// Shared domain
+	// ---------------------------------------------------------------
+
+	static final class Item
+	{
+		String name;
+		int    level;
+		String project;
+
+		Item(final String name, final int level, final String project)
+		{
+			this.name    = name;
+			this.level   = level;
+			this.project = project;
+		}
+	}
+
+	static final IndexerString<Item> PROJECT_INDEX = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item item)
+		{
+			return item.project;
+		}
+	};
+
+	// ---------------------------------------------------------------
+	// Named constraint classes (required for any persisted GigaMap)
+	// ---------------------------------------------------------------
+
+	static final class NoNamedBad extends CustomConstraint.AbstractSimple<Item>
+	{
+		@Override
+		public boolean isViolated(final Item item)
+		{
+			return item.name.equals("BAD");
+		}
+	}
+
+	static final class NoLevelZero extends CustomConstraint.AbstractSimple<Item>
+	{
+		@Override
+		public boolean isViolated(final Item item)
+		{
+			return item.level == 0;
+		}
+	}
+
+	/**
+	 * Rejects any update that decreases the level.
+	 * Uses the replacedEntity parameter to compare old vs. new state.
+	 */
+	static final class NoLevelDowngrade extends CustomConstraint.Abstract<Item>
+	{
+		@Override
+		public void check(final long entityId, final Item replaced, final Item entity)
+		{
+			if(replaced != null && entity.level < replaced.level)
+			{
+				throw new ConstraintViolationException(entityId, replaced, entity);
+			}
+		}
+	}
+
+	/**
+	 * Limits each project to at most 2 items.
+	 * Uses the GigaMap instance (Wrapper) to count existing items in the same project
+	 * before allowing the add.
+	 *
+	 * During add(), the entity is not yet in the bitmap index when this lambda runs,
+	 * so the count reflects items already committed to that project.
+	 */
+	static final CustomConstraint.Wrapper<Item> MAX_2_PER_PROJECT = new CustomConstraint.Wrapper<>(
+		(gigaMap, entityId, replaced, entity, createException) ->
+		{
+			// On update the net count stays the same — only restrict new adds.
+			if(replaced != null)
+			{
+				return null;
+			}
+			final long count = gigaMap.query(PROJECT_INDEX.is(entity.project)).count();
+			if(count >= 2)
+			{
+				return createException
+					? new ConstraintViolationException(entityId, null, entity)
+					: X.BREAK();
+			}
+			return null;
+		}
+	);
+
+	// ---------------------------------------------------------------
+	// addConstraints() — multiple constraints registered in one call
+	// ---------------------------------------------------------------
+
+	@Test
+	void addConstraints_multiple_allEnforced()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.constraints().custom().addConstraints(new NoNamedBad(), new NoLevelZero());
+
+		// Each constraint fires independently
+		assertThrows(ConstraintViolationException.class,
+			() -> map.add(new Item("BAD", 5, "A")));
+
+		assertThrows(ConstraintViolationException.class,
+			() -> map.add(new Item("ok", 0, "A")));
+
+		map.add(new Item("ok", 5, "A"));
+		assertEquals(1, map.size());
+	}
+
+	// ---------------------------------------------------------------
+	// addConstraint() on a non-empty GigaMap
+	// ---------------------------------------------------------------
+
+	@Test
+	void addConstraint_nonEmptyMap_existingViolation_throwsAndConstraintNotRegistered()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.add(new Item("BAD", 5, "A")); // already in map before constraint is added
+
+		// Adding the constraint must fail because the existing entity violates it
+		assertThrows(ConstraintViolationException.class,
+			() -> map.constraints().custom().addConstraint(new NoNamedBad()));
+
+		// Constraint must NOT be registered — adding another violating entity is still allowed
+		assertDoesNotThrow(() -> map.add(new Item("BAD", 3, "B")));
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	void addConstraint_nonEmptyMap_noViolation_constraintAppliedToFutureWrites()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.add(new Item("good", 5, "A")); // no violation
+
+		// Adding the constraint succeeds — no existing entity violates it
+		assertDoesNotThrow(() -> map.constraints().custom().addConstraint(new NoNamedBad()));
+
+		// Future writes are now checked
+		assertThrows(ConstraintViolationException.class,
+			() -> map.add(new Item("BAD", 3, "B")));
+		assertEquals(1, map.size());
+	}
+
+	// ---------------------------------------------------------------
+	// CustomConstraint.Abstract — uses replacedEntity
+	//
+	// NOTE: update() with a Consumer mutates the entity in place, so both
+	// replacedEntity and entity are the same object by the time check() is
+	// called.  Comparing them is meaningless there.  Use set() to get a
+	// genuine pre/post comparison via the replacedEntity parameter.
+	// ---------------------------------------------------------------
+
+	@Test
+	void abstract_set_upgradeAllowed_downgradeRejected()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.constraints().custom().addConstraint(new NoLevelDowngrade());
+
+		final long id = map.add(new Item("task", 5, "A"));
+
+		// Upgrade via set(): replacedEntity.level=5, entity.level=7 → no violation
+		map.set(id, new Item("task-v2", 7, "A"));
+		assertEquals(7, map.get(id).level);
+
+		// Downgrade via set(): replacedEntity.level=7, entity.level=3 → VIOLATION
+		assertThrows(ConstraintViolationException.class,
+			() -> map.set(id, new Item("task-v3", 3, "A")));
+
+		// set() rejects without ejecting — the original entity stays in place
+		assertEquals(7, map.get(id).level);
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	void abstract_addWithNullReplacedEntity_notChecked()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.constraints().custom().addConstraint(new NoLevelDowngrade());
+
+		// add() always passes — replacedEntity is null, constraint skips the check
+		map.add(new Item("x", 1, "A"));
+		map.add(new Item("y", 100, "A"));
+		assertEquals(2, map.size());
+	}
+
+	// ---------------------------------------------------------------
+	// CustomConstraint.Wrapper — cross-checks the GigaMap
+	// ---------------------------------------------------------------
+
+	@Test
+	void wrapper_crossChecksMapCount_limitsPerProject()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.constraints().custom().addConstraint(MAX_2_PER_PROJECT);
+
+		map.add(new Item("i1", 1, "Alpha"));
+		map.add(new Item("i2", 2, "Alpha"));
+
+		// Third item in "Alpha" exceeds the per-project limit
+		assertThrows(ConstraintViolationException.class,
+			() -> map.add(new Item("i3", 3, "Alpha")));
+
+		// Other projects are independent
+		map.add(new Item("j1", 1, "Beta"));
+		map.add(new Item("j2", 2, "Beta"));
+
+		assertEquals(4, map.size());
+		assertEquals(2, map.query(PROJECT_INDEX.is("Alpha")).count());
+		assertEquals(2, map.query(PROJECT_INDEX.is("Beta")).count());
+	}
+
+	@Test
+	void wrapper_updateDoesNotCountAgainstProjectLimit()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.constraints().custom().addConstraint(MAX_2_PER_PROJECT);
+
+		final Item i1 = new Item("i1", 1, "Alpha");
+		final Item i2 = new Item("i2", 2, "Alpha");
+		map.add(i1);
+		map.add(i2);
+
+		// Updating (not adding) must succeed even though Alpha is at the limit
+		assertDoesNotThrow(() -> map.update(i1, i -> i.level = 99));
+		assertEquals(99, i1.level);
+	}
+
+	// ---------------------------------------------------------------
+	// Duplicate constraint name
+	// ---------------------------------------------------------------
+
+	@Test
+	void duplicateConstraintName_throwsIllegalArgument()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+		map.constraints().custom().addConstraint(new NoNamedBad());
+
+		// Registering the same named constraint a second time must fail
+		assertThrows(IllegalArgumentException.class,
+			() -> map.constraints().custom().addConstraint(new NoNamedBad()));
+	}
+
+	@Test
+	void duplicateConstraintName_inBatch_throwsIllegalArgument()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(PROJECT_INDEX);
+
+		// Both constraints share the same class simple name = "NoNamedBad"
+		assertThrows(IllegalArgumentException.class,
+			() -> map.constraints().custom().addConstraints(new NoNamedBad(), new NoNamedBad()));
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/MultiValueConstraintRollbackTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/MultiValueConstraintRollbackTest.java
@@ -1,0 +1,174 @@
+package org.eclipse.store.gigamap.constraint;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.CustomConstraint;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerMultiValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that multi-value index keys are correctly cleaned up when an update()
+ * triggers a constraint violation part-way through.
+ */
+public class MultiValueConstraintRollbackTest
+{
+	static final class Tag
+	{
+		final String value;
+
+		Tag(final String value)
+		{
+			this.value = value;
+		}
+
+		@Override
+		public String toString()
+		{
+			return this.value;
+		}
+	}
+
+	static final class Article
+	{
+		String title;
+		List<Tag> tags;
+
+		Article(final String title, final List<Tag> tags)
+		{
+			this.title = title;
+			this.tags = tags;
+		}
+	}
+
+	static final IndexerMultiValue.Abstract<Article, Tag> TAG_INDEX =
+		new IndexerMultiValue.Abstract<Article, Tag>()
+		{
+			@Override
+			public Iterable<? extends Tag> indexEntityMultiValue(final Article entity)
+			{
+				return entity.tags;
+			}
+
+			@Override
+			public Class<Tag> keyType()
+			{
+				return Tag.class;
+			}
+		};
+
+	static final Tag T_ALPHA = new Tag("alpha");
+	static final Tag T_BETA  = new Tag("beta");
+	static final Tag T_NEW1  = new Tag("new1");
+	static final Tag T_NEW2  = new Tag("new2");
+
+	private static GigaMap<Article> createMap()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		map.index().bitmap().add(TAG_INDEX);
+		map.constraints().custom().addConstraint(
+			new CustomConstraint.AbstractSimple<Article>()
+			{
+				@Override
+				public boolean isViolated(final Article entity)
+				{
+					return entity.title.startsWith("BANNED");
+				}
+			}
+		);
+		return map;
+	}
+
+	@Test
+	void failedUpdate_entityRemovedAndOldKeysCleanedUp()
+	{
+		final GigaMap<Article> map = createMap();
+
+		final Article article1 = new Article("good-article", List.of(T_ALPHA, T_BETA));
+		final Article article2 = new Article("other-article", List.of(T_ALPHA));
+		map.addAll(article1, article2);
+
+		assertEquals(2, map.query(TAG_INDEX.is(T_ALPHA)).count());
+		assertEquals(1, map.query(TAG_INDEX.is(T_BETA)).count());
+
+		assertThrows(
+			ConstraintViolationException.class,
+			() -> map.update(article1, a -> {
+				a.title = "BANNED-title";
+				a.tags = List.of(T_NEW1, T_NEW2);
+			})
+		);
+
+		assertEquals(1, map.size());
+
+		// Old keys for article1 must be gone from the index
+		assertEquals(1, map.query(TAG_INDEX.is(T_ALPHA)).count(), "article2 still has alpha");
+		assertEquals(0, map.query(TAG_INDEX.is(T_BETA)).count(), "beta must be cleaned up");
+
+		// New keys must never have been added
+		assertEquals(0, map.query(TAG_INDEX.is(T_NEW1)).count());
+		assertEquals(0, map.query(TAG_INDEX.is(T_NEW2)).count());
+	}
+
+	@Test
+	void failedUpdate_otherEntityKeysUnaffected()
+	{
+		final GigaMap<Article> map = createMap();
+
+		final Tag sharedTag = new Tag("shared");
+		final Article article1 = new Article("a1", List.of(sharedTag, T_BETA));
+		final Article article2 = new Article("a2", List.of(sharedTag));
+		map.addAll(article1, article2);
+
+		assertEquals(2, map.query(TAG_INDEX.is(sharedTag)).count());
+
+		assertThrows(
+			ConstraintViolationException.class,
+			() -> map.update(article1, a -> {
+				a.title = "BANNED-a1";
+				a.tags = List.of(T_NEW1);
+			})
+		);
+
+		// article2 must still be queryable via the shared tag
+		assertEquals(1, map.query(TAG_INDEX.is(sharedTag)).count());
+
+		final List<Article> results = map.query(TAG_INDEX.is(sharedTag)).toList();
+		assertEquals(1, results.size());
+		assertEquals("a2", results.get(0).title);
+	}
+
+	@Test
+	void successfulUpdate_multiValueKeysCorrectlyReplaced()
+	{
+		final GigaMap<Article> map = createMap();
+
+		final Article article = new Article("ok-article", List.of(T_ALPHA, T_BETA));
+		map.add(article);
+
+		map.update(article, a -> a.tags = List.of(T_NEW1, T_NEW2));
+
+		assertEquals(0, map.query(TAG_INDEX.is(T_ALPHA)).count());
+		assertEquals(0, map.query(TAG_INDEX.is(T_BETA)).count());
+		assertEquals(1, map.query(TAG_INDEX.is(T_NEW1)).count());
+		assertEquals(1, map.query(TAG_INDEX.is(T_NEW2)).count());
+		assertEquals(1, map.size());
+	}
+}


### PR DESCRIPTION
This pull request introduces comprehensive new test coverage for constraint handling in the `GigaMap` module. The tests focus on verifying the behavior of custom constraints, unique and identity index combinations, multi-value index rollback on constraint violations, and edge cases such as duplicate constraint registration. The changes ensure that constraint violations are handled correctly and that the map's state remains consistent after failed operations.

**Constraint Violation and Index Handling:**

* Added `ConstraintViolationExceptionFieldsTest` to verify that `ConstraintViolationException` fields (`entityId`, `replacedEntity`, `violatingEntity`) are correctly set during `add`, `set`, and `update` operations, and to test the interaction of unique and identity indices via builder and post-creation APIs.
* Introduced `MultiValueConstraintRollbackTest` to ensure that when an `update()` operation fails due to a constraint violation, all multi-value index keys are properly rolled back and cleaned up, and that successful updates correctly update the index.

**Custom Constraint Edge Cases:**

* Added `CustomConstraintEdgeCasesTest` to cover:
  - Registering multiple custom constraints at once and enforcing them independently.
  - Immediate validation of existing entities when adding a constraint to a non-empty map.
  - Use of the `replacedEntity` parameter in custom constraints for detecting state changes.
  - Cross-checking constraints that depend on the current map state (e.g., per-project limits).
  - Rejection of duplicate constraint names, both individually and in batch registration.