### PR TITLE
Seed live application OIDs into GC mark cycle to prevent zombie OIDs

### DIFF
--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageFoundation.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageFoundation.java
@@ -783,7 +783,7 @@ extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary
 		}
 		
 		@Override
-		protected EmbeddedStorageObjectRegistryCallback ensureObjectIdsSelector()
+		protected EmbeddedStorageObjectRegistryCallback ensureLiveObjectIdsHandler()
 		{
 			return this.getConnectionFoundation().getObjectRegistryCallback();
 		}
@@ -864,7 +864,7 @@ extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary
 			initializeTypeDictionary(stm, ecf);
 			
 			// setup callback link from storage to object registry for the GC to check for unexpected live objectIds.
-			this.setLiveObjectIdChecker(ecf.getObjectRegistryCallback());
+			this.setLiveObjectIdsHandler(ecf.getObjectRegistryCallback());
 
 			// resolve root types to root type ids after types have been initialized
 			this.initializeEmbeddedStorageRootTypeIdProvider(this.getRootTypeIdProvider(), thm);

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
@@ -14,31 +14,42 @@ package org.eclipse.store.storage.embedded.types;
  * #L%
  */
 
-import org.eclipse.serializer.persistence.types.ObjectIdsProcessor;
-import org.eclipse.serializer.persistence.types.ObjectIdsSelector;
-import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.persistence.types.*;
+import org.eclipse.store.storage.types.LiveObjectIdsHandler;
 
 /**
  * Callback bridge between the storage layer's garbage collector and the persistence layer's
  * {@link PersistenceObjectRegistry}.
  * <p>
  * The storage GC needs to know which object ids are currently held alive on the application side so that it
- * does not erroneously delete the corresponding entities. In embedded mode the persistence layer that owns
- * those live object ids is created later than the storage layer, so this callback is registered with the
- * storage upfront and is then {@link #initializeObjectRegistry(PersistenceObjectRegistry) initialized} as soon
- * as the application-side {@link PersistenceObjectRegistry} becomes available.
+ * does not erroneously delete the corresponding entities. As a {@link LiveObjectIdsHandler} this callback
+ * serves the GC's two interaction phases against the application registry:
+ * <ul>
+ *   <li><b>Mark seeding</b> via {@link #iterateLiveObjectIds(PersistenceObjectIdAcceptor)} — at the start of a
+ *       mark cycle the GC enumerates the application-held data object ids to seed mark roots, so that
+ *       entities reachable only through application-held references have their binary references walked and
+ *       transitively kept alive.</li>
+ *   <li><b>Sweep filter</b> via {@link #processSelected(ObjectIdsProcessor)} — during sweep the GC asks the
+ *       registry "is this object id still held by the application?" as the final safety net against
+ *       erroneous deletion.</li>
+ * </ul>
+ * In embedded mode the persistence layer that owns those live object ids is created later than the storage
+ * layer, so this callback is registered with the storage upfront and is then
+ * {@link #initializeObjectRegistry(PersistenceObjectRegistry) initialized} as soon as the application-side
+ * {@link PersistenceObjectRegistry} becomes available.
  * <p>
- * Until initialization the callback reports an empty live object id set, which is a safe default during the
- * brief window between storage startup and the creation of the first storage connection.
+ * Until initialization the callback reports no live object ids — {@link #processSelected processSelected}
+ * applies an empty filter and {@link #iterateLiveObjectIds iterateLiveObjectIds} is a no-op — which is a safe
+ * default during the brief window between storage startup and the creation of the first storage connection.
  *
- * @see ObjectIdsSelector
+ * @see LiveObjectIdsHandler
  * @see PersistenceObjectRegistry
  */
-public interface EmbeddedStorageObjectRegistryCallback extends ObjectIdsSelector
+public interface EmbeddedStorageObjectRegistryCallback extends LiveObjectIdsHandler
 {
 	/**
 	 * Binds the passed {@link PersistenceObjectRegistry} as the source of live object ids reported via
-	 * {@link #processSelected(ObjectIdsProcessor)}.
+	 * {@link #processSelected(ObjectIdsProcessor)} and {@link #iterateLiveObjectIds(PersistenceObjectIdAcceptor)}.
 	 * <p>
 	 * Calling this method again with the same registry instance is a no-op; calling it with a different
 	 * registry instance is rejected to avoid silently switching the live id source under a running garbage
@@ -62,9 +73,18 @@ public interface EmbeddedStorageObjectRegistryCallback extends ObjectIdsSelector
 	}
 
 	/**
-	 * Default implementation that reports an empty live object id set until
-	 * {@link #initializeObjectRegistry(PersistenceObjectRegistry)} has been called and afterwards forwards live
-	 * id selection to the bound {@link PersistenceObjectRegistry}.
+	 * Default implementation that reports no live object ids until
+	 * {@link #initializeObjectRegistry(PersistenceObjectRegistry)} has been called, and afterwards forwards
+	 * both the sweep-time selection and the mark-time iteration to the bound {@link PersistenceObjectRegistry}.
+	 * <p>
+	 * The mark-seed iteration emits every data-OID entry present in the registry's hash table regardless of
+	 * whether the underlying {@link java.lang.ref.WeakReference} is still live, mirroring the id-only
+	 * keep-alive predicate applied during sweep. {@link Persistence.IdType#OID OID}s only — TypeIds and
+	 * ConstantIds are skipped because they are intentionally unresolvable as storage entities and would
+	 * otherwise trigger the zombie handler.
+	 * <p>
+	 * All public methods are {@code synchronized} on the instance to coordinate the late initialization with
+	 * concurrent GC callbacks.
 	 */
 	public final class Default implements EmbeddedStorageObjectRegistryCallback
 	{
@@ -120,6 +140,32 @@ public interface EmbeddedStorageObjectRegistryCallback extends ObjectIdsSelector
 
 			// efficient for embedded mode, but server mode should use #selectLiveObjectIds instead.
 			return this.objectRegistry.processLiveObjectIds(processor);
+		}
+
+		@Override
+		public synchronized void iterateLiveObjectIds(final PersistenceObjectIdAcceptor acceptor)
+		{
+			if(this.objectRegistry == null)
+			{
+				return;
+			}
+
+			this.objectRegistry.iterateEntries((objectId, instance) ->
+			{
+				// Emit every data-OID entry in the hash table, regardless of whether the
+				// WeakReference is still live. The sweep keep-alive predicate
+				// (DefaultObjectRegistry#synchIsLiveObjectId -> synchContainsObjectId) is id-only and
+				// keeps cleared-but-not-yet-reaped entries alive at sweep time; if mark seeding
+				// skipped them here, their stored binary references would not be walked, and
+				// transitively-reachable entities whose own entries were already reaped could be
+				// swept while the parent stays kept — producing a zombie OID on the next mark cycle.
+				// Skip TypeIds and ConstantIds though: those are intentionally unresolvable as
+				// storage entities and would trigger the zombie handler.
+				if(Persistence.IdType.OID.isInRange(objectId))
+				{
+					acceptor.acceptObjectId(objectId);
+				}
+			});
 		}
 
 	}

--- a/storage/storage/GC.md
+++ b/storage/storage/GC.md
@@ -1,0 +1,443 @@
+# Storage Garbage Collection
+
+This document describes the EclipseStore storage garbage collector (storage GC), how it cooperates with the JVM's garbage collector, and the two-role *registry safety net* that keeps the persistent graph consistent when the application holds entities the persistent root no longer references.
+
+---
+
+## 1. Purpose
+
+The storage GC reclaims on-disk space occupied by entities that are no longer reachable. Concretely it:
+
+- Walks the persistent object graph starting from the persistent root.
+- Marks every reached storage entity (a binary record in a storage channel file).
+- Sweeps the entity cache, deleting entries whose binary records are not reachable.
+- Triggers file-level compaction for the freed regions.
+
+It is **not** the same thing as the JVM GC. Storage entities live in storage files (and in the per-channel in-memory `StorageEntityCache`); Java objects live on the JVM heap. A single logical datum can exist as *both* a storage entity (binary record + cache entry) and a live Java object — the two are correlated via an **object id** (OID).
+
+Key classes:
+
+| Concern | Class |
+|---|---|
+| Per-channel entity cache & mark/sweep driver | `StorageEntityCache.Default` |
+| Cross-channel mark monitor, OID mark queue, completion state machine | `StorageEntityMarkMonitor.Default` |
+| Per-channel mark queue (long[] buffer) | `StorageObjectIdMarkQueue` |
+| Dangling-reference callback | `StorageGCZombieOidHandler` |
+| Application-registry bridge (combined interface) | `LiveObjectIdsHandler` |
+| — sweep filter half of the bridge | `ObjectIdsSelector` (serializer) |
+| — mark-seed half of the bridge | `LiveObjectIdsIterator` |
+| Embedded-mode implementation of the bridge | `EmbeddedStorageObjectRegistryCallback` |
+
+---
+
+## 2. Two garbage collectors, two domains
+
+There are two independent collectors operating on correlated data:
+
+| Aspect | JVM GC | Storage GC |
+|---|---|---|
+| Domain | Java heap objects | storage entities (binary records in channel files) |
+| Reachability | strong/soft/weak references between Java objects | binary references (OIDs) between entities |
+| Roots | thread stacks, statics, JNI, etc. | the persistent root OID; plus app-registry OIDs (see §7) |
+| Trigger | JVM heuristics | storage housekeeping + `issueFullGarbageCollection` |
+| Reclaims | heap memory | disk space (via file cleanup after sweep) |
+
+These two worlds meet at the **`PersistenceObjectRegistry`**, which maps OIDs to live Java objects. The registry entries are `WeakReference`s — that is what lets JVM GC influence storage GC (see §8).
+
+---
+
+## 3. Mark and sweep
+
+The storage GC is a classic tri-color mark-and-sweep, adapted for concurrent per-channel operation:
+
+### Mark phase
+
+Each channel has a `StorageObjectIdMarkQueue`. The `StorageEntityMarkMonitor` enqueues starting OIDs (see §4 for *what* gets enqueued). `StorageEntityCache.Default.incrementalMark` repeatedly pops an OID, looks up its entity via `getEntry(oid)`, walks that entity's binary references (via `iterateReferenceIds`) and pushes each referenced OID onto the appropriate channel's queue. Marked entities transition white → gray → black.
+
+Critically: if `getEntry(oid)` returns `null`, the OID has no entity — either expected (a TID/CID, see §5) or a **zombie**. Control passes to `StorageGCZombieOidHandler.handleZombieOid(oid)`.
+
+### Sweep phase
+
+When all mark queues drain and `isMarkingComplete()` is true, `callToSweepRequired()` flips each channel into sweep mode. Each channel iterates its own entity cache and, per entity:
+
+```java
+// StorageEntityCache.Default#sweep, the keep-alive check:
+if (item.isGcMarked() || isReachableInApplication.test(item.objectId)) {
+    (last = item).markWhite();           // keep (reset to white for the next cycle)
+} else {
+    this.deleteEntity(item, sweepType, last);   // delete
+}
+```
+
+Two things can rescue an entity:
+1. It was gc-marked in the preceding mark phase — reachable from the persistent root (or a mark seed).
+2. The predicate `isReachableInApplication` returned true — the **registry safety net**.
+
+When the last channel finishes its sweep, `StorageEntityMarkMonitor.Default.completeSweep` seeds the next mark cycle with two complementary sets of roots: `determineAndEnqueueRootOid` enqueues the persistent root, and `enqueueLiveApplicationOids` enqueues every object id the application currently holds (see §9).
+
+### Flowcharts by phase
+
+The GC is easier to grasp one phase at a time. The five diagrams below partition the full tick, followed by a state diagram for the hot/cold flags.
+
+#### 3.1. Store-side preparation
+
+What a `store()` call does to the GC's state — three independent side effects that together "reopen" GC work:
+
+```mermaid
+flowchart LR
+    Store(["application store /<br/>storeRoot"]) --> A["markEntityForChangedData<br/>gray-mark stored entity<br/>enqueue its OID"]
+    Store --> B["markMonitor.resetCompletion<br/>gcHot = gcCold = false<br/>liveOidsSeededForCurrentCycle = false"]
+    Store --> C["PersistenceObjectRegistry.cleanUp<br/>drain ReferenceQueue<br/>reap cleared WeakRefs"]
+```
+
+#### 3.2. GC tick dispatch
+
+Every GC tick (`incrementalGarbageCollection`) starts here. The tick either runs one mark slice or one sweep pass — never both in the same tick.
+
+```mermaid
+flowchart TD
+    Tick(["GC tick:<br/>housekeeping or<br/>issueFullGarbageCollection"]) --> Cold{"gcColdPhaseComplete?"}
+    Cold -->|yes| Idle(["idle, return"])
+    Cold -->|no| Sweep{"needsSweep?<br/>markingComplete AND<br/>no sweep in progress"}
+    Sweep -->|no: marks pending| M(["→ mark phase (3.3)"])
+    Sweep -->|yes| S(["→ sweep phase (3.4)"])
+```
+
+#### 3.3. Mark phase — `incrementalMark`
+
+Pop an OID, resolve it to an entity, walk its binary references, mark black. Zombie detection is the left branch.
+
+```mermaid
+flowchart TD
+    Enter(["enter mark phase"]) --> Pop{"pop next OID<br/>from mark queue"}
+    Pop -->|queue empty| Done(["advanceMarking,<br/>return"])
+    Pop -->|got OID| Get["getEntry oid"]
+    Get --> Null{"entry == null?"}
+    Null -->|yes| Z["zombieOidHandler<br/>.handleZombieOid"]
+    Z --> T{"constant ID<br/>(CID)?"}
+    T -->|yes: expected| Pop
+    T -->|no: data OID| ZF["ZOMBIE OID detected"]
+    ZF --> Pop
+    Null -->|no| Blk{"already black?"}
+    Blk -->|yes| Pop
+    Blk -->|no| W["iterateReferenceIds<br/>push each referenced OID<br/>into mark queue"]
+    W --> MB["entity.markBlack"]
+    MB --> Pop
+
+    classDef zombie fill:#fde0e0,stroke:#b03030,stroke-width:2px
+    class ZF zombie
+```
+
+#### 3.4. Sweep phase — per channel
+
+Each channel walks its own entity cache and applies the keep-alive predicate.
+
+```mermaid
+flowchart TD
+    Enter(["enter sweep phase"]) --> R["resetMarkQueues<br/>all queues must be empty"]
+    R --> I["initiateSweep<br/>set needsSweep=true<br/>for every channel"]
+    I --> Loop["for each entity in<br/>this channel's cache"]
+    Loop --> K{"isGcMarked OR<br/>isReachableInApplication?"}
+    K -->|yes| Keep["markWhite:<br/>keep, reset colour<br/>for next cycle"]
+    K -->|no| Del["deleteEntity:<br/>remove from cache,<br/>detach from file"]
+    Keep --> Loop
+    Del --> Loop
+    Loop -->|all entities done| CS(["markMonitor.completeSweep<br/>→ (3.5)"])
+```
+
+#### 3.5. Sweep completion and re-seeding the next mark cycle
+
+The transition point between waves. Only the last channel to call `completeSweep` advances the hot/cold flags and re-seeds the persistent root. The application-state mark roots (highlighted in green) are pushed only when there will be another mark cycle to drain them — i.e. the hot-completing path. On the cold-completing path the GC is going idle, so seeding would only park the entire registry in the mark queues until the next store.
+
+```mermaid
+flowchart TD
+    CS(["markMonitor.completeSweep"]) --> L{"last channel<br/>to finish sweep?"}
+    L -->|no| R(["return, wait for<br/>remaining channels"])
+    L -->|yes| Adv["advanceGcCompletion"]
+    Adv --> H{"gcHotPhaseComplete<br/>already?"}
+    H -->|no: first sweep of wave| SH["gcHotPhaseComplete = true"]
+    H -->|yes: second sweep,<br/>no stores since| SC["gcColdPhaseComplete = true<br/>GC will idle after this"]
+    SH --> Seed1["determineAndEnqueueRootOid<br/>enqueue persistent root"]
+    SC --> Seed1Cold["determineAndEnqueueRootOid<br/>enqueue persistent root"]
+    Seed1 --> Seed2["enqueueLiveApplicationOids<br/>iterate registry, push every<br/>registry-resident OID as a mark root"]
+    Seed2 --> N(["next GC tick"])
+    Seed1Cold --> Idle(["idle, mark queues stay<br/>empty until next store"])
+
+    classDef appRoots fill:#e5f6d9,stroke:#3d8b1e,stroke-width:2px
+    class Seed2 appRoots
+```
+
+### Reading the diagrams together
+
+- **Stores (3.1) are what reset the GC into "work pending" state** — three side effects: enqueue the stored entity, clear completion flags, drain the `ReferenceQueue`.
+- **Every tick (3.2) first checks `gcColdPhaseComplete`.** If true, the GC is idle until a store reopens work.
+- **A tick either marks (3.3) or sweeps (3.4), not both.** The sweep check gates the branch.
+- **Zombie detection (3.3, red)** sits inside the mark loop at `getEntry(oid) == null`. In the mark phase the only expected null lookup is a constant id (CID) — constants are resolved at runtime rather than stored as entities. The default handler silently accepts CIDs and flags anything else as a zombie. (Type ids (TIDs) don't appear in binary references, so they cannot enter the mark queue in practice, but the default handler accepts them too as a defensive catch-all.)
+- **The sweep keep-alive predicate (3.4)** is the OR of `isGcMarked()` and `isReachableInApplication(oid)` — that OR is the registry safety net (see §7, §8).
+- **Completion + re-seeding (3.5)** establishes the root sets for the next wave. `determineAndEnqueueRootOid` always seeds the persistent root. `enqueueLiveApplicationOids` then pushes every registry-resident OID into the mark queue **only if another mark cycle will run** — i.e. when the wave just hot-completed. On the cold-completing sweep the GC is going idle, so seeding would only park the entire registry in the mark queues until the next store. The seed uses the same id-only criterion as the sweep predicate (3.4), so cleared-but-not-yet-reaped entries (case (b) in §8) are seeded too — see §10.1.
+
+### Phase state diagram (hot / cold)
+
+The hot/cold completion flags are their own little state machine, independent of the per-tick logic above:
+
+```mermaid
+stateDiagram-v2
+    [*] --> ColdComplete: startup, gcHot and gcCold both true
+    ColdComplete --> Dirty: store triggers resetCompletion
+    Dirty --> HotComplete: first sweep finishes
+    HotComplete --> Dirty: store triggers resetCompletion
+    HotComplete --> ColdComplete: second sweep finishes, no stores since
+    ColdComplete --> ColdComplete: GC tick returns immediately
+```
+
+- `Dirty` = at least one of hot/cold is `false`; the GC has real work (mark or sweep) to do.
+- `HotComplete` = one full mark+sweep has happened since the last store. Unreachable entities from that store are gone, but a second confirmation pass is still owed.
+- `ColdComplete` = the confirmation pass has run with no new stores. GC ticks are no-ops until a store reopens work.
+
+`enqueueLiveApplicationOids` runs on the `Dirty → HotComplete` transition (so the cold mark cycle within the wave gets re-seeded application-state roots) but **not** on `HotComplete → ColdComplete`: there is no follow-up mark cycle to drain those OIDs, so seeding would just leave the whole registry resident in the mark queues until the next store. The next wave's pre-sweep gate (§10.2) re-seeds at the start of the next cycle anyway.
+
+---
+
+## 4. Mark roots
+
+The starting set of the mark phase consists of:
+
+- **The persistent root OID** — determined per channel via `StorageRootOidSelector` and unified in `determineAndEnqueueRootOid`. This is what makes the persistent graph traversable at all.
+- **Entities marked as "changed"** — when the application stores something, `markEntityForChangedData` gray-marks the stored entity and enqueues its OID. This is how newly-stored or updated data enters the mark cycle.
+- **Live application-held OIDs** — at the end of every sweep that does not cold-complete the wave, `enqueueLiveApplicationOids` iterates the `PersistenceObjectRegistry` and enqueues every live OID into the mark queues for the next cycle. (At cold-complete the GC is going idle, so seeding is skipped to keep the queues empty; the next wave's pre-sweep gate re-seeds — §10.) This makes every entity the application currently holds a mark root, so the graph reachable from application state is traversed alongside the graph reachable from the persistent root. See §7–§9.
+
+---
+
+## 5. OID classes: TIDs, CIDs, OIDs
+
+Not every long id in the system maps to a storage entity. `Persistence.IdType` defines four disjoint ranges:
+
+| Range | Meaning | Has storage entity? |
+|---|---|---|
+| TID | Type id (class metadata) | No — types are resolved at runtime. |
+| CID | Constant id (JLS constants) | No — constants are resolved at runtime. |
+| OID | Regular object id (data entity) | **Yes** — this is what the storage GC actually tracks. |
+| NULL / UNDEFINED | sentinel / invalid | No. |
+
+This matters for mark-time. At mark time, the only realistic "null but expected" case is a **CID**: entity binaries reference constants by id, constants have no storage entity, so `getEntry` returns `null` but this is not a zombie. **TIDs** don't appear in binary references at all (they identify the entity's own type, stored separately in the record header), so they should never enter the mark queue in practice. `StorageGCZombieOidHandler.Default` returns `true` for both as a defensive catch-all, and `EmbeddedStorageObjectRegistryCallback.iterateLiveObjectIds` filters its seed set to `Persistence.IdType.OID` so non-data ids are never fed to the mark queue via the application-state root path.
+
+---
+
+## 6. Hot and cold phases
+
+The mark monitor tracks two completion flags:
+
+- **`gcHotPhaseComplete`** — "no new data has been received since the last sweep". One complete mark+sweep with no stores.
+- **`gcColdPhaseComplete`** — "a second sweep has already run since then, so all unreachable entities are gone". One more mark+sweep with no stores after hot completion.
+
+Only cold completion shuts the GC off until the next store. Stores (via `resetCompletion`) reset both flags, kicking the GC back into work.
+
+The reason for two phases: the first sweep after a store cleans up the now-unreachable predecessors; the second sweep confirms the steady state. This two-pass pattern interacts with the registry safety net — which is why application-state OIDs are seeded at **every** sweep boundary that has a follow-up mark cycle (i.e. every sweep boundary except the cold-completing one — see §10.1).
+
+---
+
+## 7. Crossing the JVM boundary: the object registry
+
+`PersistenceObjectRegistry` (in the serializer module) maps OIDs ↔ Java objects. It is the only place where the storage GC can ask "does the application still care about this entity?" Entries are held as `java.lang.ref.WeakReference`s so that keeping an entity in the registry does not prevent the JVM GC from collecting the Java instance when the app drops it.
+
+The embedded wiring exposes the registry to the storage GC via `EmbeddedStorageObjectRegistryCallback`, which implements our combined `LiveObjectIdsHandler` — i.e. both roles described below.
+
+### Two roles the registry plays for the GC
+
+| Aspect | `ObjectIdsSelector` | `LiveObjectIdsIterator` |
+|---|---|---|
+| Phase | sweep | end of sweep → seed next mark |
+| Flow | sweep → registry (ask) | registry → mark queue (push) |
+| API style | filter predicate via `ObjectIdsProcessor` | acceptor-based enumeration |
+| Keeps alive | the asked-about entity | the entity **and** everything its binary transitively references |
+| Purpose | "don't delete what the app still holds" | "make sure what the app holds is traversed" |
+
+See the class-level javadoc on `LiveObjectIdsHandler` for the formal definition.
+
+---
+
+## 8. JVM `WeakReference` semantics and the registry's view of them
+
+This is the most subtle part of the interaction between JVM GC and storage GC. It rests on a three-stage `WeakReference`/`ReferenceQueue` lifecycle that is **JDK behavior**, not Eclipse Store behavior:
+
+1. **Strongly reachable** — `WeakReference.get()` returns the referent.
+2. **Only weakly reachable** — the JVM GC *clears* the reference: `get()` starts returning `null`, and the `WeakReference` object itself (not the referent) is enqueued onto its `ReferenceQueue` if one was registered. The `WeakReference` instance remains in whatever container held it.
+3. **Queue drained** — some application code polls the queue and removes the `WeakReference` from its container.
+
+Between (2) and (3) there is a window in which a container (here, a hash table) still contains a `WeakReference` whose referent is gone. The JVM does **not** automatically remove weak references from containers — the application has to do it. `java.util.WeakHashMap.expungeStaleEntries()` is the canonical example of this idiom.
+
+### How this plays out in `DefaultObjectRegistry`
+
+```java
+static final class Entry extends WeakReference<Object> {
+    final long objectId;
+    ...
+}
+```
+
+The hash-table entries **are** the weak references. The registry exposes two contains-style operations:
+
+- `synchContainsObjectId(oid)` — only compares `e.objectId == objectId`. Does **not** call `e.get()`.
+- `synchContainsLiveObject(oid)` — returns `e.get() != null`, i.e. verifies the referent is still present.
+
+These are surfaced as the public `containsObjectId(long)` and `containsLiveObject(long)` on `PersistenceObjectRegistry`.
+
+### The predicate the safety net actually uses
+
+`processLiveObjectIds` hands the storage GC this predicate:
+
+```java
+// DefaultObjectRegistry.java
+processor.processObjectIdsByFilter(this::synchIsLiveObjectId);
+
+final boolean synchIsLiveObjectId(final long objectId) {
+    return this.synchContainsObjectId(objectId);    // id-only check
+}
+```
+
+Despite the name, `synchIsLiveObjectId` delegates to the id-only `synchContainsObjectId`, **not** to `synchContainsLiveObject`. That means the safety-net predicate returns `true` for:
+
+- (a) entries whose Java instance is still strongly reachable, **and**
+- (b) entries whose Java instance has already been collected and whose `WeakReference` has been cleared, but whose `Entry` has not yet been removed from the hash table.
+
+Case (b) is exactly the JDK window between stages 2 and 3.
+
+### Why case (b) doesn't cause corruption
+
+Case (b) — a cleared `WeakReference` whose `Entry` has not yet been removed from the hash table — would be dangerous if the **mark seed** and the **sweep predicate** disagreed about whether such an entry counts as live: a parent kept alive by sweep but skipped at mark would leave its stored binary references unwalked, and a transitively-reachable child whose own entry had already been reaped would be deleted while the parent retained the stale OID on disk (a zombie OID on the next mark cycle, see §10.1).
+
+Three mechanisms keep this from happening:
+
+- **Same id-only criterion at both ends.** The post-sweep / pre-sweep mark seed (§10) enumerates *every* data-OID entry in the registry's hash table — including case (b) entries — using the same id-only test (`synchContainsObjectId`) that the sweep keep-alive predicate uses. So the two paths agree on what counts as "registry-resident", and case (b) entries always get their binaries walked transitively before sweep decides what to delete.
+- **`DefaultObjectRegistry.cleanUp()` on every storer merge.** `cleanUp()` drains the `ReferenceQueue` and removes cleared entries; it is invoked automatically from `PersistenceObjectManager.synchInternalMergeEntries`. In write-heavy workloads this collapses case (b) within milliseconds of any store.
+- **`DefaultObjectRegistry.consolidate()` on the issue-API GC path.** `StorageConnection.Default#issueGarbageCollection` calls `consolidate()` before kicking off the GC; `consolidate()` walks the entire hash table and removes every cleared entry up front. This is **not** done on the housekeeping GC path — which is precisely why aligning the mark-seed criterion with the sweep predicate (the first mechanism above) matters: the housekeeping path would otherwise be the only place case (b) can be observed by the GC, and a mark/sweep disagreement there would corrupt data even if `cleanUp()` happens to run on the next store.
+
+### Sources
+
+- JDK class javadoc of `java.lang.ref.WeakReference`, `java.lang.ref.Reference`, `java.lang.ref.ReferenceQueue` — spells out that the GC clears and enqueues but does not remove from user containers.
+- JDK source of `java.util.WeakHashMap.expungeStaleEntries()` — the canonical "poll-the-queue and unlink" idiom that `DefaultObjectRegistry.cleanUp()` mirrors.
+- Eclipse Serializer source: `DefaultObjectRegistry.java` — `Entry extends WeakReference` (class declaration), `synchContainsObjectId`, `synchContainsLiveObject`, `processLiveObjectIds`, `cleanUp`, `consolidate`.
+
+---
+
+## 9. Design rationale: why two registry roles
+
+The two registry-access roles in §7 are not redundant; each targets a distinct class of reachability that the other cannot cover.
+
+- `ObjectIdsSelector` answers **"is this entity still needed?"** at sweep time. It protects an individual entity whose Java instance is currently held, even when the persistent graph no longer reaches it.
+- `LiveObjectIdsIterator` answers **"what is reachable from application state?"** at mark time. It promotes every app-held entity to a mark root, so the mark phase walks the entity's binary references transitively.
+
+### Why the sweep-time role alone would be insufficient
+
+A sweep-time keep-alive check is *shallow*: it rescues the asked-about entity but not the entities that entity's binary record points to. The following scenario walks through what would happen with only the sweep-time role active:
+
+1. Application stores `root → Holder → Payload`. All three entities exist in the cache and registry.
+2. Application removes `Holder` from root's graph (`root.holder = null; storeRoot()`). Root's binary no longer references Holder. Holder's Java object is still alive in the app, so its registry entry stays. Holder's stored binary still references Payload's OID.
+3. Application drops its Java reference to Payload. JVM GC clears Payload's `WeakReference`. A subsequent store triggers `cleanUp()`, which reaps Payload's entry from the registry.
+4. Storage GC cycle runs.
+   - Mark: starts from the persistent root. Root doesn't reference Holder, so without the iterator role neither Holder nor Payload would be marked.
+   - Sweep: Holder is not marked but *is* in the registry → sweep-time safety net keeps it. Payload is not marked and *not* in the registry → Payload is deleted. Holder's stored binary still references Payload's OID.
+5. Application re-attaches Holder to root (`root.holder = holderRef; storeRoot()`). The lazy storer notices Holder is already registered and **skips re-serializing it** (`BinaryStorer.Default.internalStore`: if `lookupOid(root) != notFound` return early). Holder's binary record is not rewritten — it still references the now-deleted Payload OID.
+6. Next storage GC cycle.
+   - Mark: root → Holder → iterate Holder's refs → `getEntry(payloadOid)` returns `null` → zombie OID, and on shutdown + reload `StorageExceptionConsistency: No entity found for objectId N`.
+
+Three properties conspire to make this possible: the sweep-time safety net is shallow (keeps the entity but not its references), the lazy storer skips already-registered objects (so Holder's binary is never rewritten), and the JVM reaps Payload's registry entry between the two storage-GC cycles.
+
+### How the mark-time role resolves it
+
+`LiveObjectIdsIterator` promotes Holder to a mark root in step 4's mark phase. The marker then walks Holder's binary references and marks Payload — so Payload survives the sweep, Holder's binary stays valid, and no zombie ever arises. The two roles together cover both classes of reachability: the persistent-graph roots via `determineAndEnqueueRootOid`, and the application-state roots via `enqueueLiveApplicationOids`.
+
+The sweep-time role remains as defense in depth for the narrow race of an OID entering the registry between mark and sweep of the same cycle.
+
+---
+
+## 10. Implementation of mark-time registry seeding
+
+Application-state mark roots are seeded into the mark queues at **two** points around every sweep boundary. Together they ensure that an entity kept alive only by the registry safety net always has its transitive binary references walked **before** the next sweep decides what to delete.
+
+### 10.1. Post-sweep seed (primary, runs at every non-cold-completing sweep)
+
+At the end of every sweep (`StorageEntityMarkMonitor.Default.completeSweep`), immediately after `determineAndEnqueueRootOid` seeds the persistent root, `enqueueLiveApplicationOids` pushes every currently-live registry OID into the mark queues — but only when there will be another mark cycle to drain them:
+
+```java
+// StorageEntityMarkMonitor.Default#completeSweep (simplified)
+this.advanceGcCompletion();                         // may flip gcColdPhaseComplete
+this.determineAndEnqueueRootOid(rootOidSelector);
+if(!this.gcColdPhaseComplete)
+{
+    this.enqueueLiveApplicationOids(liveObjectIdsIterator);
+}
+```
+
+The iterator (`EmbeddedStorageObjectRegistryCallback.iterateLiveObjectIds`) walks the registry's `iterateEntries` and emits every data-OID entry (`Persistence.IdType.OID.isInRange(objectId)`). The id-only criterion deliberately matches the sweep keep-alive predicate (`DefaultObjectRegistry#synchIsLiveObjectId` → `synchContainsObjectId`); cleared-but-not-yet-reaped entries (case (b) in §8) are seeded as mark roots even though their `WeakReference.get()` returns `null`, because the sweep predicate keeps them alive too — skipping them at mark time would leave their stored binary references unwalked and create a zombie window on the housekeeping GC path. TIDs and CIDs are excluded so they never reach the zombie handler.
+
+#### Why the cold-complete branch skips the seed
+
+After the cold-completing sweep there is no follow-up mark cycle: `gcColdPhaseComplete` is now `true`, the housekeeping loop short-circuits via `isComplete(channel)` and stops calling `incrementalMark`, and `resetCompletion` does not clear the per-channel mark queues. If `enqueueLiveApplicationOids` ran here, the entire registry — potentially millions of `long`s in the per-channel `StorageObjectIdMarkQueue` segments — would sit resident in the queues until the next store reopens work. This made idle GC memory scale with the application-held set rather than with actual GC work in flight, and was the issue raised in PR review of #669.
+
+The skip costs nothing: the next wave starts with `resetCompletion` (which clears `liveOidsSeededForCurrentCycle`), and the pre-sweep gate (§10.2) re-seeds the registry on the very first sweep of that wave. So application-state mark roots are still established at every cycle that actually marks.
+
+So the seed runs on `Dirty → HotComplete` (the cold mark cycle within the wave gets app-state roots) but is skipped on `HotComplete → ColdComplete` (idle transition).
+
+### 10.2. Pre-sweep gate (defense in depth, runs at most once per GC cycle)
+
+`completeSweep` runs *after* a sweep has already executed. That means it cannot protect the very first sweep of a freshly-armed GC cycle, when no prior post-sweep seed exists yet (e.g. cycle 0 right after startup, or any cycle following a `resetCompletion()` triggered by a store).
+
+To close that gap, `callToSweepRequired` performs a **pre-sweep gate** the first time it observes `isMarkingComplete()` in a cycle:
+
+```java
+// StorageEntityMarkMonitor.Default#callToSweepRequired (simplified)
+if(!this.liveOidsSeededForCurrentCycle && this.liveObjectIdsIterator != null)
+{
+    this.liveOidsSeededForCurrentCycle = true;
+    this.enqueueLiveApplicationOids(this.liveObjectIdsIterator);
+
+    // If seeding raised pendingMarksCount, marking is no longer complete:
+    // tell the caller to keep marking before the sweep is initiated.
+    if(!this.isMarkingComplete())
+    {
+        return false;
+    }
+    // Otherwise (empty registry / all already marked) fall through to sweep.
+}
+```
+
+The `liveOidsSeededForCurrentCycle` flag makes this a *one-shot* gate per cycle: it is set to `true` here and cleared on every store via `resetCompletion()` and on every channel reset via `initialize()` (so a shutdown/restart starts the next cycle with the gate armed). That means:
+
+- The hot-phase pre-sweep does fire on cycle entry → registry-only-kept entities become mark roots before any sweep runs.
+- The cold-phase pre-sweep skips, because the post-hot-sweep seed (10.1) already established the same mark roots, and the subsequent cold mark phase has just drained them. Re-seeding here would only add work.
+
+The `resetMarkQueues()` invariant (which throws if any queue still has elements) is preserved: pre-sweep seeding either drains in the next mark slice (returning `false` here) or contributes zero new OIDs; only when the queues are empty does control reach `resetMarkQueues` + `initiateSweep`.
+
+### 10.3. Why both, and not just one
+
+| Boundary | Covered by | Reason the other isn't enough |
+|---|---|---|
+| First (hot) mark/sweep of a wave (wave 0 or post-`resetCompletion`) | pre-sweep gate (10.2) | post-sweep seed has not run yet in this wave |
+| Cold mark/sweep within the same wave | post-sweep seed at hot completion (10.1) | gate flag stays set for the rest of the wave; without 10.1 the cold mark phase would seed from no-one |
+| After cold completion (idle until next store) | nothing — by design | no follow-up mark cycle, so seeding would only park the registry in the mark queues; the next wave's pre-sweep gate (10.2) re-seeds when work resumes |
+| Race: OID enters registry between mark and sweep of same cycle | sweep-time `ObjectIdsSelector` predicate (shallow safety net) | per-entity, evaluated at sweep time, no transitivity needed because the entity's binary was just stored or just loaded and is consistent |
+| Case (b) entry (cleared `WeakReference`, hash-table entry not yet reaped) on the housekeeping GC path | id-only criterion shared by 10.1 / 10.2 mark seed and 3.4 sweep predicate | the housekeeping path calls neither `cleanUp()` (only fires on storer-merge) nor `consolidate()` (only fires on `issueGarbageCollection`); without the shared criterion, sweep would keep the case (b) entry while mark skipped it, leaving its stored binary references unwalked — see §8 |
+
+### Interface layering
+
+- `ObjectIdsSelector` (serializer) — sweep-time filter protocol.
+- `LiveObjectIdsIterator` (this module) — mark-time enumeration protocol.
+- `LiveObjectIdsHandler extends ObjectIdsSelector, LiveObjectIdsIterator` (this module) — combined interface the storage GC plumbing uses.
+- `EmbeddedStorageObjectRegistryCallback extends LiveObjectIdsHandler` — embedded-mode implementation, backed by `PersistenceObjectRegistry`.
+
+Internal wiring (`StorageFoundation`, `StorageSystem`, `StorageChannelsCreator`, `StorageEntityCache`) carries `LiveObjectIdsHandler` end to end, so the GC holds both capabilities in one typed reference.
+
+---
+
+## 11. Quick reference
+
+Read these together to see the full picture:
+
+- `StorageEntityCache.Default` — `sweep(_longPredicate)` (the safety-net keep-alive check), `incrementalMark` (the zombie detection site), `liveObjectIdsHandler` field.
+- `StorageEntityMarkMonitor.Default` — `completeSweep`, `determineAndEnqueueRootOid`, `enqueueLiveApplicationOids`, `acceptObjectId`/`enqueue`.
+- `LiveObjectIdsHandler` — class-level javadoc giving the role-by-role comparison.
+- `EmbeddedStorageObjectRegistryCallback.Default` — `processSelected` (sweep filter) and `iterateLiveObjectIds` (mark seeding).
+- `DefaultObjectRegistry` (serializer) — `Entry extends WeakReference`, `synchContainsObjectId` vs `synchContainsLiveObject`, `processLiveObjectIds`, `cleanUp` (drains the `ReferenceQueue`, called from `PersistenceObjectManager.synchInternalMergeEntries`), `consolidate` (walks the entire hash table and reaps every cleared entry, called from `StorageConnection.Default#issueGarbageCollection`).
+- `StorageGCZombieOidHandler.Default` — expected-null filter for TID/CID lookups, reporting path for any other null lookup.
+- `Persistence.IdType` (serializer) — TID / OID / CID range predicates.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/LiveObjectIdsHandler.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/LiveObjectIdsHandler.java
@@ -1,0 +1,94 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.persistence.types.ObjectIdsSelector;
+
+/**
+ * Combined entry point the storage GC uses to interact with application-held object ids.
+ * The GC plugs into the application's object registry at two different phases and in opposite
+ * directions; this interface bundles both:
+ *
+ * <h3>{@link ObjectIdsSelector} — sweep-time safety net (filter, pull)</h3>
+ * <ul>
+ *   <li><b>When:</b> during sweep, after marking has completed.</li>
+ *   <li><b>Direction:</b> the sweeper hands the registry a candidate and asks "is this one still
+ *       alive in the app?" The registry answers via
+ *       {@link org.eclipse.serializer.persistence.types.ObjectIdsProcessor#processObjectIdsByFilter
+ *       processObjectIdsByFilter} — essentially a {@code boolean isInRegistry(long oid)} predicate.
+ *       The sweep iterates entities it already knows about and calls the predicate per id.</li>
+ *   <li><b>Effect</b> see StorageEntityCache sweep implementation:
+ *       {@code if(item.isGcMarked() || isReachableInApplication.test(item.objectId)) markWhite} —
+ *       an unmarked entity survives the sweep solely because the application's object registry
+ *       still has a (live-{@link java.lang.ref.WeakReference WeakReference}) entry for its id,
+ *       i.e. the app has not yet released the Java instance, or has released it but
+ *       {@link org.eclipse.serializer.persistence.types.PersistenceObjectRegistry#cleanUp()
+ *       PersistenceObjectRegistry.cleanUp()} has not yet reaped the cleared WeakReference.</li>
+ *   <li><b>Scope:</b> <em>shallow</em> — it protects the entity that was asked about, nothing else.
+ *       The entity's own binary references are not consulted.</li>
+ * </ul>
+ *
+ * <h3>{@link LiveObjectIdsIterator} — mark-time seed (enumeration, push)</h3>
+ * <ul>
+ *   <li><b>When:</b> at the end of each sweep, inside
+ *       {@link StorageEntityMarkMonitor.Default#completeSweep}, immediately after
+ *       {@code determineAndEnqueueRootOid}. The next mark cycle has not started yet; the mark
+ *       queues have just been reset.</li>
+ *   <li><b>Direction:</b> the registry pushes every live object id it currently holds into the
+ *       mark queue via {@code acceptor.acceptObjectId(oid)}. The mark monitor is itself a
+ *       {@link org.eclipse.serializer.persistence.types.PersistenceObjectIdAcceptor}, so every id
+ *       lands directly in the right per-channel
+ *       {@link StorageObjectIdMarkQueue}.</li>
+ *   <li><b>Scope:</b> <em>transitive</em> — every app-held id becomes a mark root, so the next
+ *       mark phase walks its binary references (and their references, and so on), marking
+ *       everything reachable. Those transitively-reached entities then survive the subsequent
+ *       sweep normally (gc-marked, not merely safety-net-kept).</li>
+ * </ul>
+ *
+ * <h3>Why both are needed</h3>
+ * The selector alone is not enough: an entity kept alive only via the safety net retains its
+ * <em>old</em> binary record. If that record points at another entity whose Java instance got
+ * collected (and whose registry entry was cleaned up), nothing keeps the pointed-at entity alive
+ * and the sweep deletes it. The next mark phase then walks the safety-net-kept entity's stale
+ * pointer, looks up the swept id, gets {@code null}, and produces a zombie OID — persistent
+ * corruption on reload. The iterator closes that gap: by re-seeding every live registry id as a
+ * mark root, anything reachable from an app-held entity is marked <em>before</em> the sweep
+ * decides what to delete, so the stale pointer can no longer dangle.
+ *
+ * <h3>At a glance</h3>
+ * <table>
+ *   <caption>Comparison of the two roles</caption>
+ *   <tr><th></th><th>{@code ObjectIdsSelector}</th><th>{@code LiveObjectIdsIterator}</th></tr>
+ *   <tr><td>phase</td>
+ *       <td>sweep</td>
+ *       <td>pre-mark (end of previous sweep)</td></tr>
+ *   <tr><td>flow</td>
+ *       <td>sweep &rarr; registry (ask)</td>
+ *       <td>registry &rarr; mark queue (push)</td></tr>
+ *   <tr><td>API style</td>
+ *       <td>filter predicate</td>
+ *       <td>enumeration via acceptor</td></tr>
+ *   <tr><td>keeps alive</td>
+ *       <td>the asked-about entity</td>
+ *       <td>the entity <b>and</b> everything it transitively references</td></tr>
+ *   <tr><td>purpose</td>
+ *       <td>don't delete what the app still holds</td>
+ *       <td>make sure what the app holds is traversed</td></tr>
+ * </table>
+ */
+public interface LiveObjectIdsHandler extends ObjectIdsSelector, LiveObjectIdsIterator
+{
+	// combined marker interface
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/LiveObjectIdsIterator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/LiveObjectIdsIterator.java
@@ -1,0 +1,44 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectIdAcceptor;
+
+/**
+ * Enumerates every application-held object id and pushes each one to the given acceptor. Used by
+ * the storage GC to seed mark roots from the application's object registry so that
+ * safety-net-kept entities have their binary references walked transitively, preventing zombie
+ * OIDs caused by stale binary records referencing swept entities.
+ * <p>
+ * The enumerated set must match the id-only criterion used by the sweep keep-alive predicate
+ * (see {@link org.eclipse.serializer.persistence.types.ObjectIdsSelector}): every data-OID entry
+ * present in the registry's hash table is emitted, regardless of whether the underlying
+ * {@link java.lang.ref.WeakReference} is still live. If the mark seed skipped entries whose
+ * {@code WeakReference} has been cleared but not yet reaped while the sweep predicate kept them
+ * alive, their stored binary references would not be walked and transitively-reachable entities
+ * could be swept under a still-kept parent — producing zombie OIDs on the next mark cycle.
+ */
+@FunctionalInterface
+public interface LiveObjectIdsIterator
+{
+	/**
+	 * Pushes every application-held data object id into {@code acceptor}, with the id-only
+	 * inclusion criterion described on the {@linkplain LiveObjectIdsIterator type}.
+	 *
+	 * @param acceptor receives one {@code acceptObjectId} call per emitted id; typically the
+	 *                 storage mark monitor, which routes ids into per-channel mark queues.
+	 */
+	public void iterateLiveObjectIds(PersistenceObjectIdAcceptor acceptor);
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelsCreator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelsCreator.java
@@ -16,7 +16,6 @@ package org.eclipse.store.storage.types;
 
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.monitoring.MonitoringManager;
-import org.eclipse.serializer.persistence.types.ObjectIdsSelector;
 import org.eclipse.serializer.persistence.types.PersistenceLiveStorerRegistry;
 import org.eclipse.serializer.reference.Referencing;
 import org.eclipse.serializer.util.BufferSizeProvider;
@@ -48,7 +47,7 @@ public interface StorageChannelsCreator
 		StorageEntityMarkMonitor.Creator           entityMarkMonitorCreator     ,
 		StorageBackupHandler                       backupHandler                ,
 		StorageEventLogger                         eventLogger                  ,
-		ObjectIdsSelector liveObjectIdChecker                                   ,
+		LiveObjectIdsHandler                       liveObjectIdsHandler         ,
 		Referencing<PersistenceLiveStorerRegistry> refStorerRegistry            ,
 		boolean                                    switchByteOrder              ,
 		long                                       rootTypeId                   ,
@@ -87,7 +86,7 @@ public interface StorageChannelsCreator
 			final StorageEntityMarkMonitor.Creator           entityMarkMonitorCreator     ,
 			final StorageBackupHandler                       backupHandler                ,
 			final StorageEventLogger                         eventLogger                  ,
-			final ObjectIdsSelector                          liveObjectIdChecker          ,
+			final LiveObjectIdsHandler                       liveObjectIdsHandler         ,
 			final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry            ,
 			final boolean                                    switchByteOrder              ,
 			final long                                       rootTypeId                   ,
@@ -112,9 +111,10 @@ public interface StorageChannelsCreator
 			final StorageEntityMarkMonitor markMonitor = entityMarkMonitorCreator.createEntityMarkMonitor(
 				markQueues,
 				eventLogger,
-				refStorerRegistry
+				refStorerRegistry,
+				liveObjectIdsHandler
 			);
-			
+
 			final BufferSizeProviderIncremental loadingBufferSizeProvider = BufferSizeProviderIncremental.New(loadingBufferSize);
 			final BufferSizeProvider readingDefaultBufferSizeProvider     = BufferSizeProvider.New(readingDefaultBufferSize);
 			
@@ -134,7 +134,7 @@ public interface StorageChannelsCreator
 					rootTypeId                                       ,
 					markQueues[i]                                    ,
 					eventLogger                                      ,
-					liveObjectIdChecker                              ,
+					liveObjectIdsHandler                             ,
 					markingWaitTimeMs                                ,
 					markBufferLength
 				);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -30,7 +30,6 @@ import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.persistence.binary.types.ChunksBuffer;
 import org.eclipse.serializer.persistence.types.ObjectIdsProcessor;
-import org.eclipse.serializer.persistence.types.ObjectIdsSelector;
 import org.eclipse.serializer.persistence.types.Persistence;
 import org.eclipse.serializer.persistence.types.Unpersistable;
 import org.eclipse.serializer.util.X;
@@ -109,7 +108,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		private final StorageObjectIdMarkQueue  oidMarkQueue   ; // resetting handled by markMonitor
 		private final StorageReferenceMarker    referenceMarker; // resetting must be handled here.
 		
-		private final ObjectIdsSelector liveObjectIdChecker;
+		private final LiveObjectIdsHandler liveObjectIdsHandler;
 
 		
 		// state 3.0: mutable fields. Must be cleared on reset.
@@ -144,18 +143,18 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		/////////////////
 
 		Default(
-			final int                         channelIndex       ,
-			final int                         channelCount       ,
-			final StorageEntityCacheEvaluator cacheEvaluator     ,
-			final StorageTypeDictionary       typeDictionary     ,
-			final StorageEntityMarkMonitor    markMonitor        ,
-			final StorageGCZombieOidHandler   zombieOidHandler   ,
-			final StorageRootOidSelector      rootOidSelector    ,
-			final long                        rootTypeId         ,
-			final StorageObjectIdMarkQueue    oidMarkQueue       ,
-			final StorageEventLogger          eventLogger        ,
-			final ObjectIdsSelector           liveObjectIdChecker,
-			final long                        markingWaitTimeMs  ,
+			final int                         channelIndex        ,
+			final int                         channelCount        ,
+			final StorageEntityCacheEvaluator cacheEvaluator      ,
+			final StorageTypeDictionary       typeDictionary      ,
+			final StorageEntityMarkMonitor    markMonitor         ,
+			final StorageGCZombieOidHandler   zombieOidHandler    ,
+			final StorageRootOidSelector      rootOidSelector     ,
+			final long                        rootTypeId          ,
+			final StorageObjectIdMarkQueue    oidMarkQueue        ,
+			final StorageEventLogger          eventLogger         ,
+			final LiveObjectIdsHandler        liveObjectIdsHandler,
+			final long                        markingWaitTimeMs   ,
 			final int                         markingBufferLength
 		)
 		{
@@ -185,7 +184,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			// create reference marker at the very end to have all state properly initialized beforehand.
 			this.referenceMarker = markMonitor.provideReferenceMarker(this);
 			
-			this.liveObjectIdChecker = notNull(liveObjectIdChecker);
+			this.liveObjectIdsHandler = notNull(liveObjectIdsHandler);
 		}
 
 
@@ -969,12 +968,12 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 
 			// signal mark monitor that the sweep is complete and provide this channel's valid rootOid
 			final long channelRootOid = this.queryRootObjectId();
-			this.markMonitor.completeSweep(this, this.rootOidSelector, channelRootOid);
+			this.markMonitor.completeSweep(this, this.rootOidSelector, channelRootOid, this.liveObjectIdsHandler);
 		}
 		
 		private boolean sweep()
 		{
-			return this.liveObjectIdChecker.processSelected(new ApplicationCallback(this.typeHead));
+			return this.liveObjectIdsHandler.processSelected(new ApplicationCallback(this.typeHead));
 		}
 
 		final class ApplicationCallback implements ObjectIdsProcessor

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityMarkMonitor.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityMarkMonitor.java
@@ -54,9 +54,10 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 	public boolean isPendingSweep(StorageEntityCache<?> channel);
 
 	public void completeSweep(
-		StorageEntityCache<?>  channel             ,
-		StorageRootOidSelector rootObjectIdSelector,
-		long                   channelRootObjectId
+		StorageEntityCache<?>  channel                ,
+		StorageRootOidSelector rootObjectIdSelector   ,
+		long                   channelRootObjectId    ,
+		LiveObjectIdsIterator  liveObjectIdsIterator
 	);
 
 	public boolean isMarkingComplete();
@@ -64,6 +65,7 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 	public StorageReferenceMarker provideReferenceMarker(StorageEntityCache<?> channel);
 
 	public void enqueue(StorageObjectIdMarkQueue objectIdMarkQueue, long objectId);
+
 
 	/**
 	 * Reset to a clean initial state, ready to be used.
@@ -93,9 +95,10 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 	public interface Creator
 	{
 		public StorageEntityMarkMonitor createEntityMarkMonitor(
-			StorageObjectIdMarkQueue[]                 oidMarkQueues    ,
-			StorageEventLogger                         eventLogger      ,
-			Referencing<PersistenceLiveStorerRegistry> refStorerRegistry
+			StorageObjectIdMarkQueue[]                 oidMarkQueues         ,
+			StorageEventLogger                         eventLogger           ,
+			Referencing<PersistenceLiveStorerRegistry> refStorerRegistry     ,
+			LiveObjectIdsIterator                      liveObjectIdsIterator
 		);
 		
 		public StorageEntityMarkMonitor cachedInstance();
@@ -155,16 +158,18 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 			
 			@Override
 			public StorageEntityMarkMonitor createEntityMarkMonitor(
-				final StorageObjectIdMarkQueue[]                 objectIdMarkQueues,
-				final StorageEventLogger                         eventLogger       ,
-				final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry
+				final StorageObjectIdMarkQueue[]                 objectIdMarkQueues   ,
+				final StorageEventLogger                         eventLogger          ,
+				final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry    ,
+				final LiveObjectIdsIterator                      liveObjectIdsIterator
 			)
 			{
 				return this.cachedInstance = new StorageEntityMarkMonitor.Default(
 					objectIdMarkQueues.clone(),
 					eventLogger,
 					refStorerRegistry,
-					this.referenceCacheLength
+					this.referenceCacheLength,
+					liveObjectIdsIterator
 				);
 			}
 			
@@ -240,6 +245,33 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 		 */
 		private boolean gcColdPhaseComplete;
 
+		/*
+		 * Application-side iterator used to seed live object ids into the mark queue
+		 * around sweep boundaries. Constructor-injected, may be null in non-embedded
+		 * (e.g. test or REST viewer) scenarios where there is no application registry.
+		 *
+		 * Used by two complementary mechanisms:
+		 *  1. Pre-sweep gate in callToSweepRequired() - guards the very first sweep
+		 *     of a GC cycle so registry-only-kept entities are transitively marked
+		 *     before any sweep ever happens (covers cycle 0 where no prior post-sweep
+		 *     seed exists).
+		 *  2. Post-sweep seed in completeSweep() - re-establishes application-state
+		 *     mark roots after every sweep completion (both hot and cold) so the
+		 *     next mark cycle traverses everything reachable from app-held entities.
+		 */
+		private final LiveObjectIdsIterator liveObjectIdsIterator;
+
+		/*
+		 * Flag indicating whether live application OIDs have already been seeded
+		 * into the mark queue by the pre-sweep gate for the current GC cycle.
+		 * Reset on resetCompletion() (which is invoked on every store, arming the
+		 * gate again for the next cycle). This ensures the pre-sweep seed runs at
+		 * most once per cycle: the cold-phase pre-sweep skip is safe because the
+		 * post-sweep seed of the preceding hot phase already established the same
+		 * mark roots for the cold mark phase.
+		 */
+		private boolean liveOidsSeededForCurrentCycle;
+
 
 
 		///////////////////////////////////////////////////////////////////////////
@@ -247,23 +279,25 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 		/////////////////
 
 		Default(
-			final StorageObjectIdMarkQueue[]                 oidMarkQueues       ,
-			final StorageEventLogger                         eventLogger         ,
-			final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry   ,
-			final int                                        referenceCacheLength
+			final StorageObjectIdMarkQueue[]                 oidMarkQueues        ,
+			final StorageEventLogger                         eventLogger          ,
+			final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry    ,
+			final int                                        referenceCacheLength ,
+			final LiveObjectIdsIterator                      liveObjectIdsIterator
 		)
 		{
 			super();
-			this.eventLogger          = eventLogger                   ;
-			this.refStorerRegistry    = refStorerRegistry             ;
-			this.oidMarkQueues        = oidMarkQueues                 ;
-			this.referenceCacheLength = referenceCacheLength          ;
-			this.channelCount         = oidMarkQueues.length          ;
-			this.channelHash          = this.channelCount - 1         ;
-			this.pendingStoreUpdates  = new boolean[this.channelCount];
-			this.needsSweep           = new boolean[this.channelCount];
-			this.channelRootOids      = new long   [this.channelCount];
-			
+			this.eventLogger             = eventLogger                   ;
+			this.refStorerRegistry       = refStorerRegistry             ;
+			this.oidMarkQueues           = oidMarkQueues                 ;
+			this.referenceCacheLength    = referenceCacheLength          ;
+			this.channelCount            = oidMarkQueues.length          ;
+			this.channelHash             = this.channelCount - 1         ;
+			this.pendingStoreUpdates     = new boolean[this.channelCount];
+			this.needsSweep              = new boolean[this.channelCount];
+			this.channelRootOids         = new long   [this.channelCount];
+			this.liveObjectIdsIterator   = liveObjectIdsIterator         ;
+
 			this.referenceMarkers = new StorageReferenceMarker[this.channelCount];
 			
 			// mostly redundant for instance initialization, but consistency is important.
@@ -317,8 +351,9 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 		private void initializeCompletionState()
 		{
 			// GC is initially completed because there is no data at all. Initialization and stores will flip them.
-			this.gcHotPhaseComplete  = true;
-			this.gcColdPhaseComplete = true;
+			this.gcHotPhaseComplete            = true ;
+			this.gcColdPhaseComplete           = true ;
+			this.liveOidsSeededForCurrentCycle  = false;
 		}
 		
 		private void initializeGenerationalState()
@@ -360,7 +395,8 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 			// this is the only actually exclusive resetting method
 			this.synchResetReferenceMarkers();
 		}
-		
+
+
 		private void synchResetReferenceMarkers()
 		{
 			for(int i = 0; i < this.referenceMarkers.length; i++)
@@ -479,6 +515,32 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 				return false;
 			}
 
+			/*
+			 * Before initiating the sweep, ensure that all live application OIDs have been
+			 * seeded into the mark queue for this cycle. This is critical: entities that are
+			 * only alive via the PersistenceObjectRegistry safety net (not reachable from the
+			 * persisted root) must have their transitive binary references marked before
+			 * sweep, otherwise referenced entities not in the registry will be swept,
+			 * producing zombie OIDs on the next mark phase.
+			 *
+			 * If we haven't seeded yet, enqueue all live OIDs now and return false
+			 * (not ready to sweep), allowing the mark phase to process them first.
+			 */
+			if(!this.liveOidsSeededForCurrentCycle && this.liveObjectIdsIterator != null)
+			{
+				this.liveOidsSeededForCurrentCycle = true;
+				this.enqueueLiveApplicationOids(this.liveObjectIdsIterator);
+
+				// If any OIDs were actually enqueued, marking is no longer complete.
+				// Return false so the caller continues marking before retrying sweep.
+				if(!this.isMarkingComplete())
+				{
+					return false;
+				}
+				// If no OIDs were enqueued (empty registry / all already marked),
+				// fall through to proceed with sweep normally.
+			}
+
 			this.lastSweepStart = System.currentTimeMillis();
 
 			// reset channel root ids board because channels will update it upon ecountering the need to sweep.
@@ -527,9 +589,10 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 
 		@Override
 		public final synchronized void completeSweep(
-			final StorageEntityCache<?>  channel        ,
-			final StorageRootOidSelector rootOidSelector,
-			final long                   channelRootOid
+			final StorageEntityCache<?>  channel              ,
+			final StorageRootOidSelector rootOidSelector      ,
+			final long                   channelRootOid       ,
+			final LiveObjectIdsIterator  liveObjectIdsIterator
 		)
 		{
 			// register the channel's current valid root Oid after the performed sweep (potentially 0).
@@ -537,7 +600,7 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 
 			// mark this channel as having completed the sweep
 			this.needsSweep[channel.channelIndex()] = false;
-			
+
 			logger.debug("StorageChannel#{} completed sweeping", channel.channelIndex());
 			this.eventLogger.logGarbageCollectorSweepingComplete(channel);
 
@@ -548,7 +611,32 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 				this.incrementSweepGeneration();
 				this.advanceGcCompletion();
 				this.determineAndEnqueueRootOid(rootOidSelector);
+				// Only seed the next mark cycle if there will actually be one. Once advanceGcCompletion()
+				// has flipped gcColdPhaseComplete the housekeeping loop stops calling incrementalMark(),
+				// so seeded OIDs would sit unread in the mark queues until the next store. The next cycle's
+				// pre-sweep gate (after resetCompletion()) will re-seed the registry anyway.
+				if(!this.gcColdPhaseComplete)
+				{
+					this.enqueueLiveApplicationOids(liveObjectIdsIterator);
+				}
 			}
+		}
+
+		/**
+		 * Seed the upcoming mark cycle with every currently live application-held object id so that
+		 * entities kept alive only by the registry safety net still get their binary references
+		 * transitively marked. Without this, an entity that survives sweep solely because its Java
+		 * instance is registered can retain stale binary references to entities that were swept in
+		 * the same cycle, producing zombie OIDs on the next mark phase and persistent data corruption.
+		 */
+		final synchronized void enqueueLiveApplicationOids(final LiveObjectIdsIterator liveObjectIdsIterator)
+		{
+			if(liveObjectIdsIterator == null)
+			{
+				return;
+			}
+
+			liveObjectIdsIterator.iterateLiveObjectIds(this);
 		}
 		
 		private void incrementSweepGeneration()
@@ -700,7 +788,8 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 		@Override
 		public final synchronized void resetCompletion()
 		{
-			this.gcHotPhaseComplete = this.gcColdPhaseComplete = false;
+			this.gcHotPhaseComplete  = this.gcColdPhaseComplete = false;
+			this.liveOidsSeededForCurrentCycle = false;
 		}
 		
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
@@ -21,7 +21,6 @@ import java.nio.ByteOrder;
 import org.eclipse.serializer.exceptions.MissingFoundationPartException;
 import org.eclipse.serializer.monitoring.MonitoringManager;
 import org.eclipse.serializer.persistence.binary.types.BinaryEntityRawDataIterator;
-import org.eclipse.serializer.persistence.types.ObjectIdsSelector;
 import org.eclipse.serializer.persistence.types.Persistence;
 import org.eclipse.serializer.persistence.types.PersistenceLiveStorerRegistry;
 import org.eclipse.serializer.persistence.types.Unpersistable;
@@ -506,7 +505,7 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 	
 	public StorageHousekeepingBroker getHousekeepingBroker();
 	
-	public ObjectIdsSelector getLiveObjectIdChecker();
+	public LiveObjectIdsHandler getLiveObjectIdsHandler();
 
 	public Reference<PersistenceLiveStorerRegistry> getLiveStorerRegistryReference();
 
@@ -851,7 +850,7 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 
 	public F setHousekeepingBroker(StorageHousekeepingBroker housekeepingBroker);
 	
-	public F setLiveObjectIdChecker(ObjectIdsSelector liveObjectIdChecker);
+	public F setLiveObjectIdsHandler(LiveObjectIdsHandler liveObjectIdsHandler);
 
 	public F setLiveStorerRegistryReference(Reference<PersistenceLiveStorerRegistry> LiveStorerRegistryReference);
 	
@@ -944,7 +943,7 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 		private StorageEventLogger                       eventLogger                          ;
 		private StorageWriteController                   writeController                      ;
 		private StorageHousekeepingBroker                housekeepingBroker                   ;
-		private ObjectIdsSelector                        liveObjectIdChecker                  ;
+		private LiveObjectIdsHandler                     liveObjectIdsHandler                 ;
 		private Reference<PersistenceLiveStorerRegistry> storerRegistryReference              ;
 		private StorageStructureValidator                storageStructureValidator            ;
 		private MonitoringManager                        storageMonitorManager                ;
@@ -1181,9 +1180,9 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 			return StorageHousekeepingBroker.New();
 		}
 		
-		protected ObjectIdsSelector ensureObjectIdsSelector()
+		protected LiveObjectIdsHandler ensureLiveObjectIdsHandler()
 		{
-			throw new MissingFoundationPartException(ObjectIdsSelector.class);
+			throw new MissingFoundationPartException(LiveObjectIdsHandler.class);
 		}
 
 		protected Reference<PersistenceLiveStorerRegistry> ensureLiveStorerRegistryReference()
@@ -1566,13 +1565,13 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 		}
 		
 		@Override
-		public final ObjectIdsSelector getLiveObjectIdChecker()
+		public final LiveObjectIdsHandler getLiveObjectIdsHandler()
 		{
-			if(this.liveObjectIdChecker == null)
+			if(this.liveObjectIdsHandler == null)
 			{
-				this.liveObjectIdChecker = this.dispatch(this.ensureObjectIdsSelector());
+				this.liveObjectIdsHandler = this.dispatch(this.ensureLiveObjectIdsHandler());
 			}
-			return this.liveObjectIdChecker;
+			return this.liveObjectIdsHandler;
 		}
 
 		@Override
@@ -1905,9 +1904,9 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 		}
 		
 		@Override
-		public F setLiveObjectIdChecker(final ObjectIdsSelector liveObjectIdChecker)
+		public F setLiveObjectIdsHandler(final LiveObjectIdsHandler liveObjectIdsHandler)
 		{
-			this.liveObjectIdChecker = liveObjectIdChecker;
+			this.liveObjectIdsHandler = liveObjectIdsHandler;
 			return this.$();
 		}
 
@@ -1995,7 +1994,7 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 				this.getLockFileManagerCreator()               ,
 				this.getExceptionHandler()                     ,
 				this.getEventLogger()                          ,
-				this.getLiveObjectIdChecker()                  ,
+				this.getLiveObjectIdsHandler()                 ,
 				this.getLiveStorerRegistryReference()          ,
 				this.getStorageStructureValidator()            ,
 				this.getStorageMonitorManager()                ,

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.serializer.afs.types.AFileSystem;
 import org.eclipse.serializer.monitoring.MonitoringManager;
-import org.eclipse.serializer.persistence.types.ObjectIdsSelector;
 import org.eclipse.serializer.persistence.types.Persistence;
 import org.eclipse.serializer.persistence.types.PersistenceLiveStorerRegistry;
 import org.eclipse.serializer.persistence.types.Unpersistable;
@@ -184,7 +183,7 @@ public interface StorageSystem extends StorageController
 		private final StorageLockFileSetup                       lockFileSetup                 ;
 		private final StorageLockFileManager.Creator             lockFileManagerCreator        ;
 		private final StorageEventLogger                         eventLogger                   ;
-		private final ObjectIdsSelector                          liveObjectIdChecker           ;
+		private final LiveObjectIdsHandler                       liveObjectIdsHandler          ;
 		private final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry             ;
 		private final boolean                                    switchByteOrder               ;
 		private final StorageStructureValidator                  storageStructureValidator     ;
@@ -244,7 +243,7 @@ public interface StorageSystem extends StorageController
 			final StorageLockFileManager.Creator             lockFileManagerCreator        ,
 			final StorageExceptionHandler                    exceptionHandler              ,
 			final StorageEventLogger                         eventLogger                   ,
-			final ObjectIdsSelector                          liveObjectIdChecker           ,
+			final LiveObjectIdsHandler                       liveObjectIdsHandler          ,
 			final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry             ,
 			final StorageStructureValidator                  storageStructureValidator     ,
 			final MonitoringManager                          monitorManager                ,
@@ -291,7 +290,7 @@ public interface StorageSystem extends StorageController
 			this.backupSetup                    = mayNull(storageConfiguration.backupSetup())  ;
 			this.backupDataFileValidatorCreator = notNull(backupDataFileValidatorCreator)      ;
 			this.eventLogger                    = notNull(eventLogger)                         ;
-			this.liveObjectIdChecker            = notNull(liveObjectIdChecker)                 ;
+			this.liveObjectIdsHandler           = notNull(liveObjectIdsHandler)                ;
 			this.refStorerRegistry              = notNull(refStorerRegistry)                   ;
 			this.switchByteOrder                =         switchByteOrder                      ;
 			this.storageStructureValidator      = notNull(storageStructureValidator)           ;
@@ -553,7 +552,7 @@ public interface StorageSystem extends StorageController
 				this.entityMarkMonitorCreator              ,
 				this.provideBackupHandler()                ,
 				this.eventLogger                           ,
-				this.liveObjectIdChecker                   ,
+				this.liveObjectIdsHandler                  ,
 				this.refStorerRegistry                     ,
 				this.switchByteOrder                       ,
 				this.rootTypeIdProvider.provideRootTypeId(),


### PR DESCRIPTION
## Summary
- Fixes a persistent data corruption (zombie OIDs on reload) that occurs when an entity survives a sweep solely because the application's `PersistenceObjectRegistry` still holds it, while another entity it transitively references via its stored binary record gets swept in the same cycle. The next mark phase then dereferences the stale binary pointer, finds no entity for the id, and the zombie OID handler trips.
- Introduces `LiveObjectIdsIterator` (registry → mark-queue push) and bundles it with the existing `ObjectIdsSelector` (sweep-time pull) into a new combined `LiveObjectIdsHandler` interface. The embedded foundation wires the `EmbeddedStorageObjectRegistryCallback` through as the handler.
- Adds two seed points in `StorageEntityMarkMonitor.Default`:
    - **Pre-sweep gate** in `callToSweepRequired()` — guards the very first sweep of a GC cycle so registry-only-kept entities are transitively marked before any sweep happens (covers the cycle-0 case where no prior post-sweep seed exists).
    - **Post-sweep seed** in `completeSweep()` — re-establishes app-state mark roots after every sweep completion so the next mark cycle traverses everything reachable from app-held entities.
- Aligns the mark-seed inclusion criterion with the sweep keep-alive predicate: both are id-only and include cleared-but-not-yet-reaped registry entries, so the two paths cannot disagree on what counts as "registry-resident" on the housekeeping GC path (where neither `cleanUp()` nor `consolidate()` runs).
- Renames `liveObjectIdChecker` / `getLiveObjectIdChecker` / `setLiveObjectIdChecker`  to `liveObjectIdsHandler` / `getLiveObjectIdsHandler` / `setLiveObjectIdsHandler` on `StorageFoundation`, `StorageSystem`, `StorageChannelsCreator`, `StorageEntityCache`, and `EmbeddedStorageFoundation` to reflect the broader housekeeping GC path (where neither `cleanUp()` nor `consolidate()` runs).
- Renames `liveObjectIdChecker` / `getLiveObjectIdChecker` / `setLiveObjectIdChecker` to `liveObjectIdsHandler` / `getLiveObjectIdsHandler` / `setLiveObjectIdsHandler` on `StorageFoundation`, `StorageSystem`, `StorageChannelsCreator`, `StorageEntityCache`, and `EmbeddedStorageFoundation` to reflect the broader contract.
- Adds `storage/storage/GC.md` documenting the mark/sweep/registry interaction, the `WeakReference` lifecycle, the safety-net predicate, the two seed mechanisms, and the failure modes they prevent.
