### PR TITLE
Fix GigaMap builder for duplicate indexer usage

### DIFF
--- a/docs/modules/gigamap/pages/constraints.adoc
+++ b/docs/modules/gigamap/pages/constraints.adoc
@@ -33,19 +33,19 @@ A unique constraint and an xref:indexing/bitmap/types.adoc#_identity_index[ident
 
 [source, java]
 ----
-// use the builder
+// use the builder — the same indexer can be passed to both methods
 final GigaMap<Person> gigaMap = GigaMap.<Person>Builder()
     .withBitmapIdentityIndex(PersonIndices.id)
     .withBitmapUniqueIndex(PersonIndices.id) // enforce uniqueness at runtime
     ...
     .build();
 
-// or register it after creating
+// or register it after creating: addUniqueConstraint creates the backing
+// bitmap index, then setIdentityIndices promotes it to identity
 GigaMap<Person> gigaMap = GigaMap.New();
-final BitmapIndices<E> bitmap = this.gigaMap.index().bitmap();
-bitmap.ensure(PersonIndices.id);             // add index first
-bitmap.setIdentityIndices(PersonIndices.id); // set as identity
-bitmap.addUniqueConstraint(PersonIndices.id); // enforce uniqueness
+final BitmapIndices<Person> bitmap = gigaMap.index().bitmap();
+bitmap.addUniqueConstraint(PersonIndices.id); // creates index + unique constraint
+bitmap.setIdentityIndices(PersonIndices.id);  // promote it to identity
 ----
 
 == Custom Constraints

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -14,9 +14,6 @@ package org.eclipse.store.gigamap.types;
  * #L%
  */
 
-import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
-import org.eclipse.store.gigamap.types.GigaQuery.ConditionBuilder;
-import org.eclipse.store.gigamap.types.IterationThreadProvider.IterationLogicProvider;
 import org.eclipse.serializer.branching.ThrowBreak;
 import org.eclipse.serializer.chars.XChars;
 import org.eclipse.serializer.collections.BulkList;
@@ -33,6 +30,9 @@ import org.eclipse.serializer.persistence.binary.types.BinaryTypeHandler;
 import org.eclipse.serializer.persistence.types.*;
 import org.eclipse.serializer.reference.Lazy;
 import org.eclipse.serializer.util.X;
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.GigaQuery.ConditionBuilder;
+import org.eclipse.store.gigamap.types.IterationThreadProvider.IterationLogicProvider;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -881,8 +881,17 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 					? GigaMap.New(XHashing.hashEqualityValue())
 					: GigaMap.New()
 				;
-				
+
 				final BitmapIndices<E> indices = gigaMap.index().bitmap();
+
+				// addUniqueConstraints validates strictly (throws on duplicate names), so it
+				// must run first. The subsequent ensureAll calls are idempotent and simply
+				// reuse the bitmap index already created when the same indexer was passed to
+				// more than one with...Index method.
+				if(!this.uniqueIndices.isEmpty())
+				{
+					indices.addUniqueConstraints(this.uniqueIndices);
+				}
 				if(!this.bitmapIndices.isEmpty())
 				{
 					indices.ensureAll(this.bitmapIndices);
@@ -892,15 +901,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 					indices.ensureAll(this.identityIndices);
 					indices.setIdentityIndices(this.identityIndices);
 				}
-				if(!this.uniqueIndices.isEmpty())
-				{
-					indices.addUniqueConstraints(this.uniqueIndices);
-				}
 				if(!this.customConstraints.isEmpty())
 				{
 					gigaMap.constraints().custom().addConstraints(this.customConstraints);
 				}
-				
+
 				return gigaMap;
 			}
 				

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintViolationExceptionFieldsTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintViolationExceptionFieldsTest.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * - {@code entityId}, {@code replacedEntity}, {@code violatingEntity}
  *
  * Also covers the identity + unique index combination:
- * - Builder API: {@code withBitmapIdentityIndex} + {@code withBitmapUniqueIndex}
- * - Post-creation API: {@code ensure} + {@code setIdentityIndices} + {@code addUniqueConstraint}
+ * - Builder API: {@code withBitmapIdentityIndex} + {@code withBitmapUniqueIndex} on the same indexer
+ * - Post-creation API: {@code addUniqueConstraint} + {@code setIdentityIndices}
  */
 public class ConstraintViolationExceptionFieldsTest
 {
@@ -145,10 +145,9 @@ public class ConstraintViolationExceptionFieldsTest
 	// ---------------------------------------------------------------
 	// Unique + identity index — builder API
 	//
-	// withBitmapIdentityIndex and withBitmapUniqueIndex cannot use the same
-	// indexer instance inside the builder (it would register the bitmap index
-	// twice). The correct builder pattern is withBitmapUniqueIndex only, then
-	// setIdentityIndices() on the built map.
+	// The builder accepts the same indexer for both withBitmapIdentityIndex
+	// and withBitmapUniqueIndex; the underlying bitmap index is registered
+	// once and is both identity and unique.
 	// ---------------------------------------------------------------
 
 	@Test
@@ -165,6 +164,27 @@ public class ConstraintViolationExceptionFieldsTest
 			() -> map.add(new Person("alice@test.com", 99)));
 
 		assertEquals(2, map.size());
+	}
+
+	@Test
+	void uniqueAndIdentityIndex_builder_combinedIdentityAndUnique()
+	{
+		final GigaMap<Person> map = GigaMap.<Person>Builder()
+			.withBitmapIdentityIndex(EMAIL_INDEX)
+			.withBitmapUniqueIndex(EMAIL_INDEX)
+			.build();
+
+		final Person alice = new Person("alice@test.com", 1);
+		map.add(alice);
+		map.add(new Person("bob@test.com", 2));
+
+		// identity: update() finds the entity through the identity index
+		map.update(alice, p -> p.level = 42);
+		assertEquals(42, alice.level);
+
+		// unique: a second entity with the same email is rejected
+		assertThrows(UniqueConstraintViolationException.class,
+			() -> map.add(new Person("alice@test.com", 99)));
 	}
 
 	@Test

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BuilderWithIndicesTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BuilderWithIndicesTest.java
@@ -15,6 +15,7 @@ package org.eclipse.store.gigamap.indexer;
  */
 
 import org.eclipse.serializer.collections.ConstHashEnum;
+import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationException;
 import org.eclipse.store.gigamap.types.BinaryIndexerNumber;
 import org.eclipse.store.gigamap.types.BinaryIndexerString;
 import org.eclipse.store.gigamap.types.GigaMap;
@@ -30,6 +31,8 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class BuilderWithIndicesTest
@@ -271,6 +274,131 @@ public class BuilderWithIndicesTest
         assertEquals(0, gigaMap.size());
     }
 
+    // ---------------------------------------------------------------
+    // Same indexer passed to multiple with...Index methods.
+    //
+    // build() must register the underlying bitmap index only once and
+    // apply every requested role (plain bitmap / identity / unique).
+    // ---------------------------------------------------------------
+
+    @Test
+    void sameIndexer_bitmapPlusIdentity()
+    {
+        final StringIndexer stringIndexer = new StringIndexer();
+
+        final GigaMap<Entity> gigaMap = GigaMap.<Entity>Builder()
+            .withBitmapIndex(stringIndexer)
+            .withBitmapIdentityIndex(stringIndexer)
+            .build();
+
+        gigaMap.add(new Entity("1000", 1));
+        gigaMap.add(new Entity("2000", 2));
+
+        // bitmap behavior: query works
+        assertEquals("1000", gigaMap.query(stringIndexer.is("1000")).findFirst().get().value);
+        // identity is registered (single index, same name as the plain bitmap)
+        assertEquals(1, gigaMap.index().bitmap().identityIndices().size());
+        assertSame(
+            gigaMap.index().bitmap().get(stringIndexer.keyType(), stringIndexer.name()),
+            gigaMap.index().bitmap().identityIndices().get()
+        );
+    }
+
+    @Test
+    void sameIndexer_bitmapPlusUnique()
+    {
+        final StringIndexer stringIndexer = new StringIndexer();
+
+        final GigaMap<Entity> gigaMap = GigaMap.<Entity>Builder()
+            .withBitmapIndex(stringIndexer)
+            .withBitmapUniqueIndex(stringIndexer)
+            .build();
+
+        gigaMap.add(new Entity("1000", 1));
+
+        // bitmap behavior: query works
+        assertEquals("1000", gigaMap.query(stringIndexer.is("1000")).findFirst().get().value);
+        // unique behavior: duplicate is rejected
+        assertThrows(UniqueConstraintViolationException.class,
+            () -> gigaMap.add(new Entity("1000", 2)));
+    }
+
+    @Test
+    void sameIndexer_identityPlusUnique()
+    {
+        final StringIndexer stringIndexer = new StringIndexer();
+
+        final GigaMap<Entity> gigaMap = GigaMap.<Entity>Builder()
+            .withBitmapIdentityIndex(stringIndexer)
+            .withBitmapUniqueIndex(stringIndexer)
+            .build();
+
+        gigaMap.add(new Entity("1000", 1));
+
+        // identity is registered, points to the same backing index as the unique constraint
+        assertEquals(1, gigaMap.index().bitmap().identityIndices().size());
+        assertSame(
+            gigaMap.index().bitmap().identityIndices().get(),
+            gigaMap.index().bitmap().uniqueConstraints().get()
+        );
+        // unique behavior: duplicate is rejected
+        assertThrows(UniqueConstraintViolationException.class,
+            () -> gigaMap.add(new Entity("1000", 2)));
+    }
+
+    @Test
+    void sameIndexer_bitmapPlusIdentityPlusUnique()
+    {
+        final StringIndexer stringIndexer = new StringIndexer();
+
+        final GigaMap<Entity> gigaMap = GigaMap.<Entity>Builder()
+            .withBitmapIndex(stringIndexer)
+            .withBitmapIdentityIndex(stringIndexer)
+            .withBitmapUniqueIndex(stringIndexer)
+            .build();
+
+        gigaMap.add(new Entity("1000", 1));
+
+        // a single underlying index serves all three roles
+        assertEquals(1, gigaMap.index().bitmap().identityIndices().size());
+        assertEquals(1, gigaMap.index().bitmap().uniqueConstraints().size());
+        assertSame(
+            gigaMap.index().bitmap().identityIndices().get(),
+            gigaMap.index().bitmap().uniqueConstraints().get()
+        );
+        // bitmap query works
+        assertEquals("1000", gigaMap.query(stringIndexer.is("1000")).findFirst().get().value);
+        // unique behavior is enforced
+        assertThrows(UniqueConstraintViolationException.class,
+            () -> gigaMap.add(new Entity("1000", 2)));
+    }
+
+    @Test
+    void distinctIndexers_acrossAllThreeMethods()
+    {
+        // regression check: distinct indexers in different methods still produce
+        // three separate bitmap indices with the right roles.
+        final StringIndexer plainIndexer    = new StringIndexer();
+        final IdIndexer     identityIndexer = new IdIndexer();
+        final UniqueIdIndexer uniqueIndexer = new UniqueIdIndexer();
+
+        final GigaMap<Entity> gigaMap = GigaMap.<Entity>Builder()
+            .withBitmapIndex(plainIndexer)
+            .withBitmapIdentityIndex(identityIndexer)
+            .withBitmapUniqueIndex(uniqueIndexer)
+            .build();
+
+        gigaMap.add(new Entity("1000", 1));
+
+        assertEquals(1, gigaMap.index().bitmap().identityIndices().size());
+        assertEquals(1, gigaMap.index().bitmap().uniqueConstraints().size());
+        // unique constraint is the uniqueIndexer, not the identity one
+        assertEquals(uniqueIndexer.name(),
+            gigaMap.index().bitmap().uniqueConstraints().get().name());
+        assertEquals(identityIndexer.name(),
+            gigaMap.index().bitmap().identityIndices().get().name());
+    }
+
     private static class StringIndexer extends BinaryIndexerString.Abstract<Entity>
     {
     	@Override
@@ -281,6 +409,16 @@ public class BuilderWithIndicesTest
     }
 
     private static class IdIndexer extends BinaryIndexerNumber.Abstract<Entity, Integer>
+    {
+        @Override
+        protected Integer getNumber(final Entity entity)
+        {
+            return entity.id;
+        }
+    }
+
+    // a second number indexer with a distinct name, for the distinct-indexers test
+    private static class UniqueIdIndexer extends BinaryIndexerNumber.Abstract<Entity, Integer>
     {
         @Override
         protected Integer getNumber(final Entity entity)


### PR DESCRIPTION

### Description of Changes
Update `GigaMap.Builder.build()` to ensure proper handling when the same indexer is registered for multiple roles (e.g., identity and unique). The building order is adjusted so that unique constraints are validated first, preventing conflicts.

Additionally:
- Fixed documentation example in `constraints.adoc`.
- Added test cases for cross-method indexer combinations.
