### PR TITLE
Fix exact-match correctness of binary (bit-sliced) composite indexes

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -300,11 +300,14 @@ implements BitmapIndex.TopLevel<E, KS>
 		for(int i = 0; i < this.subIndices.length; i++)
 		{
 			// filter for selected positions to allow querying for specific positions instead of always all positions.
-			if(!this.isEmpty(keys, i))
+			// empty (null/zero) positions are wildcards and must be skipped; only positions that carry an actual
+			// key value are queried. (The guard was previously inverted, which skipped exactly the relevant
+			// positions and made In/All/Equals conditions on composite binary indexes return wrong results.)
+			if(this.isEmpty(keys, i))
 			{
 				continue;
 			}
-			
+
 			// query sub index at position i for the non-null key value
 			final BitmapResult result = this.subIndices[i].internalQueryForKeys(keys);
 			
@@ -455,7 +458,14 @@ implements BitmapIndex.TopLevel<E, KS>
 			try
 			{
 				final CompositePredicate<KS> predicate = this.ensureCompositePredicate(passedPredicate);
-				
+
+				if(predicate.exceedsPositions(this.subIndices.length))
+				{
+					// the searched value requires more sub-key positions than this index has ever seen,
+					// so no stored entity can possibly hold that value.
+					return EMPTY_RESULT;
+				}
+
 				for(int i = 0; i < this.subIndices.length; i++)
 				{
 					if(!predicate.setSubKeyPosition(i))

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -292,7 +292,7 @@ implements BitmapIndex.TopLevel<E, KS>
 	}
 	
 	@Override
-	public final BitmapResult internalQuery(final KS keys)
+	public BitmapResult internalQuery(final KS keys)
 	{
 		final BitmapResult[] results = new BitmapResult[this.subIndices.length];
 		int r = 0;

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
@@ -49,6 +49,11 @@ public interface BinaryIndexerString<E> extends BinaryCompositeIndexer<E>
 	
 	public static abstract class Abstract<E> extends AbstractSingleValueVariableSize<E, String> implements BinaryIndexerString<E>
 	{
+		// reserved sentinel for the empty string: byte 7 = 0xFF, which UTF-8 can never produce, so it
+		// cannot collide with any non-empty string's packed long nor with the all-null Long.MAX_VALUE.
+		private static final long EMPTY_VALUE_SENTINEL = 0xFF00000000000000L;
+
+
 //		static String longArrayToString(final long[] encoded)
 //		{
 //			// Find the actual byte length by scanning for non-zero bytes
@@ -104,6 +109,16 @@ public interface BinaryIndexerString<E> extends BinaryCompositeIndexer<E>
 		@Override
 		protected long[] fillCarrier(final String value, final long[] carrier)
 		{
+			if(value.isEmpty())
+			{
+				// An empty string packs into zero bytes, which would leave it without any bit position
+				// and therefore unindexable (never added to a sub index, never matched by a query).
+				// Use a reserved single-position sentinel so the empty string is indexable and queryable.
+				// 0xFF is never a valid UTF-8 byte, so no non-empty string can ever produce this value,
+				// and it differs from the all-null-bytes sentinel (Long.MAX_VALUE) used below.
+				return new long[]{EMPTY_VALUE_SENTINEL};
+			}
+
 			final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
 			final int size = (bytes.length + 7) / 8; // Round up division to handle any string length
 			long[] result = carrier;

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
@@ -116,7 +116,10 @@ public interface BinaryIndexerString<E> extends BinaryCompositeIndexer<E>
 				// Use a reserved single-position sentinel so the empty string is indexable and queryable.
 				// 0xFF is never a valid UTF-8 byte, so no non-empty string can ever produce this value,
 				// and it differs from the all-null-bytes sentinel (Long.MAX_VALUE) used below.
-				return new long[]{EMPTY_VALUE_SENTINEL};
+				// Reuse the (already zero-filled) carrier when possible to avoid an allocation.
+				final long[] result = carrier != null && carrier.length >= 1 ? carrier : new long[1];
+				result[0] = EMPTY_VALUE_SENTINEL;
+				return result;
 			}
 
 			final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositeBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositeBitmapIndexBinary.java
@@ -214,5 +214,16 @@ public class CompositeBitmapIndexBinary<E> extends AbstractCompositeBitmapIndex<
 	{
 		return super.is(new CompositePredicate.BinarySampleBased(key));
 	}
-	
+
+	@Override
+	public BitmapResult internalQuery(final long[] keys)
+	{
+		// Route exact-match lookups (used by In / All / Equals conditions) through the same
+		// bit-sliced predicate path as is(...). The generic super implementation treats trailing /
+		// out-of-range positions as wildcards, which would let a shorter key match longer stored
+		// values that share its prefix; BinarySampleBased correctly enforces missing-bit,
+		// trailing-position-empty, and oversized semantics.
+		return this.search(new CompositePredicate.BinarySampleBased(keys));
+	}
+
 }

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositeBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositeBitmapIndexBinary.java
@@ -128,8 +128,12 @@ public class CompositeBitmapIndexBinary<E> extends AbstractCompositeBitmapIndex<
 		final BulkList<BitmapResult> subResults
 	)
 	{
+		// each entry's key is a single bit (1L << position); accumulate which bit positions actually
+		// have an entry, so a required bit that no entity holds can be detected below.
+		final long[] coveredBits = {0L};
 		this.subIndices[subPosition].iterateEntries(e ->
 		{
+			coveredBits[0] |= (Long)e.key();
 			// binary logic: selected entries are collected as results and discarded entries must be collected as inverted results.
 			if(predicate.test(subPosition, e.key()))
 			{
@@ -140,6 +144,16 @@ public class CompositeBitmapIndexBinary<E> extends AbstractCompositeBitmapIndex<
 				subResults.add(new BitmapResult.Not(e.createResult()));
 			}
 		});
+
+		// exact-match correctness: if the searched value requires a 1-bit at a position that has no
+		// entry at all, no entity can hold that bit, so the value cannot be contained. Without this,
+		// that requirement would simply be absent from the AND chain, letting values that are bit
+		// subsets of the searched value match incorrectly (e.g. "test2" matching a search for "test3").
+		// Mirrors the null-entry check in AbstractBitmapIndexBinary#internalQueryResults.
+		if((predicate.requiredBits(subPosition) & ~coveredBits[0]) != 0L)
+		{
+			subResults.add(EMPTY_RESULT);
+		}
 	}
 	
 	@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositePredicate.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositePredicate.java
@@ -234,7 +234,8 @@ public interface CompositePredicate<KS> extends Predicate<KS>
 			// exact match, so every entry there is rejected (collected as an inverted result by the caller).
 			final long s = subKeyPosition < this.sample.length ? this.sample[subKeyPosition] : 0L;
 
-			// inherent Object#equals equality by default. Any other logic needs another implementation.
+			// binary (bit-sliced) semantics: each subKey is a single bit of the value; it is selected
+			// when that bit is set in the sample. Entries whose bit is not set are inverted by the caller.
 			return subKey != null && (s & (Long)subKey) != 0L;
 		}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositePredicate.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositePredicate.java
@@ -58,7 +58,38 @@ public interface CompositePredicate<KS> extends Predicate<KS>
 	{
 		// no-op by default
 	}
-	
+
+	/**
+	 * For binary (bit-sliced) composite predicates, returns the bit mask of bits that MUST be
+	 * present at the given sub key position for an entity to match (exact-match semantics).
+	 * <p>
+	 * The binary composite index uses this to detect when a required bit has no index entry at
+	 * all, in which case no entity can hold that bit and the result must be empty. Returns
+	 * {@code 0L} by default, meaning "no exact-match bit requirement" (e.g. for wrapped arbitrary
+	 * predicates).
+	 *
+	 * @param subKeyPosition the sub key position
+	 * @return the required bit mask, or {@code 0L} if not applicable
+	 */
+	public default long requiredBits(final int subKeyPosition)
+	{
+		return 0L;
+	}
+
+	/**
+	 * For binary (bit-sliced) composite predicates, reports whether the searched value requires any
+	 * bit at a sub key position at or beyond {@code subIndexCount} (i.e. the index has fewer
+	 * positions than the value needs). In that case no stored entity can match and the query result
+	 * must be empty. Returns {@code false} by default.
+	 *
+	 * @param subIndexCount the number of sub key positions the index currently has
+	 * @return {@code true} if the value requires a position the index does not have
+	 */
+	public default boolean exceedsPositions(final int subIndexCount)
+	{
+		return false;
+	}
+
 	/**
 	 * Tests a specific subkey within a composite structure.
 	 *
@@ -180,7 +211,7 @@ public interface CompositePredicate<KS> extends Predicate<KS>
 		
 		@Override
 		public abstract boolean setSubKeyPosition(int subKeyPosition);
-		
+
 		@Override
 		public boolean test(final long[] keys)
 		{
@@ -193,16 +224,42 @@ public interface CompositePredicate<KS> extends Predicate<KS>
 			}
 			return true;
 		}
-		
+
 		@Override
 		public boolean test(final int subKeyPosition, final Object subKey)
 		{
 			// note: the subKeyPosition has already been selected beforehand via #setSubKeyPosition.
-			
+
+			// positions beyond the sample's length carry no bits: such a position must be empty for an
+			// exact match, so every entry there is rejected (collected as an inverted result by the caller).
+			final long s = subKeyPosition < this.sample.length ? this.sample[subKeyPosition] : 0L;
+
 			// inherent Object#equals equality by default. Any other logic needs another implementation.
-			return subKey != null && (this.sample[subKeyPosition] & (Long)subKey) != 0L;
+			return subKey != null && (s & (Long)subKey) != 0L;
 		}
-		
+
+		@Override
+		public long requiredBits(final int subKeyPosition)
+		{
+			// every 1-bit of the searched value's sample must be present for an exact match;
+			// positions beyond the sample require no bits.
+			return subKeyPosition < this.sample.length ? this.sample[subKeyPosition] : 0L;
+		}
+
+		@Override
+		public boolean exceedsPositions(final int subIndexCount)
+		{
+			// if the sample needs a bit at a position the index does not have, nothing can match.
+			for(int i = subIndexCount; i < this.sample.length; i++)
+			{
+				if(this.sample[i] != 0L)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
 	}
 	
 	final class BinarySampleBased extends AbstractBinarySampleBased
@@ -215,14 +272,13 @@ public interface CompositePredicate<KS> extends Predicate<KS>
 		@Override
 		public final boolean setSubKeyPosition(final int subKeyPosition)
 		{
-			if(this.sample.length <= subKeyPosition)
-			{
-				return false;
-			}
-			
-			// default logic, but this is dangerous! A 0 value is not the same as a null reference. There might be proper 0 values.
-			// only positions with non-zero sample values are valid filtering positions. All other positions to not filter.
-			return this.sample[subKeyPosition] != 0L;
+			// Every sub-index position is relevant for an exact match: positions within the sample's
+			// length must match its bits; positions beyond it must be EMPTY (otherwise a shorter search
+			// value would wrongly match a longer stored value - see #test/#requiredBits handling the
+			// out-of-range case). Positions the sample needs beyond the index's range are handled
+			// separately via #exceedsPositions in the search routine.
+			// (Returning false for trailing positions, as before, left them unconstrained.)
+			return true;
 		}
 		
 	}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerExactMatchTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerExactMatchTest.java
@@ -1,0 +1,527 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerByte;
+import org.eclipse.store.gigamap.types.BinaryIndexerDouble;
+import org.eclipse.store.gigamap.types.BinaryIndexerFloat;
+import org.eclipse.store.gigamap.types.BinaryIndexerInteger;
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.BinaryIndexerShort;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.BinaryIndexerUUID;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exact-match correctness tests for the binary (bit-sliced) bitmap index family.
+ * <p>
+ * A binary composite index ({@link BinaryIndexerString}, {@link BinaryIndexerUUID}) stores one
+ * bitmap entry per <b>bit</b> of the indexed value and reconstructs an exact match as an AND chain
+ * ("require this bit set / that bit unset"). The dangerous edge case is when the searched value's
+ * bits are a <b>superset</b> of a stored value's bits: a naive implementation that only looks at
+ * the bits that actually have an entry will incorrectly match the stored (subset) value. This was
+ * GitHub issue #687, where stored {@code "test2"} (bytes {@code 0x32}) matched a search for
+ * {@code "test3"} (bytes {@code 0x33}) because {@code 0x32}'s bits are a subset of {@code 0x33}'s
+ * and the distinguishing bit had no index entry.
+ * <p>
+ * These tests lock in the corrected behavior across:
+ * <ul>
+ *     <li>{@link BinaryIndexerString} &mdash; variable-size composite (the #687 trigger), including
+ *         multi-byte / UTF-8, empty strings, and values longer than 8 bytes (multi-long).</li>
+ *     <li>{@link BinaryIndexerUUID} &mdash; fixed-size (2-long) composite.</li>
+ *     <li>the single-long numeric families ({@code Long/Integer/Short/Byte/Double/Float}) which use
+ *         the non-composite {@code BinaryBitmapIndex} path &mdash; regression confirmation.</li>
+ *     <li>the {@code in(...)} path, which routes composite indexes through
+ *         {@code AbstractCompositeBitmapIndex.internalQuery} (a different code path than
+ *         {@code is(...)}).</li>
+ * </ul>
+ */
+public class BinaryIndexerExactMatchTest
+{
+	// ---------------------------------------------------------------------------------------------
+	// String (variable-size composite)
+	// ---------------------------------------------------------------------------------------------
+
+	static final class StrBox
+	{
+		String value;
+
+		StrBox(final String value)
+		{
+			this.value = value;
+		}
+	}
+
+	static final BinaryIndexerString<StrBox> STRING_INDEX = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final StrBox entity)
+		{
+			return entity.value;
+		}
+	};
+
+	private static GigaMap<StrBox> stringMap(final String... values)
+	{
+		final GigaMap<StrBox> map = GigaMap.<StrBox>Builder()
+			.withBitmapIndex(STRING_INDEX)
+			.build();
+		for(final String v : values)
+		{
+			map.add(new StrBox(v));
+		}
+		return map;
+	}
+
+	@Nested
+	class StringExactMatch
+	{
+		@Test
+		void supersetSearchDoesNotMatchStoredSubset()
+		{
+			// "test"/"test2" are bit-subsets of "test3"; searching "test3" must not return them.
+			final GigaMap<StrBox> map = stringMap("test", "test2");
+			assertTrue(map.query(STRING_INDEX.is("test3")).toList().isEmpty());
+		}
+
+		@Test
+		void exactMatchAmongCollidingValues()
+		{
+			final GigaMap<StrBox> map = stringMap("test", "test2", "test3");
+			final List<StrBox> r = map.query(STRING_INDEX.is("test3")).toList();
+			assertEquals(1, r.size());
+			assertEquals("test3", r.get(0).value);
+		}
+
+		@Test
+		void nonExistentValueReturnsEmpty()
+		{
+			final GigaMap<StrBox> map = stringMap("alpha", "beta", "gamma");
+			assertTrue(map.query(STRING_INDEX.is("delta")).toList().isEmpty());
+		}
+
+		@Test
+		void exactMatchAfterUpdateIntoSuperset()
+		{
+			// reproduction of issue #687: update the first entity into a bit-superset value.
+			final GigaMap<StrBox> map = GigaMap.<StrBox>Builder().withBitmapIndex(STRING_INDEX).build();
+			final StrBox first = new StrBox("test");
+			map.add(first);
+			map.add(new StrBox("test2"));
+
+			assertTrue(map.query(STRING_INDEX.is("test3")).toList().isEmpty());
+
+			map.update(first, e -> e.value = "test3");
+
+			final List<StrBox> r = map.query(STRING_INDEX.is("test3")).toList();
+			assertEquals(1, r.size());
+			assertEquals("test3", r.get(0).value);
+			assertTrue(map.query(STRING_INDEX.is("test")).toList().isEmpty());
+		}
+
+		@Test
+		void differingByteLengthsDoNotCollide()
+		{
+			final GigaMap<StrBox> map = stringMap("a", "ab", "abc", "abcd");
+			assertEquals(1, map.query(STRING_INDEX.is("a")).toList().size());
+			assertEquals(1, map.query(STRING_INDEX.is("ab")).toList().size());
+			assertEquals(1, map.query(STRING_INDEX.is("abc")).toList().size());
+			assertEquals(1, map.query(STRING_INDEX.is("abcd")).toList().size());
+			assertTrue(map.query(STRING_INDEX.is("abcde")).toList().isEmpty());
+		}
+
+		@Test
+		void multiLongSharedPrefixDoesNotCollide()
+		{
+			// "abcdefgh" packs into exactly one long; "abcdefghi" needs a second long with the same
+			// first long. A query for the shorter value must not return the longer one and vice versa.
+			final GigaMap<StrBox> map = stringMap("abcdefgh", "abcdefghi");
+
+			final List<StrBox> shortHit = map.query(STRING_INDEX.is("abcdefgh")).toList();
+			assertEquals(1, shortHit.size());
+			assertEquals("abcdefgh", shortHit.get(0).value);
+
+			final List<StrBox> longHit = map.query(STRING_INDEX.is("abcdefghi")).toList();
+			assertEquals(1, longHit.size());
+			assertEquals("abcdefghi", longHit.get(0).value);
+		}
+
+		@Test
+		void searchValueLongerThanAnyStoredReturnsEmpty()
+		{
+			// the index only ever saw 8-byte values (one long); a 9-byte search value cannot match.
+			final GigaMap<StrBox> map = stringMap("abcdefgh", "12345678");
+			assertTrue(map.query(STRING_INDEX.is("abcdefghi")).toList().isEmpty());
+		}
+
+		@Test
+		void unicodeAndMultiByteValues()
+		{
+			final GigaMap<StrBox> map = stringMap("café", "cafe", "Ñoño", "日本語", "😀");
+
+			assertEquals(1, map.query(STRING_INDEX.is("café")).toList().size());
+			assertEquals(1, map.query(STRING_INDEX.is("cafe")).toList().size());
+			assertEquals(1, map.query(STRING_INDEX.is("Ñoño")).toList().size());
+			assertEquals(1, map.query(STRING_INDEX.is("日本語")).toList().size());
+			assertEquals(1, map.query(STRING_INDEX.is("😀")).toList().size());
+			// "cafe" and "café" differ only in the trailing multi-byte char; they must not collide.
+			assertEquals("café", map.query(STRING_INDEX.is("café")).toList().get(0).value);
+		}
+
+		@Test
+		void emptyStringIsIndexedAndMatched()
+		{
+			final GigaMap<StrBox> map = stringMap("", "x");
+			final List<StrBox> r = map.query(STRING_INDEX.is("")).toList();
+			assertEquals(1, r.size());
+			assertEquals("", r.get(0).value);
+			assertEquals(1, map.query(STRING_INDEX.is("x")).toList().size());
+		}
+
+		@Test
+		void notExcludesOnlyTheExactMatch()
+		{
+			final GigaMap<StrBox> map = stringMap("test", "test2", "test3");
+			final List<StrBox> r = map.query(STRING_INDEX.not("test3")).toList();
+			assertEquals(2, r.size());
+			assertTrue(r.stream().noneMatch(e -> e.value.equals("test3")));
+		}
+	}
+
+	@Nested
+	class CompositeInConditions
+	{
+		// in(...) on a composite index takes the long[] keys produced by the indexer, and routes
+		// through AbstractCompositeBitmapIndex.internalQuery (distinct from the is(...)/search path).
+		private long[] key(final String value)
+		{
+			return STRING_INDEX.index(new StrBox(value));
+		}
+
+		@Test
+		void inMatchesEachExactValue()
+		{
+			final GigaMap<StrBox> map = stringMap("alpha", "beta", "gamma");
+			final List<StrBox> r = map.query(STRING_INDEX.in(key("alpha"), key("gamma"))).toList();
+			assertEquals(2, r.size());
+			assertTrue(r.stream().allMatch(e -> e.value.equals("alpha") || e.value.equals("gamma")));
+		}
+
+		@Test
+		void inSingleKeyBehavesLikeIs()
+		{
+			final GigaMap<StrBox> map = stringMap("alpha", "beta", "gamma");
+			assertEquals(1, map.query(STRING_INDEX.in(key("beta"))).toList().size());
+		}
+
+		@Test
+		void inForNonExistentReturnsEmpty()
+		{
+			final GigaMap<StrBox> map = stringMap("alpha", "beta", "gamma");
+			assertTrue(map.query(STRING_INDEX.in(key("delta"), key("epsilon"))).toList().isEmpty());
+		}
+
+		@Test
+		void inWithSupersetKeyDoesNotMatchSubset()
+		{
+			final GigaMap<StrBox> map = stringMap("test", "test2");
+			assertTrue(map.query(STRING_INDEX.in(key("test3"))).toList().isEmpty());
+		}
+	}
+
+	@Nested
+	class CompositeConditionTrees
+	{
+		@Test
+		void andOfTwoStringValuesNeverMatchesSingleEntity()
+		{
+			// an entity can hold only one value for the index, so AND of two distinct values is empty.
+			final GigaMap<StrBox> map = stringMap("test", "test3");
+			assertTrue(map.query(STRING_INDEX.is("test").and(STRING_INDEX.is("test3"))).toList().isEmpty());
+		}
+
+		@Test
+		void orOfStringValuesMatchesEachExactly()
+		{
+			final GigaMap<StrBox> map = stringMap("test", "test2", "test3");
+			final List<StrBox> r = map.query(STRING_INDEX.is("test").or(STRING_INDEX.is("test3"))).toList();
+			assertEquals(2, r.size());
+			assertTrue(r.stream().noneMatch(e -> e.value.equals("test2")));
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// UUID (fixed-size 2-long composite)
+	// ---------------------------------------------------------------------------------------------
+
+	static final class UuidBox
+	{
+		UUID value;
+
+		UuidBox(final UUID value)
+		{
+			this.value = value;
+		}
+	}
+
+	static final BinaryIndexerUUID<UuidBox> UUID_INDEX = new BinaryIndexerUUID.Abstract<>()
+	{
+		@Override
+		protected UUID getUUID(final UuidBox entity)
+		{
+			return entity.value;
+		}
+	};
+
+	// both 64-bit halves are bit-subsets of the corresponding SUPER halves (0x32 ⊂ 0x33).
+	private static final UUID SUB_UUID   = new UUID(0x32L, 0x32L);
+	private static final UUID SUPER_UUID = new UUID(0x33L, 0x33L);
+
+	private static GigaMap<UuidBox> uuidMap(final UUID... values)
+	{
+		final GigaMap<UuidBox> map = GigaMap.<UuidBox>Builder()
+			.withBitmapIndex(UUID_INDEX)
+			.build();
+		for(final UUID v : values)
+		{
+			map.add(new UuidBox(v));
+		}
+		return map;
+	}
+
+	@Nested
+	class UuidExactMatch
+	{
+		@Test
+		void supersetSearchDoesNotMatchStoredSubset()
+		{
+			final GigaMap<UuidBox> map = uuidMap(SUB_UUID);
+			assertTrue(map.query(UUID_INDEX.is(SUPER_UUID)).toList().isEmpty());
+		}
+
+		@Test
+		void exactMatchAmongCollidingUuids()
+		{
+			final GigaMap<UuidBox> map = uuidMap(SUB_UUID, SUPER_UUID);
+			final List<UuidBox> r = map.query(UUID_INDEX.is(SUPER_UUID)).toList();
+			assertEquals(1, r.size());
+			assertEquals(SUPER_UUID, r.get(0).value);
+		}
+
+		@Test
+		void randomUuidsRoundTripExactly()
+		{
+			final UUID a = UUID.fromString("11111111-1111-1111-1111-111111111111");
+			final UUID b = UUID.fromString("22222222-2222-2222-2222-222222222222");
+			final GigaMap<UuidBox> map = uuidMap(a, b);
+			assertEquals(a, map.query(UUID_INDEX.is(a)).toList().get(0).value);
+			assertEquals(b, map.query(UUID_INDEX.is(b)).toList().get(0).value);
+			assertTrue(map.query(UUID_INDEX.is(UUID.randomUUID())).toList().isEmpty());
+		}
+
+		@Test
+		void exactMatchAfterUpdateIntoSuperset()
+		{
+			final GigaMap<UuidBox> map = GigaMap.<UuidBox>Builder().withBitmapIndex(UUID_INDEX).build();
+			final UuidBox box = new UuidBox(SUB_UUID);
+			map.add(box);
+
+			assertTrue(map.query(UUID_INDEX.is(SUPER_UUID)).toList().isEmpty());
+
+			map.update(box, e -> e.value = SUPER_UUID);
+
+			assertEquals(1, map.query(UUID_INDEX.is(SUPER_UUID)).toList().size());
+			assertTrue(map.query(UUID_INDEX.is(SUB_UUID)).toList().isEmpty());
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Single-long numeric families (non-composite BinaryBitmapIndex) - regression confirmation.
+	// 0x32's bits are a subset of 0x33's bits, the numeric analogue of the #687 string case.
+	// ---------------------------------------------------------------------------------------------
+
+	@Nested
+	class NumericRegression
+	{
+		record LongBox(long v) {}
+		record IntBox(int v) {}
+		record ShortBox(short v) {}
+		record ByteBox(byte v) {}
+		record DoubleBox(double v) {}
+		record FloatBox(float v) {}
+
+		static final BinaryIndexerLong<LongBox> LONG_INDEX = new BinaryIndexerLong.Abstract<>()
+		{
+			@Override
+			protected Long getLong(final LongBox e)
+			{
+				return e.v();
+			}
+		};
+
+		static final BinaryIndexerInteger<IntBox> INT_INDEX = new BinaryIndexerInteger.Abstract<>()
+		{
+			@Override
+			protected Integer getInteger(final IntBox e)
+			{
+				return e.v();
+			}
+		};
+
+		static final BinaryIndexerShort<ShortBox> SHORT_INDEX = new BinaryIndexerShort.Abstract<>()
+		{
+			@Override
+			protected Short getShort(final ShortBox e)
+			{
+				return e.v();
+			}
+		};
+
+		static final BinaryIndexerByte<ByteBox> BYTE_INDEX = new BinaryIndexerByte.Abstract<>()
+		{
+			@Override
+			protected Byte getByte(final ByteBox e)
+			{
+				return e.v();
+			}
+		};
+
+		static final BinaryIndexerDouble<DoubleBox> DOUBLE_INDEX = new BinaryIndexerDouble.Abstract<>()
+		{
+			@Override
+			protected Double getDouble(final DoubleBox e)
+			{
+				return e.v();
+			}
+		};
+
+		static final BinaryIndexerFloat<FloatBox> FLOAT_INDEX = new BinaryIndexerFloat.Abstract<>()
+		{
+			@Override
+			protected Float getFloat(final FloatBox e)
+			{
+				return e.v();
+			}
+		};
+
+		@Test
+		void longSubsetDoesNotCollide()
+		{
+			final GigaMap<LongBox> map = GigaMap.<LongBox>Builder().withBitmapIndex(LONG_INDEX).build();
+			map.add(new LongBox(0x32L));
+			map.add(new LongBox(0x33L));
+			assertEquals(0x33L, map.query(LONG_INDEX.is(0x33L)).toList().get(0).v());
+			assertEquals(1, map.query(LONG_INDEX.is(0x33L)).toList().size());
+			assertTrue(map.query(LONG_INDEX.is(0x34L)).toList().isEmpty());
+		}
+
+		@Test
+		void integerSubsetDoesNotCollide()
+		{
+			final GigaMap<IntBox> map = GigaMap.<IntBox>Builder().withBitmapIndex(INT_INDEX).build();
+			map.add(new IntBox(0x32));
+			map.add(new IntBox(0x33));
+			assertEquals(1, map.query(INT_INDEX.is(0x33)).toList().size());
+			assertEquals(0x33, map.query(INT_INDEX.is(0x33)).toList().get(0).v());
+			assertTrue(map.query(INT_INDEX.is(0x34)).toList().isEmpty());
+		}
+
+		@Test
+		void shortSubsetDoesNotCollide()
+		{
+			final GigaMap<ShortBox> map = GigaMap.<ShortBox>Builder().withBitmapIndex(SHORT_INDEX).build();
+			map.add(new ShortBox((short)0x32));
+			map.add(new ShortBox((short)0x33));
+			assertEquals(1, map.query(SHORT_INDEX.is((short)0x33)).toList().size());
+			assertTrue(map.query(SHORT_INDEX.is((short)0x34)).toList().isEmpty());
+		}
+
+		@Test
+		void byteSubsetDoesNotCollide()
+		{
+			final GigaMap<ByteBox> map = GigaMap.<ByteBox>Builder().withBitmapIndex(BYTE_INDEX).build();
+			map.add(new ByteBox((byte)0x32));
+			map.add(new ByteBox((byte)0x33));
+			assertEquals(1, map.query(BYTE_INDEX.is((byte)0x33)).toList().size());
+			assertTrue(map.query(BYTE_INDEX.is((byte)0x34)).toList().isEmpty());
+		}
+
+		@Test
+		void doubleExactMatch()
+		{
+			final GigaMap<DoubleBox> map = GigaMap.<DoubleBox>Builder().withBitmapIndex(DOUBLE_INDEX).build();
+			map.add(new DoubleBox(1.5d));
+			map.add(new DoubleBox(3.25d));
+			assertEquals(1, map.query(DOUBLE_INDEX.is(3.25d)).toList().size());
+			assertEquals(3.25d, map.query(DOUBLE_INDEX.is(3.25d)).toList().get(0).v());
+			assertTrue(map.query(DOUBLE_INDEX.is(2.0d)).toList().isEmpty());
+		}
+
+		@Test
+		void floatExactMatch()
+		{
+			final GigaMap<FloatBox> map = GigaMap.<FloatBox>Builder().withBitmapIndex(FLOAT_INDEX).build();
+			map.add(new FloatBox(1.5f));
+			map.add(new FloatBox(3.25f));
+			assertEquals(1, map.query(FLOAT_INDEX.is(3.25f)).toList().size());
+			assertTrue(map.query(FLOAT_INDEX.is(2.0f)).toList().isEmpty());
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Persistence round-trip for the composite string index.
+	// ---------------------------------------------------------------------------------------------
+
+	@Nested
+	class Persistence
+	{
+		@TempDir
+		Path tempDir;
+
+		@Test
+		void exactMatchSurvivesStoreAndReload()
+		{
+			final GigaMap<StrBox> map = stringMap("test", "test2", "test3", "abcdefghi", "日本語");
+			try(final EmbeddedStorageManager manager = EmbeddedStorage.start(map, tempDir))
+			{
+				// stored
+			}
+
+			final GigaMap<StrBox> reloaded = GigaMap.New();
+			try(final EmbeddedStorageManager manager = EmbeddedStorage.start(reloaded, tempDir))
+			{
+				assertEquals(5, reloaded.size());
+				assertEquals(1, reloaded.query(STRING_INDEX.is("test3")).toList().size());
+				// the #687 collision must still be correct after reload
+				assertEquals(1, reloaded.query(STRING_INDEX.is("test")).toList().size());
+				assertEquals(1, reloaded.query(STRING_INDEX.is("abcdefghi")).toList().size());
+				assertEquals(1, reloaded.query(STRING_INDEX.is("日本語")).toList().size());
+				assertTrue(reloaded.query(STRING_INDEX.is("nope")).toList().isEmpty());
+			}
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerExactMatchTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerExactMatchTest.java
@@ -251,6 +251,24 @@ public class BinaryIndexerExactMatchTest
 			final GigaMap<StrBox> map = stringMap("test", "test2");
 			assertTrue(map.query(STRING_INDEX.in(key("test3"))).toList().isEmpty());
 		}
+
+		@Test
+		void inWithShorterKeyDoesNotMatchLongerStoredValue()
+		{
+			// the internalQuery (In/All/Equals) path must enforce trailing-position emptiness just like
+			// is(...): a 1-long key for "abcdefgh" must not match the 2-long stored "abcdefghi".
+			final GigaMap<StrBox> map = stringMap("abcdefgh", "abcdefghi");
+			final List<StrBox> r = map.query(STRING_INDEX.in(key("abcdefgh"))).toList();
+			assertEquals(1, r.size());
+			assertEquals("abcdefgh", r.get(0).value);
+		}
+
+		@Test
+		void inWithLongerKeyThanAnyStoredReturnsEmpty()
+		{
+			final GigaMap<StrBox> map = stringMap("abcdefgh", "12345678");
+			assertTrue(map.query(STRING_INDEX.in(key("abcdefghi"))).toList().isEmpty());
+		}
 	}
 
 	@Nested

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap687Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap687Test.java
@@ -1,0 +1,90 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class GigaMap687Test
+{
+	private static class TestObject
+	{
+		private String aString;
+
+		@Override
+		public boolean equals(Object object)
+		{
+			if (!(object instanceof TestObject test))
+				return false;
+			return Objects.equals(aString, test.aString);
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return Objects.hashCode(aString);
+		}
+	}
+
+	private static final BinaryIndexerString<TestObject> testIndex = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(TestObject entity)
+		{
+			return entity.aString;
+		}
+	};
+
+	@Test
+	public void testGigaMapUpdateFirstEntity(@TempDir Path workDir)
+	{
+		try (var storage = EmbeddedStorage.start(workDir))
+		{
+			var gigaMap = GigaMap.<TestObject>Builder()
+				.withBitmapIndex(testIndex)
+				.build();
+
+			storage.setRoot(gigaMap);
+			storage.storeRoot();
+
+			var test = new TestObject();
+			test.aString = "test"; // if set to test1, it works as expected
+			gigaMap.add(test);
+
+			// it somehow seems to only affect the first object that is added to the gigamap
+			// try not to add(test2)
+			var test2 = new TestObject();
+			test2.aString = "test2";
+			gigaMap.add(test2);
+
+			gigaMap.store();
+
+			assertEquals(0, gigaMap.query(testIndex.is("test3")).count());
+
+			gigaMap.update(test, aTest -> aTest.aString = "test3");
+			gigaMap.store();
+
+			assertEquals(1, gigaMap.query(testIndex.is("test3")).count());
+		}
+	}
+}


### PR DESCRIPTION
## Summary

 `BinaryIndexerString` and `BinaryIndexerUUID` build a **bit-sliced composite bitmap index**: each composite long-position stores one bitmap entry *per bit* of the value,  and an exact match is reconstructed as an AND chain over those bits. Several edge cases silently dropped required constraints, producing **false matches**. This PR fixes them
  and adds broad regression coverage for the whole binary index family.

## The bugs

- **Subset/superset collision (#687).** The composite `search()` path only iterated bits that actually had an entry, so a stored value whose bits are a *subset* of the searched value matched it — e.g. stored `"test2"` (`0x32`) matched a query for `"test3"` (`0x33`).
- **Variable length.** A shorter search value matched longer stored values (trailing  positions were unconstrained), and a value longer than any stored value returned false positives (the searched value needed more positions than the index had).
- **Empty string** packed to zero bytes and was therefore unindexable and never matched.
- **`In` / `All` / `Equals`** on composite indexes hit an *inverted* position guard in `internalQuery` that skipped exactly the positions it should query, returning wrong (effectively empty) results.

## The fixes

| Area | Change |
|------|--------|
| `CompositeBitmapIndexBinary` | When the searched value requires a bit no entry covers, emit an empty result (via new `CompositePredicate#requiredBits`). |
| `CompositePredicate` (binary sample) | Treat every position as relevant — trailing positions must be empty — and report oversized samples via new `#exceedsPositions`. |
| `AbstractCompositeBitmapIndex#search` | Short-circuit to empty when the sample exceeds the index's position count. |
| `AbstractCompositeBitmapIndex#internalQuery` | Correct the inverted position guard so `In`/`All`/`Equals` query the right positions. |
| `BinaryIndexerString#fillCarrier` | Index the empty string via a reserved UTF-8-impossible sentinel (distinct from the all-null `Long.MAX_VALUE` sentinel). |

## Tests

- New `BinaryIndexerExactMatchTest` (27 tests): subset/superset collisions, exact match after `update()`, differing/multi-long byte lengths, UTF-8/Unicode, empty string, `not()`, `in()`, `And`/`Or`, single-long numeric regression, and persistence round-trip. (The three String cases were red before the variable-length fix, confirming the tests catch the real bugs.)
- Refactored the #687 reproduction (`GigaMap687Test`) from a `main`/`assert` snippet into a proper JUnit test matching the package conventions.
