### PR TITLE
Fix IndexerMultiValue update/set dropping pre-existing shared values

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ChangeHandler.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ChangeHandler.java
@@ -96,18 +96,54 @@ public interface ChangeHandler
 		@Override
 		public void changeInIndex(final long entityId, final ChangeHandler prevEntityHandler)
 		{
-			// Remove from all old entries once, then add to all new entries.
-			// Each individual handler.changeInIndex calls prevEntityHandler.removeFromIndex,
-			// so calling it for every handler would remove the entity from shared keys
-			// that were just re-added by a previous handler in this chain.
-			prevEntityHandler.removeFromIndex(entityId);
+			// Keys present in both the previous and the new state must be left untouched.
+			// Removing such a shared key first can empty its entry, causing the index to
+			// detach (delete) that entry; the subsequent re-add then operates on the now
+			// orphaned entry and is silently lost. So only remove keys that are gone and
+			// only add keys that are genuinely new; shared keys stay as they are.
+			if(!(prevEntityHandler instanceof final Chain prevChain))
+			{
+				// No comparable previous chain (e.g. transition from no previous state):
+				// remove from all previous entries once, then add to all new entries.
+				prevEntityHandler.removeFromIndex(entityId);
+				for(final ChangeHandler handler : this.handlers)
+				{
+					handler.changeInIndex(entityId, NullChangeChandler.SINGLETON);
+				}
+				return;
+			}
 
+			// Remove the entity from previous keys that are no longer present.
+			for(final ChangeHandler prev : prevChain.handlers)
+			{
+				if(!containsEqual(this.handlers, prev))
+				{
+					prev.removeFromIndex(entityId);
+				}
+			}
+
+			// Add the entity to newly introduced keys; shared keys are left untouched.
 			for(final ChangeHandler handler : this.handlers)
 			{
-				handler.changeInIndex(entityId, NullChangeChandler.SINGLETON);
+				if(!containsEqual(prevChain.handlers, handler))
+				{
+					handler.changeInIndex(entityId, NullChangeChandler.SINGLETON);
+				}
 			}
 		}
-		
+
+		private static boolean containsEqual(final XGettingList<ChangeHandler> handlers, final ChangeHandler handler)
+		{
+			for(final ChangeHandler h : handlers)
+			{
+				if(h.isEqual(handler) || handler.isEqual(h))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
 	}
 	
 }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/MultipleValueIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/MultipleValueIndexTest.java
@@ -131,6 +131,59 @@ public class MultipleValueIndexTest
     }
 
     @Test
+    void multivalueUpdateAddingKeyKeepsSoleExistingKey()
+    {
+        // Regression: adding a key while keeping a pre-existing one must not drop the existing
+        // key. The existing key's entry is held *only* by this entity, so removing-then-re-adding
+        // it during the update would empty (and detach) the entry, silently losing the entity.
+        GigaMap<Patient>         gigaMap                  = GigaMap.New();
+        PatientIdentifierIndexer patientIdentifierIndexer = new PatientIdentifierIndexer();
+        gigaMap.index().bitmap().add(patientIdentifierIndexer);
+        Patient patient1 = new Patient("John", 25, new ArrayList<>(List.of("123")));
+        gigaMap.add(patient1);
+
+        gigaMap.update(patient1, p -> p.getIdentifiers().add("456"));   // identifiers are now ["123","456"]
+
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("456")).count(), "newly added key must match");
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("123")).count(), "pre-existing sole key must still match");
+    }
+
+    @Test
+    void multivalueSetAddingKeyKeepsSoleExistingKey()
+    {
+        // Regression: same as multivalueUpdateAddingKeyKeepsSoleExistingKey, but via set(id, entity).
+        GigaMap<Patient>         gigaMap                  = GigaMap.New();
+        PatientIdentifierIndexer patientIdentifierIndexer = new PatientIdentifierIndexer();
+        gigaMap.index().bitmap().add(patientIdentifierIndexer);
+        Patient patient1 = new Patient("John", 25, new ArrayList<>(List.of("123")));
+        long id = gigaMap.add(patient1);
+
+        gigaMap.set(id, new Patient("John", 25, new ArrayList<>(List.of("123", "456"))));
+
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("456")).count(), "newly added key must match");
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("123")).count(), "pre-existing sole key must still match");
+    }
+
+    @Test
+    void multivalueUpdateAddingKeyKeepsAllSoleExistingKeys()
+    {
+        // Regression: with multiple pre-existing keys held only by this entity, adding one more
+        // must keep all of them findable - none of the existing entries may be detached.
+        GigaMap<Patient>         gigaMap                  = GigaMap.New();
+        PatientIdentifierIndexer patientIdentifierIndexer = new PatientIdentifierIndexer();
+        gigaMap.index().bitmap().add(patientIdentifierIndexer);
+        Patient patient1 = new Patient("John", 25, new ArrayList<>(List.of("aaa", "bbb", "ccc")));
+        gigaMap.add(patient1);
+
+        gigaMap.update(patient1, p -> p.getIdentifiers().add("ddd"));   // now ["aaa","bbb","ccc","ddd"]
+
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("ddd")).count(), "newly added key must match");
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("aaa")).count(), "pre-existing 'aaa' must still match");
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("bbb")).count(), "pre-existing 'bbb' must still match");
+        assertEquals(1L, gigaMap.query(patientIdentifierIndexer.is("ccc")).count(), "pre-existing 'ccc' must still match");
+    }
+
+    @Test
     void multivalueUpdateCompleteKeyChange()
     {
         GigaMap<Patient>         gigaMap                  = GigaMap.New();


### PR DESCRIPTION
## Problem

When `update()` or `set()` changed the key set of an entity indexed by an `IndexerMultiValue`, a key present in **both** the old and new state was silently dropped from the index — if that key's bitmap entry was held *solely* by the entity being updated.

Example: an entity tagged `["a"]`, then `update(e, x -> x.tags.add("b"))`.
Afterwards `is("b")` matches but `is("a")` returns `0`, even though the entity is still in the map and its collection still contains `"a"`. A silent false-negative: the entity becomes partially unfindable via the index.

## Root cause

`ChangeHandler.Chain.changeInIndex` removed the entity from **all** old entries first, then re-added it to **all** new entries. Removing it from a shared key's entry emptied that entry, so `internalRemoveFromEntry` (`BitmapIndex.java`) deleted — *detached* — the entry from the `entries` table. The subsequent re-add then operated on the now-orphaned `BitmapEntry` instance, so the bit was set on an object no longer reachable via `entries.get(key)` and was effectively lost.

(This is the flip side of #685: the earlier "remove-all-then-add-all" rewrite avoided double-removing shared keys but re-added them onto a detached entry.)

## Fix

`Chain.changeInIndex` now diffs the previous and new handler sets:

- keys present in **both** states are left untouched,
- only dropped keys are removed,
- only genuinely new keys are added.

A non-`Chain` previous handler keeps the original remove-then-add fallback.

## Scope

Affects **only multi-value hashing indexes** — the sole producers of `ChangeHandler.Chain`. Single-value, binary/bit-sliced, and composite indexes use `internalHandleChanged` (ensure-new-entry-then-remove-old, with a same-entry short-circuit) and are structurally immune to this scenario, so no other index type is impacted. The `Chain` code is key-type- and source-agnostic, so the fix covers explicit, `List`-backed, array-backed, and annotation-generated multi-value indexers alike.

## Tests

Reproducers woven into `MultipleValueIndexTest` (all three fail without the fix, pass with it):

- `multivalueUpdateAddingKeyKeepsSoleExistingKey`
- `multivalueSetAddingKeyKeepsSoleExistingKey`
- `multivalueUpdateAddingKeyKeepsAllSoleExistingKeys`

The existing `multivalueUpdateRemovesOldKeys` *looked* like it covered this, but its shared key was also held by a second entity, so the entry never emptied and never detached — these new tests close that gap. Full gigamap suite passes.