### PR TITLE
Improve documentation for StorageManager and StorageController

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageController.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageController.java
@@ -21,7 +21,7 @@ import org.eclipse.store.storage.exceptions.StorageExceptionShutdown;
  * The StorageController interface defines the contract for managing and controlling a storage system.
  * It provides methods to initialize, start, monitor, and shut down the storage operations, ensuring
  * appropriate handling of state transitions and task processing capabilities.
- *
+ * <p>
  * This interface extends both StorageActivePart and AutoCloseable, combining functionalities for
  * active storage management and resource cleanup during lifecycle management.
  */
@@ -31,16 +31,32 @@ public interface StorageController extends StorageActivePart, AutoCloseable
 	 * "Starts" the storage controlled by this {@link StorageController} instance, with "starting" meaning:<br>
 	 * <ul>
 	 * <li>Reading, indexing and potentially caching all the persisted data in the storage.</li>
+	 * <li>Recovering from a previous unclean shutdown by truncating any partially written tail of the
+	 *     last store, so that the in-memory state matches the last fully persisted state.</li>
 	 * <li>Starting storage managing threads to execute requests like storing, loading and issued utility functions.</li>
 	 * </ul>
-	 * 
+	 * After this method returns successfully, the storage is ready to accept tasks (see
+	 * {@link #isAcceptingTasks()}) and the registered root reference (if any) has been resolved.
+	 *
 	 * @return this to allow writing of fluent code.
 	 */
 	public StorageController start();
 
 	/**
 	 * Issues a command to shut down all active threads managing the storage.
-	 * 
+	 * <p>
+	 * <b>Calling {@code shutdown()} is not required for data integrity.</b> The storage is designed so
+	 * that every successful {@code store(...)} call physically commits its data before returning;
+	 * a process crash, kill, or {@code System.exit(0)} therefore cannot corrupt the persisted data, and
+	 * the next {@link #start()} will resume from the last fully persisted state.
+	 * <p>
+	 * An explicit shutdown is meaningful only when:
+	 * <ul>
+	 *   <li>The application keeps running but wants to stop the storage threads (e.g. to change
+	 *       configuration, copy or back up the storage files, then call {@link #start()} again).</li>
+	 *   <li>The application uses {@link AutoCloseable} / try-with-resources purely for hygiene reasons.</li>
+	 * </ul>
+	 *
 	 * @return <code>true</code> after a successful shutdown or <code>false</code>
 	 *         if an internal {@link InterruptedException} happened.
 	 */
@@ -83,7 +99,7 @@ public interface StorageController extends StorageActivePart, AutoCloseable
 	
 	/**
 	 * Checks whether the storage controlled by this instance has been shut down.
-	 *
+	 * <p>
 	 * This method determines the shutdown state by checking if the storage is no longer running.
 	 *
 	 * @return true if the storage is shut down, false otherwise.
@@ -97,7 +113,7 @@ public interface StorageController extends StorageActivePart, AutoCloseable
 	 * Ensures that the storage is accepting tasks by internally checking its state.
 	 * This method verifies the ability of the storage to process new tasks and may
 	 * throw an exception if the storage is not in a state to accept tasks.
-	 *
+	 * <p>
 	 * Depending on the internal implementation, it could check conditions like whether
 	 * the storage is running, not shutting down, and has not encountered critical errors.
 	 *
@@ -144,7 +160,7 @@ public interface StorageController extends StorageActivePart, AutoCloseable
 	 * Closes the storage controller by shutting down all associated resources and
 	 * threads managing the storage. This method ensures that the storage is properly
 	 * terminated and no background processes are left running.
-	 *
+	 * <p>
 	 * If the shutdown process fails, a {@link StorageExceptionShutdown} is thrown with
 	 * an appropriate error message and cause if available.
 	 *
@@ -153,7 +169,7 @@ public interface StorageController extends StorageActivePart, AutoCloseable
 	@Override
 	public default void close() throws StorageExceptionShutdown
 	{
-		boolean success;
+		final boolean success;
 		try
 		{
 			success = this.shutdown();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageController.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageController.java
@@ -50,11 +50,16 @@ public interface StorageController extends StorageActivePart, AutoCloseable
 	 * a process crash, kill, or {@code System.exit(0)} therefore cannot corrupt the persisted data, and
 	 * the next {@link #start()} will resume from the last fully persisted state.
 	 * <p>
-	 * An explicit shutdown is meaningful only when:
+	 * That said, a clean shutdown is still recommended. Using {@link AutoCloseable} /
+	 * try-with-resources is the preferred idiom for shutting the storage down at the end of its
+	 * lifecycle. An explicit shutdown:
 	 * <ul>
-	 *   <li>The application keeps running but wants to stop the storage threads (e.g. to change
+	 *   <li>Releases the storage lock file promptly. After a crash the lock entry remains on disk
+	 *       and the next {@link #start()} is blocked until the lock expires; a clean shutdown
+	 *       avoids that delay.</li>
+	 *   <li>Releases held file handles and other OS resources owned by the storage threads.</li>
+	 *   <li>Allows stopping the storage while the application keeps running (e.g. to change
 	 *       configuration, copy or back up the storage files, then call {@link #start()} again).</li>
-	 *   <li>The application uses {@link AutoCloseable} / try-with-resources purely for hygiene reasons.</li>
 	 * </ul>
 	 *
 	 * @return <code>true</code> after a successful shutdown or <code>false</code>

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
@@ -26,19 +26,41 @@ import java.util.function.Supplier;
  * Central managing type for a native Java database's storage layer.
  * <p>
  * For all intents and purposes, a {@link StorageManager} instance represents the storage of a database in the
- * Java application that uses it. It is used for starting and stopping storage managements threads,
- * call storage-level utility functionality like clearing the low-level data cache, cleaning up / condensing
+ * Java application that uses it. It is used for starting and stopping storage management threads,
+ * calling storage-level utility functionality like clearing the low-level data cache, cleaning up / condensing
  * storage files or calling the storage-level garbage collector to remove data that has become unreachable in the
  * entity graph. This type also allows querying the used {@link StorageConfiguration} or the
  * {@link StorageTypeDictionary} that defines the persistent structure of all handled types.
  * <p>
- * For the most cases, only the methods {@link #root()}, {@link #setRoot(Object)}, {@link #start()} and
- * {@link #shutdown()} are important. Everything else is used for more or less advanced purposes and should only be used
- * with good knowledge about the effects caused by it.
+ * For most cases, only the methods {@link #root()}, {@link #setRoot(Object)}, {@link #storeRoot()},
+ * {@link #start()} and {@link #shutdown()} are important. Everything else is used for more or less advanced
+ * purposes and should only be used with good knowledge about the effects caused by it.
  * <p>
  * A {@link StorageManager} instance is also implicitly a {@link StorageConnection}, so that developers don't
  * need to care about connections at all if a single connection suffices.
  *
+ * <h2>Usage rules every caller must know</h2>
+ * <ul>
+ *   <li><b>The modified object must be stored.</b> The default storer is lazy: it persists only instances
+ *       that are not yet known to the persistent context. An already-persisted object whose fields you
+ *       mutated will <i>not</i> be picked up by storing one of its ancestors. Call {@code store(Object)}
+ *       on the actually modified instance, or use {@link #createEagerStorer()} when you need recursive
+ *       storing of already-known instances.</li>
+ *   <li><b>Mutation and storing must happen under the same lock.</b> {@link StorageManager} does not
+ *       synchronize the in-memory object graph for you. In a multi-threaded application, the modification
+ *       of an object and the corresponding {@code store(...)} call must be executed atomically with
+ *       respect to other threads &mdash; otherwise other threads may observe partially modified state, or
+ *       the persisted data may not reflect the intended change.</li>
+ *   <li><b>Crash safety.</b> Once a {@code store(...)} call returns, the data it stored is guaranteed to
+ *       be physically written to the underlying storage layer. A process crash before that point causes
+ *       the next {@link #start()} to truncate the partially written store and resume from the last fully
+ *       persisted state. As a consequence, calling {@link #shutdown()} is not required for data
+ *       integrity; see {@link #shutdown()} for the cases in which it is actually meaningful.</li>
+ *   <li><b>One running {@link StorageManager} per data location.</b> Any number of {@link StorageManager}
+ *       instances may run in the same JVM, but no two running instances may target the same data
+ *       location. The read-only mode (see {@code StorageWriteControllerReadOnlyMode}) lifts this for
+ *       read access, with the limitations documented there.</li>
+ * </ul>
  */
 public interface StorageManager extends StorageController, StorageConnection, DatabasePart
 {
@@ -54,7 +76,7 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	 * handled by the storage represented by this {@link StorageManager} instance. This list grows dynamically
 	 * as so far unknown types are discovered, analyzed, mapped and added on the fly by a store.
 	 * 
-	 * @return thr current {@link StorageTypeDictionary}.
+	 * @return the current {@link StorageTypeDictionary}.
 	 */
 	public StorageTypeDictionary typeDictionary();
 
@@ -72,10 +94,14 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 
 	/**
 	 * Creates a new {@link StorageConnection} instance. See the type description for details.<br>
-	 * Not that while it makes sense on an architectural level to have a connecting mechanism between
+	 * Note that while it makes sense on an architectural level to have a connecting mechanism between
 	 * application logic and storage level, there is currently no need to create additional connections beyond the
-	 * intrinsic one held inside a {@link StorageManager} instance. Just use it instead.
-	 * 
+	 * intrinsic one held inside a {@link StorageManager} instance for typical use cases. Just use the
+	 * {@link StorageManager} instance itself.<br>
+	 * Creating a dedicated connection is only relevant for advanced scenarios where you need a
+	 * connection-scoped {@link org.eclipse.serializer.persistence.types.PersistenceManager} (e.g. for
+	 * isolating a parallel storer with its own object registry view).
+	 *
 	 * @return a new {@link StorageConnection} instance.
 	 */
 	public StorageConnection createConnection();
@@ -83,20 +109,46 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	/**
 	 * Returns the current root object of the persistent object graph managed by this instance.
 	 * The root object is the entry point for accessing the graph of persisted objects.
+	 * <p>
+	 * Internally there are two distinct root mechanisms: a <i>default root</i> (set via
+	 * {@link #setRoot(Object)} after the manager has been started) and a <i>custom root</i> (registered
+	 * directly at database setup, e.g. via {@code EmbeddedStorage.start(myRoot)}). This method
+	 * transparently returns whichever variant is in use.
+	 * <p>
+	 * The return type is {@link Object} by design &mdash; the storage layer cannot know the concrete root
+	 * type, and adding a type parameter just for this would be more complication than benefit. The
+	 * {@code <R>} type parameter is therefore an unchecked convenience cast; prefer keeping a typed
+	 * reference to your root in application code instead of relying on it.
 	 *
-	 * @param <R> the type of the root object
-	 * @return the root object of the persistent object graph, or null if no root is currently set
+	 * @param <R> the type of the root object (unchecked convenience cast)
+	 * @return the root object of the persistent object graph, or {@code null} if no root is currently set
+	 *
+	 * @see #setRoot(Object)
+	 * @see #storeRoot()
 	 */
 	public <R> R root();
 	
 	/**
 	 * Sets the passed instance as the new root for the persistent object graph.<br>
-	 * Note that this will replace the old root instance, potentially resulting in wiping the whole database.
+	 * Note that this will replace the old root reference, potentially making the previously reachable
+	 * graph unreachable and thus eligible for storage-level garbage collection.
+	 * <p>
+	 * <b>This change is in-memory only.</b> The new root reference is not persisted until
+	 * {@link #storeRoot()} is called. The canonical pattern is therefore:
+	 * <pre>{@code
+	 * storageManager.setRoot(newRoot);
+	 * storageManager.storeRoot();
+	 * }</pre>
+	 * As with any state-changing operation, the {@code setRoot(...)} / {@code storeRoot()} pair must be
+	 * executed under the same lock as any concurrent reads or modifications of the graph (see the
+	 * class-level javadoc).
 	 *
 	 * @param <R> the type of the root object
 	 * @param newRoot the new root instance to be set.
-	 * 
+	 *
 	 * @return the passed {@literal newRoot} to allow fluent usage of this method.
+	 *
+	 * @see #storeRoot()
 	 */
 	public <R> R setRoot(R newRoot);
 	
@@ -118,6 +170,10 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	 * therefore skipped, and such changes will silently not be reflected in the storage. To persist
 	 * modifications to an existing object, call {@code store(Object)} on the actually modified
 	 * instance (or a suitable ancestor that owns the changed reference) instead.
+	 * <p>
+	 * As with any storing operation, the modification that prompted this call and the call itself must be
+	 * executed under the same lock as any concurrent access to the affected part of the object graph (see
+	 * the class-level javadoc).
 	 *
 	 * @return the root instance's objectId.
 	 *
@@ -129,9 +185,19 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 
 	/**
 	 * Ensures that the root object of the persistent object graph is initialized and available.
-	 * If the storage is not running, it starts the storage. If the root object is not set, it uses
-	 * the given supplier to provide the initial root and stores it. Throws an exception if the
-	 * initial root provided by the supplier is null.
+	 * <p>
+	 * Behavior:
+	 * <ul>
+	 *   <li>If the storage is not yet running, it is started &mdash; <i>before</i> the supplier is invoked.
+	 *       This means the storage threads are running even if the supplier ultimately returns
+	 *       {@code null} and this method throws.</li>
+	 *   <li>If no root is currently set, the {@code initialRootSupplier} is invoked, the supplied root is
+	 *       set via {@link #setRoot(Object)} and persisted via {@link #storeRoot()}.</li>
+	 *   <li>If a root is already set (loaded from the storage on start), the supplier is <i>not</i>
+	 *       invoked and {@link #storeRoot()} is <i>not</i> called.</li>
+	 * </ul>
+	 * The supplier may not return {@code null} on the initialization branch &mdash; doing so triggers an
+	 * {@link IllegalArgumentException} after the storage has already been started.
 	 *
 	 * @param <R> the type of the root object
 	 * @param initialRootSupplier a supplier that provides the initial root object if it is not already set
@@ -162,9 +228,13 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	}
 	
 	/**
-	 * Returns a read-only view on all technical root instance registered in this {@link StorageManager} instance.<br>
+	 * Returns a read-only view on all technical root instances registered in this {@link StorageManager}.<br>
 	 * See the description in {@link PersistenceRootsView} for details.
-	 * 
+	 * <p>
+	 * Most applications will not need this method &mdash; use {@link #root()} for the application's root.
+	 * This view is useful for advanced scenarios such as inspecting registered constants/JVM-implicit
+	 * roots, tooling, or migration logic that needs to enumerate all registered root references.
+	 *
 	 * @return a new {@link PersistenceRootsView} instance allowing to iterate all technical root instances.
 	 */
 	public PersistenceRootsView viewRoots();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageManager.java
@@ -101,14 +101,29 @@ public interface StorageManager extends StorageController, StorageConnection, Da
 	public <R> R setRoot(R newRoot);
 	
 	/**
-	 * Stores the registered root instance (as returned by {@link #root()}) by using the default storing logic
-	 * by calling {@link #createStorer()} to create the {@link Storer} to be used.<br>
-	 * Depending on the storer logic, storing the root instance can cause many other object to be stored, as well.
-	 * For example for the default behavior (as implemented in {@link #createLazyStorer()}, all recursively referenced
-	 * instances that are not yet known to the persistent context (i.e. have an associated objectId registered in the
-	 * context's {@link PersistenceObjectRegistry}) are stored as well.
-	 * 
+	 * Stores the registered root instance (as returned by {@link #root()}) using the default storing logic
+	 * by calling {@link #createStorer()} to create the {@link Storer} to be used.
+	 * <p>
+	 * <b>Intended use cases.</b> This method is only meaningful in two situations:
+	 * <ul>
+	 *   <li>The root reference itself has been replaced via {@link #setRoot(Object)}.</li>
+	 *   <li>The root is being stored for the first time on an otherwise empty storage.</li>
+	 * </ul>
+	 * <p>
+	 * <b>Common pitfall.</b> {@code storeRoot()} is <i>not</i> a "save everything" operation. It does
+	 * <b>not</b> persist arbitrary modifications made somewhere deep in the object graph. The default
+	 * storer (see {@link #createLazyStorer()}) only stores instances that are not yet known to the
+	 * persistent context (i.e. that do not yet have an objectId registered in the
+	 * {@link PersistenceObjectRegistry}). Already-persisted objects whose fields have been mutated are
+	 * therefore skipped, and such changes will silently not be reflected in the storage. To persist
+	 * modifications to an existing object, call {@code store(Object)} on the actually modified
+	 * instance (or a suitable ancestor that owns the changed reference) instead.
+	 *
 	 * @return the root instance's objectId.
+	 *
+	 * @see #setRoot(Object)
+	 * @see #createStorer()
+	 * @see #createLazyStorer()
 	 */
 	public long storeRoot();
 


### PR DESCRIPTION
Clarify and enhance Javadoc for `StorageManager` and `StorageController`:

- Added "Usage rules every caller must know" section for `StorageManager` to outline key constraints (e.g., lazy-default rule, locking requirements, crash safety).
- Detailed explanations and usage guidelines for methods such as `root()`, `setRoot()`, `storeRoot()`, `ensureRoot()`, and others in `StorageManager`.
- Improved documentation for `StorageController` including `start()` and `shutdown()` behavior, unclean-shutdown recovery, and guarantees. 
- Fixed typos and added clarifications for better usability.