### PR TITLE
Documentation update

### DIFF
--- a/docs/modules/gigamap/pages/indexing/bitmap/defining.adoc
+++ b/docs/modules/gigamap/pages/indexing/bitmap/defining.adoc
@@ -56,6 +56,8 @@ Either define them directly in the entity class or separately.
 
 The `Indexer` implementations must at least override the method that extracts the key value. By default, the name of the index is derived from its declaration; for example, when written as a constant, the fully qualified name of the constant will be used. If you want to provide a name yourself, simply override the `name()` method.
 
+IMPORTANT: Indexer names must be unique within a `GigaMap`. Registering a second indexer under a name that is already taken throws a `RuntimeException` at registration time. This is rarely an issue when names come from the default derivation, since declaration-based names are naturally distinct, but it can bite when you override `name()` manually or use anonymous `Indexer` instances whose derived names collide. Give each indexer an explicit, unique `name()` in those cases.
+
 The predefined indexers are usually sufficient; just extend from their `Abstract` base type.
 
 [source, java]

--- a/docs/modules/intro/pages/installation.adoc
+++ b/docs/modules/intro/pages/installation.adoc
@@ -225,9 +225,6 @@ These are the different modules that make up {product-name}.
 |storage-restservice-javalin
 |REST service implementation which utilizes Javalin and provides REST endpoints.
 
-|storage-restservice-sparkjava (deprecated)
-|REST service implementation which utilizes SparkJava and provides REST endpoints. (Deprecated, use storage-restservice-javalin instead.)
-
 |storage-restservice-springboot
 |REST service implementation for Spring Boot which provides REST endpoints.
 |===

--- a/docs/modules/storage/pages/queries.adoc
+++ b/docs/modules/storage/pages/queries.adoc
@@ -1,23 +1,662 @@
 = Queries
 
 The {product-name} engine takes care of persisting your object graph.
-When you do queries, they are not run on the data stored by {product-name}, queries run on your data in the local system memory.
-There is no need to use special query languages like SQL.
-All operations can be done with plain Java.
-{product-name} does not restrict you in the way you query your object graph.
-You are totally free to choose the best method fitting to your application.
+Queries do not run on the data stored on disk — they run on your data in the local JVM heap.
+There is no query language, no SQL dialect, no DSL, no annotations.
+Anything you can express in plain Java against your collections is a query.
 
-One possibility may be Streams if you use the standard Java collections.
+That means you keep full control over how your data is shaped, indexed and traversed.
+The fastest "query" is the one you do not write at all, because the data is already where you need it: a field on a parent object, an entry in a `HashMap`, an item in a sorted `List`.
+For everything else, the standard library — primarily Streams — is usually all you need.
+
+== Example model
+
+The examples on this page assume the following small model.
 
 [source, java]
 ----
-public List<Article> getUnAvailableArticles()
+public class Shop
 {
-	return shop.getArticles().stream()
-		.filter(a -> !a.available())
-		.collect(Collectors.toList())
-	;
+    private List<Article>  articles  = new ArrayList<>();
+    private List<Customer> customers = new ArrayList<>();
+    private List<Order>    orders    = new ArrayList<>();
+    // getters ...
+}
+
+public class Article
+{
+    private String  name;
+    private String  category;
+    private double  price;
+    private boolean available;
+}
+
+public class Customer
+{
+    private long   id;
+    private String name;
+    private String city;
+}
+
+public class Order
+{
+    private Customer        customer;
+    private List<OrderLine> lines;
+    private LocalDate       date;
+}
+
+public class OrderLine
+{
+    private Article article;
+    private int     quantity;
 }
 ----
 
-NOTE: Of course you must care about xref:loading-data/lazy-loading/index.adoc[lazy loading] if you use that feature.
+== Streams over collections
+
+The most common pattern is a `stream()` over the collection you already hold a reference to.
+
+[source, java]
+----
+// All articles that are currently out of stock
+List<Article> unavailable = shop.getArticles().stream()
+    .filter(a -> !a.isAvailable())
+    .toList();
+----
+
+[source, java]
+----
+// Find a specific article by name
+Optional<Article> coffee = shop.getArticles().stream()
+    .filter(a -> "Coffee".equals(a.getName()))
+    .findFirst();
+----
+
+[source, java]
+----
+// Count available articles
+long availableCount = shop.getArticles().stream()
+    .filter(Article::isAvailable)
+    .count();
+----
+
+The same works on `Set`, `Map.values()`, `Map.entrySet()` or any `Iterable` via `StreamSupport.stream(...)`.
+
+== Compared to SQL and Cypher
+
+If you come from SQL, JPQL, HQL or Cypher, you might expect a dedicated query syntax — and miss it for about a day.
+Once the data is an object graph in your own JVM, the language *is* Java.
+That alone gives you four things a query language cannot:
+
+* *Compile-time type safety* — rename `Article.price` and every "query" that touches it either updates or fails to compile.
+* *Real IDE support* — autocomplete, jump-to-definition, find-usages, refactor, all the way through the query.
+* *Step-through debugging* — set a breakpoint inside the lambda; inspect the entity that just failed the predicate.
+* *No mapping layer* — the result is already domain objects in the right types. No `ResultSet`, no `Object[]`, no DTO mapper.
+
+The side-by-sides below are not "Java is shorter than SQL" trophies (sometimes it's longer).
+The point is what each line *means*: in the SQL/Cypher version it's a string the database parses; in the Java version it's code your compiler and IDE already understand.
+
+=== Filter
+
+[source, sql]
+----
+SELECT * FROM article WHERE available = FALSE;
+----
+
+[source, java]
+----
+shop.getArticles().stream()
+    .filter(a -> !a.isAvailable())
+    .toList();
+----
+
+=== Aggregate per group
+
+[source, sql]
+----
+SELECT category, AVG(price)
+FROM   article
+GROUP  BY category;
+----
+
+[source, java]
+----
+shop.getArticles().stream()
+    .collect(Collectors.groupingBy(
+        Article::getCategory,
+        Collectors.averagingDouble(Article::getPrice)));
+----
+
+The SQL returns rows of `(VARCHAR, DOUBLE)` that you still have to map.
+The Java returns a typed `Map<String, Double>`, ready to use.
+
+=== Join
+
+This is where the gap really opens up.
+"All distinct articles ordered by customers from Berlin" needs four tables, three joins and a `WHERE` in SQL:
+
+[source, sql]
+----
+SELECT DISTINCT a.*
+FROM   customer    c
+JOIN   "order"     o ON o.customer_id = c.id
+JOIN   order_line  l ON l.order_id    = o.id
+JOIN   article     a ON a.id          = l.article_id
+WHERE  c.city = 'Berlin';
+----
+
+In Java the relationships *are* references, so the join is just dereferencing them in order:
+
+[source, java]
+----
+shop.getCustomers().stream()
+    .filter(c -> "Berlin".equals(c.getCity()))
+    .flatMap(c -> c.getOrders().stream())
+    .flatMap(o -> o.getLines().stream())
+    .map(OrderLine::getArticle)
+    .distinct()
+    .toList();
+----
+
+No join keys, no aliases, no foreign-key direction to reason about.
+If the relationship is bidirectional in your model, you can start from the article side and the query mirrors that — without rewriting any join clauses.
+
+=== Existence check
+
+[source, sql]
+----
+SELECT c.*
+FROM   customer c
+WHERE  EXISTS (
+    SELECT 1
+    FROM   "order"    o
+    JOIN   order_line l ON l.order_id = o.id
+    JOIN   article    a ON a.id       = l.article_id
+    WHERE  o.customer_id = c.id
+      AND  a.name = 'Coffee'
+);
+----
+
+[source, java]
+----
+shop.getCustomers().stream()
+    .filter(c -> c.getOrders().stream()
+        .flatMap(o -> o.getLines().stream())
+        .anyMatch(l -> "Coffee".equals(l.getArticle().getName())))
+    .toList();
+----
+
+The SQL needs a correlated subquery; the Java just nests the predicates the same way the data is nested.
+
+=== Graph traversal (Cypher)
+
+Cypher is closer in spirit, because it pattern-matches on a graph — but the pattern still lives in a separate language whose runtime is not your JVM.
+
+[source, cypher]
+----
+MATCH (c:Customer {city: 'Berlin'})-[:PLACED]->(:Order)
+      -[:CONTAINS]->(:OrderLine)-[:OF]->(a:Article)
+RETURN DISTINCT a;
+----
+
+The Java version is the join example above — same shape, no pattern syntax, no driver, no separate result mapper.
+
+For variable-length traversals (Cypher's `-[:KNOWS*1..3]->`), a small recursive method walks the references with full control over depth, cycle detection and pruning:
+
+[source, java]
+----
+Set<Person> withinDistance(Person start, int maxDepth)
+{
+    Set<Person> visited = new HashSet<>();
+    visit(start, maxDepth, visited);
+    return visited;
+}
+
+void visit(Person p, int depthLeft, Set<Person> visited)
+{
+    if(depthLeft < 0 || !visited.add(p))
+    {
+        return;
+    }
+    for(Person friend : p.getFriends())
+    {
+        visit(friend, depthLeft - 1, visited);
+    }
+}
+----
+
+The Cypher pattern is more concise when it fits.
+When it doesn't — branching depth, conditional pruning, custom scoring — pattern syntax tends to hit a wall.
+Plain Java has no such wall.
+
+[NOTE]
+====
+This is not a claim that SQL or Cypher are bad — they are excellent at what they do, particularly across a network boundary against a dataset and a process you do not own.
+The point is narrower: if your data is already a Java object graph in your own JVM, introducing a query language buys you very little and costs you the compile-time safety, IDE support and debugability you get for free in Java.
+====
+
+== Sorting and paging
+
+`sorted` takes any `Comparator`; chain `thenComparing` for tie-breakers, and use `skip` + `limit` for paging.
+
+[source, java]
+----
+List<Article> byPriceThenName = shop.getArticles().stream()
+    .sorted(Comparator.comparingDouble(Article::getPrice)
+        .thenComparing(Article::getName))
+    .toList();
+----
+
+[source, java]
+----
+int pageSize  = 50;
+int pageIndex = 2; // zero-based
+
+List<Article> page = shop.getArticles().stream()
+    .sorted(Comparator.comparing(Article::getName))
+    .skip((long) pageIndex * pageSize)
+    .limit(pageSize)
+    .toList();
+----
+
+For descending order, use `Comparator.reversed()` or `Comparator.comparing(...).reversed()`.
+
+== Mapping and aggregation
+
+The primitive stream specializations (`mapToInt`, `mapToLong`, `mapToDouble`) and `Collectors.summarizing*` cover the typical SQL aggregates.
+
+[source, java]
+----
+// Sum: total value of all available articles
+double inStockValue = shop.getArticles().stream()
+    .filter(Article::isAvailable)
+    .mapToDouble(Article::getPrice)
+    .sum();
+----
+
+[source, java]
+----
+// Average price across all articles
+OptionalDouble averagePrice = shop.getArticles().stream()
+    .mapToDouble(Article::getPrice)
+    .average();
+----
+
+[source, java]
+----
+// All aggregates in one pass
+DoubleSummaryStatistics stats = shop.getArticles().stream()
+    .collect(Collectors.summarizingDouble(Article::getPrice));
+
+double min     = stats.getMin();
+double max     = stats.getMax();
+double avg     = stats.getAverage();
+long   count   = stats.getCount();
+double sum     = stats.getSum();
+----
+
+== Projections with records
+
+When you only need a subset of fields, a `record` is a one-line typed shape that doubles as a DTO.
+
+[source, java]
+----
+record ArticleSummary(String name, double price) {}
+
+List<ArticleSummary> summaries = shop.getArticles().stream()
+    .filter(Article::isAvailable)
+    .map(a -> new ArticleSummary(a.getName(), a.getPrice()))
+    .toList();
+----
+
+That's the SQL `SELECT name, price FROM article WHERE available` — except the result is a list of typed, immutable objects, not a `ResultSet`, and the same record can flow straight into a controller, a test or a cache without any mapping layer.
+
+Records are also the cleanest way to build composite group-by keys.
+
+[source, java]
+----
+record CategoryYear(String category, int year) {}
+
+Map<CategoryYear, Long> ordersPerCategoryAndYear = shop.getOrders().stream()
+    .flatMap(o -> o.getLines().stream()
+        .map(l -> new CategoryYear(
+            l.getArticle().getCategory(),
+            o.getDate().getYear())))
+    .collect(Collectors.groupingBy(k -> k, Collectors.counting()));
+----
+
+== Grouping and partitioning
+
+`Collectors.groupingBy` covers SQL's `GROUP BY`; `partitioningBy` is the boolean special case.
+
+[source, java]
+----
+// Number of articles per category
+Map<String, Long> countByCategory = shop.getArticles().stream()
+    .collect(Collectors.groupingBy(
+        Article::getCategory,
+        Collectors.counting()));
+----
+
+[source, java]
+----
+// Average price per category
+Map<String, Double> avgPriceByCategory = shop.getArticles().stream()
+    .collect(Collectors.groupingBy(
+        Article::getCategory,
+        Collectors.averagingDouble(Article::getPrice)));
+----
+
+[source, java]
+----
+// Split into available / unavailable in one pass
+Map<Boolean, List<Article>> byAvailability = shop.getArticles().stream()
+    .collect(Collectors.partitioningBy(Article::isAvailable));
+----
+
+== Top-N per group
+
+SQL needs a window function for "the three most expensive articles per category":
+
+[source, sql]
+----
+SELECT *
+FROM (
+    SELECT a.*,
+           ROW_NUMBER() OVER (PARTITION BY category ORDER BY price DESC) AS rn
+    FROM   article a
+)
+WHERE rn <= 3;
+----
+
+In Java, a `groupingBy` whose downstream collector trims each group is enough.
+
+[source, java]
+----
+Map<String, List<Article>> topThreePerCategory = shop.getArticles().stream()
+    .collect(Collectors.groupingBy(
+        Article::getCategory,
+        Collectors.collectingAndThen(
+            Collectors.toList(),
+            list -> list.stream()
+                .sorted(Comparator.comparingDouble(Article::getPrice).reversed())
+                .limit(3)
+                .toList())));
+----
+
+The result is a typed `Map<String, List<Article>>` ready to render — no row-number column, no subquery wrapper, no result-set mapping.
+
+== Multiple criteria
+
+Compose `Predicate`s with `and`, `or` and `negate` instead of building one giant lambda.
+Reusable predicates make the call site read like a sentence and keep test coverage simple.
+
+[source, java]
+----
+Predicate<Article> available = Article::isAvailable;
+Predicate<Article> cheap     = a -> a.getPrice() < 10.0;
+Predicate<Article> drink     = a -> "Drinks".equals(a.getCategory());
+
+List<Article> cheapAvailableDrinks = shop.getArticles().stream()
+    .filter(available.and(cheap).and(drink))
+    .toList();
+
+List<Article> expensiveOrUnavailable = shop.getArticles().stream()
+    .filter(available.negate().or(cheap.negate()))
+    .toList();
+----
+
+== Traversing relationships
+
+What SQL solves with a `JOIN`, plain Java solves by following references.
+`flatMap` flattens nested collections; `anyMatch` / `allMatch` / `noneMatch` express "exists" / "for all" without materialising results.
+
+[source, java]
+----
+// All articles that have ever been ordered (with duplicates)
+List<Article> everOrdered = shop.getOrders().stream()
+    .flatMap(o -> o.getLines().stream())
+    .map(OrderLine::getArticle)
+    .toList();
+----
+
+[source, java]
+----
+// Distinct customers who ever bought "Coffee"
+Set<Customer> coffeeBuyers = shop.getOrders().stream()
+    .filter(o -> o.getLines().stream()
+        .anyMatch(l -> "Coffee".equals(l.getArticle().getName())))
+    .map(Order::getCustomer)
+    .collect(Collectors.toSet());
+----
+
+[source, java]
+----
+// Revenue per customer
+Map<Customer, Double> revenuePerCustomer = shop.getOrders().stream()
+    .collect(Collectors.groupingBy(
+        Order::getCustomer,
+        Collectors.summingDouble(o -> o.getLines().stream()
+            .mapToDouble(l -> l.getArticle().getPrice() * l.getQuantity())
+            .sum())));
+----
+
+[source, java]
+----
+// Customers who placed an order in 2026
+LocalDate from = LocalDate.of(2026, 1, 1);
+LocalDate to   = LocalDate.of(2027, 1, 1);
+
+Set<Customer> activeIn2026 = shop.getOrders().stream()
+    .filter(o -> !o.getDate().isBefore(from) && o.getDate().isBefore(to))
+    .map(Order::getCustomer)
+    .collect(Collectors.toSet());
+----
+
+== Encapsulate queries as domain methods
+
+Most "queries" are about a specific entity — a customer's revenue, an article's stock level.
+Put the query on the class instead of repeating it in every caller.
+
+[source, java]
+----
+public class Customer
+{
+    private List<Order> orders = new ArrayList<>();
+
+    public double totalRevenue()
+    {
+        return this.orders.stream()
+            .flatMap(o -> o.getLines().stream())
+            .mapToDouble(l -> l.getArticle().getPrice() * l.getQuantity())
+            .sum();
+    }
+
+    public boolean hasEverBought(String articleName)
+    {
+        return this.orders.stream()
+            .flatMap(o -> o.getLines().stream())
+            .anyMatch(l -> articleName.equals(l.getArticle().getName()));
+    }
+}
+----
+
+The call site becomes the readable version of the question:
+
+[source, java]
+----
+double revenue = customer.totalRevenue();
+
+List<Customer> coffeeBuyers = shop.getCustomers().stream()
+    .filter(c -> c.hasEverBought("Coffee"))
+    .toList();
+----
+
+This is what SQL views and Cypher procedures *try* to be — except here the method is part of the same compiled type, refactor-safe, debuggable and indistinguishable from any other piece of your domain model.
+
+== Maps as indexes
+
+Streams scan; maps look up.
+When a query is on the hot path and you know the access pattern, store the right map at the root and the query collapses to a single `get`.
+
+[source, java]
+----
+public class Shop
+{
+    // ...
+    private final Map<Long,   Customer>      customersById      = new HashMap<>();
+    private final Map<String, List<Article>> articlesByCategory = new HashMap<>();
+}
+----
+
+[source, java]
+----
+Customer c = shop.customersById.get(42L);
+
+List<Article> drinks = shop.articlesByCategory
+    .getOrDefault("Drinks", List.of());
+----
+
+You populate and maintain these maps yourself in the methods that add or change entities, and you store the map alongside the entity that changed.
+This is the same trade-off any database makes between a sequential scan and a secondary index — only here the index is just a regular Java field.
+
+TIP: For collections that are too large to keep fully resident, see xref:loading-data/lazy-loading/lazy-collections.adoc[Lazy Collections] (`LazyHashMap`, `LazyArrayList`, `LazyHashSet`).
+
+== Range queries with `NavigableMap`
+
+For range-based lookups — date windows, price bands, score thresholds — `TreeMap` (or any `NavigableMap`) covers the SQL `BETWEEN` / `>=` / `<=` cases without any scan.
+
+[source, java]
+----
+NavigableMap<LocalDate, List<Order>> ordersByDate = new TreeMap<>();
+// populate / maintain this alongside writes ...
+
+// All orders in March 2026
+// SQL: WHERE date >= '2026-03-01' AND date < '2026-04-01'
+NavigableMap<LocalDate, List<Order>> march = ordersByDate.subMap(
+    LocalDate.of(2026, 3, 1), true,
+    LocalDate.of(2026, 4, 1), false);
+
+// Most recent order at or before today
+// SQL: SELECT ... WHERE date <= ? ORDER BY date DESC LIMIT 1
+Map.Entry<LocalDate, List<Order>> latest = ordersByDate.floorEntry(LocalDate.now());
+----
+
+`subMap`, `headMap` and `tailMap` return *live views* that walk only the matching range, not copies.
+For multidimensional ranges (e.g. price *and* date), nest two `NavigableMap`s, or fall back to a xref:gigamap:queries/index.adoc[GigaMap] with the appropriate indices.
+
+== Materialized aggregates
+
+When an aggregate is queried often and only changes on specific writes, store it as a field and update it where the write happens.
+
+[source, java]
+----
+public class Shop
+{
+    private final List<Order>             orders             = new ArrayList<>();
+    private       long                    orderCount         = 0;
+    private       double                  revenueTotal       = 0.0;
+    private final Map<Customer, Double>   revenuePerCustomer = new HashMap<>();
+
+    public void addOrder(Order order)
+    {
+        this.orders.add(order);
+
+        double value = order.totalValue();
+        this.orderCount++;
+        this.revenueTotal += value;
+        this.revenuePerCustomer.merge(order.getCustomer(), value, Double::sum);
+
+        // store the changed entities in one transaction ...
+    }
+}
+----
+
+Now `shop.orderCount`, `shop.revenueTotal` and `shop.revenuePerCustomer.get(c)` are all O(1) reads — no stream, no scan.
+This is the same idea as a SQL materialized view, except the "refresh" runs synchronously inside the same method that performs the write, so the aggregate is always exactly consistent with the data.
+
+[NOTE]
+====
+Keep the derived state and the underlying entities under the same lock, and store them in the same transaction.
+A crash mid-method must not be able to leave the aggregate out of sync with its source — see xref:storing-data/transactions.adoc[Convenience Methods and Explicit Storing].
+====
+
+== Lazy references inside queries
+
+If part of the graph sits behind an xref:loading-data/lazy-loading/index.adoc[`Lazy<T>`] reference, you have to ask for it before you can stream it.
+Use the static `Lazy.get(...)` to stay null-safe.
+
+[source, java]
+----
+public class BusinessYear
+{
+    private Lazy<List<Order>> orders;
+    // ...
+}
+
+// Triggers load on first access; transparent on subsequent calls
+List<Order> orders = Lazy.get(year.getOrders());
+
+double yearRevenue = orders.stream()
+    .flatMap(o -> o.getLines().stream())
+    .mapToDouble(l -> l.getArticle().getPrice() * l.getQuantity())
+    .sum();
+----
+
+[IMPORTANT]
+====
+Streaming over a `Lazy<List<...>>` loads the whole list into memory.
+If the list is large and you only want a subset, design for it: split the data into multiple smaller lazy partitions (e.g. one `Lazy<List<Order>>` per year), or use xref:loading-data/lazy-loading/lazy-collections.adoc[Lazy Collections] which only load the segments you actually touch.
+====
+
+== Parallel streams
+
+Parallel streams are useful when the predicate or mapping does real CPU work over data that is *already* loaded.
+
+[source, java]
+----
+double total = shop.getArticles().parallelStream()
+    .filter(Article::isAvailable)
+    .mapToDouble(Article::getPrice)
+    .sum();
+----
+
+[WARNING]
+====
+Do not parallelise across `Lazy.get(...)` boundaries.
+A parallel stream over a list of `Lazy` references will trigger many concurrent storage loads — at best it just shifts the bottleneck to I/O, at worst it produces unpredictable latency spikes.
+Load first, parallelise second.
+====
+
+== Concurrency and consistency
+
+Queries see the live object graph, including changes made by other threads.
+If your application updates entities concurrently with read-only queries, you have to coordinate that yourself — {product-name} does not introduce hidden snapshots or transactions for queries.
+
+Two pragmatic patterns:
+
+* Synchronise reads and writes through a single lock or a `ReadWriteLock` around the affected sub-graph.
+  See xref:misc:locking/index.adoc[Locking] for ready-made utilities.
+* Take a defensive copy at the start of a long-running query (`new ArrayList<>(shop.getArticles())`) so concurrent mutations cannot affect the iteration.
+
+For most read-heavy workloads, the second pattern is enough and avoids any contention with writers.
+
+== When you outgrow plain Java: GigaMap
+
+Plain-Java queries assume the data you query against is loaded.
+Once a single collection grows beyond what is sensible to keep on the heap — millions of entities, frequent equality / range / full-text lookups, or a need to query before loading — switch that collection to a xref:gigamap:index.adoc[`GigaMap`].
+
+A `GigaMap` keeps an off-heap bitmap index, executes the query against the index, and only loads the segments that match.
+The query API is fluent and composable, but conceptually still operates on Java objects.
+
+[source, java]
+----
+GigaMap<Person> people = ...;
+
+List<Person> berliners = people.query()
+    .and(PersonIndices.city.is("Berlin"))
+    .and(PersonIndices.age.greaterThanEqual(18))
+    .toList();
+----
+
+For the full surface — defining indices, condition methods, executing queries, multithreaded execution — see xref:gigamap:queries/index.adoc[GigaMap Queries].

--- a/docs/modules/storage/pages/rest-interface/index.adoc
+++ b/docs/modules/storage/pages/rest-interface/index.adoc
@@ -29,11 +29,11 @@ It is made up of the following modules:
 |storage-restclient
 |Abstract REST client interface, which serves as a Java wrapper for the REST API.
 
-|storage-restservice-sparkjava
-|REST service implementation which utilizes SparkJava and provides REST endpoints.
+|storage-restservice-javalin
+|REST service implementation which utilizes Javalin and provides REST endpoints. Recommended for standalone applications.
 
 |storage-restservice-springboot
-|REST service implementation which utilizes SpringBoot and Spring MVC and provides REST endpoints.
+|REST service implementation which utilizes SpringBoot and Spring MVC and provides REST endpoints. Recommended for Spring Boot applications.
 
 |storage-restclient-jersey
 |REST client implementation which utilizes Jersey as a webservice framework.

--- a/docs/modules/storage/pages/rest-interface/rest-api.adoc
+++ b/docs/modules/storage/pages/rest-interface/rest-api.adoc
@@ -22,9 +22,6 @@ implementation (see xref:storage:rest-interface/setup.adoc[Setup]):
 |`+http://<host>:<port>/store-data/<storage-name>+`
 |===
 
-NOTE: A Spark Java implementation also exists, but is deprecated and will be removed
-in a future release. New applications should use the Javalin or Spring Boot service.
-
 In the route tables below, `[instance-name]` is the placeholder for the storage
 instance segment of the URL.
 

--- a/docs/modules/storage/pages/rest-interface/rest-api.adoc
+++ b/docs/modules/storage/pages/rest-interface/rest-api.adoc
@@ -1,6 +1,93 @@
 = REST API
 :table-caption!:
 
+The REST API exposes a read-only view of an {product-name} Storage instance.
+It is intended for inspection, monitoring, and tooling — not as a query language.
+All endpoints are HTTP `GET` and return `application/json` by default.
+
+== Base URL and instance name
+
+Every endpoint is mounted below a base URL whose shape depends on the chosen service
+implementation (see xref:storage:rest-interface/setup.adoc[Setup]):
+
+[options="header",cols="1,3"]
+|===
+|Implementation
+|Default base URL
+
+|Javalin (recommended for standalone applications)
+|`+http://<host>:4567/store-data+`
+
+|Spring Boot (recommended for Spring Boot applications)
+|`+http://<host>:<port>/store-data/<storage-name>+`
+|===
+
+NOTE: A Spark Java implementation also exists, but is deprecated and will be removed
+in a future release. New applications should use the Javalin or Spring Boot service.
+
+In the route tables below, `[instance-name]` is the placeholder for the storage
+instance segment of the URL.
+
+* For Javalin, this is a single configurable name (`store-data` by default; see
+  xref:storage:rest-interface/setup.adoc[Setup] for the environment variables that
+  override the port and name).
+* For Spring Boot, this is the bean name of the storage manager, or `default` when
+  the auto-configured manager is used. Multiple storage managers are exposed side
+  by side under their respective bean names.
+
+NOTE: All numeric `objectId` and length fields are emitted as JSON strings, not
+JSON numbers, to preserve full 64-bit precision in JavaScript clients.
+
+== Endpoint overview
+
+[options="header",cols="1,3,3"]
+|===
+|Method
+|Route
+|Purpose
+
+|`GET`
+|`/`
+|List all available routes of the service.
+
+|`GET`
+|`[instance-name]/root`
+|Return name and object id of the storage root.
+
+|`GET`
+|`[instance-name]/object/\{objectId\}`
+|Return type information and member values of a single object.
+
+|`GET`
+|`[instance-name]/dictionary`
+|Return the persistent type dictionary.
+
+|`GET`
+|`[instance-name]/maintenance/filesStatistics`
+|Return statistics of storage files and channels.
+|===
+
+== GET Routes
+
+[source,javascript]
+----
+/
+----
+
+Returns the list of all routes registered by the service. Useful for discovering the
+available endpoints at runtime.
+
+[source, json, title="Response"]
+----
+[
+  { "url": "/store-data/default/",                            "httpMethod": "get" },
+  { "url": "/store-data/default/root",                        "httpMethod": "get" },
+  { "url": "/store-data/default/dictionary",                  "httpMethod": "get" },
+  { "url": "/store-data/default/object/:oid",                 "httpMethod": "get" },
+  { "url": "/store-data/default/maintenance/filesStatistics", "httpMethod": "get" }
+]
+----
+
 == GET Root
 
 [source,javascript]
@@ -8,24 +95,50 @@
 [instance-name]/root
 ----
 
-Returns the name and object id of the current storage root element.
+Returns the name and object id of the storage root element. The returned `objectId`
+is the entry point for traversing the object graph through the
+xref:#_get_object[GET Object] endpoint.
 
 [source, json, title="Response"]
 ----
 {
-	"name": "ROOT",
-	"objectId": "1000000000000000028"
+    "name": "ROOT",
+    "objectId": "1000000000000000028"
 }
 ----
 
+.Response fields
+[options="header",cols="1,1,3a"]
+|===
+|Field
+|Type
+|Description
+
+|name
+|string
+|The registered name of the root object (e.g. `ROOT` for the default root).
+
+|objectId
+|string
+|The object id of the root object.
+|===
+
+[#_get_object]
 == GET Object
 
 [source,javascript]
 ----
-[instance-name]/object/:objectid
+[instance-name]/object/{objectId}
 ----
 
-Returns description and values of a distinct object.
+Returns the description and values of a single persisted object identified by its
+object id. The response contains type information together with the object's
+fixed-size and variable-size members.
+
+For container-like objects (collections, arrays, maps, ...) the response can be
+paginated using the `fixedOffset`, `fixedLength`, `variableOffset`, and
+`variableLength` query parameters. For value-bearing members (e.g. long strings or
+byte arrays) the size of each emitted value can be capped via `valueLength`.
 
 .Path parameters
 [options="header",cols="1,1,3a"]
@@ -33,10 +146,10 @@ Returns description and values of a distinct object.
 |Parameter
 |Type
 |Description
-//-------------
+
 |objectId
 |long
-|The requested object's id
+|The requested object's id.
 |===
 
 .Query parameters
@@ -46,59 +159,124 @@ Returns description and values of a distinct object.
 |Type
 |Description
 |Default
-//-------------
+
 |valueLength
 |long
-|Limit size of returned value elements, e.g. String values.
+|Maximum length of each emitted value. Applies to variable-length values such as
+ `String`, `byte[]`, and `char[]`. Values longer than this limit are truncated in
+ the response.
 |unlimited
 
 |fixedOffset
 |long
-|Fixed size members start offset.
+|Index of the first fixed-size member to include in the response.
 |0
 
 |fixedLength
 |long
-|Amount of returned fixed size members.
+|Maximum number of fixed-size members to return, starting at `fixedOffset`.
 |unlimited
 
 |variableOffset
 |long
-|Variable size members start offset.
+|Index of the first element to include for each variable-size member (e.g. the
+ entries of a list).
 |0
 
 |variableLength
 |long
-|Amount of returned variable size members.
+|Maximum number of elements to return for each variable-size member, starting at
+ `variableOffset`.
 |unlimited
 
 |references
 |boolean
-|Determines if top-level references of the object should be returned as well.
+|If `true`, top-level references of the object are resolved and included in the
+ `references` array of the response.
 |false
+
+|format
+|string
+|Requested response format. Currently `json` (alias `application/json`) is
+ supported.
+|json
 |===
 
 [source, json, title="Response"]
 ----
 {
-	"objectId": "1000000000000000028",
-	"typeId": "110",
-	"length": "0",
-	"variableLength": [
-	"3"
-	],
-	"simplified": false,
-	"data": [
-		[
-			"1000000000000000029",
-			"1000000000000000030",
-			"1000000000000000031"
-		]
-	],
-	"references": null
+    "objectId": "1000000000000000028",
+    "typeId": "110",
+    "length": "0",
+    "variableLength": [
+        "3"
+    ],
+    "simplified": false,
+    "data": [
+        [
+            "1000000000000000029",
+            "1000000000000000030",
+            "1000000000000000031"
+        ]
+    ],
+    "references": null
 }
 ----
 
+.Response fields
+[options="header",cols="1,1,3a"]
+|===
+|Field
+|Type
+|Description
+
+|objectId
+|string
+|Object id of the described object.
+
+|typeId
+|string
+|Type id of the object. Resolves against the
+ xref:#_get_type_dictionary[type dictionary].
+
+|length
+|string
+|Number of fixed-size members of the object as defined by its type. `0` if the
+ type has no fixed-size members.
+
+|variableLength
+|string[]
+|For each variable-size member, the total number of elements available — independent
+ of `variableOffset` / `variableLength`. Use this to drive pagination.
+
+|simplified
+|boolean
+|`true` for primitive wrapper objects whose value is reported in `data` directly
+ instead of as a member array. `false` for ordinary objects.
+
+|data
+|array
+|The collected members. Fixed-size members are emitted first, in declared order,
+ followed by variable-size members. Each variable-size member is itself a JSON
+ array. References to other persisted objects are emitted as their object id
+ (string).
+
+|references
+|array
+|`null` unless `references=true` was requested. When present, contains a fully
+ nested object description for every top-level reference held by the object,
+ using the same shape as this response.
+|===
+
+.Pagination example
+[source]
+----
+[instance-name]/object/1000000000000000028?variableOffset=100&variableLength=50
+----
+
+Returns elements 100..149 of each variable-size member of the object.
+
+[#_get_type_dictionary]
 == GET Type Dictionary
 
 [source,javascript]
@@ -106,45 +284,135 @@ Returns description and values of a distinct object.
 [instance-name]/dictionary
 ----
 
-Returns the type dictionary as text output.
+Returns the persistent type dictionary of the storage as plain text. The dictionary
+maps type ids (as returned in the `typeId` field of object descriptions) to fully
+qualified Java type names and their persisted member layout.
 
-[source, json, title="Response"]
+The response is the textual representation produced by the underlying serializer and
+is intended to be consumed by tooling rather than parsed ad hoc.
+
+[source, text, title="Response (excerpt)"]
 ----
-[Type dictionary contents]
+1:java.lang.Object
+{
+}
+
+110:java.util.ArrayList
+{
+    int                                            size            ;
+    [java.lang.Object]                             elementData     ;
+}
 ----
 
-== GET Statistics
+== GET Files Statistics
 
 [source,javascript]
 ----
 [instance-name]/maintenance/filesStatistics
 ----
 
-Returns statistics of the used storage files and channels.
+Returns statistics about the storage's data files broken down per channel. Use this
+endpoint to monitor storage size, channel balance, and the ratio of live to total
+data.
 
 [source, json, title="Response"]
 ----
 {
-	"creationTime": "2020-04-15T13:32:26.003Z",
-	"channelStatistics": {
-		"0": {
-			"channelIndex": 0,
-			"files": [
-				{
-					"fileNumber": "1",
-					"file": "storage\\channel_0\\channel_0_1.dat",
-					"fileCount": "1",
-					"liveDataLength": "2898",
-					"totalDataLength": "2930"
-				}
-			],
-			"fileCount": "1",
-			"liveDataLength": "2898",
-			"totalDataLength": "2930"
-		}
-	},
-	"fileCount": "1",
-	"liveDataLength": "2898",
-	"totalDataLength": "2930"
+    "creationTime": "2020-04-15T13:32:26.003Z",
+    "channelStatistics": {
+        "0": {
+            "channelIndex": 0,
+            "files": [
+                {
+                    "fileNumber": "1",
+                    "file": "storage/channel_0/channel_0_1.dat",
+                    "fileCount": "1",
+                    "liveDataLength": "2898",
+                    "totalDataLength": "2930"
+                }
+            ],
+            "fileCount": "1",
+            "liveDataLength": "2898",
+            "totalDataLength": "2930"
+        }
+    },
+    "fileCount": "1",
+    "liveDataLength": "2898",
+    "totalDataLength": "2930"
 }
 ----
+
+.Top-level fields
+[options="header",cols="1,1,3a"]
+|===
+|Field
+|Type
+|Description
+
+|creationTime
+|string (ISO-8601)
+|Time at which the statistics were computed.
+
+|channelStatistics
+|object
+|Map of channel index (as string) to the statistics of that channel.
+
+|fileCount
+|string
+|Total number of data files across all channels.
+
+|liveDataLength
+|string
+|Sum of live (still referenced) data bytes across all channels.
+
+|totalDataLength
+|string
+|Sum of total data bytes (live + garbage) across all channels.
+|===
+
+.Per-channel and per-file fields
+[options="header",cols="1,1,3a"]
+|===
+|Field
+|Type
+|Description
+
+|channelIndex
+|number
+|Zero-based index of the channel.
+
+|files
+|array
+|Per-file statistics for this channel.
+
+|fileNumber
+|string
+|Sequence number of the data file within its channel.
+
+|file
+|string
+|Storage-relative path of the data file.
+
+|liveDataLength
+|string
+|Live data bytes in this file.
+
+|totalDataLength
+|string
+|Total data bytes in this file (live + garbage). The difference between
+ `totalDataLength` and `liveDataLength` represents space that can be reclaimed by
+ housekeeping.
+|===
+
+== Error responses
+
+All endpoints return HTTP `404 Not Found` with a plain-text body when:
+
+* a path or query parameter has an invalid type (e.g. a non-numeric `objectId`,
+  a negative offset / length, or an unsupported `format`),
+* the requested object id does not exist,
+* the requested storage name is not registered (Spring Boot only — multiple storage
+  managers are addressed by bean name).
+
+The body of the response contains a short human-readable description of the failing
+parameter or condition.

--- a/docs/modules/storage/pages/rest-interface/setup.adoc
+++ b/docs/modules/storage/pages/rest-interface/setup.adoc
@@ -6,9 +6,8 @@ An application that will expose the REST endpoints needs one of the provided imp
 
 Currently, two implementations are available:
 
-- SpringBoot 3.x REST Service
-- Javalin REST Service
-- Spark Java REST Service (Deprecated, will be removed in future versions)
+- Javalin REST Service — recommended for standalone applications.
+- Spring Boot 3.x REST Service — recommended for Spring Boot applications.
 
 
 == Spring Boot REST Service
@@ -93,70 +92,3 @@ If you want to change the default port (4567) or instance name (_store-data_) it
 | `store-data`
 | Instance name used in the base URL (without leading/trailing "/").
 |===
-
-== Spark Java REST Service
-
-In this example, we will use the https://sparkjava.com/[Spark] implementation that {product-name} provides.
-This has no dependencies to other frameworks and makes no assumptions about your runtime environment, IoC container,
-dependency injection, web server or anything else.
-
-Just add the dependency to your project, the logger is optional.
-
-[source, xml, title="pom.xml", subs=attributes+]
-----
-<dependencies>
-    <dependency>
-        <groupId>org.eclipse.store</groupId>
-        <artifactId>storage-restservice-sparkjava</artifactId>
-        <version>{maven-version}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>1.7.32</version>
-    </dependency>
-</dependencies>
-----
-
-Now use the resolver to connect the REST service to the storage, start it, and you're good to go.
-
-[source, java]
-----
-EmbeddedStorageManager storage = EmbeddedStorage.start();
-if (storage.root() == null)
-{
-   storage.setRoot(new Object[] {
-      LocalDate.now(),
-      X.List("a", "b", "c"),
-      1337
-   });
-   storage.storeRoot();
-}
-
-// create the REST service
-StorageRestService service = StorageRestServiceResolver.resolve(storage);
-
-// and start it
-service.start();
-----
-
-That's all you have to do to open the REST endpoints to access the stored data.
-
-The base URL of the provided endpoints is per default: http://localhost:4567/store-data/ and you can find out all available endpoints on the root http://localhost:4567
-
-=== Additional Configuration
-
-If you want to change the default port (4567) or instance name (_store-data_) it can be done by using the rest service implementation directly, and not go through the _Resolver` as in the previous snippet.
-
-The Spark service can then be customized to your liking.
-
-[source, java]
-----
-StorageRestServiceSparkJava service = StorageRestServiceSparkJava.New(storage);
-service.setSparkService(
-   Service.ignite().port(8888)
-);
-service.setInstanceName("my-name");
-----
-
-This will change the base URL to http://localhost:8888/my-name/

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -48,15 +48,21 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	/**
 	 * Adds an {@link Indexer} to this group.
 	 * <p>
-	 * Shortcut for
-	 * <code>
-	 * add(indexer.name(), indexer)
-	 * </code>
+	 * The indexer's {@link Indexer#name() name()} is used as its unique registry key
+	 * within this {@code BitmapIndices}. Registering a second indexer under a name
+	 * that is already taken fails fast with a {@link RuntimeException} rather than
+	 * silently overwriting the existing one. This is mostly invisible when names come
+	 * from the default derivation (declaration-based names are naturally distinct),
+	 * but it can bite when {@link Indexer#name() name()} is overridden manually or
+	 * when anonymous {@link Indexer} instances produce colliding default names; give
+	 * each indexer an explicit, unique name in those cases.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the indexing logic
 	 * @return the resuling index
-	 * @throws IllegalStateException if an indexer with the same name is already registered
+	 * @throws IllegalArgumentException if {@code indexer} or its name is {@code null}
+	 * @throws RuntimeException if an indexer with the same name is already registered
+	 * @see Indexer#name()
 	 */
 	public <K> BitmapIndex<E, K> add(final Indexer<? super E, K> indexer);
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Indexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Indexer.java
@@ -138,6 +138,15 @@ public interface Indexer<E, K> extends IndexIdentifier<E, K>
 	 * This class provides a default behavior for obtaining a name, which can be either
 	 * explicitly set or derived dynamically using reflection if not available. The name
 	 * is used as a unique identifier for indexing operations.
+	 * <p>
+	 * The default name derivation prefers the fully qualified name of the {@code static}
+	 * field that declares the indexer instance, which makes names naturally unique when
+	 * indexers are declared as constants. For instances that are <em>not</em> assigned to
+	 * a {@code static} field (for example, anonymous classes created inline), the name
+	 * falls back to a class-based identifier that may collide with other anonymous
+	 * instances of the same indexer type. Override {@link #name()} to provide an explicit,
+	 * unique name in those cases. Indexer names must be unique within a
+	 * {@link BitmapIndices}; duplicates are rejected at registration time.
 	 *
 	 * @param <E> the entity type
 	 * @param <K> the key type

--- a/storage/rest/service-sparkjava/README.md
+++ b/storage/rest/service-sparkjava/README.md
@@ -1,4 +1,17 @@
-sparkjava# Storage Viewer HowTo:
+# Storage Viewer HowTo (Spark Java)
+
+> ## ⚠️ Deprecated
+>
+> The Spark Java REST service implementation is **deprecated** and will be **removed in a future release**.
+>
+> New applications should use one of the supported implementations instead:
+>
+> - **`storage-restservice-javalin`** — recommended for standalone applications.
+> - **`storage-restservice-springboot`** — recommended for Spring Boot applications.
+>
+> See the [REST Interface documentation](https://docs.eclipsestore.io/manual/storage/rest-interface/index.html) for setup instructions.
+>
+> The content below is kept for reference only and no longer receives feature updates.
 
 # Content
 - [Setup](#1-setup)


### PR DESCRIPTION
## Summary
Documentation roll-up on the `docs-update` branch covering four independent improvements:

- **REST API reference** (7f8232be) — expand `docs/modules/storage/pages/rest-interface/rest-api.adoc` with the full set of endpoints, response structures, and worked examples.
- **Spark Java REST service deprecation** (16df2464) — mark the SparkJava-based REST service as deprecated and steer readers towards the Javalin and Spring Boot alternatives. Removes Spark-specific setup/install instructions from the docs and updates the module's `README.md` accordingly.
- **Storage queries guide** (433a2904) — rewrite and substantially expand `docs/modules/storage/pages/queries.adoc` with examples, comparisons, and best-practice guidance.
- **GigaMap indexer name uniqueness** (6fcd977e, closes #528) — add an `IMPORTANT` admonition to `docs/modules/gigamap/pages/indexing/bitmap/defining.adoc` and rewrite the Javadoc on `BitmapIndices.add(Indexer)` and `Indexer.Abstract` so the uniqueness contract is discoverable from both the docs site and the API reference. Also fixes the existing `@throws IllegalStateException` claim on `add(Indexer)` (the impl throws `RuntimeException`) and drops a stale "Shortcut for `add(indexer.name(), indexer)`" reference to a non-existent overload.