### PR TITLE
Fix Condition.and() silently dropping the second range bound (#653)

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ByteIndexerInstant.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ByteIndexerInstant.java
@@ -160,7 +160,7 @@ public interface ByteIndexerInstant<E> extends HashingCompositeIndexer<E>, Index
 					.and(this.is(new ByteFieldPredicate(pos, b -> b > boundUnsigned[pos])))
 				);
 			}
-			return (Condition<S>)result;
+			return (Condition<S>)result.complete();
 		}
 
 		@SuppressWarnings({"unchecked", "rawtypes"})
@@ -190,7 +190,7 @@ public interface ByteIndexerInstant<E> extends HashingCompositeIndexer<E>, Index
 					.and(this.is(new ByteFieldPredicate(pos, b -> b < boundUnsigned[pos])))
 				);
 			}
-			return (Condition<S>)result;
+			return (Condition<S>)result.complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -202,7 +202,7 @@ public interface ByteIndexerInstant<E> extends HashingCompositeIndexer<E>, Index
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -214,7 +214,7 @@ public interface ByteIndexerInstant<E> extends HashingCompositeIndexer<E>, Index
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ByteIndexerNumber.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ByteIndexerNumber.java
@@ -153,7 +153,7 @@ public interface ByteIndexerNumber<E, K extends Number> extends HashingComposite
 			{
 				result = result.or(this.is(keys[i]));
 			}
-			return result;
+			return keys.length > 1 ? result.complete() : result;
 		}
 
 		@SafeVarargs
@@ -191,7 +191,7 @@ public interface ByteIndexerNumber<E, K extends Number> extends HashingComposite
 					.and(this.is(new ByteFieldPredicate(pos, b -> b > boundUnsigned[pos])))
 				);
 			}
-			return (Condition<S>)result;
+			return (Condition<S>)result.complete();
 		}
 
 		@SuppressWarnings({"unchecked", "rawtypes"})
@@ -222,7 +222,7 @@ public interface ByteIndexerNumber<E, K extends Number> extends HashingComposite
 					.and(this.is(new ByteFieldPredicate(pos, b -> b < boundUnsigned[pos])))
 				);
 			}
-			return (Condition<S>)result;
+			return (Condition<S>)result.complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -234,7 +234,7 @@ public interface ByteIndexerNumber<E, K extends Number> extends HashingComposite
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.greaterThan(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.greaterThan(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -246,7 +246,7 @@ public interface ByteIndexerNumber<E, K extends Number> extends HashingComposite
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.lessThan(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.lessThan(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerInstant.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerInstant.java
@@ -260,7 +260,7 @@ public interface IndexerInstant<E> extends IndexerDateTime<E, Object[], Instant>
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, second -> second < bound.getSecond()))
 				)
-			);
+			).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -272,7 +272,7 @@ public interface IndexerInstant<E> extends IndexerDateTime<E, Object[], Instant>
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -318,7 +318,7 @@ public interface IndexerInstant<E> extends IndexerDateTime<E, Object[], Instant>
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, second -> second > bound.getSecond()))
 				)
-			);
+			).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -330,7 +330,7 @@ public interface IndexerInstant<E> extends IndexerDateTime<E, Object[], Instant>
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerLocalDate.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerLocalDate.java
@@ -153,9 +153,9 @@ public interface IndexerLocalDate<E> extends IndexerDate<E, Object[], LocalDate>
 				).and(
 					this.is(new FieldPredicate(DAY_INDEX, day -> day < boundExclusive.getDayOfMonth()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> beforeEqual(final LocalDate boundInclusive)
@@ -164,8 +164,8 @@ public interface IndexerLocalDate<E> extends IndexerDate<E, Object[], LocalDate>
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive)).complete();
 		}
 		
 		@SuppressWarnings("unchecked")
@@ -191,9 +191,9 @@ public interface IndexerLocalDate<E> extends IndexerDate<E, Object[], LocalDate>
 				).and(
 					this.is(new FieldPredicate(DAY_INDEX, day -> day > boundExclusive.getDayOfMonth()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> afterEqual(final LocalDate boundInclusive)
@@ -202,8 +202,8 @@ public interface IndexerLocalDate<E> extends IndexerDate<E, Object[], LocalDate>
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive)).complete();
 		}
 		
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerLocalDateTime.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerLocalDateTime.java
@@ -246,9 +246,9 @@ public interface IndexerLocalDateTime<E> extends IndexerDateTime<E, Object[], Lo
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, day -> day < boundExclusive.getSecond()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> beforeEqual(final LocalDateTime boundInclusive)
@@ -257,8 +257,8 @@ public interface IndexerLocalDateTime<E> extends IndexerDateTime<E, Object[], Lo
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive)).complete();
 		}
 		
 		@SuppressWarnings("unchecked")
@@ -302,9 +302,9 @@ public interface IndexerLocalDateTime<E> extends IndexerDateTime<E, Object[], Lo
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, day -> day > boundExclusive.getSecond()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> afterEqual(final LocalDateTime boundInclusive)
@@ -313,8 +313,8 @@ public interface IndexerLocalDateTime<E> extends IndexerDateTime<E, Object[], Lo
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive)).complete();
 		}
 		
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerLocalTime.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerLocalTime.java
@@ -149,9 +149,9 @@ public interface IndexerLocalTime<E> extends IndexerTime<E, Object[], LocalTime>
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, second -> second < boundExclusive.getSecond()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> beforeEqual(final LocalTime boundInclusive)
@@ -160,8 +160,8 @@ public interface IndexerLocalTime<E> extends IndexerTime<E, Object[], LocalTime>
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive)).complete();
 		}
 		
 		@SuppressWarnings("unchecked")
@@ -187,9 +187,9 @@ public interface IndexerLocalTime<E> extends IndexerTime<E, Object[], LocalTime>
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, second -> second > boundExclusive.getSecond()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> afterEqual(final LocalTime boundInclusive)
@@ -198,8 +198,8 @@ public interface IndexerLocalTime<E> extends IndexerTime<E, Object[], LocalTime>
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive)).complete();
 		}
 		
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerYearMonth.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerYearMonth.java
@@ -180,9 +180,9 @@ public interface IndexerYearMonth<E> extends IndexerTemporal<E, Object[], YearMo
 				).and(
 					this.is(new FieldPredicate(MONTH_INDEX, month -> month < boundExclusive.getMonthValue()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> beforeEqual(final YearMonth boundInclusive)
@@ -191,10 +191,10 @@ public interface IndexerYearMonth<E> extends IndexerTemporal<E, Object[], YearMo
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive)).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> after(final YearMonth boundExclusive)
@@ -203,7 +203,7 @@ public interface IndexerYearMonth<E> extends IndexerTemporal<E, Object[], YearMo
 			{
 				throw new IllegalArgumentException("boundExclusive cannot be null");
 			}
-			
+
 			return (Condition<S>)this.is(
 				new FieldPredicate(YEAR_INDEX, year -> year > boundExclusive.getYear())
 			).or(
@@ -212,9 +212,9 @@ public interface IndexerYearMonth<E> extends IndexerTemporal<E, Object[], YearMo
 				).and(
 					this.is(new FieldPredicate(MONTH_INDEX, month -> month > boundExclusive.getMonthValue()))
 				)
-			);
+			).complete();
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		@Override
 		public final <S extends E> Condition<S> afterEqual(final YearMonth boundInclusive)
@@ -223,8 +223,8 @@ public interface IndexerYearMonth<E> extends IndexerTemporal<E, Object[], YearMo
 			{
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
-			
-			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive));
+
+			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive)).complete();
 		}
 		
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerZonedDateTime.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerZonedDateTime.java
@@ -267,7 +267,7 @@ public interface IndexerZonedDateTime<E> extends IndexerDateTime<E, Object[], Zo
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, second -> second < bound.getSecond()))
 				)
-			);
+			).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -279,7 +279,7 @@ public interface IndexerZonedDateTime<E> extends IndexerDateTime<E, Object[], Zo
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.before(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -326,7 +326,7 @@ public interface IndexerZonedDateTime<E> extends IndexerDateTime<E, Object[], Zo
 				).and(
 					this.is(new FieldPredicate(SECOND_INDEX, second -> second > bound.getSecond()))
 				)
-			);
+			).complete();
 		}
 
 		@SuppressWarnings("unchecked")
@@ -338,7 +338,7 @@ public interface IndexerZonedDateTime<E> extends IndexerDateTime<E, Object[], Zo
 				throw new IllegalArgumentException("boundInclusive cannot be null");
 			}
 
-			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive));
+			return (Condition<S>)this.is(boundInclusive).or(this.after(boundInclusive)).complete();
 		}
 
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SpatialIndexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SpatialIndexer.java
@@ -248,28 +248,32 @@ public interface SpatialIndexer<E> extends HashingCompositeIndexer<E>
 			return this.is(carrier);
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public <S extends E> Condition<S> latitudeAbove(final double minInclusive)
 		{
-			return this.coordinateGreaterThanEqual(toUnsignedBytes(minInclusive), LAT_OFFSET);
+			return (Condition<S>)this.coordinateGreaterThanEqual(toUnsignedBytes(minInclusive), LAT_OFFSET).complete();
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public <S extends E> Condition<S> latitudeBelow(final double maxInclusive)
 		{
-			return this.coordinateLessThanEqual(toUnsignedBytes(maxInclusive), LAT_OFFSET);
+			return (Condition<S>)this.coordinateLessThanEqual(toUnsignedBytes(maxInclusive), LAT_OFFSET).complete();
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public <S extends E> Condition<S> longitudeAbove(final double minInclusive)
 		{
-			return this.coordinateGreaterThanEqual(toUnsignedBytes(minInclusive), LON_OFFSET);
+			return (Condition<S>)this.coordinateGreaterThanEqual(toUnsignedBytes(minInclusive), LON_OFFSET).complete();
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public <S extends E> Condition<S> longitudeBelow(final double maxInclusive)
 		{
-			return this.coordinateLessThanEqual(toUnsignedBytes(maxInclusive), LON_OFFSET);
+			return (Condition<S>)this.coordinateLessThanEqual(toUnsignedBytes(maxInclusive), LON_OFFSET).complete();
 		}
 
 		@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/InstantIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/InstantIndexTest.java
@@ -15,8 +15,10 @@ package org.eclipse.store.gigamap.indexer;
  */
 
 import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerInstant;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
@@ -371,6 +373,53 @@ public class InstantIndexTest
         }
     }
 
+    /**
+     * Regression test for issue #653 / #654: composing an {@link IndexerInstant} range condition
+     * via {@link Condition#and(Condition)} (i) with another range condition and (ii) with a
+     * condition from a different indexer type must produce the same result as composing via
+     * {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     */
+    @Test
+    void rangeCompositionViaConditionAnd()
+    {
+        final InstantPersonIndex instantIdx = new InstantPersonIndex();
+        final NameIndex          nameIdx    = new NameIndex();
+
+        final GigaMap<InstantPerson> map = GigaMap.<InstantPerson>Builder()
+            .withBitmapIndex(instantIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new InstantPerson("Alice",   toInstant(2021, 1, 1, 12, 0, 0)));
+        map.add(new InstantPerson("Bob",     toInstant(2021, 1, 1, 13, 0, 0)));
+        map.add(new InstantPerson("Charlie", toInstant(2021, 1, 1, 14, 0, 0)));
+        map.add(new InstantPerson("Dave",    toInstant(2021, 1, 1, 15, 0, 0)));
+
+        final Instant lower = toInstant(2021, 1, 1, 12, 30, 0); // exclusive
+        final Instant upper = toInstant(2021, 1, 1, 14, 30, 0); // exclusive
+
+        // (i) range AND range — was broken before #653 fix (returned all "after" matches).
+        final Condition<InstantPerson> after  = instantIdx.after(lower);
+        final Condition<InstantPerson> before = instantIdx.before(upper);
+
+        final List<InstantPerson> rangeAnd = map.query(after.and(before)).toList();
+        final List<InstantPerson> rangeQ   = map.query().and(after).and(before).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(p -> assertNotEquals("Alice", p.name()));
+        rangeAnd.forEach(p -> assertNotEquals("Dave",  p.name()));
+
+        // (ii) range AND condition from a different indexer (issue #654's concern).
+        final Condition<InstantPerson> bobMatch = nameIdx.is("Bob");
+
+        final List<InstantPerson> mixedAnd = map.query(after.and(bobMatch)).toList();
+        final List<InstantPerson> mixedQ   = map.query().and(after).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
     private GigaMap<InstantPerson> prepageGigaMap()
     {
         GigaMap<InstantPerson> map = GigaMap.New();
@@ -407,6 +456,15 @@ public class InstantIndexTest
         protected Instant getInstant(InstantPerson entity)
         {
             return entity.getTimestamp();
+        }
+    }
+
+    private static class NameIndex extends IndexerString.Abstract<InstantPerson>
+    {
+        @Override
+        protected String getString(final InstantPerson entity)
+        {
+            return entity.name();
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateIndexTest.java
@@ -15,8 +15,10 @@ package org.eclipse.store.gigamap.indexer;
  */
 
 import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerLocalDate;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
@@ -283,6 +285,53 @@ public class LocalDateIndexTest
         }
     }
 
+    /**
+     * Regression test for issue #653 / #654: composing an {@link IndexerLocalDate} range
+     * condition via {@link Condition#and(Condition)} (i) with another range condition and
+     * (ii) with a condition from a different indexer type must produce the same result as
+     * composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     */
+    @Test
+    void rangeCompositionViaConditionAnd()
+    {
+        final LocalDatePersonIndex dateIdx = new LocalDatePersonIndex();
+        final NameIndex            nameIdx = new NameIndex();
+
+        final GigaMap<LocalDatePerson> map = GigaMap.<LocalDatePerson>Builder()
+            .withBitmapIndex(dateIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new LocalDatePerson("Alice",   LocalDate.of(1980, 1, 1)));
+        map.add(new LocalDatePerson("Bob",     LocalDate.of(1990, 1, 1)));
+        map.add(new LocalDatePerson("Charlie", LocalDate.of(2000, 1, 1)));
+        map.add(new LocalDatePerson("Dave",    LocalDate.of(2010, 1, 1)));
+
+        final LocalDate lower = LocalDate.of(1985, 1, 1); // exclusive
+        final LocalDate upper = LocalDate.of(2005, 1, 1); // exclusive
+
+        // (i) range AND range
+        final Condition<LocalDatePerson> after  = dateIdx.after(lower);
+        final Condition<LocalDatePerson> before = dateIdx.before(upper);
+
+        final List<LocalDatePerson> rangeAnd = map.query(after.and(before)).toList();
+        final List<LocalDatePerson> rangeQ   = map.query().and(after).and(before).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(p -> assertNotEquals("Alice", p.name()));
+        rangeAnd.forEach(p -> assertNotEquals("Dave",  p.name()));
+
+        // (ii) range AND condition from a different indexer
+        final Condition<LocalDatePerson> bobMatch = nameIdx.is("Bob");
+
+        final List<LocalDatePerson> mixedAnd = map.query(after.and(bobMatch)).toList();
+        final List<LocalDatePerson> mixedQ   = map.query().and(after).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
     private GigaMap<LocalDatePerson> prepageGigaMap()
     {
         GigaMap<LocalDatePerson> map = GigaMap.New();
@@ -307,6 +356,15 @@ public class LocalDateIndexTest
         protected LocalDate getLocalDate(LocalDatePerson entity)
         {
             return entity.getBirthday();
+        }
+    }
+
+    private static class NameIndex extends IndexerString.Abstract<LocalDatePerson>
+    {
+        @Override
+        protected String getString(final LocalDatePerson entity)
+        {
+            return entity.name();
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateTimeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalDateTimeIndexTest.java
@@ -15,8 +15,10 @@ package org.eclipse.store.gigamap.indexer;
  */
 
 import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerLocalDateTime;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
@@ -369,6 +371,53 @@ public class LocalDateTimeIndexTest
         }
     }
 
+    /**
+     * Regression test for issue #653 / #654: composing an {@link IndexerLocalDateTime} range
+     * condition via {@link Condition#and(Condition)} (i) with another range condition and
+     * (ii) with a condition from a different indexer type must produce the same result as
+     * composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     */
+    @Test
+    void rangeCompositionViaConditionAnd()
+    {
+        final LocalDateTimePersonIndex dateIdx = new LocalDateTimePersonIndex();
+        final NameIndex                nameIdx = new NameIndex();
+
+        final GigaMap<LocalDateTimePerson> map = GigaMap.<LocalDateTimePerson>Builder()
+            .withBitmapIndex(dateIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new LocalDateTimePerson("Alice",   LocalDateTime.of(2021, 1, 1, 12, 0)));
+        map.add(new LocalDateTimePerson("Bob",     LocalDateTime.of(2021, 1, 1, 13, 0)));
+        map.add(new LocalDateTimePerson("Charlie", LocalDateTime.of(2021, 1, 1, 14, 0)));
+        map.add(new LocalDateTimePerson("Dave",    LocalDateTime.of(2021, 1, 1, 15, 0)));
+
+        final LocalDateTime lower = LocalDateTime.of(2021, 1, 1, 12, 30); // exclusive
+        final LocalDateTime upper = LocalDateTime.of(2021, 1, 1, 14, 30); // exclusive
+
+        // (i) range AND range
+        final Condition<LocalDateTimePerson> after  = dateIdx.after(lower);
+        final Condition<LocalDateTimePerson> before = dateIdx.before(upper);
+
+        final List<LocalDateTimePerson> rangeAnd = map.query(after.and(before)).toList();
+        final List<LocalDateTimePerson> rangeQ   = map.query().and(after).and(before).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(p -> assertNotEquals("Alice", p.name()));
+        rangeAnd.forEach(p -> assertNotEquals("Dave",  p.name()));
+
+        // (ii) range AND condition from a different indexer
+        final Condition<LocalDateTimePerson> bobMatch = nameIdx.is("Bob");
+
+        final List<LocalDateTimePerson> mixedAnd = map.query(after.and(bobMatch)).toList();
+        final List<LocalDateTimePerson> mixedQ   = map.query().and(after).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
     private GigaMap<LocalDateTimePerson> prepageGigaMap()
     {
         GigaMap<LocalDateTimePerson> map = GigaMap.New();
@@ -400,6 +449,15 @@ public class LocalDateTimeIndexTest
         protected LocalDateTime getLocalDateTime(LocalDateTimePerson entity)
         {
             return entity.getBirthday();
+        }
+    }
+
+    private static class NameIndex extends IndexerString.Abstract<LocalDateTimePerson>
+    {
+        @Override
+        protected String getString(final LocalDateTimePerson entity)
+        {
+            return entity.name();
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalTimeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/LocalTimeIndexTest.java
@@ -15,8 +15,10 @@ package org.eclipse.store.gigamap.indexer;
  */
 
 import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerLocalTime;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
@@ -272,6 +274,53 @@ public class LocalTimeIndexTest
         }
     }
 
+    /**
+     * Regression test for issue #653 / #654: composing an {@link IndexerLocalTime} range
+     * condition via {@link Condition#and(Condition)} (i) with another range condition and
+     * (ii) with a condition from a different indexer type must produce the same result as
+     * composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     */
+    @Test
+    void rangeCompositionViaConditionAnd()
+    {
+        final LocalTimePersonIndex timeIdx = new LocalTimePersonIndex();
+        final NameIndex            nameIdx = new NameIndex();
+
+        final GigaMap<LocalTimePerson> map = GigaMap.<LocalTimePerson>Builder()
+            .withBitmapIndex(timeIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new LocalTimePerson("Alice",   LocalTime.of(11, 0)));
+        map.add(new LocalTimePerson("Bob",     LocalTime.of(12, 0)));
+        map.add(new LocalTimePerson("Charlie", LocalTime.of(13, 0)));
+        map.add(new LocalTimePerson("Dave",    LocalTime.of(14, 0)));
+
+        final LocalTime lower = LocalTime.of(11, 30); // exclusive
+        final LocalTime upper = LocalTime.of(13, 30); // exclusive
+
+        // (i) range AND range
+        final Condition<LocalTimePerson> after  = timeIdx.after(lower);
+        final Condition<LocalTimePerson> before = timeIdx.before(upper);
+
+        final List<LocalTimePerson> rangeAnd = map.query(after.and(before)).toList();
+        final List<LocalTimePerson> rangeQ   = map.query().and(after).and(before).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(p -> assertNotEquals("Alice", p.name()));
+        rangeAnd.forEach(p -> assertNotEquals("Dave",  p.name()));
+
+        // (ii) range AND condition from a different indexer
+        final Condition<LocalTimePerson> bobMatch = nameIdx.is("Bob");
+
+        final List<LocalTimePerson> mixedAnd = map.query(after.and(bobMatch)).toList();
+        final List<LocalTimePerson> mixedQ   = map.query().and(after).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
     private GigaMap<LocalTimePerson> prepageGigaMap()
     {
         GigaMap<LocalTimePerson> map = GigaMap.New();
@@ -295,6 +344,15 @@ public class LocalTimeIndexTest
         protected LocalTime getLocalTime(LocalTimePerson entity)
         {
             return entity.getLunchTime();
+        }
+    }
+
+    private static class NameIndex extends IndexerString.Abstract<LocalTimePerson>
+    {
+        @Override
+        protected String getString(final LocalTimePerson entity)
+        {
+            return entity.name();
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/SpatialIndexerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/SpatialIndexerTest.java
@@ -15,7 +15,9 @@ package org.eclipse.store.gigamap.indexer;
  */
 
 import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.gigamap.types.SpatialIndexer;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -354,6 +356,65 @@ public class SpatialIndexerTest
 	}
 
 
+	/**
+	 * Regression test for issue #653 / #654: composing a {@link SpatialIndexer} range
+	 * condition via {@link Condition#and(Condition)} (i) with another range condition and
+	 * (ii) with a condition from a different indexer type must produce the same result as
+	 * composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+	 * Also covers (iii) latitudeBetween().and(longitudeBetween()) — 2D box composition where
+	 * the two operands are themselves AND-of-Term, exercising And.linkCondition flattening.
+	 */
+	@Test
+	void rangeCompositionViaConditionAnd()
+	{
+		final NameIndex          nameIdx = new NameIndex();
+		final GigaMap<Location>  map     = GigaMap.<Location>Builder()
+			.withBitmapIndex(this.locationIndex)
+			.withBitmapIndex(nameIdx)
+			.build();
+		map.addAll(
+			new Location("New York",   40.7128,  -74.0060),
+			new Location("London",     51.5074,   -0.1278),
+			new Location("Tokyo",      35.6762,  139.6503),
+			new Location("Sydney",    -33.8688,  151.2093),
+			new Location("Cape Town", -33.9249,   18.4241),
+			new Location("Fiji",      -17.7134,  178.065 )
+		);
+
+		// (i) range AND range — northern hemisphere AND latitude < 45 → New York, Tokyo
+		final Condition<Location> above = this.locationIndex.latitudeAbove(0.0);
+		final Condition<Location> below = this.locationIndex.latitudeBelow(45.0);
+
+		final List<Location> rangeAnd = map.query(above.and(below)).toList();
+		final List<Location> rangeQ   = map.query().and(above).and(below).toList();
+
+		assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+		assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+		rangeAnd.forEach(l -> assertNotEquals("London", l.name));
+
+		// (ii) range AND condition from a different indexer
+		final Condition<Location> tokyoMatch = nameIdx.is("Tokyo");
+
+		final List<Location> mixedAnd = map.query(above.and(tokyoMatch)).toList();
+		final List<Location> mixedQ   = map.query().and(above).and(tokyoMatch).toList();
+
+		assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+		assertEquals("Tokyo", mixedAnd.get(0).name);
+		assertEquals(mixedQ.size(), mixedAnd.size());
+
+		// (iii) latitudeBetween AND longitudeBetween — both operands are And, not Or
+		final Condition<Location> latBox = this.locationIndex.latitudeBetween(0.0, 45.0);
+		final Condition<Location> lonBox = this.locationIndex.longitudeBetween(100.0, 180.0);
+
+		final List<Location> boxAnd = map.query(latBox.and(lonBox)).toList();
+		final List<Location> boxQ   = map.query().and(latBox).and(lonBox).toList();
+
+		assertEquals(1, boxAnd.size(), "2D box composition must intersect correctly");
+		assertEquals("Tokyo", boxAnd.get(0).name);
+		assertEquals(boxQ.size(), boxAnd.size());
+	}
+
+
 	// ---- test infrastructure ----
 
 	private GigaMap<Location> prepareGigaMap()
@@ -388,6 +449,16 @@ public class SpatialIndexerTest
 		protected Double getLongitude(final Location entity)
 		{
 			return entity.longitude;
+		}
+	}
+
+
+	private static class NameIndex extends IndexerString.Abstract<Location>
+	{
+		@Override
+		protected String getString(final Location entity)
+		{
+			return entity.name;
 		}
 	}
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/YearMonthIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/YearMonthIndexTest.java
@@ -14,11 +14,14 @@ package org.eclipse.store.gigamap.indexer;
  * #L%
  */
 
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.gigamap.types.IndexerYearMonth;
 import org.junit.jupiter.api.Test;
 
 import java.time.YearMonth;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -106,6 +109,53 @@ public class YearMonthIndexTest
         assertEquals(1, map.query(indexer.isYear(2022)).count());
     }
 
+    /**
+     * Regression test for issue #653 / #654: composing an {@link IndexerYearMonth} range
+     * condition via {@link Condition#and(Condition)} (i) with another range condition and
+     * (ii) with a condition from a different indexer type must produce the same result as
+     * composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     */
+    @Test
+    void rangeCompositionViaConditionAnd()
+    {
+        final NamedYMIndexer ymIdx   = new NamedYMIndexer();
+        final NameIndex      nameIdx = new NameIndex();
+
+        final GigaMap<NamedYMEntity> map = GigaMap.<NamedYMEntity>Builder()
+            .withBitmapIndex(ymIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new NamedYMEntity("Alice",   YearMonth.of(2023,  3)));
+        map.add(new NamedYMEntity("Bob",     YearMonth.of(2023,  9)));
+        map.add(new NamedYMEntity("Charlie", YearMonth.of(2024,  3)));
+        map.add(new NamedYMEntity("Dave",    YearMonth.of(2024, 11)));
+
+        final YearMonth lower = YearMonth.of(2023, 6); // exclusive
+        final YearMonth upper = YearMonth.of(2024, 9); // exclusive
+
+        // (i) range AND range
+        final Condition<NamedYMEntity> after  = ymIdx.after(lower);
+        final Condition<NamedYMEntity> before = ymIdx.before(upper);
+
+        final List<NamedYMEntity> rangeAnd = map.query(after.and(before)).toList();
+        final List<NamedYMEntity> rangeQ   = map.query().and(after).and(before).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(e -> assertNotEquals("Alice", e.name()));
+        rangeAnd.forEach(e -> assertNotEquals("Dave",  e.name()));
+
+        // (ii) range AND condition from a different indexer
+        final Condition<NamedYMEntity> bobMatch = nameIdx.is("Bob");
+
+        final List<NamedYMEntity> mixedAnd = map.query(after.and(bobMatch)).toList();
+        final List<NamedYMEntity> mixedQ   = map.query().and(after).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
     private static class YMIndexer extends IndexerYearMonth.Abstract<YMEntity>
     {
 
@@ -113,6 +163,46 @@ public class YearMonthIndexTest
         protected YearMonth getYearMonth(YMEntity entity)
         {
             return entity.getYearMonthField();
+        }
+    }
+
+    private static class NamedYMIndexer extends IndexerYearMonth.Abstract<NamedYMEntity>
+    {
+        @Override
+        protected YearMonth getYearMonth(final NamedYMEntity entity)
+        {
+            return entity.yearMonth();
+        }
+    }
+
+    private static class NameIndex extends IndexerString.Abstract<NamedYMEntity>
+    {
+        @Override
+        protected String getString(final NamedYMEntity entity)
+        {
+            return entity.name();
+        }
+    }
+
+    private static class NamedYMEntity
+    {
+        private final String    name;
+        private final YearMonth yearMonth;
+
+        NamedYMEntity(final String name, final YearMonth yearMonth)
+        {
+            this.name      = name;
+            this.yearMonth = yearMonth;
+        }
+
+        String name()
+        {
+            return this.name;
+        }
+
+        YearMonth yearMonth()
+        {
+            return this.yearMonth;
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ZonedDateTimeIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/ZonedDateTimeIndexTest.java
@@ -15,7 +15,9 @@ package org.eclipse.store.gigamap.indexer;
  */
 
 import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.gigamap.types.IndexerZonedDateTime;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -395,6 +397,53 @@ public class ZonedDateTimeIndexTest
         assertEquals(1, count2);
     }
 
+    /**
+     * Regression test for issue #653 / #654: composing an {@link IndexerZonedDateTime} range
+     * condition via {@link Condition#and(Condition)} (i) with another range condition and
+     * (ii) with a condition from a different indexer type must produce the same result as
+     * composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     */
+    @Test
+    void rangeCompositionViaConditionAnd()
+    {
+        final ZonedDateTimePersonIndex zdtIdx  = new ZonedDateTimePersonIndex();
+        final NameIndex                nameIdx = new NameIndex();
+
+        final GigaMap<ZonedDateTimePerson> map = GigaMap.<ZonedDateTimePerson>Builder()
+            .withBitmapIndex(zdtIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new ZonedDateTimePerson("Alice",   toUTC(2021, 1, 1, 12, 0, 0)));
+        map.add(new ZonedDateTimePerson("Bob",     toUTC(2021, 1, 1, 13, 0, 0)));
+        map.add(new ZonedDateTimePerson("Charlie", toUTC(2021, 1, 1, 14, 0, 0)));
+        map.add(new ZonedDateTimePerson("Dave",    toUTC(2021, 1, 1, 15, 0, 0)));
+
+        final ZonedDateTime lower = toUTC(2021, 1, 1, 12, 30, 0); // exclusive
+        final ZonedDateTime upper = toUTC(2021, 1, 1, 14, 30, 0); // exclusive
+
+        // (i) range AND range
+        final Condition<ZonedDateTimePerson> after  = zdtIdx.after(lower);
+        final Condition<ZonedDateTimePerson> before = zdtIdx.before(upper);
+
+        final List<ZonedDateTimePerson> rangeAnd = map.query(after.and(before)).toList();
+        final List<ZonedDateTimePerson> rangeQ   = map.query().and(after).and(before).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(p -> assertNotEquals("Alice", p.name()));
+        rangeAnd.forEach(p -> assertNotEquals("Dave",  p.name()));
+
+        // (ii) range AND condition from a different indexer
+        final Condition<ZonedDateTimePerson> bobMatch = nameIdx.is("Bob");
+
+        final List<ZonedDateTimePerson> mixedAnd = map.query(after.and(bobMatch)).toList();
+        final List<ZonedDateTimePerson> mixedQ   = map.query().and(after).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
     private GigaMap<ZonedDateTimePerson> prepageGigaMap()
     {
         GigaMap<ZonedDateTimePerson> map = GigaMap.New();
@@ -431,6 +480,15 @@ public class ZonedDateTimeIndexTest
         protected ZonedDateTime getZonedDateTime(ZonedDateTimePerson entity)
         {
             return entity.getTimestamp();
+        }
+    }
+
+    private static class NameIndex extends IndexerString.Abstract<ZonedDateTimePerson>
+    {
+        @Override
+        protected String getString(final ZonedDateTimePerson entity)
+        {
+            return entity.name();
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/byte_/ByteIndexerInstantTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/byte_/ByteIndexerInstantTest.java
@@ -15,7 +15,9 @@ package org.eclipse.store.gigamap.indexer.byte_;
  */
 
 import org.eclipse.store.gigamap.types.ByteIndexerInstant;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ByteIndexerInstantTest
@@ -302,6 +305,54 @@ public class ByteIndexerInstantTest
     }
 
 
+    /**
+     * Regression test for issue #653 / #654: composing a {@link ByteIndexerInstant} range
+     * condition via {@link Condition#and(Condition)} (i) with another range condition and
+     * (ii) with a condition from a different indexer type must produce the same result as
+     * composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     */
+    @Test
+    void rangeCompositionViaConditionAnd()
+    {
+        final NamedEventTimestampIndexer tsIdx   = new NamedEventTimestampIndexer();
+        final NameIndex                  nameIdx = new NameIndex();
+
+        final GigaMap<NamedEvent> map = GigaMap.<NamedEvent>Builder()
+            .withBitmapIndex(tsIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new NamedEvent("Alice",   Instant.parse("2021-01-01T12:00:00Z")));
+        map.add(new NamedEvent("Bob",     Instant.parse("2021-01-01T13:00:00Z")));
+        map.add(new NamedEvent("Charlie", Instant.parse("2021-01-01T14:00:00Z")));
+        map.add(new NamedEvent("Dave",    Instant.parse("2021-01-01T15:00:00Z")));
+
+        final Instant lower = Instant.parse("2021-01-01T12:30:00Z"); // exclusive
+        final Instant upper = Instant.parse("2021-01-01T14:30:00Z"); // exclusive
+
+        // (i) range AND range
+        final Condition<NamedEvent> after  = tsIdx.after(lower);
+        final Condition<NamedEvent> before = tsIdx.before(upper);
+
+        final List<NamedEvent> rangeAnd = map.query(after.and(before)).toList();
+        final List<NamedEvent> rangeQ   = map.query().and(after).and(before).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(e -> assertNotEquals("Alice", e.name()));
+        rangeAnd.forEach(e -> assertNotEquals("Dave",  e.name()));
+
+        // (ii) range AND condition from a different indexer
+        final Condition<NamedEvent> bobMatch = nameIdx.is("Bob");
+
+        final List<NamedEvent> mixedAnd = map.query(after.and(bobMatch)).toList();
+        final List<NamedEvent> mixedQ   = map.query().and(after).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
+
     static class EventTimestampIndexer extends ByteIndexerInstant.Abstract<Event>
     {
         @Override
@@ -321,6 +372,46 @@ public class ByteIndexerInstantTest
         }
 
         public Instant getTimestamp()
+        {
+            return this.timestamp;
+        }
+    }
+
+    static class NamedEventTimestampIndexer extends ByteIndexerInstant.Abstract<NamedEvent>
+    {
+        @Override
+        protected Instant getInstant(final NamedEvent entity)
+        {
+            return entity.timestamp();
+        }
+    }
+
+    static class NameIndex extends IndexerString.Abstract<NamedEvent>
+    {
+        @Override
+        protected String getString(final NamedEvent entity)
+        {
+            return entity.name();
+        }
+    }
+
+    static class NamedEvent
+    {
+        private final String  name;
+        private final Instant timestamp;
+
+        NamedEvent(final String name, final Instant timestamp)
+        {
+            this.name      = name;
+            this.timestamp = timestamp;
+        }
+
+        String name()
+        {
+            return this.name;
+        }
+
+        Instant timestamp()
         {
             return this.timestamp;
         }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/byte_/ByteIndexerLongTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/byte_/ByteIndexerLongTest.java
@@ -15,7 +15,9 @@ package org.eclipse.store.gigamap.indexer.byte_;
  */
 
 import org.eclipse.store.gigamap.types.ByteIndexerLong;
+import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ByteIndexerLongTest
 {
@@ -121,6 +124,54 @@ public class ByteIndexerLongTest
     }
 
 
+    /**
+     * Regression test for issue #653 / #654: composing a {@link ByteIndexerLong} numeric
+     * range condition via {@link Condition#and(Condition)} (i) with another range condition
+     * and (ii) with a condition from a different indexer type must produce the same result
+     * as composing via {@link org.eclipse.store.gigamap.types.GigaQuery#and(Condition)}.
+     * <p>
+     * Representative coverage for {@link org.eclipse.store.gigamap.types.ByteIndexerNumber};
+     * all numeric subclasses share the same abstract greaterThan/lessThan implementation.
+     */
+    @Test
+    void numberRangeCompositionViaConditionAnd()
+    {
+        final NamedLongValueIndexer valueIdx = new NamedLongValueIndexer();
+        final NameIndex             nameIdx  = new NameIndex();
+
+        final GigaMap<NamedLongPojo> map = GigaMap.<NamedLongPojo>Builder()
+            .withBitmapIndex(valueIdx)
+            .withBitmapIndex(nameIdx)
+            .build();
+        map.add(new NamedLongPojo("Alice",   10L));
+        map.add(new NamedLongPojo("Bob",     20L));
+        map.add(new NamedLongPojo("Charlie", 30L));
+        map.add(new NamedLongPojo("Dave",    40L));
+
+        // (i) range AND range
+        final Condition<NamedLongPojo> greater = valueIdx.greaterThan(15L);
+        final Condition<NamedLongPojo> less    = valueIdx.lessThan(35L);
+
+        final List<NamedLongPojo> rangeAnd = map.query(greater.and(less)).toList();
+        final List<NamedLongPojo> rangeQ   = map.query().and(greater).and(less).toList();
+
+        assertEquals(2, rangeAnd.size(), "Condition.and() must respect both bounds");
+        assertEquals(rangeQ.size(), rangeAnd.size(), "Condition.and() and GigaQuery.and() must agree");
+        rangeAnd.forEach(e -> assertNotEquals("Alice", e.name()));
+        rangeAnd.forEach(e -> assertNotEquals("Dave",  e.name()));
+
+        // (ii) range AND condition from a different indexer
+        final Condition<NamedLongPojo> bobMatch = nameIdx.is("Bob");
+
+        final List<NamedLongPojo> mixedAnd = map.query(greater.and(bobMatch)).toList();
+        final List<NamedLongPojo> mixedQ   = map.query().and(greater).and(bobMatch).toList();
+
+        assertEquals(1, mixedAnd.size(), "range AND non-range condition must intersect correctly");
+        assertEquals("Bob", mixedAnd.get(0).name());
+        assertEquals(mixedQ.size(), mixedAnd.size());
+    }
+
+
     static class LongValueIndexer extends ByteIndexerLong.Abstract<LongPojo>
     {
         @Override
@@ -140,6 +191,46 @@ public class ByteIndexerLongTest
         }
 
         public Long getValue()
+        {
+            return this.value;
+        }
+    }
+
+    static class NamedLongValueIndexer extends ByteIndexerLong.Abstract<NamedLongPojo>
+    {
+        @Override
+        protected Long getLong(final NamedLongPojo entity)
+        {
+            return entity.value();
+        }
+    }
+
+    static class NameIndex extends IndexerString.Abstract<NamedLongPojo>
+    {
+        @Override
+        protected String getString(final NamedLongPojo entity)
+        {
+            return entity.name();
+        }
+    }
+
+    static class NamedLongPojo
+    {
+        private final String name;
+        private final Long   value;
+
+        NamedLongPojo(final String name, final Long value)
+        {
+            this.name  = name;
+            this.value = value;
+        }
+
+        String name()
+        {
+            return this.name;
+        }
+
+        Long value()
         {
             return this.value;
         }


### PR DESCRIPTION
## Summary

`Condition.and(other)` between two `Or`-chain conditions silently dropped the right operand because `Condition.Or.linkCondition` follows fluent "replace last" semantics — only the last clause of the receiver `Or` was
AND-ed with `other`, the remaining clauses passed through unconstrained.
For range queries built by `IndexerInstant.before()`/`after()` (and the equivalents on every other date / time / number / spatial indexer), this produced silent overcounts: e.g. `IDX.after(t).and(IDX.before(u))` returned all entries after `t`, ignoring `u`.

The fluent "replace last" rule is intentional for `a.or(b).or(c).and(d)` — it preserves AND-binds-stronger semantics. The fix is at the indexer level: wrap the internal `Or` chain in a `Term` (via `.complete()`) so subsequent `.and(…)` / `.or(…)` treats the range as an atomic unit.

Fixes #653. Also addresses #654, which reframed the same symptom as a structural concern with `IndexerInstant`'s composite design — the underlying implementation is in fact a correct lexicographic comparison, and #653's fix
removes the practical problem.

## Changes

### `Term`-wrap the `Or` chain returned by every range factory

| Indexer | Methods |
| --- | --- |
| `IndexerInstant`, `IndexerLocalDate`, `IndexerLocalDateTime`, `IndexerLocalTime`, `IndexerYearMonth`, `IndexerZonedDateTime`, `ByteIndexerInstant` | `before`, `after`, `beforeEqual`, `afterEqual` |
| `ByteIndexerNumber` | `greaterThan`, `lessThan`, `greaterThanEqual`, `lessThanEqual`, `in` (multi-key) |
| `SpatialIndexer` | `latitudeAbove`, `latitudeBelow`, `longitudeAbove`, `longitudeBelow` |

`between` / `latitudeBetween` / `longitudeBetween` are correct by composition
once their building blocks are wrapped (they return `And(Term, Term)`, which
is already atomic for further composition).

### Regression tests

Added `rangeCompositionViaConditionAnd` to every affected indexer's test
class. Each test:

- Builds a 2-indexer `GigaMap` (range + `IndexerString` over a name field).
- Uses 4 entities arranged so range1 ∩ range2 has 2 hits and range ∩ name has 1 hit (counts that don't coincide with the buggy result).
- Asserts the **identities** of matching entities, not just counts — the prior count-only tests would have missed the #653 bug.
- Asserts `Condition.and(…)` and `GigaQuery.and(…)` produce the same set, locking in API parity.

`SpatialIndexerTest` additionally covers `latitudeBetween().and(longitudeBetween())` to exercise the 2D-box composition where both operands are `And`, not `Or`.
