### PR TITLE
Fix update of null-valued Boolean-indexed entities (+ align predicate/query semantics)

### DIFF
--- a/docs/modules/gigamap/pages/indexing/bitmap/types.adoc
+++ b/docs/modules/gigamap/pages/indexing/bitmap/types.adoc
@@ -123,7 +123,7 @@ The bitmap index offers three families of indexers: **regular indexers** (e.g. `
 |Composite sub-indices with at most 256 entries per byte position
 
 |Null values
-|Native support
+|Native support footnote:[Exception: the Boolean index cannot distinguish `null` from `false` — both are absent from the `true` set. See the Boolean section under xref:queries/index.adoc[Queries].]
 |Requires sentinel value handling
 |Requires sentinel value handling
 

--- a/docs/modules/gigamap/pages/queries/index.adoc
+++ b/docs/modules/gigamap/pages/queries/index.adoc
@@ -188,6 +188,16 @@ Each of them comes with specialized query methods.
 
 |===
 
+[NOTE]
+====
+A Boolean index only materializes the set of `true`-valued entities; `false` and `null` are
+indistinguishable, as both are simply absent from the `true` set. Consequently `isFalse()`, `isNull()`,
+`is(false)` and `is(null)` all resolve to the same result set: every entity whose key is *not*
+`true` (i.e. `false` **or** `null`). This also applies to predicate queries, e.g. `is(k -> k == null)`
+matches the same set as `isFalse()`. If you need to tell `null` apart from `false`, index a
+non-Boolean key instead (for example an enum with explicit `UNKNOWN` / `YES` / `NO` values).
+====
+
 === Multi-value
 
 [options="header",cols="1,2"]

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerBoolean.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerBoolean.java
@@ -76,6 +76,20 @@ public interface IndexerBoolean<E> extends Indexer<E, Boolean>
 		{
 			return this.getBoolean(entity);
 		}
+
+		@Override
+		public boolean test(final E entity, final Boolean key)
+		{
+			// A Boolean index is backed by a SingleBitmapIndex, which only materializes the TRUE
+			// set: FALSE and null are both simply "not in the TRUE set" and cannot be told apart.
+			// The bitmap query (SingleBitmapIndex#internalQuery) collapses them accordingly, so this
+			// in-memory predicate (used by Condition#test) must do the same to stay consistent:
+			// key==TRUE matches a TRUE-indexed entity, key==FALSE or null matches any non-TRUE
+			// (FALSE or null) entity. The default strict-key-equality test would diverge from the
+			// bitmap result for both FALSE and null.
+			final boolean entityIsTrue = Boolean.TRUE.equals(this.index(entity));
+			return Boolean.TRUE.equals(key) ? entityIsTrue : !entityIsTrue;
+		}
 		
 		protected abstract Boolean getBoolean(E entity);
 		

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerBoolean.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerBoolean.java
@@ -77,16 +77,23 @@ public interface IndexerBoolean<E> extends Indexer<E, Boolean>
 			return this.getBoolean(entity);
 		}
 
+		/**
+		 * {@inheritDoc}
+		 * <p>
+		 * <b>Note:</b> a Boolean index is backed by a single-bucket bitmap index that only
+		 * materializes the {@code TRUE} set; {@code FALSE} and {@code null} are indistinguishable
+		 * (both are simply "not {@code TRUE}"). To keep this in-memory predicate consistent with the
+		 * bitmap query, {@code null} and {@code FALSE} are treated equivalently: a {@code key} of
+		 * {@code TRUE} matches a {@code TRUE}-indexed entity, while a {@code key} of {@code FALSE}
+		 * <i>or</i> {@code null} matches any non-{@code TRUE} (i.e. {@code FALSE} or {@code null})
+		 * entity. Consequently {@code test(entity, null)} returns {@code true} for a
+		 * {@code FALSE}-indexed entity, and {@code test(entity, FALSE)} returns {@code true} for a
+		 * {@code null}-indexed entity - this is intentional and mirrors {@code is(false)} /
+		 * {@code is(null)} resolving to the same candidate set.
+		 */
 		@Override
 		public boolean test(final E entity, final Boolean key)
 		{
-			// A Boolean index is backed by a SingleBitmapIndex, which only materializes the TRUE
-			// set: FALSE and null are both simply "not in the TRUE set" and cannot be told apart.
-			// The bitmap query (SingleBitmapIndex#internalQuery) collapses them accordingly, so this
-			// in-memory predicate (used by Condition#test) must do the same to stay consistent:
-			// key==TRUE matches a TRUE-indexed entity, key==FALSE or null matches any non-TRUE
-			// (FALSE or null) entity. The default strict-key-equality test would diverge from the
-			// bitmap result for both FALSE and null.
 			final boolean entityIsTrue = Boolean.TRUE.equals(this.index(entity));
 			return Boolean.TRUE.equals(key) ? entityIsTrue : !entityIsTrue;
 		}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
@@ -106,15 +106,17 @@ implements BitmapIndex.TopLevel<E, Boolean>, ChangeHandler
 	@Override
 	public final BitmapResult internalQuery(final Boolean key)
 	{
-		if(key == null)
-		{
-			return EMPTY_RESULT;
-		}
-		if(key == true)
+		if(Boolean.TRUE.equals(key))
 		{
 			return this.createResult();
 		}
-		
+
+		// A SingleBitmapIndex only materializes the TRUE set; FALSE and null are both simply
+		// "not in the TRUE entry" and cannot be told apart by this index. Both must therefore
+		// resolve to the inverted (NOT-TRUE) result. Returning EMPTY_RESULT for null would make
+		// a present null-valued entity unfindable by the entity locator (used by update / apply /
+		// set / replace via like(entity) -> is(null)), throwing "Entity not found", and would also
+		// make is(null) inconsistent with the is(false) it is indistinguishable from.
 		return this.entryResultInverted();
 	}
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
@@ -288,11 +288,16 @@ implements BitmapIndex.TopLevel<E, Boolean>, ChangeHandler
 		{
 			results[r++] = this.createResult();
 		}
-		if(predicate.test(Boolean.FALSE))
+		// FALSE and null are indistinguishable in this index: both live in the NOT-TRUE set. A
+		// predicate matching either therefore maps to the same inverted result, added at most once.
+		// Testing null here (consistent with how hashing indexes invoke predicates against a null
+		// key) keeps search() consistent with internalQuery(FALSE) / internalQuery(null), which both
+		// resolve to NOT-TRUE.
+		if(predicate.test(Boolean.FALSE) || predicate.test(null))
 		{
 			results[r++] = this.entryResultInverted();
 		}
-		
+
 		// it is theoretically possible that the predicate just always returns false, so r == 0 must be checked.
 		if(r == 0)
 		{

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
@@ -217,6 +217,38 @@ public class BooleanIndexTest
     }
 
     @Test
+    void conditionTestMatchesBitmapQuery()
+    {
+        // The in-memory predicate path (Condition#test) must agree with the bitmap query for this
+        // index. Since SingleBitmapIndex cannot tell FALSE from null (neither is in the TRUE set),
+        // is(false) and is(null) both resolve to the NOT-TRUE set in BOTH paths.
+        GigaMap<BooleanPerson> map = GigaMap.New();
+        map.index().bitmap().add(this.booleanPersonIndex);
+
+        BooleanPerson adult   = new BooleanPerson("Alice", Boolean.TRUE);
+        BooleanPerson child   = new BooleanPerson("Bob",   Boolean.FALSE);
+        BooleanPerson unknown = new BooleanPerson("Dave",  null);
+        map.addAll(adult, child, unknown);
+
+        // isTrue(): only the TRUE-valued entity, consistent across query and predicate.
+        assertEquals(1, map.query(this.booleanPersonIndex.isTrue()).count());
+        assertTrue(this.booleanPersonIndex.isTrue().test(adult));
+        assertFalse(this.booleanPersonIndex.isTrue().test(child));
+        assertFalse(this.booleanPersonIndex.isTrue().test(unknown));
+
+        // isFalse() / is(null): the NOT-TRUE set (FALSE and null), consistent across query and predicate.
+        assertEquals(2, map.query(this.booleanPersonIndex.isFalse()).count());
+        assertFalse(this.booleanPersonIndex.isFalse().test(adult));
+        assertTrue(this.booleanPersonIndex.isFalse().test(child));
+        assertTrue(this.booleanPersonIndex.isFalse().test(unknown));   // null is NOT-TRUE
+
+        assertEquals(2, map.query(this.booleanPersonIndex.is((Boolean)null)).count());
+        assertFalse(this.booleanPersonIndex.is((Boolean)null).test(adult));
+        assertTrue(this.booleanPersonIndex.is((Boolean)null).test(child));      // false is NOT-TRUE
+        assertTrue(this.booleanPersonIndex.is((Boolean)null).test(unknown));
+    }
+
+    @Test
     void booleanPersonTest()
     {
         GigaMap<BooleanPerson> map = prepageGigaMap();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
@@ -16,6 +16,7 @@ package org.eclipse.store.gigamap.indexer;
 
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerBoolean;
+import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
@@ -152,6 +153,70 @@ public class BooleanIndexTest
     }
 
     @Test
+    void nullValuedEntityUpdateDoesNotThrow()
+    {
+        // Reproducer: update() / apply() on an entity whose indexed Boolean is null used to throw
+        // IllegalArgumentException("Entity not found"), even though the entity is present
+        // (counted by size(), retrievable by get(id)).
+        //
+        // Root cause: the entity locator queries the indices with the entity's current value;
+        // SingleBitmapIndex.internalQuery(null) returned the empty result, so a null-valued entity
+        // yielded no candidate id. A false value is located via the inverted (NOT-TRUE) result, so
+        // the defect was null-specific (see falseValuedEntityUpdateDoesNotThrow for the contrast).
+        GigaMap<BooleanPerson> map = GigaMap.New();
+        map.index().bitmap().add(this.booleanPersonIndex);
+
+        BooleanPerson person = new BooleanPerson("Dave", null);   // optional flag left unset
+        map.add(person);
+        assertEquals(1, map.size());                              // the entity is present...
+
+        map.update(person, p -> p.setAdult(Boolean.TRUE));        // ...and must not throw "Entity not found"
+
+        assertEquals(1, map.query(this.booleanPersonIndex.isTrue()).count());
+    }
+
+    @Test
+    void falseValuedEntityUpdateDoesNotThrow()
+    {
+        // Control: a false-valued entity updates fine - proves the null reproducer is not vacuous.
+        GigaMap<BooleanPerson> map = GigaMap.New();
+        map.index().bitmap().add(this.booleanPersonIndex);
+
+        BooleanPerson person = new BooleanPerson("Eve", Boolean.FALSE);
+        map.add(person);
+
+        map.update(person, p -> p.setAdult(Boolean.TRUE));
+
+        assertEquals(1, map.query(this.booleanPersonIndex.isTrue()).count());
+    }
+
+    @Test
+    void nullValuedEntityWithSecondNonNullIndexUpdates()
+    {
+        // Even with a second, non-null index (so the entity is findable via that index), updating a
+        // null-valued Boolean entity must succeed: the entity locator intersects across indices, and
+        // the null-boolean leg must not contribute an empty set.
+        IndexerString<BooleanPerson> nameIndex = new IndexerString.Abstract<>()
+        {
+            @Override
+            protected String getString(BooleanPerson e)
+            {
+                return e.name();
+            }
+        };
+        GigaMap<BooleanPerson> map = GigaMap.New();
+        map.index().bitmap().add(this.booleanPersonIndex);
+        map.index().bitmap().add(nameIndex);
+
+        BooleanPerson person = new BooleanPerson("Alice", null);   // adult null, name non-null
+        map.add(person);
+
+        map.update(person, p -> p.setAdult(Boolean.TRUE));
+
+        assertEquals(1, map.query(this.booleanPersonIndex.isTrue()).count());
+    }
+
+    @Test
     void booleanPersonTest()
     {
         GigaMap<BooleanPerson> map = prepageGigaMap();
@@ -210,7 +275,7 @@ public class BooleanIndexTest
         private final String name;
         private Boolean isAdult;
 
-        public BooleanPerson(String name, boolean isAdult)
+        public BooleanPerson(String name, Boolean isAdult)
         {
             this.name = name;
             this.isAdult = isAdult;

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
@@ -246,6 +246,12 @@ public class BooleanIndexTest
         assertFalse(this.booleanPersonIndex.is((Boolean)null).test(adult));
         assertTrue(this.booleanPersonIndex.is((Boolean)null).test(child));      // false is NOT-TRUE
         assertTrue(this.booleanPersonIndex.is((Boolean)null).test(unknown));
+
+        // Predicate-based query (search path) must also map FALSE and null to the same NOT-TRUE set:
+        // a predicate matching only TRUE -> the TRUE set; a predicate matching only null -> NOT-TRUE.
+        assertEquals(1, map.query(this.booleanPersonIndex.is(k -> Boolean.TRUE.equals(k))).count());
+        assertEquals(2, map.query(this.booleanPersonIndex.is(k -> k == null)).count());
+        assertEquals(2, map.query(this.booleanPersonIndex.is(k -> Boolean.FALSE.equals(k))).count());
     }
 
     @Test


### PR DESCRIPTION
## Problem

`update()` / `apply()` / `set()` / `replace()` on an entity whose indexed `Boolean` value is `null` threw `IllegalArgumentException: "Entity not found"`, even though the entity is present (counted by `size()`, retrievable by `get(id)`).

Realistic trigger: an optional `Boolean` field (e.g. `Boolean active`) is indexed and left `null` when the entity is created, then a later `update()` sets it.

## Root cause

The entity locator narrows candidates by querying the indices with the entity's own current value (`like(entity)` → `is(key)`). `SingleBitmapIndex` (the index backing `IndexerBoolean`) only materializes the `TRUE` set — `null` and `false` are both simply "not in the TRUE entry" and cannot be told apart. `internalQuery(null)` returned `EMPTY_RESULT`, so a null-valued entity yielded no candidate id and could not be located. A `false` value was already resolved via the inverted (NOT-TRUE) result, so the defect was specific to `null`.

## Fix

1. **`SingleBitmapIndex.internalQuery(null)`** now returns the inverted (NOT-TRUE) result, the same as `false` — the value it is indistinguishable from. This lets the locator find null-valued entities. The key check was reordered to use `Boolean.TRUE.equals(key)` so the now-reachable `null` key does not auto-unbox into a `NullPointerException`.

2. **`IndexerBoolean.Abstract.test(entity, key)`** override (consistency follow-up): the in-memory predicate path (`Condition#test`) used strict key equality and so diverged from the collapsed bitmap result — `isFalse()` includes null entities in the query but `isFalse().test(nullEntity)` returned `false` (pre-existing for `false`, extended to `null` by fix 1). The override applies the same TRUE-vs-NOT-TRUE semantics as the bitmap query, so `Condition#test` and the bitmap query now agree.

## Scope

The locate defect was unique to `SingleBitmapIndex`: hashing indexes (`String`, `Integer`, `LocalDate`, …) and binary indexes (`BinaryUUID`, …) store `null` as a first-class key and update null-valued entities fine. No other index type needed changing.