### PR TITLE
  Cache: support Cache.unwrap to JCache management MXBeans    

### DIFF
--- a/cache/cache/src/main/java/org/eclipse/store/cache/types/Cache.java
+++ b/cache/cache/src/main/java/org/eclipse/store/cache/types/Cache.java
@@ -323,6 +323,20 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			throw new IllegalArgumentException("Unsupported configuration type: " + clazz.getName());
 		}
 
+		@Override
+		public <T> T unwrap(final Class<T> clazz)
+		{
+			if(clazz.isInstance(this.cacheStatisticsMXBean))
+			{
+				return clazz.cast(this.cacheStatisticsMXBean);
+			}
+			if(clazz.isInstance(this.cacheConfigurationMXBean))
+			{
+				return clazz.cast(this.cacheConfigurationMXBean);
+			}
+			return Unwrappable.Static.unwrap(this, clazz);
+		}
+
 		@SuppressWarnings("unchecked")
 		private void updateConfiguration(final Consumer<MutableConfiguration<K, V>> c)
 		{


### PR DESCRIPTION
## Summary
`org.eclipse.store.cache.types.Cache.unwrap(Class<T>)` previously delegated straight to `Unwrappable.Static.unwrap(this, clazz)`, which only succeeds when the requested class is a supertype of the `Cache` implementation itself. Calls like `cache.unwrap(CacheStatisticsMXBean.class)` therefore threw `IllegalArgumentException: Unwrapping to ... is not supported by this implementation` — even though the cache instance owns a registered statistics MXBean and a configuration MXBean as private fields.

This PR overrides `unwrap(Class<T>)` in `Cache.Default` to also return those two MXBeans when asked. Behavior for every other class falls through to the existing `Unwrappable.Static.unwrap(...)` path, so nothing previously supported regresses.

## Why
JSR-107 does not strictly mandate `Cache.unwrap(CacheStatisticsMXBean.class)` to work — the spec only requires that, on an unsupported class, the call throws `IllegalArgumentException`. The documented JSR-107 way to read statistics is the JMX `MBeanServer` (`javax.cache:type=CacheStatistics, CacheManager=...,Cache=...`), which Eclipse Store already wires up via `MBeanServerUtils.registerCacheObject(...)`.

Other major JCache providers (Ehcache 3, Hazelcast) additionally expose the same MBeans via `Cache.unwrap(...)` as a convenience. Customers porting from those providers (or using examples / blog posts that assume this convenience) hit the IAE on the first call. Closing this DX gap removes a class of "why doesn't statistics work?" support requests without changing the spec-prescribed JMX route.

## Change
`cache/cache/src/main/java/org/eclipse/store/cache/types/Cache.java`: new override in `Cache.Default`.

```java
@Override
public <T> T unwrap(final Class<T> clazz)
{
    if(clazz.isInstance(this.cacheStatisticsMXBean))
    {
        return clazz.cast(this.cacheStatisticsMXBean);
    }
    if(clazz.isInstance(this.cacheConfigurationMXBean))
    {
        return clazz.cast(this.cacheConfigurationMXBean);
    }
    return Unwrappable.Static.unwrap(this, clazz);
}                      
```                                                                                                                                                                                                                                                                                         
                                                            
`clazz.isInstance(...)` covers both the JCache spec types (`javax.cache.management.CacheStatisticsMXBean`, `javax.cache.management.CacheMXBean`) and Eclipse Store's narrowed subtypes (`org.eclipse.store.cache.types.CacheStatisticsMXBean`, `org.eclipse.store.cache.types.CacheConfigurationMXBean`).

## Compatibility
* **No public API change.** `Cache.unwrap(Class<T>)` already exists; this PR expands the set of accepted classes.
* **No regression for existing accepted classes.** `Unwrappable.Static.unwrap` is the final fallback, so `cache.unwrap(Cache.Default.class)` (and any supertype) keeps working unchanged.
* `unwrap(Exception.class)` and other unsupported classes still throw `IllegalArgumentException` exactly as before.

## Verification
* **JCache TCK** — `mvn -P cache_tck test` against the patched snapshot, all green (locally verified).
* **vmt/cache (microstream-test)** — 15/15 green (`CacheEvictTest`, `SkillVerifyCacheJCacheTest`).
* **simplecache (microstream-test)** — 7/7 green; the `pitfall_7_statistics_reflect_cacheable_calls` test now uses the natural `cache.unwrap(CacheStatisticsMXBean.class)` path (and asserts `cache.unwrap(CacheMXBean.class)` for the configuration MBean) instead of the JMX `MBeanServer` boilerplate.                                                                                                                                                                                                                                                                                 
                                                                           