### PR TITLE
Fix SingleBitmapIndex throwing Error on update/set/replace (#685)

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
@@ -239,7 +239,14 @@ implements BitmapIndex.TopLevel<E, Boolean>, ChangeHandler
 		// entryResultInverted) keep working. Reached via internalRemoveFromEntry on the
 		// change-handler path used by update / set / replace when the last TRUE entity flips
 		// to FALSE / null.
-		//
+		if(entry != this.entry)
+		{
+			// Defensive guard: this index owns exactly one entry by construction. If the
+			// generic cleanup ever passes a different entry, the invariant has regressed
+			// somewhere else and we want to fail loudly rather than silently mark the
+			// wrong children dirty.
+			throw new IllegalArgumentException("SingleBitmapIndex received an unexpected BitmapEntry instance in removeEntry");
+		}
 		// internalRemoveFromEntry marks the index instance-changed (not children-changed) after
 		// invoking removeEntry, but since the entry is kept, its child bitmap also needs to be
 		// re-stored on the next store(). Mark children-changed here so storeChangedChildren

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
@@ -233,8 +233,18 @@ implements BitmapIndex.TopLevel<E, Boolean>, ChangeHandler
 	@Override
 	protected final void removeEntry(final BitmapEntry<E, E, Boolean> entry)
 	{
-		// not used in this implementation since ... well ... there is only one entry. Lol.
-		throw new Error();
+		// SingleBitmapIndex holds exactly one permanent BitmapEntry (the TRUE-set), allocated
+		// in the constructor. An empty entry is a valid state (no TRUE-indexed entities) and
+		// must remain in place so future TRUE additions and FALSE / inverted queries (see
+		// entryResultInverted) keep working. Reached via internalRemoveFromEntry on the
+		// change-handler path used by update / set / replace when the last TRUE entity flips
+		// to FALSE / null.
+		//
+		// internalRemoveFromEntry marks the index instance-changed (not children-changed) after
+		// invoking removeEntry, but since the entry is kept, its child bitmap also needs to be
+		// re-stored on the next store(). Mark children-changed here so storeChangedChildren
+		// reaches the entry's level3 — matching what internalRemove does on the direct path.
+		this.markStateChangeChildren();
 	}
 	
 	@Override

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
@@ -98,6 +98,60 @@ public class BooleanIndexTest
     }
 
     @Test
+    void updateLastTrueToFalse_doesNotThrow()
+    {
+        // Regression for issue 685: flipping the indexed boolean from TRUE to FALSE on the
+        // last (and only) TRUE-indexed entity used to throw java.lang.Error from
+        // SingleBitmapIndex.removeEntry via the update / set / replace change-handler path.
+        GigaMap<BooleanPerson> map = GigaMap.New();
+        map.index().bitmap().add(this.booleanPersonIndex);
+
+        BooleanPerson person = new BooleanPerson("Solo", true);
+        map.add(person);
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(map, tempDir)) {
+            map.update(person, p -> p.setAdult(Boolean.FALSE));
+            map.store();
+
+            assertEquals(0, map.query(this.booleanPersonIndex.isTrue()).count());
+            assertEquals(1, map.query(this.booleanPersonIndex.isFalse()).count());
+        }
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
+            GigaMap<BooleanPerson> newMap = manager.root();
+            assertEquals(0, newMap.query(this.booleanPersonIndex.isTrue()).count());
+            assertEquals(1, newMap.query(this.booleanPersonIndex.isFalse()).count());
+        }
+    }
+
+    @Test
+    void setLastTrueToFalse_doesNotThrow()
+    {
+        // Regression for issue 685, set-based path. Same shape as updateLastTrueToFalse_doesNotThrow
+        // but mutates via map.set(entityId, replacement) instead of map.update(...).
+        GigaMap<BooleanPerson> map = GigaMap.New();
+        map.index().bitmap().add(this.booleanPersonIndex);
+
+        BooleanPerson person = new BooleanPerson("Solo", true);
+        long entityId = map.add(person);
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(map, tempDir)) {
+            BooleanPerson replacement = new BooleanPerson("Solo", false);
+            map.set(entityId, replacement);
+            map.store();
+
+            assertEquals(0, map.query(this.booleanPersonIndex.isTrue()).count());
+            assertEquals(1, map.query(this.booleanPersonIndex.isFalse()).count());
+        }
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
+            GigaMap<BooleanPerson> newMap = manager.root();
+            assertEquals(0, newMap.query(this.booleanPersonIndex.isTrue()).count());
+            assertEquals(1, newMap.query(this.booleanPersonIndex.isFalse()).count());
+        }
+    }
+
+    @Test
     void booleanPersonTest()
     {
         GigaMap<BooleanPerson> map = prepageGigaMap();


### PR DESCRIPTION
## Summary

Fixes #685.

A `GigaMap` configured with an `IndexerBoolean` indexer (i.e. a `SingleBitmapIndex`) threw `java.lang.Error` whenever an `update`, `set`, or `replace` flipped the indexed boolean from `TRUE` to `FALSE` / `null` on the **last** entity still indexed as `TRUE`. The error originated from a `throw new Error()` stub in `SingleBitmapIndex.removeEntry` that was marked unreachable but was in fact reached via the change-handler path (`changeInIndex` → `BitmapEntry.removeFromIndex` → `BitmapIndex.Abstract.internalRemoveFromEntry`, which unconditionally calls `removeEntry` when the entry becomes empty).

`gigaMap.remove(entity)` was never affected because `SingleBitmapIndex.internalRemove` bypasses the empty-entry cleanup branch. Only `update` / `set` / `replace` were broken.

## Fix

`SingleBitmapIndex` holds exactly one permanent `BitmapEntry` by design (allocated in the constructor; an empty entry is a valid state, and `entryResultInverted` relies on it continuing to exist). Change `removeEntry` from "throw" to "keep the entry + mark children-changed":

- No-op for the entry removal itself (entry stays in place).
- Call `markStateChangeChildren()` so the now-empty bitmap is re-persisted on the next `store()` — `internalRemoveFromEntry` only marks the index instance-changed in the empty-entry branch, so without this the in-memory query returned the right count but the persisted entry still held the old `TRUE` bit. This matches what `internalRemove` does on the direct `gigaMap.remove(entity)` path.

`BitmapIndex.Abstract.internalRemoveFromEntry` is `final`, so the only override point is `removeEntry`.

## Test plan

- [x] Added `BooleanIndexTest.updateLastTrueToFalse_doesNotThrow` — `gigaMap.update(...)` path, with persistence round-trip.
- [x] Added `BooleanIndexTest.setLastTrueToFalse_doesNotThrow` — `gigaMap.set(...)` path, with persistence round-trip.
- [x] Full `gigamap` module test suite: 887 passed, 0 failures, 1 skipped (pre-existing).

Both new tests fail before the fix (`java.lang.Error` from the in-memory mutation) and pass after.
