### PR TITLE
Fix anonymous indexer name resolution after GigaMap reload

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndicesDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapIndicesDefault.java
@@ -188,6 +188,8 @@ public class BinaryHandlerBitmapIndicesDefault extends AbstractBinaryHandlerStat
 	@Override
 	public void complete(final Binary data, final BitmapIndices.Default<?> instance, final PersistenceLoadHandler handler)
 	{
+		// restore indexer names lost with their transient field before they are used (see method doc).
+		instance.restoreIndexerNames();
 		instance.rebuildCache();
 	}
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -525,6 +525,29 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				// changeHandler arrays stay empty until needed.
 			}
 		}
+
+		/**
+		 * Re-binds each index' indexer to the name the index is registered and persisted under.
+		 * <p>
+		 * Invoked once after deserialization (see {@code BinaryHandlerBitmapIndicesDefault#complete}).
+		 * An anonymous {@link Indexer.Abstract} loses its {@code transient} derived name on reload and
+		 * would otherwise recompute a divergent fallback name, breaking index resolution (e.g.
+		 * {@link GigaMap#update}, whose lookup condition is built from the indexer via
+		 * {@code HashingBitmapIndex#like}).
+		 */
+		final void restoreIndexerNames()
+		{
+			// the table key is the name the index is registered under and the name index resolution
+			// (BitmapIndices#internalGet) looks up by, so it is the authoritative name to re-bind to.
+			for(final KeyValue<String, ? extends BitmapIndex.Internal<E, ?>> entry : this.bitmapIndices)
+			{
+				final Indexer<? super E, ?> indexer = entry.value().indexer();
+				if(indexer instanceof Indexer.Abstract)
+				{
+					((Indexer.Abstract<?, ?>)indexer).initializeResolvedName(entry.key());
+				}
+			}
+		}
 		
 		@Override
 		public final GigaMap.Internal<E> parentMap()

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Indexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Indexer.java
@@ -162,10 +162,29 @@ public interface Indexer<E, K> extends IndexIdentifier<E, K>
 			{
 				this.name = this.defaultName();
 			}
-			
+
 			return this.name;
 		}
-		
+
+		/**
+		 * Re-binds the resolved (cached) name of this indexer to the name its owning index is
+		 * registered and persisted under.
+		 * <p>
+		 * The {@link #name} field is {@code transient}, so a reloaded indexer loses its derived
+		 * name. For an anonymous indexer the {@link #defaultName() reflectively derived} default
+		 * name cannot be reconstructed from a deserialized instance (it is no longer the value of
+		 * the declaring {@code static} field), so {@code name()} would otherwise compute a divergent
+		 * fallback name that no longer matches the registered index name. Pushing the persisted index
+		 * name back into the indexer on reload keeps both consistent so index resolution (e.g. during
+		 * {@link GigaMap#update}) succeeds.
+		 *
+		 * @param resolvedName the name the owning index is registered under
+		 */
+		final void initializeResolvedName(final String resolvedName)
+		{
+			this.name = resolvedName;
+		}
+
 		private String defaultName()
 		{
 			final Class<?> clazz = this.getClass();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/AnonymousIndexerReloadMutationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/AnonymousIndexerReloadMutationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Covers mutation of entities through the entity-locator path (update / replace / remove by entity)
@@ -169,7 +170,7 @@ public class AnonymousIndexerReloadMutationTest
 			assertEquals(0, reloaded.query(NAME_INDEX.is("alice")).count());
 			assertEquals(1, reloaded.query(NAME_INDEX.is("bob")).count());
 			assertEquals(1, reloaded.size());
-			assertEquals(true, removedId >= 0);
+			assertTrue(removedId >= 0);
 		}
 	}
 }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/AnonymousIndexerReloadMutationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/AnonymousIndexerReloadMutationTest.java
@@ -1,0 +1,175 @@
+package org.eclipse.store.gigamap.indexer;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers mutation of entities through the entity-locator path (update / replace / remove by entity)
+ * after a {@link GigaMap} has been reloaded from storage, using indexes that were registered with an
+ * <em>anonymous</em> indexer (the common {@code new IndexerString.Abstract<>(){...}} idiom).
+ * <p>
+ * Regression test: an anonymous {@link IndexerString.Abstract} loses its (transient) derived name on
+ * reload. The mutation locator builds its lookup condition from the indexer
+ * (see {@code HashingBitmapIndex#like}), so a recomputed, divergent fallback name used to make index
+ * resolution fail with {@code IllegalArgumentException: "... does not have an index defined with name ..."}.
+ * The reloaded indexer must report the name the index is registered/persisted under.
+ */
+public class AnonymousIndexerReloadMutationTest
+{
+	static class Person
+	{
+		String name;
+
+		Person()
+		{
+			// required for deserialization
+		}
+
+		Person(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	static final IndexerString<Person> NAME_INDEX = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	private static GigaMap<Person> newStoredMap(final Path dir, final String... names)
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME_INDEX);
+		for(final String name : names)
+		{
+			map.add(new Person(name));
+		}
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(map, dir))
+		{
+			// initial state stored on close
+		}
+		return map;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Person> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Person>)m.root();
+	}
+
+	@Test
+	void queryAfterReloadResolvesAnonymousIndex(@TempDir final Path dir)
+	{
+		newStoredMap(dir, "alice");
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+
+			assertEquals(1, reloaded.query(NAME_INDEX.is("alice")).count());
+			assertEquals(0, reloaded.query(NAME_INDEX.is("bob")).count());
+		}
+	}
+
+	@Test
+	void updateAfterReloadResolvesAnonymousIndex(@TempDir final Path dir)
+	{
+		newStoredMap(dir, "alice");
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			final Person alice = reloaded.query(NAME_INDEX.is("alice")).toList().get(0);
+
+			reloaded.update(alice, p -> p.name = "bob");
+
+			assertEquals(1, reloaded.query(NAME_INDEX.is("bob")).count());
+			assertEquals(0, reloaded.query(NAME_INDEX.is("alice")).count());
+		}
+	}
+
+	@Test
+	void updateAfterReloadPersistsAcrossSecondReload(@TempDir final Path dir)
+	{
+		newStoredMap(dir, "alice");
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			final Person alice = reloaded.query(NAME_INDEX.is("alice")).toList().get(0);
+
+			reloaded.update(alice, p -> p.name = "bob");
+			reloaded.store();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+
+			assertEquals(1, reloaded.query(NAME_INDEX.is("bob")).count());
+			assertEquals(0, reloaded.query(NAME_INDEX.is("alice")).count());
+		}
+	}
+
+	@Test
+	void replaceAfterReloadResolvesAnonymousIndex(@TempDir final Path dir)
+	{
+		newStoredMap(dir, "alice");
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			final Person alice = reloaded.query(NAME_INDEX.is("alice")).toList().get(0);
+
+			reloaded.replace(alice, new Person("bob"));
+
+			assertEquals(1, reloaded.query(NAME_INDEX.is("bob")).count());
+			assertEquals(0, reloaded.query(NAME_INDEX.is("alice")).count());
+		}
+	}
+
+	@Test
+	void removeByEntityAfterReloadResolvesAnonymousIndex(@TempDir final Path dir)
+	{
+		newStoredMap(dir, "alice", "bob");
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			final Person alice = reloaded.query(NAME_INDEX.is("alice")).toList().get(0);
+
+			final long removedId = reloaded.remove(alice);
+
+			assertEquals(0, reloaded.query(NAME_INDEX.is("alice")).count());
+			assertEquals(1, reloaded.query(NAME_INDEX.is("bob")).count());
+			assertEquals(1, reloaded.size());
+			assertEquals(true, removedId >= 0);
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Mutating a reloaded `GigaMap` via the entity-locator paths — `update()`, `replace()`, `remove(entity)` — threw:

IllegalArgumentException: GigaMap ... does not have an index defined with name "...IndexerString.Abstract".

…whenever the index had been registered with an *anonymous* indexer, i.e. the common idiom:

```java
static final IndexerString<Person> NAME_INDEX = new IndexerString.Abstract<>() {
    @Override protected String getString(Person e) { return e.name; }
};
```

Direct queries (map.query(NAME_INDEX.is(...))) worked; only mutations failed, and only after a reload.

## Root cause

- Indexer.Abstract.name is transient, so a reloaded indexer loses its resolved name and recomputes it lazily via defaultName().
- defaultName() derives the name by finding the static field whose value is this. After reload the deserialized indexer is a different instance than the static field, so the lookup misses and it falls back to a class-based name (…IndexerString.Abstract) — diverging from the name the index was actually registered and persisted under (…NAME_INDEX).
- The mutation locator (lookupEntityIdPeeking) builds its lookup Condition from the indexer, because HashingBitmapIndex#like delegates to indexer().like() (intentional, for IndexerMultiValue semantics). So resolution used the fragile recomputed name and failed.
- Queries through the live static instance were unaffected, which is why the failure only surfaced on mutation after reload.

## Fix

On reload, re-bind each index's indexer to the name the index is registered under — the bitmapIndices table key, which is exactly what BitmapIndices#internalGet (and therefore resolveFor) looks up by.

- Indexer.Abstract#initializeResolvedName(String) — sets the cached name.
- BitmapIndices.Default#restoreIndexerNames() — re-binds every indexer from its table key (guarded by instanceof Indexer.Abstract, so explicitly-named user indexers are untouched; covers String/Binary/Composite/MultiValue).
- Invoked once from BinaryHandlerBitmapIndicesDefault#complete, keeping name restoration a deserialization-only concern (not in the per-add rebuildCache() path).

## Tests

New AnonymousIndexerReloadMutationTest covers update, update + persistence across a second reload, replace, remove(entity), and a query-path regression guard. Verified that all four mutation tests fail with the original exception when the fix is disabled, and pass with it restored.