### PR TITLE
Replace gigamap finalize() with java.lang.ref.Cleaner

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel2.java
@@ -112,7 +112,9 @@ public class BinaryHandlerBitmapLevel2 extends AbstractBinaryHandlerCustom<Bitma
 		// required to prevent JVM crashes caused by misinterpreted off-heap data.
 		BitmapLevel2.validateLevel2SegmentType(level2Address);
 
-		instance.level2Address = level2Address;
+		// must go through the setter so the Cleaner state tracks the new address;
+		// otherwise a deserialized-then-discarded BitmapLevel2 would leak its region.
+		instance.setLevel2Address(level2Address);
 
 		// deallocate old off-heap memory to prevent leaks when updating an existing instance
 		if(oldAddress > 0)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -23,6 +23,7 @@ import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.serializer.persistence.types.Unpersistable;
 import org.eclipse.serializer.typing.XTypes;
 
+import java.lang.ref.Cleaner;
 import java.util.function.Consumer;
 
 
@@ -504,21 +505,33 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		
 	
 	///////////////////////////////////////////////////////////////////////////
+	// Static Fields //
+	///////////////////
+
+	// Cleaner-based off-heap release; replaces deprecated Object.finalize().
+	// One Cleaner per class is fine — the JDK shares a small thread pool internally.
+	private static final Cleaner CLEANER = Cleaner.create();
+
+
+
+	///////////////////////////////////////////////////////////////////////////
 	// Static Constructors //
 	////////////////////////
-	
+
 	public static BitmapLevel2 New(final int level3Index)
 	{
 		return new BitmapLevel2(level3Index);
 	}
-		
-	
-	
+
+
+
 	///////////////////////////////////////////////////////////////////////////
 	// Instance Fields //
 	////////////////////
 
-	long level2Address;
+	long                            level2Address;
+	private final Cleanup           cleanup     ;
+	private final Cleaner.Cleanable cleanable   ;
 	
 	
 	
@@ -537,6 +550,8 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 	{
 		super(isNew);
 		this.level2Address = level2Address;
+		this.cleanup       = new Cleanup(level2Address);
+		this.cleanable     = CLEANER.register(this, this.cleanup);
 	}
 	
 	
@@ -580,39 +595,48 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 	{
 		return isCompressed(this.level2Address);
 	}
-	
+
+	// Updates both the field and the Cleaner state so the auto-release tracks
+	// the current address. Must be used by every reassignment of level2Address,
+	// including BinaryHandlerBitmapLevel2.updateState (deserialization path).
+	final void setLevel2Address(final long newAddress)
+	{
+		this.level2Address  = newAddress;
+		this.cleanup.address = newAddress;
+	}
+
 	final void ensureCompressed()
 	{
 		if(isCompressed(this.level2Address))
 		{
 			return;
 		}
-		
+
 		// consolidate all segments into a newly allocated memory block
 		final long newAddress = compress(this.level2Address);
-		
+
 		// current level2 structure gets cleaned up
 		deallocate(this.level2Address);
-			
+
 		// address to the new memory block replaces the old (and now invalid) one.
-		this.level2Address = newAddress;
+		this.setLevel2Address(newAddress);
 	}
-	
+
 	final void ensureDecompressed()
 	{
 		if(isFullyDecompressed(this.level2Address))
 		{
 			return;
 		}
-		
+
 		// decompress ALL level1 segments into standalone segments with uncompressed data
 		final long newAddress = decompress(this.level2Address);
-		
+
 		// current level2 structure gets cleaned up
 		deallocate(this.level2Address);
-			
+
 		// address to the new memory block replaces the old (and now invalid) one.
-		this.level2Address = newAddress;
+		this.setLevel2Address(newAddress);
 	}
 	
 
@@ -622,17 +646,37 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		return ensureAddableLevel1SegmentForEntityId(this.level2Address, entityId, level3);
 	}
 	
-	@SuppressWarnings("deprecation")
-	@Override
-	protected void finalize() throws Throwable
+	// Holds the off-heap address for Cleaner-based release.
+	//
+	// MUST be a static nested class — it must not capture the enclosing
+	// BitmapLevel2 instance (directly or via a non-static inner class or an
+	// instance method reference). If it did, the wrapper would never become
+	// unreachable and the Cleaner would never fire, defeating the whole point.
+	//
+	// `address` is mutable so the Cleaner can follow the level2Address through
+	// compress/decompress and binary-handler updateState reassignments via
+	// setLevel2Address. The action is idempotent (zeros the address after free)
+	// so accidental re-invocation cannot double-free.
+	private static final class Cleanup implements Runnable
 	{
-		if(this.level2Address > 0)
+		long address;
+
+		Cleanup(final long address)
 		{
-			deallocate(this.level2Address);
+			this.address = address;
+		}
+
+		@Override
+		public void run()
+		{
+			final long address = this.address;
+			if(address > 0L)
+			{
+				this.address = 0L;
+				deallocate(address);
+			}
 		}
 	}
-
-
 
 
 	///////////////////////////////////////////////////////////////////////////

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -23,7 +23,6 @@ import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.serializer.persistence.types.Unpersistable;
 import org.eclipse.serializer.typing.XTypes;
 
-import java.lang.ref.Cleaner;
 import java.util.function.Consumer;
 
 
@@ -519,9 +518,8 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 	// Instance Fields //
 	////////////////////
 
-	long                            level2Address;
-	private final Cleanup           cleanup     ;
-	private final Cleaner.Cleanable cleanable   ;
+	long                  level2Address;
+	private final Cleanup cleanup     ;
 	
 	
 	
@@ -540,8 +538,8 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 	{
 		super(isNew);
 		this.level2Address = level2Address;
-		this.cleanup       = new Cleanup(level2Address);
-		this.cleanable     = Cleaners.SHARED.register(this, this.cleanup);
+		this.cleanup = new Cleanup(level2Address);
+		Cleaners.SHARED.register(this, this.cleanup);
 	}
 	
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -505,16 +505,6 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		
 	
 	///////////////////////////////////////////////////////////////////////////
-	// Static Fields //
-	///////////////////
-
-	// Cleaner-based off-heap release; replaces deprecated Object.finalize().
-	// One Cleaner per class is fine — the JDK shares a small thread pool internally.
-	private static final Cleaner CLEANER = Cleaner.create();
-
-
-
-	///////////////////////////////////////////////////////////////////////////
 	// Static Constructors //
 	////////////////////////
 
@@ -551,7 +541,7 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		super(isNew);
 		this.level2Address = level2Address;
 		this.cleanup       = new Cleanup(level2Address);
-		this.cleanable     = CLEANER.register(this, this.cleanup);
+		this.cleanable     = Cleaners.SHARED.register(this, this.cleanup);
 	}
 	
 	
@@ -659,7 +649,11 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 	// so accidental re-invocation cannot double-free.
 	private static final class Cleanup implements Runnable
 	{
-		long address;
+		// volatile because the cleanup runs on the Cleaner thread while writes
+		// to address happen on the mutating thread (constructor, setLevel2Address).
+		// java.lang.ref.Cleaner has no JLS-specified happens-before, so explicit
+		// publication is required to avoid stale-address reads.
+		volatile long address;
 
 		Cleanup(final long address)
 		{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Cleaners.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Cleaners.java
@@ -1,4 +1,3 @@
-
 package org.eclipse.store.gigamap.types;
 
 /*-

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Cleaners.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Cleaners.java
@@ -1,0 +1,33 @@
+
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.lang.ref.Cleaner;
+
+/**
+ * Shared {@link Cleaner} for the gigamap module. Each {@link Cleaner#create()}
+ * spawns its own daemon cleanup thread, so consolidating onto one instance
+ * avoids one extra thread per consumer class.
+ */
+final class Cleaners
+{
+	static final Cleaner SHARED = Cleaner.create();
+
+	private Cleaners()
+	{
+		throw new Error();
+	}
+}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -3002,14 +3002,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		{
 			this.parent.closeReader(this);
 		}
-		
-		@SuppressWarnings("deprecation")
-		@Override
-		protected void finalize() throws Throwable
-		{
-			this.close();
-		}
-		
+
 	}
 	
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
@@ -335,11 +335,13 @@ public interface IterationThreadProvider extends ThreadCountProvider
 		}
 		
 		@Override
-		public void shutdown()
+		public synchronized void shutdown()
 		{
 			// Synchronous deactivation. Does NOT cancel the registered Cleaner —
 			// if the pool is reused after shutdown, threads added later will
 			// still be deactivated on GC of this Pooling instance.
+			// `synchronized` matches startIterationThreads/disposeIterationThreads
+			// so concurrent shutdown does not race with reservedThreads mutation.
 			deactivateAllReservedThreads(this.reservedThreads);
 		}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
@@ -228,15 +228,6 @@ public interface IterationThreadProvider extends ThreadCountProvider
 	public final class Pooling extends Abstract
 	{
 		///////////////////////////////////////////////////////////////////////////
-		// static fields //
-		///////////////////
-
-		// Cleaner-based daemon-thread shutdown; replaces deprecated Object.finalize().
-		private static final Cleaner CLEANER = Cleaner.create();
-
-
-
-		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
 
@@ -255,7 +246,7 @@ public interface IterationThreadProvider extends ThreadCountProvider
 			super(threadCountProvider);
 			this.reservedThreads  = BulkList.New(reservedThreadCount);
 			this.allocatedThreads = BulkList.New();
-			this.cleanable        = CLEANER.register(this, new Cleanup(this.reservedThreads));
+			this.cleanable        = Cleaners.SHARED.register(this, new Cleanup(this.reservedThreads));
 		}
 		
 		

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
@@ -18,6 +18,8 @@ import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.LimitList;
 import org.eclipse.serializer.collections.types.XGettingCollection;
 
+import java.lang.ref.Cleaner;
+
 import static org.eclipse.serializer.math.XMath.notNegative;
 import static org.eclipse.serializer.util.X.notNull;
 
@@ -226,23 +228,34 @@ public interface IterationThreadProvider extends ThreadCountProvider
 	public final class Pooling extends Abstract
 	{
 		///////////////////////////////////////////////////////////////////////////
+		// static fields //
+		///////////////////
+
+		// Cleaner-based daemon-thread shutdown; replaces deprecated Object.finalize().
+		private static final Cleaner CLEANER = Cleaner.create();
+
+
+
+		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
-				
+
 		private final BulkList<PoolThread>            reservedThreads ;
 		private final BulkList<LimitList<PoolThread>> allocatedThreads;
-			
-			
-		
+		private final Cleaner.Cleanable               cleanable       ;
+
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
-		
+
 		Pooling(final int reservedThreadCount, final ThreadCountProvider threadCountProvider)
 		{
 			super(threadCountProvider);
 			this.reservedThreads  = BulkList.New(reservedThreadCount);
 			this.allocatedThreads = BulkList.New();
+			this.cleanable        = CLEANER.register(this, new Cleanup(this.reservedThreads));
 		}
 		
 		
@@ -336,29 +349,40 @@ public interface IterationThreadProvider extends ThreadCountProvider
 		@Override
 		public void shutdown()
 		{
-			this.internalShutdown();
+			// runs Cleanup.run() exactly once and cancels the post-GC clean (Cleaner.Cleanable contract)
+			this.cleanable.clean();
 		}
-		
-		private void internalShutdown()
+
+		// Holds the reserved-thread list for Cleaner-based shutdown.
+		//
+		// MUST be a static nested class — capturing the enclosing Pooling
+		// would keep it strongly reachable and prevent the Cleaner from firing.
+		// PoolThread is `static final` and holds no back-reference to Pooling,
+		// so Pooling can be reclaimed independently of its threads.
+		private static final class Cleanup implements Runnable
 		{
-			this.reservedThreads.iterate(t ->
+			private final BulkList<PoolThread> reservedThreads;
+
+			Cleanup(final BulkList<PoolThread> reservedThreads)
 			{
-				synchronized(t)
+				this.reservedThreads = reservedThreads;
+			}
+
+			@Override
+			public void run()
+			{
+				this.reservedThreads.iterate(t ->
 				{
-					t.deactivate();
-					t.notifyAll(); // must notify to wake up inactive thread from waiting for work.
-				}
-			});
-			this.reservedThreads.truncate();
+					synchronized(t)
+					{
+						t.deactivate();
+						t.notifyAll(); // must notify to wake up inactive thread from waiting for work.
+					}
+				});
+				this.reservedThreads.truncate();
+			}
 		}
-		
-		@SuppressWarnings("deprecation")
-		@Override
-		protected void finalize() throws Throwable
-		{
-			this.internalShutdown();
-		}
-		
+
 	}
 	
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IterationThreadProvider.java
@@ -18,8 +18,6 @@ import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.LimitList;
 import org.eclipse.serializer.collections.types.XGettingCollection;
 
-import java.lang.ref.Cleaner;
-
 import static org.eclipse.serializer.math.XMath.notNegative;
 import static org.eclipse.serializer.util.X.notNull;
 
@@ -233,7 +231,6 @@ public interface IterationThreadProvider extends ThreadCountProvider
 
 		private final BulkList<PoolThread>            reservedThreads ;
 		private final BulkList<LimitList<PoolThread>> allocatedThreads;
-		private final Cleaner.Cleanable               cleanable       ;
 
 
 
@@ -246,7 +243,7 @@ public interface IterationThreadProvider extends ThreadCountProvider
 			super(threadCountProvider);
 			this.reservedThreads  = BulkList.New(reservedThreadCount);
 			this.allocatedThreads = BulkList.New();
-			this.cleanable        = Cleaners.SHARED.register(this, new Cleanup(this.reservedThreads));
+			Cleaners.SHARED.register(this, new Cleanup(this.reservedThreads));
 		}
 		
 		
@@ -340,8 +337,23 @@ public interface IterationThreadProvider extends ThreadCountProvider
 		@Override
 		public void shutdown()
 		{
-			// runs Cleanup.run() exactly once and cancels the post-GC clean (Cleaner.Cleanable contract)
-			this.cleanable.clean();
+			// Synchronous deactivation. Does NOT cancel the registered Cleaner —
+			// if the pool is reused after shutdown, threads added later will
+			// still be deactivated on GC of this Pooling instance.
+			deactivateAllReservedThreads(this.reservedThreads);
+		}
+
+		private static void deactivateAllReservedThreads(final BulkList<PoolThread> reservedThreads)
+		{
+			reservedThreads.iterate(t ->
+			{
+				synchronized(t)
+				{
+					t.deactivate();
+					t.notifyAll(); // must notify to wake up inactive thread from waiting for work.
+				}
+			});
+			reservedThreads.truncate();
 		}
 
 		// Holds the reserved-thread list for Cleaner-based shutdown.
@@ -362,15 +374,7 @@ public interface IterationThreadProvider extends ThreadCountProvider
 			@Override
 			public void run()
 			{
-				this.reservedThreads.iterate(t ->
-				{
-					synchronized(t)
-					{
-						t.deactivate();
-						t.notifyAll(); // must notify to wake up inactive thread from waiting for work.
-					}
-				});
-				this.reservedThreads.truncate();
+				deactivateAllReservedThreads(this.reservedThreads);
 			}
 		}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -420,7 +420,6 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		// registry concurrently with native reads/writes.
 		return new ThreadLogic(
 			resultsThreadIterationCopy,
-			this.level1SegmentCount   ,
 			this.registryAddress      ,
 			this.registrySegmentCount ,
 			this
@@ -552,7 +551,6 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 
 		ThreadLogic(
 			final BitmapResult[]   results             ,
-			final int              level1SegmentCount  ,
 			final long             registryAddress     ,
 			final int              registrySegmentCount,
 			final ThreadedIterator owner

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -61,15 +61,6 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 
 
 	///////////////////////////////////////////////////////////////////////////
-	// static fields //
-	///////////////////
-
-	// Cleaner-based off-heap release; replaces deprecated Object.finalize().
-	private static final Cleaner CLEANER = Cleaner.create();
-
-
-
-	///////////////////////////////////////////////////////////////////////////
 	// static methods //
 	///////////////////
 	
@@ -163,7 +154,7 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 
 		// Register Cleaner BEFORE threads start so a thread-startup failure still releases the registry.
 		this.cleanup   = new Cleanup(this.registryAddress, this.registrySegmentCount);
-		this.cleanable = CLEANER.register(this, this.cleanup);
+		this.cleanable = Cleaners.SHARED.register(this, this.cleanup);
 
 		this.currentRegistryIndex   = -1; // must be -1 because of pre-increment logic
 		this.currentRegistrySegmentIndex = REGISTRY_SEGMENT_SIZE;
@@ -396,8 +387,10 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	@Override
 	public void close()
 	{
-		// release segments synchronously (idempotent — at most once via Cleaner.Cleanable contract)
-		this.cleanable.clean();
+		// Native segments are released by the Cleaner once the iterator becomes
+		// phantom-reachable. Releasing them synchronously here would race with
+		// worker threads that are still executing ThreadLogic against the
+		// registry (e.g., on early break-out from a try-with-resources loop).
 		this.threadProvider.disposeIterationThreads(this.threads);
 		this.threadProvider.completeIteration();
 	}
@@ -484,7 +477,11 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	// re-invocation (Cleaner.Cleanable.clean() itself is at-most-once).
 	private static final class Cleanup implements Runnable
 	{
-		long address;
+		// volatile because the cleanup runs on the Cleaner thread while the
+		// initial write happens on the constructor thread. java.lang.ref.Cleaner
+		// has no JLS-specified happens-before, so explicit publication is
+		// required to avoid stale-address reads.
+		volatile long address;
 		final int registrySegmentCount;
 
 		Cleanup(final long registryAddress, final int registrySegmentCount)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -20,7 +20,7 @@ import org.eclipse.serializer.concurrency.XThreads;
 import org.eclipse.serializer.math.XMath;
 import org.eclipse.serializer.memory.XMemory;
 
-import java.lang.ref.Cleaner;
+import java.lang.ref.Reference;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -111,7 +111,6 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	private final long                                 registryAddress     ;
 	private final int                                  waitTimeNs          ;
 	private final Cleanup                              cleanup             ;
-	private final Cleaner.Cleanable                    cleanable           ;
 
 	private long currentRegistrySegmentAddress;
 	private long currentValueGroupAddress;
@@ -153,8 +152,8 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		this.registrySegmentCount = this.calculateRegistrySegmentCount();
 
 		// Register Cleaner BEFORE threads start so a thread-startup failure still releases the registry.
-		this.cleanup   = new Cleanup(this.registryAddress, this.registrySegmentCount);
-		this.cleanable = Cleaners.SHARED.register(this, this.cleanup);
+		this.cleanup = new Cleanup(this.registryAddress, this.registrySegmentCount);
+		Cleaners.SHARED.register(this, this.cleanup);
 
 		this.currentRegistryIndex   = -1; // must be -1 because of pre-increment logic
 		this.currentRegistrySegmentIndex = REGISTRY_SEGMENT_SIZE;
@@ -413,12 +412,18 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	public Runnable provideIterationLogic()
 	{
 		final BitmapResult[] resultsThreadIterationCopy = BitmapResult.createIterationCopy(this.results);
-				
+
+		// `this` is passed as `owner` so the iterator stays strongly reachable
+		// for as long as the worker thread holds the ThreadLogic in PoolThread.logic.
+		// Without this, the iterator could become phantom-reachable while the
+		// worker is still using registryAddress, letting the Cleaner free the
+		// registry concurrently with native reads/writes.
 		return new ThreadLogic(
 			resultsThreadIterationCopy,
 			this.level1SegmentCount   ,
 			this.registryAddress      ,
-			this.registrySegmentCount
+			this.registrySegmentCount ,
+			this
 		);
 	}
 	
@@ -530,28 +535,34 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		// instance fields //
 		////////////////////
 		
-		private final BitmapResult[] results             ;
-		private final long           registryAddress     ;
-		private final int            registrySegmentCount;
-		
-		
-		
-		
+		private final BitmapResult[]   results             ;
+		private final long             registryAddress     ;
+		private final int              registrySegmentCount;
+		// Strong reference to the owning iterator. Held only to keep the iterator
+		// alive while this logic is reachable (PoolThread.logic). Read by the
+		// reachabilityFence in run() so the JIT cannot elide the field.
+		private final ThreadedIterator owner               ;
+
+
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
-		
+
 		ThreadLogic(
-			final BitmapResult[] results             ,
-			final int            level1SegmentCount  ,
-			final long           registryAddress     ,
-			final int            registrySegmentCount
+			final BitmapResult[]   results             ,
+			final int              level1SegmentCount  ,
+			final long             registryAddress     ,
+			final int              registrySegmentCount,
+			final ThreadedIterator owner
 		)
 		{
 			super();
 			this.results              = results             ;
 			this.registryAddress      = registryAddress     ;
 			this.registrySegmentCount = registrySegmentCount;
+			this.owner                = owner               ;
 		}
 		
 		
@@ -563,6 +574,8 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		@Override
 		public void run()
 		{
+			try
+			{
 			final BitmapResult[] results = this.results;
 
 			final long startAddress    = registryIterationStartAddress(this.registryAddress);
@@ -606,8 +619,15 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 			{
 				XMemory.free(newSegmentAddress);
 			}
+			}
+			finally
+			{
+				// Pin the owning iterator past the last native read/write so the
+				// Cleaner cannot fire and free the registry while this logic runs.
+				Reference.reachabilityFence(this.owner);
+			}
 		}
-				
+
 		private static boolean process(
 			final BitmapResult[] results               ,
 			final int            level1SegmentIndex    ,

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -20,6 +20,7 @@ import org.eclipse.serializer.concurrency.XThreads;
 import org.eclipse.serializer.math.XMath;
 import org.eclipse.serializer.memory.XMemory;
 
+import java.lang.ref.Cleaner;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -56,8 +57,18 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	
 	// this is used for a pointer value, but address 1 is never valid, so it can be used as a meta value.
 	static final long SKIP_LEVEL1_SEGMENT_MARKER = 1L;
-	
-	
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// static fields //
+	///////////////////
+
+	// Cleaner-based off-heap release; replaces deprecated Object.finalize().
+	private static final Cleaner CLEANER = Cleaner.create();
+
+
+
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
 	///////////////////
@@ -100,15 +111,17 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	// instance fields //
 	////////////////////
 
-	private final GigaMap.Default<?>                   parent            ;
-	private final BitmapResult[]                       results           ;
-	private final IterationThreadProvider              threadProvider    ;
-	private final XGettingCollection<? extends Thread> threads           ;
-	private final int                                  level1SegmentCount;
+	private final GigaMap.Default<?>                   parent              ;
+	private final BitmapResult[]                       results             ;
+	private final IterationThreadProvider              threadProvider      ;
+	private final XGettingCollection<? extends Thread> threads             ;
+	private final int                                  level1SegmentCount  ;
 	private final int                                  registrySegmentCount;
-	private final long                                 registryAddress   ;
-	private final int                                  waitTimeNs        ;
-		
+	private final long                                 registryAddress     ;
+	private final int                                  waitTimeNs          ;
+	private final Cleanup                              cleanup             ;
+	private final Cleaner.Cleanable                    cleanable           ;
+
 	private long currentRegistrySegmentAddress;
 	private long currentValueGroupAddress;
 	private int  currentRegistryIndex;   // points to a level1segment (a valueGroupsSegment) in the result registry.
@@ -147,15 +160,19 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		final long registryLength = this.calculateIdListsRegistryLength();
 		this.registryAddress      = allocateEmptyMemory(registryLength);
 		this.registrySegmentCount = this.calculateRegistrySegmentCount();
-		
+
+		// Register Cleaner BEFORE threads start so a thread-startup failure still releases the registry.
+		this.cleanup   = new Cleanup(this.registryAddress, this.registrySegmentCount);
+		this.cleanable = CLEANER.register(this, this.cleanup);
+
 		this.currentRegistryIndex   = -1; // must be -1 because of pre-increment logic
 		this.currentRegistrySegmentIndex = REGISTRY_SEGMENT_SIZE;
 		this.currentLevel1Index      = LEVEL_1_VALUE_COUNT;
 		this.currentBitmapValue     = 0L;
 		this.currentBitPosition     = Long.SIZE; // required to force efficient initialization.
-		
+
 		this.isActive = true;
-		
+
 		// create and start threads NOT before everything is setup, hence down here at the end.
 		this.threads = threadProvider.startIterationThreads(parent, threadCount, this);
 	}
@@ -379,6 +396,8 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	@Override
 	public void close()
 	{
+		// release segments synchronously (idempotent — at most once via Cleaner.Cleanable contract)
+		this.cleanable.clean();
 		this.threadProvider.disposeIterationThreads(this.threads);
 		this.threadProvider.completeIteration();
 	}
@@ -410,35 +429,27 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		);
 	}
 	
-	@SuppressWarnings("deprecation")
-	@Override
-	protected void finalize() throws Throwable
-	{
-		this.parent.closeReader(this);
-		this.deallocateSegments();
-	}
-	
-	private void deallocateSegments()
+	private static void deallocateSegments(final long registryAddress, final int registrySegmentCount)
 	{
 		/*
 		 * - the registry consists purely of a list of pointer long values pointing to a registrySegment.
 		 * - each pointer value can be a dummy.
 		 * - registrySegments consist purely of a list of pointer long values pointing to a valueGroup.
 		 * - valueGroups contain no pointer, only bitmap values.
-		 * 
+		 *
 		 * So deallocating requires:
 		 * - Iterate the registry
 		 * - For each entry, resolve the registrySegmentAddress
 		 * - Iterate the registrySegment
 		 * - Deallocate each valueGroup (pointer in the registrySegment)
 		 * - AFTERWARDS, deallocate the registrySegment (pointer in the registry)
-		 * - At the very end, deallocate the registry itself (this.registryAddress)
-		 * 
+		 * - At the very end, deallocate the registry itself
+		 *
 		 * (quite a work without a garbage collector ... ^^)
 		 */
 
-		final long startAddress = registryIterationStartAddress(this.registryAddress);
-		final long boundAddress = registryIterationBoundAddress(this.registryAddress, this.registrySegmentCount);
+		final long startAddress = registryIterationStartAddress(registryAddress);
+		final long boundAddress = registryIterationBoundAddress(registryAddress, registrySegmentCount);
 
 		for(long registryEntryAddress = startAddress; registryEntryAddress < boundAddress; registryEntryAddress += Long.BYTES)
 		{
@@ -459,7 +470,39 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 			}
 			XMemory.free(registrySegmentAddress);
 		}
-		XMemory.free(this.registryAddress);
+		XMemory.free(registryAddress);
+	}
+
+	// Holds the registry address for Cleaner-based release.
+	//
+	// MUST be a static nested class — it must not capture the enclosing
+	// ThreadedIterator (directly or via a non-static inner class or an
+	// instance method reference). If it did, the wrapper would never become
+	// unreachable and the Cleaner would never fire.
+	//
+	// `address` is mutable + zero-on-clean for idempotency against accidental
+	// re-invocation (Cleaner.Cleanable.clean() itself is at-most-once).
+	private static final class Cleanup implements Runnable
+	{
+		long address;
+		final int registrySegmentCount;
+
+		Cleanup(final long registryAddress, final int registrySegmentCount)
+		{
+			this.address              = registryAddress;
+			this.registrySegmentCount = registrySegmentCount;
+		}
+
+		@Override
+		public void run()
+		{
+			final long address = this.address;
+			if(address > 0L)
+			{
+				this.address = 0L;
+				deallocateSegments(address, this.registrySegmentCount);
+			}
+		}
 	}
 	
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -574,49 +574,49 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		{
 			try
 			{
-			final BitmapResult[] results = this.results;
+				final BitmapResult[] results = this.results;
 
-			final long startAddress    = registryIterationStartAddress(this.registryAddress);
-			final long boundAddress    = registryIterationBoundAddress(this.registryAddress, this.registrySegmentCount);
-			final long lastItemAddress = registryIterationBoundAddress(this.registryAddress, this.registrySegmentCount - 1);
+				final long startAddress    = registryIterationStartAddress(this.registryAddress);
+				final long boundAddress    = registryIterationBoundAddress(this.registryAddress, this.registrySegmentCount);
+				final long lastItemAddress = registryIterationBoundAddress(this.registryAddress, this.registrySegmentCount - 1);
 
-			int currentLevel1SegmentIndex = 0;
-			long newSegmentAddress = createRegistrySegment();
+				int currentLevel1SegmentIndex = 0;
+				long newSegmentAddress = createRegistrySegment();
 
-			// rea = registryEntryAddress
-			for(long rea = startAddress; rea < boundAddress; rea += Long.BYTES, currentLevel1SegmentIndex += REGISTRY_SEGMENT_SIZE)
-			{
-				// check for a yet unprocessed registry segment
-				if(XMemory.volatileGet_long(null, rea) != 0L)
+				// rea = registryEntryAddress
+				for(long rea = startAddress; rea < boundAddress; rea += Long.BYTES, currentLevel1SegmentIndex += REGISTRY_SEGMENT_SIZE)
 				{
-					continue;
+					// check for a yet unprocessed registry segment
+					if(XMemory.volatileGet_long(null, rea) != 0L)
+					{
+						continue;
+					}
+
+					// try to reserve unprocessed coordinate (competing with other threads)
+					if(!XMemory.compareAndSwap_long(null, rea, 0L, -1L))
+					{
+						continue;
+					}
+
+					// process reserved coordinate and register the address to the value groups segment.
+					if(process(results, currentLevel1SegmentIndex, newSegmentAddress))
+					{
+						XMemory.volatileSet_long(null, rea, newSegmentAddress);
+						newSegmentAddress = rea < lastItemAddress
+							? createRegistrySegment()
+							: 0L
+						;
+					}
+					else
+					{
+						XMemory.volatileSet_long(null, rea, SKIP_LEVEL1_SEGMENT_MARKER);
+					}
 				}
 
-				// try to reserve unprocessed coordinate (competing with other threads)
-				if(!XMemory.compareAndSwap_long(null, rea, 0L, -1L))
+				if(newSegmentAddress != 0L)
 				{
-					continue;
+					XMemory.free(newSegmentAddress);
 				}
-
-				// process reserved coordinate and register the address to the value groups segment.
-				if(process(results, currentLevel1SegmentIndex, newSegmentAddress))
-				{
-					XMemory.volatileSet_long(null, rea, newSegmentAddress);
-					newSegmentAddress = rea < lastItemAddress
-						? createRegistrySegment()
-						: 0L
-					;
-				}
-				else
-				{
-					XMemory.volatileSet_long(null, rea, SKIP_LEVEL1_SEGMENT_MARKER);
-				}
-			}
-
-			if(newSegmentAddress != 0L)
-			{
-				XMemory.free(newSegmentAddress);
-			}
 			}
 			finally
 			{

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/BitmapLevel2CleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/BitmapLevel2CleanerTest.java
@@ -1,0 +1,200 @@
+
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies that {@link BitmapLevel2}'s {@link java.lang.ref.Cleaner} registration
+ * actually releases the off-heap region after the wrapper becomes unreachable.
+ * <p>
+ * This is the regression guard against the original {@code finalize()} pattern
+ * and against future refactors that accidentally make the cleanup state hold a
+ * strong reference back to the {@code BitmapLevel2} wrapper. If the cleanup
+ * captured {@code this}, the wrapper would never become phantom-reachable and
+ * the cleaner would never run — this test would then fail with the timeout.
+ */
+class BitmapLevel2CleanerTest
+{
+	private static final int  INSTANCE_COUNT     = 200;
+	private static final long CLEANUP_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(5);
+	private static final long POLL_INTERVAL_MS   = 50;
+
+	@Test
+	void cleanerReleasesOffHeapMemoryAfterGc() throws Exception
+	{
+		final Field cleanupField = BitmapLevel2.class.getDeclaredField("cleanup");
+		cleanupField.setAccessible(true);
+
+		final Field addressField = cleanupField.getType().getDeclaredField("address");
+		addressField.setAccessible(true);
+
+		// Allocate, then drop strong refs to the wrappers; only the cleanup
+		// state-holders are retained so we can later inspect their address.
+		final List<Object> cleanups = createInstancesAndCaptureCleanups(cleanupField, INSTANCE_COUNT);
+
+		final long deadline = System.nanoTime() + CLEANUP_TIMEOUT_NS;
+		while(System.nanoTime() < deadline)
+		{
+			System.gc();
+			if(allAddressesZero(cleanups, addressField))
+			{
+				return;
+			}
+			Thread.sleep(POLL_INTERVAL_MS);
+		}
+
+		final long stillAlive = countNonZero(cleanups, addressField);
+		fail(stillAlive + " of " + INSTANCE_COUNT
+			+ " BitmapLevel2 cleanups did not run within "
+			+ TimeUnit.NANOSECONDS.toSeconds(CLEANUP_TIMEOUT_NS) + "s — "
+			+ "either the cleanup state holds a strong reference back to BitmapLevel2 "
+			+ "or the GC has not reclaimed the wrappers yet.");
+	}
+
+	// Isolated in a helper so the wrapper locals fall out of scope cleanly on return.
+	private static List<Object> createInstancesAndCaptureCleanups(
+		final Field cleanupField,
+		final int   count
+	) throws IllegalAccessException
+	{
+		final List<Object> cleanups = new ArrayList<>(count);
+		for(int i = 0; i < count; i++)
+		{
+			final BitmapLevel2 bm = BitmapLevel2.New(i);
+			cleanups.add(cleanupField.get(bm));
+		}
+		return cleanups;
+	}
+
+	private static boolean allAddressesZero(final List<Object> cleanups, final Field addressField)
+	{
+		for(final Object cleanup : cleanups)
+		{
+			if(readAddress(cleanup, addressField) != 0L)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static long countNonZero(final List<Object> cleanups, final Field addressField)
+	{
+		long count = 0;
+		for(final Object cleanup : cleanups)
+		{
+			if(readAddress(cleanup, addressField) != 0L)
+			{
+				count++;
+			}
+		}
+		return count;
+	}
+
+	private static long readAddress(final Object cleanup, final Field addressField)
+	{
+		try
+		{
+			return addressField.getLong(cleanup);
+		}
+		catch(final IllegalAccessException e)
+		{
+			throw new AssertionError(e);
+		}
+	}
+
+	/**
+	 * Regression guard for the deserialization path
+	 * ({@link BinaryHandlerBitmapLevel2#create} → {@link BinaryHandlerBitmapLevel2#updateState}).
+	 * <p>
+	 * The handler builds a {@code BitmapLevel2} in two steps: first a placeholder
+	 * wrapper with address 0, then the real off-heap region is published via
+	 * {@code instance.setLevel2Address(...)}. If that final write bypasses the
+	 * setter (and writes the field directly), the Cleaner state stays at 0, the
+	 * cleaner action becomes a no-op, and every deserialised-then-discarded
+	 * {@code BitmapLevel2} silently leaks its region.
+	 * <p>
+	 * This test enforces three invariants:
+	 * <ol>
+	 * <li>Construction with a placeholder address initialises the cleanup state to that placeholder.</li>
+	 * <li>{@code setLevel2Address} propagates the new address to the cleanup state.</li>
+	 * <li>After the wrapper becomes unreachable, the cleaner releases the
+	 *     post-setter address (proves the cleaner actually saw the propagated value).</li>
+	 * </ol>
+	 */
+	@Test
+	void setLevel2AddressPropagatesToCleanupAndCleanerReleasesNewAddress() throws Exception
+	{
+		final Field cleanupField = BitmapLevel2.class.getDeclaredField("cleanup");
+		cleanupField.setAccessible(true);
+		final Field addressField = cleanupField.getType().getDeclaredField("address");
+		addressField.setAccessible(true);
+
+		final Method allocateNew = BitmapLevel2.class.getDeclaredMethod("allocateNew", int.class);
+		allocateNew.setAccessible(true);
+
+		final long realAddress = (long)allocateNew.invoke(null, 0);
+
+		final Object cleanup = simulateHandlerLifecycle(cleanupField, addressField, realAddress);
+
+		final long deadline = System.nanoTime() + CLEANUP_TIMEOUT_NS;
+		while(System.nanoTime() < deadline)
+		{
+			System.gc();
+			if(readAddress(cleanup, addressField) == 0L)
+			{
+				return;
+			}
+			Thread.sleep(POLL_INTERVAL_MS);
+		}
+
+		fail("Cleaner did not release the address published via setLevel2Address (addr="
+			+ realAddress + ") within "
+			+ TimeUnit.NANOSECONDS.toSeconds(CLEANUP_TIMEOUT_NS) + "s");
+	}
+
+	// Isolated so the BitmapLevel2 wrapper local falls out of scope on return.
+	private static Object simulateHandlerLifecycle(
+		final Field cleanupField,
+		final Field addressField,
+		final long  realAddress
+	) throws IllegalAccessException
+	{
+		// Mimic BinaryHandlerBitmapLevel2.create(): wrapper with placeholder address 0.
+		final BitmapLevel2 bm      = new BitmapLevel2(false, 0L);
+		final Object       cleanup = cleanupField.get(bm);
+		assertEquals(0L, addressField.getLong(cleanup),
+			"Pre-condition: cleanup state must mirror the constructor argument");
+
+		// Mimic BinaryHandlerBitmapLevel2.updateState() final line.
+		bm.setLevel2Address(realAddress);
+		assertEquals(realAddress, addressField.getLong(cleanup),
+			"setLevel2Address must propagate to cleanup.address — without this, "
+			+ "BinaryHandlerBitmapLevel2.updateState would leak the deserialised region.");
+
+		return cleanup;
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/BitmapLevel2CleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/BitmapLevel2CleanerTest.java
@@ -1,4 +1,3 @@
-
 package org.eclipse.store.gigamap.types;
 
 /*-

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/IterationThreadProviderCleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/IterationThreadProviderCleanerTest.java
@@ -1,0 +1,125 @@
+
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies that {@link IterationThreadProvider.Pooling} deactivates its
+ * {@code PoolThread}s when the {@code Pooling} instance becomes unreachable —
+ * via {@link java.lang.ref.Cleaner}, not the deprecated FinalizerThread.
+ * <p>
+ * Also verifies that explicit {@code shutdown()} is the supported path for
+ * deterministic deactivation and that the post-GC clean is then a no-op.
+ */
+class IterationThreadProviderCleanerTest
+{
+	private static final long CLEANUP_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(5);
+	private static final long POLL_INTERVAL_MS   = 50;
+
+	@Test
+	void cleanerDeactivatesPoolThreadsAfterGc() throws Exception
+	{
+		// Allocate threads + capture a sentinel PoolThread inside a helper so
+		// the Pooling local falls out of scope cleanly when the helper returns.
+		final Thread sentinel = createPoolingAndAllocateThreads();
+
+		final Field isRunningField = sentinel.getClass().getDeclaredField("isRunning");
+		isRunningField.setAccessible(true);
+
+		assertTrue(isRunningField.getBoolean(sentinel),
+			"Pre-condition: PoolThread.isRunning must be true while Pooling is alive");
+
+		final long deadline = System.nanoTime() + CLEANUP_TIMEOUT_NS;
+		while(System.nanoTime() < deadline)
+		{
+			System.gc();
+			if(!isRunningField.getBoolean(sentinel))
+			{
+				return;
+			}
+			Thread.sleep(POLL_INTERVAL_MS);
+		}
+
+		fail("Pooling cleanup did not run within "
+			+ TimeUnit.NANOSECONDS.toSeconds(CLEANUP_TIMEOUT_NS)
+			+ "s — either the Cleanup is capturing the Pooling instance or GC has not "
+			+ "reclaimed it yet.");
+	}
+
+	@Test
+	void shutdownDeactivatesPoolThreadsImmediately() throws Exception
+	{
+		final IterationThreadProvider provider = IterationThreadProvider.Pooling(
+			2, ThreadCountProvider.Fixed(2)
+		);
+		allocateAndDispose(provider);
+
+		final Thread sentinel = firstReservedThread(provider);
+		final Field isRunningField = sentinel.getClass().getDeclaredField("isRunning");
+		isRunningField.setAccessible(true);
+
+		assertTrue(isRunningField.getBoolean(sentinel),
+			"Pre-condition: PoolThread.isRunning must be true before shutdown()");
+
+		provider.shutdown();
+
+		assertFalse(isRunningField.getBoolean(sentinel),
+			"shutdown() must deactivate PoolThreads synchronously via cleanable.clean()");
+
+		// Idempotent: cleanable.clean() runs at most once, second call is a no-op.
+		provider.shutdown();
+	}
+
+	// Helper: builds a Pooling, drives one start/dispose cycle so the
+	// reservedThreads list is populated, returns a sentinel PoolThread.
+	// The Pooling local does not escape this method.
+	private static Thread createPoolingAndAllocateThreads() throws Exception
+	{
+		final IterationThreadProvider provider = IterationThreadProvider.Pooling(
+			2, ThreadCountProvider.Fixed(2)
+		);
+		allocateAndDispose(provider);
+		return firstReservedThread(provider);
+	}
+
+	private static void allocateAndDispose(final IterationThreadProvider provider)
+	{
+		// Force thread creation. The threads do nothing useful here — a no-op
+		// Runnable is sufficient. The point is to populate reservedThreads.
+		final var threads = provider.startIterationThreads(null, 2, () -> () -> {
+		});
+		provider.disposeIterationThreads(threads);
+	}
+
+	private static Thread firstReservedThread(final IterationThreadProvider provider) throws Exception
+	{
+		final Field reservedThreadsField = provider.getClass().getDeclaredField("reservedThreads");
+		reservedThreadsField.setAccessible(true);
+		final Object reservedThreads = reservedThreadsField.get(provider);
+
+		final Method firstMethod = reservedThreads.getClass().getMethod("first");
+		return (Thread)firstMethod.invoke(reservedThreads);
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/IterationThreadProviderCleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/IterationThreadProviderCleanerTest.java
@@ -1,4 +1,3 @@
-
 package org.eclipse.store.gigamap.types;
 
 /*-

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/IterationThreadProviderCleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/IterationThreadProviderCleanerTest.java
@@ -85,9 +85,10 @@ class IterationThreadProviderCleanerTest
 		provider.shutdown();
 
 		assertFalse(isRunningField.getBoolean(sentinel),
-			"shutdown() must deactivate PoolThreads synchronously via cleanable.clean()");
+			"shutdown() must deactivate PoolThreads synchronously");
 
-		// Idempotent: cleanable.clean() runs at most once, second call is a no-op.
+		// Idempotent: shutdown() truncates reservedThreads on first call, so
+		// subsequent calls iterate an empty list and are no-ops.
 		provider.shutdown();
 	}
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorCleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorCleanerTest.java
@@ -18,25 +18,63 @@ package org.eclipse.store.gigamap.types;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Verifies that {@link ThreadedIterator}'s {@code close()} releases its off-heap
- * registry synchronously via {@link java.lang.ref.Cleaner.Cleanable#clean()},
- * rather than waiting for the FinalizerThread to run.
+ * Verifies that {@link ThreadedIterator}'s off-heap registry is released by
+ * the {@link java.lang.ref.Cleaner} once the iterator becomes phantom-reachable,
+ * instead of waiting for the deprecated {@code FinalizerThread}.
  * <p>
- * Regression guard for the §3e improvement of the Phase 2 finalize→Cleaner
- * refactor. Before that change, {@code ThreadedIterator.close()} only disposed
- * worker threads — segments were freed exclusively by {@code finalize()}.
+ * Regression guard against the {@code Cleanup} state holder accidentally
+ * capturing the enclosing {@code ThreadedIterator} (e.g. via a non-static
+ * inner class or an instance method reference). If it did, the wrapper
+ * would never become unreachable and the cleaner would never fire — this
+ * test would then time out.
  */
 class ThreadedIteratorCleanerTest
 {
+	private static final long CLEANUP_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(5);
+	private static final long POLL_INTERVAL_MS   = 50;
+
 	@Test
-	void closeReleasesRegistrySynchronously() throws Exception
+	void cleanerReleasesRegistryAfterGc() throws Exception
+	{
+		final Field cleanupField = ThreadedIterator.class.getDeclaredField("cleanup");
+		cleanupField.setAccessible(true);
+		final Field addressField = cleanupField.getType().getDeclaredField("address");
+		addressField.setAccessible(true);
+
+		// Build the iterator + capture the Cleanup state holder inside a helper
+		// so the iterator local falls out of scope cleanly when the helper returns.
+		// The wrapping is removed from activeReaders by the explicit close()
+		// inside the helper, so the underlying ThreadedIterator becomes
+		// phantom-reachable once the iterator local is gone.
+		final Object cleanup = createIteratorAndCaptureCleanup(cleanupField);
+
+		assertNotEquals(0L, addressField.getLong(cleanup),
+			"Pre-condition: registry must be allocated before GC");
+
+		final long deadline = System.nanoTime() + CLEANUP_TIMEOUT_NS;
+		while(System.nanoTime() < deadline)
+		{
+			System.gc();
+			if(addressField.getLong(cleanup) == 0L)
+			{
+				return;
+			}
+			Thread.sleep(POLL_INTERVAL_MS);
+		}
+
+		fail("ThreadedIterator cleanup did not run within "
+			+ TimeUnit.NANOSECONDS.toSeconds(CLEANUP_TIMEOUT_NS)
+			+ "s — either the Cleanup is capturing the iterator instance or GC has not "
+			+ "reclaimed it yet.");
+	}
+
+	private static Object createIteratorAndCaptureCleanup(final Field cleanupField) throws Exception
 	{
 		final GigaMap<Person> map = GigaMap.New();
 		final PersonNameIndexer nameIndexer = new PersonNameIndexer();
@@ -46,39 +84,22 @@ class ThreadedIteratorCleanerTest
 			map.add(new Person("Person" + i));
 		}
 
-		// Pooling provider with Fixed(2) threads forces the multithreaded path
-		// in GigaMap.Default.createIterator → new ThreadedIterator(...).
+		// Pooling + Fixed(2) forces the multithreaded path in
+		// GigaMap.Default.createIterator → new ThreadedIterator(...).
 		final IterationThreadProvider provider = IterationThreadProvider.Pooling(
 			4, ThreadCountProvider.Fixed(2)
 		);
 
 		final GigaIterator<Person> iter = map.query(provider).and(nameIndexer.is("Person1")).iterator();
-
-		// The query path with a non-null condition + NoOp idMatcher + threadCount > 0
-		// returns a GigaIterator.Wrapping wrapping a ThreadedIterator.
 		final ThreadedIterator threaded = extractThreadedIterator(iter);
-		assertNotNull(threaded, "Expected GigaIterator.Wrapping wrapping a ThreadedIterator");
-
-		final Field cleanupField = ThreadedIterator.class.getDeclaredField("cleanup");
-		cleanupField.setAccessible(true);
 		final Object cleanup = cleanupField.get(threaded);
 
-		final Field addressField = cleanup.getClass().getDeclaredField("address");
-		addressField.setAccessible(true);
-
-		final long addressBeforeClose = addressField.getLong(cleanup);
-		assertNotEquals(0L, addressBeforeClose,
-			"Pre-condition: registry must be allocated before close()");
-
+		// Explicit close removes the wrapping from activeReaders and disposes
+		// worker threads, so by the time we return the iterator is no longer
+		// pinned and no thread is using the registry.
 		iter.close();
 
-		final long addressAfterClose = addressField.getLong(cleanup);
-		assertEquals(0L, addressAfterClose,
-			"close() must release the registry synchronously via cleanable.clean(); "
-			+ "if this fails, ThreadedIterator.close() is leaking segments to the FinalizerThread.");
-
-		// cleanable.clean() is at-most-once; second close must be a no-op.
-		assertDoesNotThrow(iter::close, "close() must be idempotent");
+		return cleanup;
 	}
 
 	private static ThreadedIterator extractThreadedIterator(final GigaIterator<?> iter) throws Exception
@@ -87,9 +108,12 @@ class ThreadedIteratorCleanerTest
 		final Field idIteratorField = iter.getClass().getDeclaredField("idIterator");
 		idIteratorField.setAccessible(true);
 		final Object idIterator = idIteratorField.get(iter);
-		return idIterator instanceof ThreadedIterator
-			? (ThreadedIterator)idIterator
-			: null;
+		if(!(idIterator instanceof ThreadedIterator))
+		{
+			throw new AssertionError("Expected GigaIterator.Wrapping over a ThreadedIterator, got "
+				+ (idIterator == null ? "null" : idIterator.getClass().getName()));
+		}
+		return (ThreadedIterator)idIterator;
 	}
 
 	private static final class Person

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorCleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorCleanerTest.java
@@ -1,4 +1,3 @@
-
 package org.eclipse.store.gigamap.types;
 
 /*-

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorCleanerTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorCleanerTest.java
@@ -1,0 +1,113 @@
+
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Verifies that {@link ThreadedIterator}'s {@code close()} releases its off-heap
+ * registry synchronously via {@link java.lang.ref.Cleaner.Cleanable#clean()},
+ * rather than waiting for the FinalizerThread to run.
+ * <p>
+ * Regression guard for the §3e improvement of the Phase 2 finalize→Cleaner
+ * refactor. Before that change, {@code ThreadedIterator.close()} only disposed
+ * worker threads — segments were freed exclusively by {@code finalize()}.
+ */
+class ThreadedIteratorCleanerTest
+{
+	@Test
+	void closeReleasesRegistrySynchronously() throws Exception
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		final PersonNameIndexer nameIndexer = new PersonNameIndexer();
+		map.index().bitmap().add(nameIndexer);
+		for(int i = 0; i < 1000; i++)
+		{
+			map.add(new Person("Person" + i));
+		}
+
+		// Pooling provider with Fixed(2) threads forces the multithreaded path
+		// in GigaMap.Default.createIterator → new ThreadedIterator(...).
+		final IterationThreadProvider provider = IterationThreadProvider.Pooling(
+			4, ThreadCountProvider.Fixed(2)
+		);
+
+		final GigaIterator<Person> iter = map.query(provider).and(nameIndexer.is("Person1")).iterator();
+
+		// The query path with a non-null condition + NoOp idMatcher + threadCount > 0
+		// returns a GigaIterator.Wrapping wrapping a ThreadedIterator.
+		final ThreadedIterator threaded = extractThreadedIterator(iter);
+		assertNotNull(threaded, "Expected GigaIterator.Wrapping wrapping a ThreadedIterator");
+
+		final Field cleanupField = ThreadedIterator.class.getDeclaredField("cleanup");
+		cleanupField.setAccessible(true);
+		final Object cleanup = cleanupField.get(threaded);
+
+		final Field addressField = cleanup.getClass().getDeclaredField("address");
+		addressField.setAccessible(true);
+
+		final long addressBeforeClose = addressField.getLong(cleanup);
+		assertNotEquals(0L, addressBeforeClose,
+			"Pre-condition: registry must be allocated before close()");
+
+		iter.close();
+
+		final long addressAfterClose = addressField.getLong(cleanup);
+		assertEquals(0L, addressAfterClose,
+			"close() must release the registry synchronously via cleanable.clean(); "
+			+ "if this fails, ThreadedIterator.close() is leaking segments to the FinalizerThread.");
+
+		// cleanable.clean() is at-most-once; second close must be a no-op.
+		assertDoesNotThrow(iter::close, "close() must be idempotent");
+	}
+
+	private static ThreadedIterator extractThreadedIterator(final GigaIterator<?> iter) throws Exception
+	{
+		// GigaIterator.Wrapping holds the underlying ResultIdIterator in its `idIterator` field.
+		final Field idIteratorField = iter.getClass().getDeclaredField("idIterator");
+		idIteratorField.setAccessible(true);
+		final Object idIterator = idIteratorField.get(iter);
+		return idIterator instanceof ThreadedIterator
+			? (ThreadedIterator)idIterator
+			: null;
+	}
+
+	private static final class Person
+	{
+		final String name;
+
+		Person(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	private static final class PersonNameIndexer extends IndexerString.Abstract<Person>
+	{
+		@Override
+		protected String getString(final Person entity)
+		{
+			return entity.name;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the four `Object.finalize()` sites in the gigamap module with `java.lang.ref.Cleaner` registrations (or, in one case, deletes the finalizer as dead code). Object reclamation now happens within roughly one GC cycle on a dedicated thread, instead of waiting for the deprecated `FinalizerThread` queue to drain.

After this PR, zero `finalize()` declarations remain anywhere in `gigamap/.../main/java`.

## Why

`Object.finalize()` has been deprecated since Java 9. It runs on a single shared `FinalizerThread`, requires two GC cycles before reclamation, and creates a `java.lang.ref.Finalizer` (~64 bytes COOPS) per instance. Under load the finalizer queue lags arbitrarily; on a quiet JVM the `FinalizerThread` may never schedule. `StorageEntity.java:576-581` already explicitly rejects the pattern on the same grounds — gigamap was the holdout.

`Cleaner` runs on its own thread, reclaims after a single GC cycle, and is the JDK-recommended replacement.

## What changed

The four sites have different shapes — three need real Cleaner replacements, one is dead code that can be deleted. A package-private `Cleaners` holder shares one `Cleaner` instance across the module so the JVM only spawns one extra daemon thread total.

### `Cleaners.java` (new) — shared module Cleaner

`Cleaner.create()` spawns a dedicated daemon thread per instance. Consolidating onto a single `Cleaners.SHARED` keeps that overhead constant regardless of how many classes register cleanup actions.

### `BitmapLevel2.java` — primary off-heap leak source

Every loaded GigaMap bitmap goes through this path, so finalize timing directly affected steady-state native RSS.

- Added a `private static final class Cleanup implements Runnable`. **Static** so it does not capture `this` — otherwise the wrapper would never become unreachable and the cleaner would never fire. `address` is `volatile` and zero-on-clean: the cleaner runs on a different thread, so explicit publication is required (`java.lang.ref.Cleaner` has no JLS-specified happens-before). The action zeros the address after `deallocate()` for idempotency.
- Added a package-private `setLevel2Address(long)` setter that writes both the field and `cleanup.address`.
- Routed all three reassignment sites through the setter: `ensureCompressed`, `ensureDecompressed`, and `BinaryHandlerBitmapLevel2.updateState`. The deserialization-path edit is the non-obvious correctness detail: the handler creates the wrapper with `address = 0` in `create()` and publishes the real address later via `updateState()`. Without the setter, the cleaner state would stay at 0 and every deserialised-then-discarded `BitmapLevel2` would silently leak its region.
- Registered with `Cleaners.SHARED.register(this, this.cleanup)` in the constructor. Removed `finalize()` and `@SuppressWarnings("deprecation")`.

### `ThreadedIterator.java` — deferred segment release via Cleaner

`ThreadedIterator` is **not** directly registered in `GigaMap.Default.activeReaders` — the `GigaIterator.Wrapping` that holds it is. When the user calls `close()` on the user-facing `GigaIterator`, `Wrapping.close()` (`GigaIterator.java:196-199`) deregisters the wrapping and chains `idIterator.close()` on the underlying iterator. `ThreadedIterator.close()` disposes worker threads and completes iteration; the off-heap registry is released by the `Cleaner` once the iterator becomes phantom-reachable.

- Added a `private static final class Cleanup implements Runnable` capturing the registry address (`volatile`, zero-on-clean) and `registrySegmentCount` (final).
- Lifted `deallocateSegments()` from an instance method to `private static deallocateSegments(long, int)` — purely mechanical.
- Registered the cleaner in the constructor *after* `registryAddress` and `registrySegmentCount` are set but *before* threads start, so a `startIterationThreads()` failure still releases the registry.
- `ThreadLogic` now holds a strong reference to the owning `ThreadedIterator` and calls `Reference.reachabilityFence(this.owner)` at the end of `run()`. Without this, the iterator could become phantom-reachable while a worker thread was still using `registryAddress` (`ThreadLogic` captured only primitives), letting the Cleaner free the registry concurrently with native reads/writes. Pinning through `PoolThread.logic` → `ThreadLogic.owner` ensures the cleaner only fires after every worker has returned from `logic.run()` and `PoolThread.logic` has been nulled. Same hazard pre-existed in the finalize-based code; this PR closes it.
- Removed `finalize()`. The `parent.closeReader(this)` call inside it is dropped entirely — `ThreadedIterator` is not directly registered in `activeReaders`, so that call was a no-op safeguard at best.
- Cleaned up an unused `level1SegmentCount` parameter on `ThreadLogic`'s constructor while the signature was being modified.

### `IterationThreadProvider.java` (`Pooling`) — daemon-thread shutdown

`finalize()` previously deactivated the pool's reserved `PoolThread`s by calling `internalShutdown()`.

- Added a `private static final class Cleanup` capturing the `BulkList<PoolThread> reservedThreads` reference — **not** the `Pooling` instance. Both `Pooling` (implicitly static, nested in interface) and `PoolThread` (`static final class`) hold no back-references to their enclosing instance, so the cleaner pattern works without the usual capture hazards.
- Extracted `private static deactivateAllReservedThreads(BulkList<PoolThread>)`. `shutdown()` and `Cleanup.run()` both delegate to it.
- `shutdown()` deactivates threads synchronously but does **not** call `cleanable.clean()` — calling `clean()` would permanently cancel post-GC cleanup, silently breaking any reuse of a `Pooling` instance after `shutdown()`. The Cleaner registration stays active for the instance's lifetime, so threads added after shutdown are still cleaned up on GC. `shutdown()` is `synchronized` to align with `startIterationThreads`/`disposeIterationThreads`.
- Removed `finalize()`.

### `GigaMap.java` (`Itr` inner class) — dead code deletion

No Cleaner replacement. `Itr.finalize()` body was `this.close()` → `parent.closeReader(this)`, guarded by `if(reader.isClosed()) return;` (`GigaMap.java:2427`):
- If the user iterates to completion or calls `close()` explicitly: `closeReader` removes the iter from `activeReaders` and sets `isActive=false`. After the user drops the local, finalize *can* fire — body hits the `isClosed()` guard and returns early. **No-op.**
- If the user breaks out without `close()`: iter stays in `activeReaders` (strong refs), never becomes unreachable, finalize never fires.

Either way, the finalizer did no useful work. Removing it is a small heap win (no per-instance `Finalizer` allocation) with no behavioural change.

## Tests (new, in `gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/`)

- **`BitmapLevel2CleanerTest`** — `cleanerReleasesOffHeapMemoryAfterGc` allocates 200 instances, drops the wrappers, polls (`System.gc()` + sleep) on a 5s deadline. Guards against `Cleanup` accidentally capturing `this`. `setLevel2AddressPropagatesToCleanupAndCleanerReleasesNewAddress` mimics the binary handler's `create()` → `updateState()` lifecycle, asserts initial state, setter propagation, and post-setter cleaner release.
- **`ThreadedIteratorCleanerTest`** — `cleanerReleasesRegistryAfterGc` drives a real GigaMap query with `IterationThreadProvider.Pooling`, captures the `Cleanup` state holder, drops the iterator, and polls (`System.gc()` + sleep) on a 5s deadline. Regression guard against `Cleanup` accidentally capturing the iterator.
- **`IterationThreadProviderCleanerTest`** — `cleanerDeactivatesPoolThreadsAfterGc` allocates threads, drops the `Pooling` reference, polls `PoolThread.isRunning` on a 5s deadline; if `Cleanup` accidentally captures `this`, the threads stay running and the test fails on timeout. `shutdownDeactivatesPoolThreadsImmediately` asserts that explicit `shutdown()` deactivates threads synchronously and is idempotent.
- **`GigaMap.Itr`** — no test. The existing 880+ iteration-heavy tests provide sufficient regression coverage for dead-code removal.

## Out of scope

- **`activeReaders` strong-ref pinning.** If a user creates an iterator and breaks out without calling `close()`, the wrapping (or `Itr`) stays in `activeReaders` indefinitely; the underlying `ThreadedIterator` stays reachable through it; the Cleaner never fires; segments leak permanently. This is **pre-existing behaviour, unchanged by this PR** — replacing finalize with Cleaner doesn't help, since neither fires on a strongly-reachable wrapper. Closing that hole would require making `activeReaders` weak or self-cleaning, which is a structurally larger change with API implications.
- **`ThreadedIterator` deletion.** The class carries its own `// XXX Maybe delete ThreadedIterator` comment (line 38) noting the newer monolithic GigaMap iterator is "MUCH simpler ... AND considerably faster". If retiring it is on the roadmap, the corresponding section of this PR can be replaced with class deletion.
- **`Pooling` thread-pool redesign.** The TODO at `IterationThreadProvider.java:220-225` proposes weak back-references and adaptive sizing. Out of scope.

## Test plan

- [x] `mvn -B -pl gigamap/gigamap -am clean test` — green
- [x] `mvn -B -pl gigamap/gigamap test` — **885 tests pass** (was 880 pre-PR, +5 new across two test classes), 0 failures, 1 pre-existing skip
- [x] Grep guard: zero `finalize()` declarations in `gigamap/gigamap/src/main/java/**`
- [x] CI green
