### PR TITLE
Fix BinaryIndexerString collision on NUL-containing keys

### DIFF
--- a/docs/modules/gigamap/pages/indexing/bitmap/types.adoc
+++ b/docs/modules/gigamap/pages/indexing/bitmap/types.adoc
@@ -74,8 +74,9 @@ All other long values are fully supported.
 
 `BinaryIndexerString` packs a string's UTF-8 bytes into long values and does not encode the byte length.
 Trailing `0x00` (NUL) bytes would therefore be indistinguishable from absent bytes, so `"alpha"` and `"alpha"` with a trailing NUL — or NUL-only strings of different length — could not be told apart.
-As a consequence, keys containing the NUL character (`U+0000`) are not supported and will throw an `IllegalArgumentException`, on both adding an entity and querying.
-The empty string and all other (NUL-free) strings are fully supported.
+As a consequence, keys containing the NUL character (`U+0000`) are not supported and will throw an `IllegalArgumentException`. This applies to every operation that derives the index key from the value — adding, querying, and also updating or removing an entity (which re-index it to maintain the bitmap). The empty string and all other (NUL-free) strings are fully supported.
+
+WARNING: If you have an existing storage that already contains NUL-valued keys (written before this validation existed), not only adds and queries but also updates and removals of those entities will now throw, because they re-index the value. Normalize the affected values (see below) as part of your upgrade.
 
 If your input may contain NUL — for example fixed-width records padded with `\0`, or null-terminated buffers from native/JNI/FFI code — normalize it before indexing (cut at the terminator or strip NUL). Doing this explicitly at the input is preferable to a silent, partial normalization inside the index.
 

--- a/docs/modules/gigamap/pages/indexing/bitmap/types.adoc
+++ b/docs/modules/gigamap/pages/indexing/bitmap/types.adoc
@@ -70,6 +70,46 @@ For sub-64-bit types (`Byte`, `Short`, `Integer`, `Float`), this mapping is coll
 As a consequence, `Long.MAX_VALUE` is not supported as an index key and will throw an `IllegalArgumentException`.
 All other long values are fully supported.
 
+=== String Keys and the NUL Character
+
+`BinaryIndexerString` packs a string's UTF-8 bytes into long values and does not encode the byte length.
+Trailing `0x00` (NUL) bytes would therefore be indistinguishable from absent bytes, so `"alpha"` and `"alpha"` with a trailing NUL — or NUL-only strings of different length — could not be told apart.
+As a consequence, keys containing the NUL character (`U+0000`) are not supported and will throw an `IllegalArgumentException`, on both adding an entity and querying.
+The empty string and all other (NUL-free) strings are fully supported.
+
+If your input may contain NUL — for example fixed-width records padded with `\0`, or null-terminated buffers from native/JNI/FFI code — normalize it before indexing (cut at the terminator or strip NUL). Doing this explicitly at the input is preferable to a silent, partial normalization inside the index.
+
+The simplest place to normalize is in the indexer's value extractor, so the stored key is always NUL-free. Apply the *same* normalization to query keys (e.g. `nameIndex.is(cutAtNul(input))`) so a query matches what was stored:
+
+[source, java]
+----
+// Strategy 1: cut at the first NUL terminator (typical for null-terminated buffers)
+static String cutAtNul(final String s)
+{
+    final int nul = s.indexOf('\u0000');
+    return nul < 0 ? s : s.substring(0, nul);
+}
+
+// Strategy 2: remove every NUL character (typical for fixed-width padding)
+static String stripNul(final String s)
+{
+    return s.indexOf('\u0000') < 0 ? s : s.replace("\u0000", "");
+}
+
+// normalize inside the indexer so every stored key is NUL-free
+final BinaryIndexerString<Person> nameIndex = new BinaryIndexerString.Abstract<>()
+{
+    @Override
+    protected String getString(final Person person)
+    {
+        return cutAtNul(person.name());
+    }
+};
+
+// ... and normalize the query key the same way
+final List<Person> result = gigaMap.query(nameIndex.is(cutAtNul(userInput))).toList();
+----
+
 == Byte Index
 
 A composite bitmap index designed for high cardinality numeric types with range query support.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
@@ -153,10 +153,4 @@ public interface BinaryIndexerString<E> extends BinaryCompositeIndexer<E>
 		}
 	}
 
-
-
-
-
-
-
 }

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerString.java
@@ -9,7 +9,7 @@ package org.eclipse.store.gigamap.types;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
@@ -35,7 +35,7 @@ public interface BinaryIndexerString<E> extends BinaryCompositeIndexer<E>
 	 * @return a new condition representing the equality check for the given key
 	 */
 	public <S extends E> Condition<S> is(String key);
-	
+
 	/**
 	 * Creates a negated condition for the given key. This condition checks whether
 	 * the key extracted by this index is not equal to the specified key.
@@ -45,70 +45,62 @@ public interface BinaryIndexerString<E> extends BinaryCompositeIndexer<E>
 	 * @return a new condition representing the inequality check for the given key
 	 */
 	public <S extends E> Condition<S> not(String key);
-	
-	
+
+
 	public static abstract class Abstract<E> extends AbstractSingleValueVariableSize<E, String> implements BinaryIndexerString<E>
 	{
 		// reserved sentinel for the empty string: byte 7 = 0xFF, which UTF-8 can never produce, so it
 		// cannot collide with any non-empty string's packed long nor with the all-null Long.MAX_VALUE.
 		private static final long EMPTY_VALUE_SENTINEL = 0xFF00000000000000L;
 
-
-//		static String longArrayToString(final long[] encoded)
-//		{
-//			// Find the actual byte length by scanning for non-zero bytes
-//			int byteLength = encoded.length * 8;
-//			for(int i = encoded.length * 8 - 1; i >= 0; i--)
-//			{
-//				final int arrayIndex = i / 8;
-//				final int bitPosition = (i % 8) * 8;
-//				if(((encoded[arrayIndex] >> bitPosition) & 0xFF) != 0)
-//				{
-//					byteLength = i + 1;
-//					break;
-//				}
-//			}
-//
-//			final byte[] bytes = new byte[byteLength];
-//
-//			for(int i = 0; i < byteLength; i++)
-//			{
-//				final int arrayIndex = i / 8;
-//				final int bitPosition = (i % 8) * 8;
-//				bytes[i] = (byte)((encoded[arrayIndex] >> bitPosition) & 0xFF);
-//			}
-//
-//			return new String(bytes, StandardCharsets.UTF_8);
-//		}
-		
-		
 		protected Abstract()
 		{
 			super();
 		}
-		
+
 		protected abstract String getString(E entity);
-		
+
 		@Override
 		protected final String getValue(final E entity)
 		{
 			return this.getString(entity);
 		}
-		
+
 		/**
 		 * Packs the string's UTF-8 bytes into long values (8 bytes per long), ensuring no position
 		 * is {@code 0L} since the composite bitmap index treats {@code 0L} as "empty position".
 		 * <p>
-		 * For non-zero packed values, the raw encoding is used (backwards compatible with existing storages).
-		 * Only 8 consecutive null bytes ({@code 0x00}) at a position boundary produce {@code 0L},
-		 * which is mapped to {@code Long.MAX_VALUE}. This is collision-free because
-		 * {@code Long.MAX_VALUE} ({@code 0x7FFFFFFFFFFFFFFF}) requires {@code 0xFF} bytes in
-		 * positions 0-6, and {@code 0xFF} is invalid in UTF-8 — it can never appear in the
+		 * Strings containing the NUL character (code point {@code 0}) are rejected with an
+		 * {@link IllegalArgumentException}: their UTF-8 representation contains {@code 0x00} bytes,
+		 * and because the byte length is not encoded, trailing NUL bytes vanish during packing.
+		 * That would make e.g. {@code "alpha"} and {@code "alpha"} followed by a NUL - or NUL-only
+		 * strings of different length - collide on the same index key, so an exact-match query would return
+		 * entities that an in-memory {@link Condition#test(Object)} scan rejects. Failing loudly is
+		 * preferred over silently returning wrong results; normalize NUL out at the input instead.
+		 * <p>
+		 * For the remaining (NUL-free) values the raw encoding is used (backwards compatible with
+		 * existing storages). The only way to obtain {@code 0L} for a non-empty, NUL-free string is
+		 * a packed long whose bytes are all zero, which cannot occur once NUL is rejected; the
+		 * {@code Long.MAX_VALUE} remapping below is therefore a defensive guard. It is collision-free
+		 * because {@code Long.MAX_VALUE} ({@code 0x7FFFFFFFFFFFFFFF}) requires {@code 0xFF} bytes in
+		 * positions 0-6, and {@code 0xFF} is invalid in UTF-8 - it can never appear in the
 		 * output of {@code String.getBytes(UTF_8)}.
 		 */
 		@Override
 		protected long[] fillCarrier(final String value, final long[] carrier)
 		{
+			// indexOf(int) searches by code point; 0 is the NUL char. Using the int overload avoids
+			// embedding a literal NUL in the source. A 0x00 UTF-8 byte can only originate from U+0000,
+			// so this is an exact and cheap check for the only offending character.
+			if(value.indexOf(0) >= 0)
+			{
+				throw new IllegalArgumentException(
+					"NUL (\\u0000) is not supported as part of a BinaryIndexerString key, "
+					+ "because the binary index cannot distinguish trailing NUL bytes. "
+					+ "Normalize the value at the input (e.g. cut at the terminator) before indexing."
+				);
+			}
+
 			if(value.isEmpty())
 			{
 				// An empty string packs into zero bytes, which would leave it without any bit position
@@ -147,24 +139,24 @@ public interface BinaryIndexerString<E> extends BinaryCompositeIndexer<E>
 
 			return result;
 		}
-		
+
 		@Override
 		public <S extends E> Condition<S> is(final String key)
 		{
 			return this.isValue(key);
 		}
-		
+
 		@Override
 		public <S extends E> Condition<S> not(final String key)
 		{
 			return new Condition.Not<>(this.is(key));
 		}
 	}
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerStringNulRejectionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerStringNulRejectionTest.java
@@ -1,0 +1,143 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link BinaryIndexerString} cannot encode the byte length of a key, so trailing NUL bytes vanish
+ * during packing: {@code "alpha"} and {@code "alpha"}+NUL, or NUL-only strings of different length,
+ * would collide on the same index key and an exact-match query would return entities that an
+ * in-memory scan rejects.
+ * <p>
+ * The fix rejects any key containing the NUL character ({@code U+0000}) with an
+ * {@link IllegalArgumentException} - turning a silent false-positive into a loud failure, mirroring
+ * how {@code BinaryIndexerLong} rejects the reserved {@code Long.MAX_VALUE}. The check sits in
+ * {@code fillCarrier}, which both the add path and the query path go through, so NUL is rejected on
+ * both adding an entity and forming a query condition. This test verifies that contract, and that
+ * normal keys / the empty string remain unaffected.
+ */
+public class BinaryIndexerStringNulRejectionTest
+{
+	record StrBox(String name, String value) {}
+
+	static final BinaryIndexerString<StrBox> INDEX = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final StrBox entity)
+		{
+			return entity.value();
+		}
+	};
+
+	/** A string of {@code n} NUL characters - char[] defaults to NUL, so no raw NUL byte in source. */
+	private static String nul(final int n)
+	{
+		return new String(new char[n]);
+	}
+
+	/** {@code "alpha"} with a single trailing NUL, built at runtime to keep the source NUL-free. */
+	private static String alphaTrailingNul()
+	{
+		return "alpha" + nul(1);
+	}
+
+	/** {@code "a?b"} with one embedded NUL between two non-zero bytes. */
+	private static String embeddedNul()
+	{
+		return "a" + nul(1) + "b";
+	}
+
+	private static GigaMap<StrBox> newMap()
+	{
+		return GigaMap.<StrBox>Builder()
+			.withBitmapIndex(INDEX)
+			.build();
+	}
+
+	@Test
+	void nulOnlyStringRejectedOnAdd()
+	{
+		final GigaMap<StrBox> map = newMap();
+		assertThrows(IllegalArgumentException.class,
+			() -> map.add(new StrBox("one", nul(1))),
+			"a NUL-only string must be rejected on add");
+	}
+
+	@Test
+	void trailingNulStringRejectedOnAdd()
+	{
+		final GigaMap<StrBox> map = newMap();
+		assertThrows(IllegalArgumentException.class,
+			() -> map.add(new StrBox("padded", alphaTrailingNul())),
+			"a string with a trailing NUL must be rejected on add");
+	}
+
+	@Test
+	void embeddedNulStringRejectedOnAdd()
+	{
+		// Embedded NUL is technically distinguishable, but option B rejects ALL NUL for a simple,
+		// consistent contract: the index never accepts a key it cannot guarantee to round-trip.
+		final GigaMap<StrBox> map = newMap();
+		assertThrows(IllegalArgumentException.class,
+			() -> map.add(new StrBox("embedded", embeddedNul())),
+			"a string with an embedded NUL must be rejected on add");
+	}
+
+	@Test
+	void nulStringRejectedOnQuery()
+	{
+		// The query path (is -> isValue -> fillCarrier) must reject NUL too, before any matching.
+		assertThrows(IllegalArgumentException.class,
+			() -> INDEX.is(alphaTrailingNul()),
+			"a NUL key must be rejected when building a query condition");
+		assertThrows(IllegalArgumentException.class,
+			() -> INDEX.is(nul(2)),
+			"a NUL-only key must be rejected when building a query condition");
+	}
+
+	@Test
+	void normalKeysStillWork()
+	{
+		final GigaMap<StrBox> map = newMap();
+		map.add(new StrBox("plain", "alpha"));
+		map.add(new StrBox("other", "beta"));
+
+		final List<StrBox> alpha = map.query(INDEX.is("alpha")).toList();
+		assertEquals(1, alpha.size(), "exact-match query for a normal key must match exactly one entity");
+		assertEquals("plain", alpha.get(0).name());
+	}
+
+	@Test
+	void emptyStringStillWorks()
+	{
+		// Regression guard for the #688 empty-string sentinel: the empty string is NUL-free and must
+		// remain indexable and queryable.
+		final GigaMap<StrBox> map = newMap();
+		map.add(new StrBox("empty", ""));
+		map.add(new StrBox("nonEmpty", "alpha"));
+
+		final List<StrBox> empty = map.query(INDEX.is("")).toList();
+		assertEquals(1, empty.size(), "the empty string must still be queryable");
+		assertEquals("empty", empty.get(0).name());
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerStringTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerStringTest.java
@@ -43,12 +43,12 @@ public class BinaryIndexerStringTest
             .withBitmapIdentityIndex(indexer)
             .build();
 
-        String nullBytes = "\0\0\0\0\0\0\0\0";
+        String fourthValue = "alpha";
 
         map.add(new StringBinaryIndexerPojo("one"));
         map.add(new StringBinaryIndexerPojo("two"));
         map.add(new StringBinaryIndexerPojo("three"));
-        map.add(new StringBinaryIndexerPojo(nullBytes));
+        map.add(new StringBinaryIndexerPojo(fourthValue));
 
         List<StringBinaryIndexerPojo> one = map.query(indexer.is("one")).toList();
         assertEquals(1, one.size());
@@ -56,9 +56,9 @@ public class BinaryIndexerStringTest
             assertEquals("one",  pojo.getStringValue());
         });
 
-        List<StringBinaryIndexerPojo> nullByteResult = map.query(indexer.is(nullBytes)).toList();
-        assertEquals(1, nullByteResult.size());
-        assertEquals(nullBytes, nullByteResult.get(0).getStringValue());
+        List<StringBinaryIndexerPojo> fourthResult = map.query(indexer.is(fourthValue)).toList();
+        assertEquals(1, fourthResult.size());
+        assertEquals(fourthValue, fourthResult.get(0).getStringValue());
 
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(map, tempDir)) {
             // Storage operations can be performed here
@@ -74,9 +74,9 @@ public class BinaryIndexerStringTest
                 assertEquals("one", pojo.getStringValue());
             });
 
-            List<StringBinaryIndexerPojo> newNullByteResult = newMap.query(indexer.is(nullBytes)).toList();
-            assertEquals(1, newNullByteResult.size());
-            assertEquals(nullBytes, newNullByteResult.get(0).getStringValue());
+            List<StringBinaryIndexerPojo> newFourthResult = newMap.query(indexer.is(fourthValue)).toList();
+            assertEquals(1, newFourthResult.size());
+            assertEquals(fourthValue, newFourthResult.get(0).getStringValue());
 
             newMap.add(new StringBinaryIndexerPojo("four"));
             newMap.store();


### PR DESCRIPTION
## Summary

`BinaryIndexerString` packs a string's UTF-8 bytes into `long`s without encoding the byte length. Trailing `0x00` (NUL) bytes occupy the high bytes of the last `long` and
contribute nothing, so they vanish during packing — and a `long` that ends up fully `0L` is additionally remapped to the `Long.MAX_VALUE` "all-null" sentinel. As a result:

- `"alpha"` and `"alpha\u0000"` pack to the same index key, and
- every NUL-only string of length 1..8 maps to the identical key `[Long.MAX_VALUE]`.

An exact-match query for one therefore returns the other. This contradicts the index's own equality notion — `Condition#test(entity)` (the in-memory predicate the same condition uses) reports no match — so the index disagrees with a linear scan. It's a false-positive only (no missed results, no data loss), but a genuine exact-match correctness gap, and it survives the empty-string-sentinel fix from #688 (the empty string has its own distinct sentinel; NUL strings still don't).

## Fix

Reject keys containing the NUL character (`U+0000`) with an `IllegalArgumentException` in `fillCarrier`. Both the add path (`index → indexValue → fillCarrier`) and the query path (`is → isValue → indexValue → fillCarrier`) converge there, so NUL is rejected on both adding an entity and forming a query condition.

This mirrors the existing family pattern where `BinaryIndexerLong` rejects the reserved `Long.MAX_VALUE`. It turns a silent wrong-result into a loud failure, requires **no change to the persistent format** (no migration of existing GigaMaps), and leaves NUL-free strings and the empty string fully supported. Lenient "trim trailing garbage" behavior, if desired, belongs at the input — not as a silent, partial, NUL-only normalization inside the index.

## Changes

- **`BinaryIndexerString.java`** — guard at the top of `fillCarrier` throwing `IllegalArgumentException` for NUL keys; updated Javadoc.
- **`BinaryIndexerStringNulRejectionTest.java`** (new) — verifies NUL-only, trailing-NUL, and embedded-NUL keys are rejected on both add and query, and that normal keys / the empty string still work. NUL strings are built at runtime so the source contains no raw NUL bytes.
- **`BinaryIndexerStringTest.java`** — the existing test stored an 8-NUL string (now rejected); replaced that scenario with a normal value.
- **`docs/.../indexing/bitmap/types.adoc`** — documented the limitation alongside the `BinaryIndexerLong`/`Long.MAX_VALUE` note, with a code example showing how to normalize NUL out (`cutAtNul` / `stripNul`) on both the indexed value and the query key.

## Trade-off

Breaks callers that currently store NUL-containing strings (rare). They must strip or cut at the terminator before indexing — see the new docs example.