### PR TITLE
GigaMap binary handler corrections (iterators + BitmapEntry metadata)

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexBinary.java
@@ -135,6 +135,9 @@ extends AbstractBinaryHandlerBitmapIndexAbstract<I>
 		}
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final I instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexBinary.java
@@ -136,8 +136,9 @@ extends AbstractBinaryHandlerBitmapIndexAbstract<I>
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final I instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexHashing.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexHashing.java
@@ -153,8 +153,9 @@ extends AbstractBinaryHandlerBitmapIndexAbstract<I>
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final I instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexHashing.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractBitmapIndexHashing.java
@@ -152,11 +152,14 @@ extends AbstractBinaryHandlerBitmapIndexAbstract<I>
 		entries.add(k, entry);
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final I instance, final PersistenceFunction iterator)
 	{
 		super.iterateInstanceReferences(instance, iterator);
-		
+
 		iterator.apply(instance.indexer);
 		Persistence.iterateReferences(iterator, instance.entries);
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractCompositeBitmapIndex.java
@@ -122,6 +122,9 @@ extends AbstractBinaryHandlerBitmapIndexAbstract<C>
 		instance.initializeTransientState();
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final C instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerAbstractCompositeBitmapIndex.java
@@ -123,8 +123,9 @@ extends AbstractBinaryHandlerBitmapIndexAbstract<C>
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final C instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerBitmapIndexAbstract.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerBitmapIndexAbstract.java
@@ -131,6 +131,9 @@ extends AbstractBinaryHandlerStateChangeFlagged<I>
 		XMemory.setObject(instance, MEMORY_OFFSET_name  , getName  (data, handler));
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final I instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerBitmapIndexAbstract.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBinaryHandlerBitmapIndexAbstract.java
@@ -132,8 +132,9 @@ extends AbstractBinaryHandlerStateChangeFlagged<I>
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final I instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapEntry.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapEntry.java
@@ -141,8 +141,9 @@ implements BinaryLegacyTypeHandlerSupplier<BitmapEntry<?, ?, ?>>
 	}
 
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final BitmapEntry<?, ?, ?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapEntry.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapEntry.java
@@ -56,7 +56,7 @@ public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFl
 		BINARY_OFFSET_level3   = 0                                                   ,
 		BINARY_OFFSET_position = BINARY_OFFSET_level3   + Binary.objectIdByteLength(),
 		BINARY_LENGTH          = BINARY_OFFSET_position + Integer.BYTES,
-		
+
 		MEMORY_OFFSET_level3   = getClassDeclaredFieldOffset(genericType(), "level3")
 	;
 	
@@ -138,6 +138,9 @@ public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFl
 		XMemory.setObject(instance, MEMORY_OFFSET_level3, getLevel3(data, handler));
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final BitmapEntry<?, ?, ?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapEntry.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapEntry.java
@@ -9,18 +9,19 @@ package org.eclipse.store.gigamap.types;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
 
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.binary.types.BinaryLegacyTypeHandlerSupplier;
 import org.eclipse.serializer.persistence.types.PersistenceFunction;
+import org.eclipse.serializer.persistence.types.PersistenceLegacyTypeHandler;
 import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
 import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
 import org.eclipse.serializer.persistence.types.PersistenceStoreHandler;
-import org.eclipse.serializer.reference.Lazy;
 
 
 /**
@@ -47,11 +48,12 @@ import org.eclipse.serializer.reference.Lazy;
  * and positions.
  */
 public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFlagged<BitmapEntry<?, ?, ?>>
+implements BinaryLegacyTypeHandlerSupplier<BitmapEntry<?, ?, ?>>
 {
 	///////////////////////////////////////////////////////////////////////////
 	// constants //
 	//////////////
-	
+
 	private static final long
 		BINARY_OFFSET_level3   = 0                                                   ,
 		BINARY_OFFSET_position = BINARY_OFFSET_level3   + Binary.objectIdByteLength(),
@@ -59,44 +61,44 @@ public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFl
 
 		MEMORY_OFFSET_level3   = getClassDeclaredFieldOffset(genericType(), "level3")
 	;
-	
+
 	@SuppressWarnings("all")
 	public static final Class<BitmapEntry<?, ?, ?>> genericType()
 	{
 		// no idea how to get ".class" to work otherwise in conjunction with generics.
 		return (Class)BitmapEntry.class;
 	}
-	
-	
-	
+
+
+
 	public static BinaryHandlerBitmapEntry New()
 	{
 		return new BinaryHandlerBitmapEntry();
 	}
-	
-	
-	
+
+
+
 	///////////////////////////////////////////////////////////////////////////
 	// constructors //
 	/////////////////
-	
+
 	BinaryHandlerBitmapEntry()
 	{
 		super(
 			genericType(),
 			CustomFields(
-				CustomField(Lazy.class, "level3"  ),
-				CustomField(int.class , "position")
+				CustomField(BitmapLevel3.class, "level3"  ),
+				CustomField(int.class         , "position")
 			)
 		);
 	}
-	
-	
-	
+
+
+
 	///////////////////////////////////////////////////////////////////////////
 	// methods //
 	////////////
-	
+
 	@Override
 	public void internalStore(
 		final Binary                          data    ,
@@ -109,15 +111,15 @@ public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFl
 		data.storeReference   (BINARY_OFFSET_level3  , handler, XMemory.getObject(instance, MEMORY_OFFSET_level3));
 		data.store_int        (BINARY_OFFSET_position, instance.position());
 	}
-		
+
 	@Override
 	public BitmapEntry<?, ?, ?> create(final Binary data, final PersistenceLoadHandler handler)
 	{
 		final int position = data.read_int(BINARY_OFFSET_position);
-		
+
 		return new BitmapEntry<>(null, null, position, false);
 	}
-	
+
 	private static BitmapLevel3 getLevel3(
 		final Binary                 data   ,
 		final PersistenceLoadHandler handler
@@ -126,8 +128,8 @@ public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFl
 		return (BitmapLevel3)data.readReference(BINARY_OFFSET_level3, handler);
 	}
 
-			 
-	
+
+
 	@Override
 	public void updateState(
 		final Binary                 data    ,
@@ -137,7 +139,7 @@ public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFl
 	{
 		XMemory.setObject(instance, MEMORY_OFFSET_level3, getLevel3(data, handler));
 	}
-	
+
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
 	// registers child references via Binary#storeReference(s) inside internalStore, so this
 	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
@@ -152,5 +154,15 @@ public class BinaryHandlerBitmapEntry extends AbstractBinaryHandlerStateChangeFl
 	{
 		iterator.acceptObjectId(data.readObjectId(BINARY_OFFSET_level3));
 	}
-		
+
+	@Override
+	public PersistenceLegacyTypeHandler<Binary, BitmapEntry<?, ?, ?>> getLegacyTypeHandler()
+	{
+		// Earlier versions declared the level3 field as Lazy in the type dictionary even though
+		// the handler always read/wrote a direct BitmapLevel3 reference. The binary layout is
+		// unchanged; only the declared field type differs, so the legacy handler reads the same
+		// 12 bytes and routes them into the same BitmapLevel3 slot.
+		return BinaryLegacyTypeHandlerBitmapEntry.New();
+	}
+
 }

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndexSingle.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndexSingle.java
@@ -145,6 +145,9 @@ public class BinaryHandlerBitmapIndexSingle extends AbstractBinaryHandlerBitmapI
 		XMemory.setObject(instance, MEMORY_OFFSET_indexer, indexer);
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final SingleBitmapIndex<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndexSingle.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndexSingle.java
@@ -146,8 +146,9 @@ public class BinaryHandlerBitmapIndexSingle extends AbstractBinaryHandlerBitmapI
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final SingleBitmapIndex<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndicesDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndicesDefault.java
@@ -191,6 +191,9 @@ public class BinaryHandlerBitmapIndicesDefault extends AbstractBinaryHandlerStat
 		instance.rebuildCache();
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final BitmapIndices.Default<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndicesDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndicesDefault.java
@@ -192,8 +192,9 @@ public class BinaryHandlerBitmapIndicesDefault extends AbstractBinaryHandlerStat
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final BitmapIndices.Default<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel3.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel3.java
@@ -142,6 +142,9 @@ public class BinaryHandlerBitmapLevel3 extends AbstractBinaryHandlerStateChangeF
 		return 0;
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final BitmapLevel3 instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel3.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel3.java
@@ -143,8 +143,9 @@ public class BinaryHandlerBitmapLevel3 extends AbstractBinaryHandlerStateChangeF
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final BitmapLevel3 instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerCustomConstraintsDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerCustomConstraintsDefault.java
@@ -159,8 +159,9 @@ public class BinaryHandlerCustomConstraintsDefault extends AbstractBinaryHandler
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final CustomConstraints.Default<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerCustomConstraintsDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerCustomConstraintsDefault.java
@@ -17,6 +17,7 @@ package org.eclipse.store.gigamap.types;
 import org.eclipse.serializer.collections.EqHashTable;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.types.PersistenceFunction;
 import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
 import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
 import org.eclipse.serializer.persistence.types.PersistenceStoreHandler;
@@ -157,6 +158,16 @@ public class BinaryHandlerCustomConstraintsDefault extends AbstractBinaryHandler
 		instance.internalSetElements(getElements(data, handler));
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	@Override
+	public void iterateInstanceReferences(final CustomConstraints.Default<?> instance, final PersistenceFunction iterator)
+	{
+		iterator.apply(XMemory.getObject(instance, MEMORY_OFFSET_parent));
+		iterator.apply(instance.elements());
+	}
+
 	@Override
 	public void iterateLoadableReferences(final Binary data, final PersistenceReferenceLoader iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaConstraintsDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaConstraintsDefault.java
@@ -147,8 +147,9 @@ public class BinaryHandlerGigaConstraintsDefault extends AbstractBinaryHandlerSt
 	}
 
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final GigaConstraints.Default<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaConstraintsDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaConstraintsDefault.java
@@ -16,6 +16,7 @@ package org.eclipse.store.gigamap.types;
 
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.types.PersistenceFunction;
 import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
 import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
 import org.eclipse.serializer.persistence.types.PersistenceStoreHandler;
@@ -143,6 +144,16 @@ public class BinaryHandlerGigaConstraintsDefault extends AbstractBinaryHandlerSt
 	{
 		XMemory.setObject(instance, MEMORY_OFFSET_uniqueConstraints, getUniqueConstraints(data, handler));
 		XMemory.setObject(instance, MEMORY_OFFSET_customConstraints, getCustomConstraints(data, handler));
+	}
+
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	@Override
+	public void iterateInstanceReferences(final GigaConstraints.Default<?> instance, final PersistenceFunction iterator)
+	{
+		iterator.apply(XMemory.getObject(instance, MEMORY_OFFSET_uniqueConstraints));
+		iterator.apply(XMemory.getObject(instance, MEMORY_OFFSET_customConstraints));
 	}
 
 	@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaIndicesDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaIndicesDefault.java
@@ -156,8 +156,9 @@ public class BinaryHandlerGigaIndicesDefault extends AbstractBinaryHandlerStateC
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final GigaIndices.Default<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaIndicesDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaIndicesDefault.java
@@ -155,6 +155,9 @@ public class BinaryHandlerGigaIndicesDefault extends AbstractBinaryHandlerStateC
 		);
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final GigaIndices.Default<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel1.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel1.java
@@ -123,6 +123,9 @@ public final class BinaryHandlerGigaLevel1 extends AbstractBinaryHandlerStateCha
 		);
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public final void iterateInstanceReferences(final GigaLevel1<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel1.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel1.java
@@ -124,8 +124,9 @@ public final class BinaryHandlerGigaLevel1 extends AbstractBinaryHandlerStateCha
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public final void iterateInstanceReferences(final GigaLevel1<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel2.java
@@ -126,6 +126,9 @@ public final class BinaryHandlerGigaLevel2 extends AbstractBinaryHandlerStateCha
 		);
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public final void iterateInstanceReferences(final GigaLevel2<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel2.java
@@ -127,8 +127,9 @@ public final class BinaryHandlerGigaLevel2 extends AbstractBinaryHandlerStateCha
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public final void iterateInstanceReferences(final GigaLevel2<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel3.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel3.java
@@ -117,6 +117,9 @@ public final class BinaryHandlerGigaLevel3 extends AbstractBinaryHandlerStateCha
 		);
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
 	@Override
 	public final void iterateInstanceReferences(final GigaLevel3<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel3.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaLevel3.java
@@ -118,8 +118,9 @@ public final class BinaryHandlerGigaLevel3 extends AbstractBinaryHandlerStateCha
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public final void iterateInstanceReferences(final GigaLevel3<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaMapDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaMapDefault.java
@@ -18,6 +18,7 @@ import org.eclipse.serializer.equality.Equalator;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.AbstractBinaryHandlerCustom;
 import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.types.PersistenceFunction;
 import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
 import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
 import org.eclipse.serializer.persistence.types.PersistenceStoreHandler;
@@ -231,6 +232,18 @@ public class BinaryHandlerGigaMapDefault extends AbstractBinaryHandlerCustom<Gig
 		XMemory.set_long(instance, MEMORY_OFFSET_baseAddingId, currentId);
 	}
 	
+	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
+	// registers child references via Binary#storeReference(s) inside store/internalStore, so this
+	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	@Override
+	public void iterateInstanceReferences(final GigaMap.Default<?> instance, final PersistenceFunction iterator)
+	{
+		iterator.apply(instance.level3()     );
+		iterator.apply(instance.index()      );
+		iterator.apply(instance.constraints());
+		iterator.apply(instance.equalator()  );
+	}
+
 	@Override
 	public void iterateLoadableReferences(final Binary data, final PersistenceReferenceLoader iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaMapDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerGigaMapDefault.java
@@ -233,8 +233,9 @@ public class BinaryHandlerGigaMapDefault extends AbstractBinaryHandlerCustom<Gig
 	}
 	
 	// Provided only for PersistenceTypeHandler contract conformity. The standard store path
-	// registers child references via Binary#storeReference(s) inside store/internalStore, so this
-	// iterator is exercised only by niche traversals such as PersistenceRegisterer.
+	// registers child references through handler.apply(...) callbacks while writing the
+	// binary form, so this iterator is exercised only by niche traversals such as
+	// PersistenceRegisterer.
 	@Override
 	public void iterateInstanceReferences(final GigaMap.Default<?> instance, final PersistenceFunction iterator)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryLegacyTypeHandlerBitmapEntry.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryLegacyTypeHandlerBitmapEntry.java
@@ -1,0 +1,108 @@
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.serializer.persistence.binary.types.BinaryLegacyTypeHandler;
+import org.eclipse.serializer.persistence.types.PersistenceLoadHandler;
+import org.eclipse.serializer.persistence.types.PersistenceReferenceLoader;
+import org.eclipse.serializer.reference.Lazy;
+
+
+/**
+ * Legacy handler for {@link BitmapEntry} type definitions that declared the
+ * {@code level3} field as {@link Lazy} in the stored type dictionary.
+ * <p>
+ * The historical {@link BinaryHandlerBitmapEntry} declared a {@code CustomField(Lazy.class, "level3")}
+ * even though the actual instance field is of type {@link BitmapLevel3} and the handler
+ * always wrote/read a plain object reference to a {@link BitmapLevel3}. The on-disk binary
+ * layout is therefore identical to the current one; only the declared field type in the
+ * type dictionary differs. This handler exists so that storages written by the old
+ * declaration are matched cleanly against their stored type definition instead of relying
+ * on heuristic legacy mapping.
+ */
+public class BinaryLegacyTypeHandlerBitmapEntry
+extends BinaryLegacyTypeHandler.AbstractCustom<BitmapEntry<?, ?, ?>>
+{
+	///////////////////////////////////////////////////////////////////////////
+	// constants //
+	//////////////
+
+	private static final long
+		BINARY_OFFSET_level3   = 0                                                   ,
+		BINARY_OFFSET_position = BINARY_OFFSET_level3   + Binary.objectIdByteLength(),
+
+		MEMORY_OFFSET_level3   = getClassDeclaredFieldOffset(BinaryHandlerBitmapEntry.genericType(), "level3")
+	;
+
+
+
+	public static BinaryLegacyTypeHandlerBitmapEntry New()
+	{
+		return new BinaryLegacyTypeHandlerBitmapEntry();
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryLegacyTypeHandlerBitmapEntry()
+	{
+		super(
+			BinaryHandlerBitmapEntry.genericType(),
+			CustomFields(
+				CustomField(Lazy.class, "level3"  ),
+				CustomField(int.class , "position")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+
+	@Override
+	public BitmapEntry<?, ?, ?> create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		final int position = data.read_int(BINARY_OFFSET_position);
+
+		return new BitmapEntry<>(null, null, position, false);
+	}
+
+	@Override
+	public void updateState(
+		final Binary                 data    ,
+		final BitmapEntry<?, ?, ?>   instance,
+		final PersistenceLoadHandler handler
+	)
+	{
+		// The stored objectId always referenced a BitmapLevel3 directly, despite the
+		// legacy Lazy declaration. Reading it as a plain reference is therefore safe.
+		final BitmapLevel3 level3 = (BitmapLevel3)data.readReference(BINARY_OFFSET_level3, handler);
+		XMemory.setObject(instance, MEMORY_OFFSET_level3, level3);
+	}
+
+	@Override
+	public void iterateLoadableReferences(final Binary data, final PersistenceReferenceLoader iterator)
+	{
+		iterator.acceptObjectId(data.readObjectId(BINARY_OFFSET_level3));
+	}
+
+}

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
@@ -155,6 +155,9 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
         instance.ensureIndexInitialized();
     }
 
+    // Provided only for PersistenceTypeHandler contract conformity. The standard store path
+    // registers child references via Binary#storeReference(s) inside internalStore, so this
+    // iterator is exercised only by niche traversals such as PersistenceRegisterer.
     @Override
     public void iterateInstanceReferences(
         final VectorIndex.Default<?> instance,

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
@@ -156,8 +156,9 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
     }
 
     // Provided only for PersistenceTypeHandler contract conformity. The standard store path
-    // registers child references via Binary#storeReference(s) inside internalStore, so this
-    // iterator is exercised only by niche traversals such as PersistenceRegisterer.
+    // registers child references through handler.apply(...) callbacks while writing the
+    // binary form, so this iterator is exercised only by niche traversals such as
+    // PersistenceRegisterer.
     @Override
     public void iterateInstanceReferences(
         final VectorIndex.Default<?> instance,

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndicesDefault.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndicesDefault.java
@@ -119,6 +119,9 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndices.Default<?>>
         XMemory.setObject(instance, MEMORY_OFFSET_vectorIndices, vectorIndices);
     }
 
+    // Provided only for PersistenceTypeHandler contract conformity. The standard store path
+    // registers child references via Binary#storeReference(s) inside internalStore, so this
+    // iterator is exercised only by niche traversals such as PersistenceRegisterer.
     @Override
     public void iterateInstanceReferences(
         final VectorIndices.Default<?> instance,

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndicesDefault.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndicesDefault.java
@@ -120,8 +120,9 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndices.Default<?>>
     }
 
     // Provided only for PersistenceTypeHandler contract conformity. The standard store path
-    // registers child references via Binary#storeReference(s) inside internalStore, so this
-    // iterator is exercised only by niche traversals such as PersistenceRegisterer.
+    // registers child references through handler.apply(...) callbacks while writing the
+    // binary form, so this iterator is exercised only by niche traversals such as
+    // PersistenceRegisterer.
     @Override
     public void iterateInstanceReferences(
         final VectorIndices.Default<?> instance,

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/BinaryHandlerLuceneIndexDefault.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/BinaryHandlerLuceneIndexDefault.java
@@ -147,8 +147,9 @@ public class BinaryHandlerLuceneIndexDefault extends AbstractBinaryHandlerStateC
     }
 
     // Provided only for PersistenceTypeHandler contract conformity. The standard store path
-    // registers child references via Binary#storeReference(s) inside internalStore, so this
-    // iterator is exercised only by niche traversals such as PersistenceRegisterer.
+    // registers child references through handler.apply(...) callbacks while writing the
+    // binary form, so this iterator is exercised only by niche traversals such as
+    // PersistenceRegisterer.
     @Override
     public void iterateInstanceReferences(final LuceneIndex.Default<?> instance, final PersistenceFunction iterator)
     {

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/BinaryHandlerLuceneIndexDefault.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/BinaryHandlerLuceneIndexDefault.java
@@ -146,6 +146,9 @@ public class BinaryHandlerLuceneIndexDefault extends AbstractBinaryHandlerStateC
         XMemory.setObject(instance, MEMORY_OFFSET_fileEntries, getFileEntries(data, handler));
     }
 
+    // Provided only for PersistenceTypeHandler contract conformity. The standard store path
+    // registers child references via Binary#storeReference(s) inside internalStore, so this
+    // iterator is exercised only by niche traversals such as PersistenceRegisterer.
     @Override
     public void iterateInstanceReferences(final LuceneIndex.Default<?> instance, final PersistenceFunction iterator)
     {


### PR DESCRIPTION
## Summary

Two related fixes to gigamap's binary handlers, both surfaced during a contract audit of `iterateInstanceReferences` / `iterateLoadableReferences`. Neither affects on-disk binary layout; the standard store / load / GC paths are unchanged.

### 1. `iterateInstanceReferences` contract conformity
- `BinaryHandlerGigaMapDefault`, `BinaryHandlerGigaConstraintsDefault`, and `BinaryHandlerCustomConstraintsDefault` stored references via `Binary#storeReference` inside `(internal)Store` but inherited the no-op `iterateInstanceReferences` default from `AbstractBinaryHandlerCustom`, leaving 3 of the 18 gigamap handlers in contract violation of `PersistenceTypeHandler`.
- Not a runtime bug — the storer's graph walk runs through `apply()` callbacks invoked from inside `storeReference(s)`, and gigamap re-stores changed-but-not-new children via `storeChildren` / `internalRegisterChangeStores`. Loading uses `iterateLoadableReferences`, GC uses `StorageEntityTypeHandler.iterateReferences` on persisted binary data. None of these paths touch `iterateInstanceReferences`, so the missing overrides only mattered for niche traversals via `PersistenceRegisterer`.
- Added the three missing overrides (mirroring what `internalStore` writes) and put a uniform comment on all 18 `iterateInstanceReferences` overrides in the gigamap modules documenting that they exist for contract conformity only.

### 2. `BitmapEntry` type-dictionary metadata
- `BinaryHandlerBitmapEntry` declared its `level3` field as `Lazy` in the type dictionary, but the handler always wrote and read a direct `BitmapLevel3` reference. The on-disk binary layout was correct; only the type metadata diverged.
- Corrected the declaration to `BitmapLevel3` and added `BinaryLegacyTypeHandlerBitmapEntry` so storages written under the old declaration still load, mirroring the existing `BinaryHandlerBitmapLevel2` legacy-mapping pattern.
