### PR TITLE
Mirror deletion / truncation directories to the backup

### DIFF
--- a/docs/modules/storage/pages/configuration/backup/continuous-backup.adoc
+++ b/docs/modules/storage/pages/configuration/backup/continuous-backup.adoc
@@ -31,6 +31,32 @@ EmbeddedStorageManager storageManager = EmbeddedStorageConfigurationBuilder.New(
 backupDirectory = backupDir
 ----
 
+== Mirroring deletion and truncation directories
+
+When the live storage uses a `deletion-directory` and/or `truncation-directory`, configure the backup-side counterparts so the rescued files are also preserved on the backup side. Without this, files removed from the backup during housekeeping are physically deleted even though the live side keeps them for recovery.
+
+[source,java,title="Java"]
+----
+EmbeddedStorageManager storageManager = EmbeddedStorageConfigurationBuilder.New()
+	.setStorageDirectory("storageDir")
+	.setDeletionDirectory("storageDir/deleted")
+	.setTruncationDirectory("storageDir/truncated")
+	.setBackupDirectory("backupDir")
+	.setBackupDeletionDirectory("backupDir/deleted")
+	.setBackupTruncationDirectory("backupDir/truncated")
+	.createEmbeddedStorageFoundation()
+	.createEmbeddedStorageManager();
+----
+
+[source,text,title="external configuration:"]
+----
+backup-directory = backupDir
+backup-deletion-directory = backupDir/deleted
+backup-truncation-directory = backupDir/truncated
+----
+
+On startup, the backup is synchronized with the live deletion and truncation directories: any rescued file already present on the live side is copied to the backup-side counterpart if it isn't there yet. The check is idempotent and matches files by their parsed channel and file number.
+
 With {product-name} foundation classes:
 
 [source,java,title="Java"]

--- a/docs/modules/storage/pages/configuration/properties.adoc
+++ b/docs/modules/storage/pages/configuration/properties.adoc
@@ -34,6 +34,14 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 |The backup file system configuration. See xref:storage-targets/index.adoc[storage targets] configuration.
 |xref:#type-complex[Complex]
 
+|backup-deletion-directory
+|If configured, files removed from the backup will be moved to this directory instead of being physically deleted. Mirrors files already present in the live `deletion-directory`.
+|xref:#type-string[String]
+
+|backup-truncation-directory
+|If configured, backup files that get truncated are copied into this directory. Mirrors files already present in the live `truncation-directory`.
+|xref:#type-string[String]
+
 |xref:#channel-count[channel-count]
 |The number of threads and number of directories used by the storage engine. Every thread has exclusive access to its directory. Default is `1`.
 |xref:#type-integer[Integer]
@@ -276,6 +284,12 @@ This list shows which property configures which type, used by the foundation typ
 
 | backup-filesystem
 | `StorageBackupSetup`
+
+| backup-deletion-directory
+| `StorageBackupFileProvider`
+
+| backup-truncation-directory
+| `StorageBackupFileProvider`
 
 | channel-count
 | `StorageChannelCountProvider`

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -65,6 +65,16 @@ public class EclipseStoreProperties
     private StorageFilesystem backupFilesystem;
 
     /**
+     * If configured, files removed from the backup will be moved to this directory instead of being physically deleted.
+     */
+    private String backupDeletionDirectory;
+
+    /**
+     * If configured, backup files that get truncated are copied into this directory.
+     */
+    private String backupTruncationDirectory;
+
+    /**
      * The number of threads and number of directories used by the storage engine. Every thread has exclusive access to its directory. Default is 1.
      */
     private String channelCount;
@@ -278,6 +288,26 @@ public class EclipseStoreProperties
     public void setBackupFilesystem(final StorageFilesystem backupFilesystem)
     {
         this.backupFilesystem = backupFilesystem;
+    }
+
+    public String getBackupDeletionDirectory()
+    {
+        return this.backupDeletionDirectory;
+    }
+
+    public void setBackupDeletionDirectory(final String backupDeletionDirectory)
+    {
+        this.backupDeletionDirectory = backupDeletionDirectory;
+    }
+
+    public String getBackupTruncationDirectory()
+    {
+        return this.backupTruncationDirectory;
+    }
+
+    public void setBackupTruncationDirectory(final String backupTruncationDirectory)
+    {
+        this.backupTruncationDirectory = backupTruncationDirectory;
     }
 
     public String getChannelCount()

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -48,6 +48,8 @@ public class EclipseStoreConfigConverter
     protected static final String TRUNCATION_DIRECTORY = EmbeddedStorageConfigurationPropertyNames.TRUNCATION_DIRECTORY;
     protected static final String BACKUP_DIRECTORY = EmbeddedStorageConfigurationPropertyNames.BACKUP_DIRECTORY;
     protected static final String BACKUP_FILESYSTEM = EmbeddedStorageConfigurationPropertyNames.BACKUP_FILESYSTEM;
+    protected static final String BACKUP_DELETION_DIRECTORY = EmbeddedStorageConfigurationPropertyNames.BACKUP_DELETION_DIRECTORY;
+    protected static final String BACKUP_TRUNCATION_DIRECTORY = EmbeddedStorageConfigurationPropertyNames.BACKUP_TRUNCATION_DIRECTORY;
 
     // Fields for the channel configuration
     protected static final String CHANNEL_COUNT = EmbeddedStorageConfigurationPropertyNames.CHANNEL_COUNT;
@@ -108,6 +110,9 @@ public class EclipseStoreConfigConverter
         {
             configValues.putAll(this.prepareFileSystem(properties.getBackupFilesystem(), BACKUP_FILESYSTEM));
         }
+
+        configValues.put(BACKUP_DELETION_DIRECTORY, properties.getBackupDeletionDirectory());
+        configValues.put(BACKUP_TRUNCATION_DIRECTORY, properties.getBackupTruncationDirectory());
 
         configValues.put(CHANNEL_COUNT, properties.getChannelCount());
         configValues.put(CHANNEL_DIRECTORY_PREFIX, properties.getChannelDirectoryPrefix());

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
@@ -113,6 +113,26 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 	}
 
 	/**
+	 * The deletion directory of the backup. Files removed from the backup by
+	 * housekeeping are moved here instead of being physically deleted, mirroring
+	 * the behavior of {@link #setDeletionDirectory(String)} for the live storage.
+	 *
+	 * @param backupDeletionDirectory the deletion directory of the backup
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setBackupDeletionDirectory(String backupDeletionDirectory);
+
+	/**
+	 * The truncation directory of the backup. Truncated backup files are copied
+	 * here before being shortened, mirroring the behavior of
+	 * {@link #setTruncationDirectory(String)} for the live storage.
+	 *
+	 * @param backupTruncationDirectory the truncation directory of the backup
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setBackupTruncationDirectory(String backupTruncationDirectory);
+
+	/**
 	 * The number of threads and number of directories used by the storage
 	 * engine. Every thread has exclusive access to its directory. Default is
 	 * <code>1</code>.
@@ -467,6 +487,22 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 		)
 		{
 			return this.set(BACKUP_DIRECTORY, backupDirectory);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setBackupDeletionDirectory(
+			final String backupDeletionDirectory
+		)
+		{
+			return this.set(BACKUP_DELETION_DIRECTORY, backupDeletionDirectory);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setBackupTruncationDirectory(
+			final String backupTruncationDirectory
+		)
+		{
+			return this.set(BACKUP_TRUNCATION_DIRECTORY, backupTruncationDirectory);
 		}
 
 		@Override

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
@@ -48,6 +48,16 @@ public interface EmbeddedStorageConfigurationPropertyNames
 	public final static String BACKUP_FILESYSTEM             = "backup-filesystem";
 
 	/**
+	 * @see EmbeddedStorageConfigurationBuilder#setBackupDeletionDirectory(String)
+	 */
+	public final static String BACKUP_DELETION_DIRECTORY     = "backup-deletion-directory";
+
+	/**
+	 * @see EmbeddedStorageConfigurationBuilder#setBackupTruncationDirectory(String)
+	 */
+	public final static String BACKUP_TRUNCATION_DIRECTORY   = "backup-truncation-directory";
+
+	/**
 	 * @see EmbeddedStorageConfigurationBuilder#setChannelCount(int)
 	 */
 	public final static String CHANNEL_COUNT                 = "channel-count";

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -30,6 +30,8 @@ import org.eclipse.store.afs.nio.types.NioFileSystem;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
 import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageBackupFileProvider;
+import org.eclipse.store.storage.types.StorageBackupSetup;
 import org.eclipse.store.storage.types.StorageChannelCountProvider;
 import org.eclipse.store.storage.types.StorageConfiguration;
 import org.eclipse.store.storage.types.StorageDataFileEvaluator;
@@ -118,8 +120,28 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 						BACKUP_FILESYSTEM,
 						() -> fileSystem
 					);
-					configBuilder.setBackupSetup(Storage.BackupSetup(
-						backupFileSystem.ensureDirectoryPath(backupDirectory)
+
+					final StorageBackupFileProvider.Builder<?> backupBuilder =
+						Storage.BackupFileProviderBuilder(backupFileSystem)
+							.setDirectory(backupFileSystem.ensureDirectoryPath(backupDirectory))
+					;
+
+					this.configuration.opt(BACKUP_DELETION_DIRECTORY)
+						.filter(deletionDirectory -> !XChars.isEmpty(deletionDirectory))
+						.ifPresent(deletionDirectory -> backupBuilder.setDeletionDirectory(
+							backupFileSystem.ensureDirectoryPath(deletionDirectory)
+						))
+					;
+
+					this.configuration.opt(BACKUP_TRUNCATION_DIRECTORY)
+						.filter(truncationDirectory -> !XChars.isEmpty(truncationDirectory))
+						.ifPresent(truncationDirectory -> backupBuilder.setTruncationDirectory(
+							backupFileSystem.ensureDirectoryPath(truncationDirectory)
+						))
+					;
+
+					configBuilder.setBackupSetup(StorageBackupSetup.New(
+						backupBuilder.createFileProvider()
 					));
 				})
 			;

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupHandler.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupHandler.java
@@ -16,6 +16,9 @@ package org.eclipse.store.storage.types;
 
 import static org.eclipse.serializer.util.X.notNull;
 
+import java.util.HashSet;
+
+import org.eclipse.serializer.afs.types.ADirectory;
 import org.eclipse.serializer.afs.types.AFS;
 import org.eclipse.serializer.afs.types.AFile;
 import org.eclipse.serializer.collections.BulkList;
@@ -54,7 +57,25 @@ public interface StorageBackupHandler extends Runnable, StorageActivePart
 	public void deleteFile(
 		StorageLiveChannelFile<?> file
 	);
-	
+
+	/**
+	 * Mirrors any files that already exist in the live storage's deletion or truncation directory
+	 * to the backup's corresponding directory. Idempotent: files already present on the backup
+	 * side (matched by parsed channel/file-number) are skipped.
+	 * <p>
+	 * Has no effect for sides where the deletion / truncation directory is not configured.
+	 *
+	 * @param channelIndex the storage channel index
+	 * @param liveFileProvider the live file provider whose rescued files shall be mirrored
+	 */
+	public default void synchronizeRescuedFiles(
+		final int                 channelIndex    ,
+		final StorageFileProvider liveFileProvider
+	)
+	{
+		// default no-op for non-default implementations
+	}
+
 	public StorageBackupHandler start();
 	
 	public default StorageBackupHandler stop()
@@ -609,20 +630,114 @@ public interface StorageBackupHandler extends Runnable, StorageActivePart
 			{
 				return;
 			}
-			
+
 			final StorageBackupChannelFile backupTargetFile = file.ensureBackupFile(this);
-			
+
 			logger.debug("Deleting backup file: {}", backupTargetFile.file().toPathString());
-			
+
 			StorageFileWriter.deleteFile(
 				backupTargetFile,
 				this.writeController,
 				this.backupSetup.backupFileProvider()
 			);
-			
+
 			// no user decrement since only the identifier is required and the actual file can well have been deleted.
 		}
-		
+
+		@Override
+		public void synchronizeRescuedFiles(
+			final int                 channelIndex    ,
+			final StorageFileProvider liveFileProvider
+		)
+		{
+			final StorageBackupFileProvider backupFileProvider = this.backupSetup.backupFileProvider();
+
+			this.synchronizeRescuedDirectory(
+				channelIndex                                ,
+				liveFileProvider.deletionDirectory()        ,
+				backupFileProvider.deletionDirectory()      ,
+				liveFileProvider                            ,
+				backupFileProvider                          ,
+				true
+			);
+
+			this.synchronizeRescuedDirectory(
+				channelIndex                                ,
+				liveFileProvider.truncationDirectory()      ,
+				backupFileProvider.truncationDirectory()    ,
+				liveFileProvider                            ,
+				backupFileProvider                          ,
+				false
+			);
+		}
+
+		private void synchronizeRescuedDirectory(
+			final int                       channelIndex      ,
+			final ADirectory                liveRescueDir     ,
+			final ADirectory                backupRescueDir   ,
+			final StorageFileProvider       liveFileProvider  ,
+			final StorageBackupFileProvider backupFileProvider,
+			final boolean                   isDeletion
+		)
+		{
+			if(liveRescueDir == null || backupRescueDir == null)
+			{
+				return;
+			}
+
+			final BulkList<StorageDataInventoryFile> liveRescued   = BulkList.New();
+			final BulkList<StorageDataInventoryFile> backupRescued = BulkList.New();
+			if(isDeletion)
+			{
+				liveFileProvider  .collectDeletedDataFiles(StorageDataInventoryFile::New, liveRescued  , channelIndex);
+				backupFileProvider.collectDeletedDataFiles(StorageDataInventoryFile::New, backupRescued, channelIndex);
+			}
+			else
+			{
+				liveFileProvider  .collectTruncatedDataFiles(StorageDataInventoryFile::New, liveRescued  , channelIndex);
+				backupFileProvider.collectTruncatedDataFiles(StorageDataInventoryFile::New, backupRescued, channelIndex);
+			}
+
+			if(liveRescued.isEmpty())
+			{
+				return;
+			}
+
+			final HashSet<Long> existingNumbers = new HashSet<>();
+			for(final StorageDataInventoryFile f : backupRescued)
+			{
+				existingNumbers.add(f.number());
+			}
+
+			final String channelDirName = backupFileProvider.fileNameProvider()
+				.provideChannelDirectoryName(channelIndex)
+			;
+
+			for(final StorageDataInventoryFile liveFile : liveRescued)
+			{
+				if(existingNumbers.contains(liveFile.number()))
+				{
+					continue;
+				}
+
+				final ADirectory backupChannelDir = backupRescueDir.ensureDirectory(channelDirName);
+				backupChannelDir.ensureExists();
+				final AFile backupTarget = backupChannelDir.ensureFile(
+					liveFile.file().name(),
+					liveFile.file().type()
+				);
+
+				logger.debug(
+					"Mirroring rescued file to backup: {}",
+					backupTarget.toPathString()
+				);
+
+				AFS.executeWriting(backupTarget, wf ->
+					liveFile.copyTo(wf)
+				);
+			}
+		}
+
 		final void closeAllDataFiles()
 		{
 			final DisruptionCollectorExecuting<StorageClosableFile> closer = DisruptionCollectorExecuting.New(file ->

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -997,8 +997,9 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			{
 				return;
 			}
-			
+
 			this.backupHandler.synchronize(inventory);
+			this.backupHandler.synchronizeRescuedFiles(this.channelIndex(), this.fileProvider);
 		}
 
 		private StorageIdAnalysis initializeForExistingFiles(

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileProvider.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileProvider.java
@@ -56,6 +56,12 @@ public interface StorageFileProvider extends PersistenceTypeDictionaryIoHandler.
 			C                          collector   ,
 			int                        channelIndex
 	);
+
+	public <F extends StorageDataFile, C extends Consumer<F>> C collectTruncatedDataFiles(
+			StorageDataFile.Creator<F> creator     ,
+			C                          collector   ,
+			int                        channelIndex
+	);
 	
 	public interface Builder<B extends Builder<?>>
 	{
@@ -489,13 +495,32 @@ public interface StorageFileProvider extends PersistenceTypeDictionaryIoHandler.
 			C collector,
 			int channelIndex)
 		{
-			if(this.deletionDirectory == null)
+			return this.collectRescuedDataFiles(this.deletionDirectory, creator, collector, channelIndex);
+		}
+
+		@Override
+		public <F extends StorageDataFile, C extends Consumer<F>> C collectTruncatedDataFiles(
+			StorageDataFile.Creator<F> creator,
+			C collector,
+			int channelIndex)
+		{
+			return this.collectRescuedDataFiles(this.truncationDirectory, creator, collector, channelIndex);
+		}
+
+		private <F extends StorageDataFile, C extends Consumer<F>> C collectRescuedDataFiles(
+			final ADirectory                 sourceDirectory,
+			final StorageDataFile.Creator<F> creator        ,
+			final C                          collector      ,
+			final int                        channelIndex
+		)
+		{
+			if(sourceDirectory == null)
 			{
 				return collector;
 			}
 
-			this.deletionDirectory.inventorize();
-			final ADirectory directory = this.deletionDirectory.getDirectory(
+			sourceDirectory.inventorize();
+			final ADirectory directory = sourceDirectory.getDirectory(
 				fileNameProvider.provideChannelDirectoryName(channelIndex));
 
 			if(directory != null)


### PR DESCRIPTION
### Description

When deletion-directory (or truncation-directory) is configured, housekeeping rescues data files into that directory instead of physically deleting/truncating them, so they stay recoverable. The continuous backup was blind to this in two ways:                            

1. Property-based configuration only exposed these directories for the live StorageLiveFileProvider. Storage.BackupSetup(backupDirectory) left the backup provider's deletion/truncation dirs null, so rescueFromDeletion returned false and backup files were hard-deleted.
2. StorageBackupHandler.fillEmptyBackup / updateExistingBackup only iterate dataFiles() and the transactions file. Anything already in the live rescue directories at startup was never copied over.

Net effect: a consumer holding only the backup couldn't recover rescued data, defeating the purpose of the feature.

### Configuration
- New properties backup-deletion-directory / backup-truncation-directory (constants, builder setters, foundation-creator wiring, Spring Boot EclipseStoreProperties + EclipseStoreConfigConverter).
- The underlying StorageBackupFileProvider.Builder already inherited the corresponding setters from StorageFileProvider.Builder.Abstract; the configuration layer simply never invoked them.

### Startup synchronization
- StorageFileProvider.collectTruncatedDataFiles(...) added next to the existing collectDeletedDataFiles; the Abstract impl shares one helper for both.
- New StorageBackupHandler.synchronizeRescuedFiles(channelIndex, liveFileProvider): for each rescue directory configured on both sides, enumerates the live channel subdir and copies any rescued file whose parsed file-number is missing on the backup. Matching by file-number keeps it idempotent across restarts even though rescue timestamps differ between sides.
- StorageFileManager.initializeBackupHandler(StorageInventory) invokes it right after the existing synchronize.

### Runtime — no code change
Once the backup provider has its own rescue directories, the existing pipeline (StorageFileWriterBackupping → queue → StorageBackupHandler.deleteFile / truncateFile → StorageFileWriter) rescues backup files automatically.

### Docs
- continuous-backup.adoc gains a section with Java-builder and external-configuration snippets.
- properties.adoc documents the two new properties and their target type.

### Notes
- Defaults to off: without the new properties, behavior is unchanged.
- Rescue filenames carry a timestamp generated independently per side, so the two directories hold content-equivalent files with potentially differing names. The dedupe key (channel + file-number) is unique per rescued file and matches what collectDeletedDataFiles already uses for recovery.

### Test plan

- Force housekeeping rescues with both directories configured; verify each rescued live file has a content-equivalent counterpart on the backup, restart is idempotent.
- Repeat for truncation.
- Negative: live rescue dir set, backup rescue dir unset → backup files hard-deleted as before, no exception.
- External configuration loads both new keys into the resulting StorageBackupFileProvider.
- Existing storage / embedded-configuration / embedded test suites pass.