### PR TITLE
Structural lifecycle for GigaMap indexes & constraints: removal across all families, redefinition for bitmap

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerCustomConstraintsDefault.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerCustomConstraintsDefault.java
@@ -102,15 +102,15 @@ public class BinaryHandlerCustomConstraintsDefault extends AbstractBinaryHandler
 	)
 	{
 		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
-		
+
 		data.store_long(
 			BINARY_OFFSET_parent,
 			handler.apply(XMemory.getObject(instance, MEMORY_OFFSET_parent))
 		);
-		data.store_long(
-			BINARY_OFFSET_elements,
-			handler.apply(instance.elements())
-		);
+		// must be stored eagerly so that structural mutations of the elements table (adding or
+		// removing a constraint after the first store) are actually re-persisted, not just referenced.
+		// Mirrors BinaryHandlerBitmapIndicesDefault, which stores its registries eagerly for the same reason.
+		data.storeReferenceEager(BINARY_OFFSET_elements, handler, instance.elements());
 	}
 		
 	@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapEntry.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapEntry.java
@@ -151,6 +151,14 @@ implements ChangeHandler, Unpersistable
 	{
 		this.getLevel3().ensureDecompressed();
 	}
+
+	// Deterministically frees this entry's off-heap level2 memory. Used when the owning index is
+	// dropped (see BitmapIndices#removeIndex / update); accesses the level3 field directly to avoid
+	// touching parent back-references during teardown.
+	final void releaseOffHeap()
+	{
+		this.level3.release();
+	}
 	
 	void internalSetBackReferences(final BitmapIndex.Abstract<E, I, K> parent, final K key)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
@@ -192,10 +192,18 @@ public interface BitmapIndex<E, K> extends IndexIdentifier<E, K>, GigaIndex<E>
 		public void internalRemoveAll();
 		
 		public boolean internalContains(E entity);
-		
+
 		public BitmapResult internalQuery(K key);
-		
+
 		public void clearStateChangeMarkers();
+
+		/**
+		 * Deterministically frees the off-heap memory held by this index' currently loaded bitmap
+		 * segments. Called when the index is dropped (see {@link BitmapIndices#removeIndex(String)} /
+		 * {@code update}) so native memory is released immediately rather than only when the garbage
+		 * collector eventually runs the segments' cleaners.
+		 */
+		public void internalReleaseOffHeap();
 	}
 	
 	
@@ -278,7 +286,14 @@ public interface BitmapIndex<E, K> extends IndexIdentifier<E, K>, GigaIndex<E>
 		}
 						
 		public abstract void iterateEntries(Consumer<? super BitmapEntry<?, ?, ?>> logic);
-		
+
+		// Concrete here so every index type (hashing, binary, single, composite — whose iterateEntries
+		// fans out to its sub-indices) inherits a correct release; satisfies BitmapIndex.Internal.
+		public void internalReleaseOffHeap()
+		{
+			this.iterateEntries(BitmapEntry::releaseOffHeap);
+		}
+
 		public abstract int entryCount();
 		
 		protected abstract K indexEntity(I entity);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -739,13 +739,26 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
+				this.ensureMutable();
 				this.validateIndexToAdd(indexer);
-				
+
 				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
 				this.internalAddBitmapIndex(index);
 				this.rebuildCache();
 
 				return index;
+			}
+		}
+
+		/**
+		 * Guards structural mutations against a read-only parent {@link GigaMap}. Must be called while
+		 * holding the parent-map lock.
+		 */
+		private void ensureMutable()
+		{
+			if(this.parentMap().isReadOnly())
+			{
+				throw new BitmapIndicesException("Cannot modify indices: the parent GigaMap is read-only.", this);
 			}
 		}
 
@@ -941,6 +954,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
+				this.ensureMutable();
 				for(final Indexer<? super E, ?> indexer : indexers)
 				{
 					this.validateIndexToAdd(indexer);
@@ -1185,9 +1199,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 			
 			final BulkList<BitmapIndex<E, ?>> resolved = BulkList.New(identityIndices.size());
-			
+
 			synchronized(this.parentMap())
 			{
+				this.ensureMutable();
 				for(final IndexIdentifier<? super E, ?> i : identityIndices)
 				{
 					final BitmapIndex<E, ?> index = i.resolveFor(this);
@@ -1322,6 +1337,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
+				this.ensureMutable();
 				// Basic validation before changing any state.
 				for(final Indexer<? super E, ?> indexer : indexers)
 				{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -761,7 +761,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 						this
 					);
 				}
-				return this.internalRemoveIndex(name, false) != null;
+				return this.internalRemoveIndex(name, false, true) != null;
 			}
 		}
 
@@ -769,9 +769,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		 * @param allowIdentity whether an index that is currently an identity index may be removed.
 		 *        {@code false} for the public {@link #removeIndex(String)}; {@code true} for
 		 *        {@link #update(Indexer)}, which re-points the identity set to the rebuilt index.
+		 * @param rebuildCache whether to rebuild the index cache here. {@code false} lets a caller that
+		 *        performs further structural changes (e.g. {@link #update(Indexer)}) do a single rebuild
+		 *        at the end instead of rebuilding twice.
 		 * @return the removed index, or {@code null} if no index was registered under the given name
 		 */
-		private BitmapIndex.Internal<E, ?> internalRemoveIndex(final String name, final boolean allowIdentity)
+		private BitmapIndex.Internal<E, ?> internalRemoveIndex(final String name, final boolean allowIdentity, final boolean rebuildCache)
 		{
 			final BitmapIndex.Internal<E, ?> index = this.bitmapIndices.get(name);
 			if(index == null)
@@ -788,7 +791,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 			this.bitmapIndices.removeFor(name);
 			this.internalRemoveUniqueConstraint(index);
-			this.rebuildCache();
+			if(rebuildCache)
+			{
+				this.rebuildCache();
+			}
 			this.markStateChangeInstance();
 			this.parent.internalReportIndexGroupStateChange(this);
 			return index;
@@ -799,6 +805,13 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
+				if(this.parentMap().isReadOnly())
+				{
+					throw new BitmapIndicesException(
+						"Cannot remove unique constraint \"" + name + "\": the parent GigaMap is read-only.",
+						this
+					);
+				}
 				final BitmapIndex.Internal<E, ?> index = this.bitmapIndices.get(name);
 				if(index == null || this.uniqueConstraints == null || !this.uniqueConstraints.contains(index))
 				{
@@ -889,8 +902,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				}
 
 				// commit: drop the old index (logic + data), then register the rebuilt index.
-				// identity removal is allowed here and restored below.
-				this.internalRemoveIndex(name, true);
+				// identity removal is allowed here and restored below; skip the intermediate cache
+				// rebuild since update() rebuilds the cache once at the end.
+				this.internalRemoveIndex(name, true, false);
 				if(wasUnique)
 				{
 					this.internalAddUniqueConstraint(index);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -91,7 +91,69 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	public BitmapIndices<E> addAll(Iterable<? extends Indexer<? super E, ?>> indexers);
 	
 	/**
+	 * Removes the index registered under the given name.
+	 * <p>
+	 * The index and its data are dropped from this group. If the index is also registered as a
+	 * unique constraint, that constraint is lifted as well. The orphaned index data is reclaimed
+	 * by the storage's garbage collection on the next housekeeping cycle after the surrounding
+	 * {@link GigaMap} is stored - it is not freed synchronously.
+	 * <p>
+	 * Removing an index that is currently registered as an
+	 * {@link #identityIndices() identity index} is rejected with a {@link RuntimeException},
+	 * because doing so would silently break entity lookup and removal; update the identity indices
+	 * first via {@link #setIdentityIndices(org.eclipse.serializer.collections.types.XGettingEnum)}.
+	 *
+	 * @param name the name of the index to remove
+	 * @return {@code true} if an index with that name existed and was removed, {@code false} otherwise
+	 * @throws RuntimeException if the index is currently registered as an identity index, or if the
+	 *         parent {@link GigaMap} is read-only
+	 * @see #update(Indexer)
+	 */
+	public boolean removeIndex(String name);
+
+	/**
+	 * Removes the index registered under the {@link IndexIdentifier#name() name} of the given identifier.
+	 * <p>
+	 * For details see {@link #removeIndex(String)}.
+	 *
+	 * @param identifier the identifier whose name identifies the index to remove
+	 * @return {@code true} if an index with that name existed and was removed, {@code false} otherwise
+	 */
+	public default boolean removeIndex(final IndexIdentifier<? super E, ?> identifier)
+	{
+		return this.removeIndex(identifier.name());
+	}
+
+	/**
+	 * Replaces the indexing logic of the already-registered index that has the same
+	 * {@link Indexer#name() name} as the given indexer, and rebuilds that index's data from all
+	 * entities currently contained in the parent {@link GigaMap}.
+	 * <p>
+	 * Unlike {@link #ensure(Indexer)}, which never changes an existing index, this method is the
+	 * supported way to change an index's logic. Unique-constraint and identity-index membership of
+	 * the existing index are preserved: if the index was a unique constraint, the rebuild
+	 * re-validates uniqueness under the new logic (and fails with a
+	 * {@link org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationException} if the current
+	 * data is no longer unique); if it was an identity index, the identity set is re-pointed to the
+	 * rebuilt index.
+	 *
+	 * @param <K> the key type
+	 * @param indexer the new indexing logic, whose name selects the index to replace
+	 * @return the rebuilt index
+	 * @throws RuntimeException if no index is registered under the indexer's name, or if the parent
+	 *         {@link GigaMap} is read-only
+	 * @see #removeIndex(String)
+	 */
+	public <K> BitmapIndex<E, K> update(Indexer<? super E, K> indexer);
+
+	/**
 	 * Ensures that an index exists in this group.
+	 * <p>
+	 * This is a get-or-create operation: if an index is already registered under the given
+	 * indexer's {@link Indexer#name() name} (and key type), that existing index is returned
+	 * <b>unchanged</b> and the passed {@code indexer}'s logic is ignored. {@code ensure} therefore
+	 * never modifies an existing index. To change the logic of an already-registered index, use
+	 * {@link #update(Indexer)}.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the indexing logic
@@ -682,11 +744,184 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
 				this.internalAddBitmapIndex(index);
 				this.rebuildCache();
-				
+
 				return index;
 			}
 		}
-		
+
+		@Override
+		public boolean removeIndex(final String name)
+		{
+			synchronized(this.parentMap())
+			{
+				if(this.parentMap().isReadOnly())
+				{
+					throw new BitmapIndicesException(
+						"Cannot remove index \"" + name + "\": the parent GigaMap is read-only.",
+						this
+					);
+				}
+				return this.internalRemoveIndex(name, false) != null;
+			}
+		}
+
+		/**
+		 * @param allowIdentity whether an index that is currently an identity index may be removed.
+		 *        {@code false} for the public {@link #removeIndex(String)}; {@code true} for
+		 *        {@link #update(Indexer)}, which re-points the identity set to the rebuilt index.
+		 * @return the removed index, or {@code null} if no index was registered under the given name
+		 */
+		private BitmapIndex.Internal<E, ?> internalRemoveIndex(final String name, final boolean allowIdentity)
+		{
+			final BitmapIndex.Internal<E, ?> index = this.bitmapIndices.get(name);
+			if(index == null)
+			{
+				return null;
+			}
+			if(!allowIdentity && this.isIdentityIndex(index))
+			{
+				throw new BitmapIndicesException(
+					"Index \"" + name + "\" is registered as an identity index and cannot be removed; "
+					+ "update the identity indices first.",
+					this
+				);
+			}
+			this.bitmapIndices.removeFor(name);
+			this.internalRemoveUniqueConstraint(index);
+			this.rebuildCache();
+			this.markStateChangeInstance();
+			this.parent.internalReportIndexGroupStateChange(this);
+			return index;
+		}
+
+		@Override
+		public boolean removeUniqueConstraint(final String name)
+		{
+			synchronized(this.parentMap())
+			{
+				final BitmapIndex.Internal<E, ?> index = this.bitmapIndices.get(name);
+				if(index == null || this.uniqueConstraints == null || !this.uniqueConstraints.contains(index))
+				{
+					return false;
+				}
+				this.internalRemoveUniqueConstraint(index);
+				// the index stays registered, but its unique flag in the cache must be cleared.
+				this.rebuildCache();
+				this.markStateChangeInstance();
+				return true;
+			}
+		}
+
+		private void internalRemoveUniqueConstraint(final BitmapIndex.Internal<E, ?> index)
+		{
+			if(this.uniqueConstraints == null || !this.uniqueConstraints.contains(index))
+			{
+				return;
+			}
+			final BulkList<BitmapIndex.Internal<E, ?>> remaining = BulkList.New();
+			for(final BitmapIndex.Internal<E, ?> e : this.uniqueConstraints)
+			{
+				if(e != index)
+				{
+					remaining.add(e);
+				}
+			}
+			this.uniqueConstraints = remaining.isEmpty() ? null : ConstHashEnum.New(remaining);
+			this.parent.internalReportIndexGroupStateChange(this);
+		}
+
+		private boolean isIdentityIndex(final BitmapIndex.Internal<E, ?> index)
+		{
+			if(this.identityIndices == null)
+			{
+				return false;
+			}
+			for(final BitmapIndex<E, ?> identityIndex : this.identityIndices)
+			{
+				if(identityIndex == index)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public <K> BitmapIndex<E, K> update(final Indexer<? super E, K> indexer)
+		{
+			synchronized(this.parentMap())
+			{
+				if(this.parentMap().isReadOnly())
+				{
+					throw new BitmapIndicesException(
+						"Cannot update indexer \"" + indexer.name() + "\": the parent GigaMap is read-only.",
+						this
+					);
+				}
+				final String                     name     = indexer.name();
+				final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(name);
+				if(existing == null)
+				{
+					throw new BitmapIndicesException(
+						"No index registered for name \"" + name + "\" to update; use add(...) to create it.",
+						this
+					);
+				}
+				final boolean wasUnique   = this.isUniqueConstraint(existing);
+				final boolean wasIdentity = this.isIdentityIndex(existing);
+
+				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
+				if(wasUnique)
+				{
+					if(!index.isSuitableAsUniqueConstraint())
+					{
+						throw new BitmapIndicesException(
+							"Index not suited as a unique constraint: \"" + index.name() + "\" class " + index.getClass(),
+							this
+						);
+					}
+					// Build and validate the new index' data against all existing entities BEFORE dropping
+					// the old one, so that a uniqueness violation under the new logic leaves the existing
+					// index untouched (atomic failure). The new index is standalone (not yet registered).
+					final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
+					indices.add(index.name(), index);
+					this.buildIndexDataAndValidateUniqueness(indices);
+				}
+
+				// commit: drop the old index (logic + data), then register the rebuilt index.
+				// identity removal is allowed here and restored below.
+				this.internalRemoveIndex(name, true);
+				if(wasUnique)
+				{
+					this.internalAddUniqueConstraint(index);
+				}
+				// registers the index and back-fills it from all existing entities (idempotent for the unique branch).
+				this.internalAddBitmapIndex(index);
+
+				if(wasIdentity)
+				{
+					this.internalReplaceIdentityIndex(existing, index);
+				}
+				this.rebuildCache();
+				return index;
+			}
+		}
+
+		private void internalReplaceIdentityIndex(final BitmapIndex<E, ?> oldIndex, final BitmapIndex<E, ?> newIndex)
+		{
+			if(this.identityIndices == null)
+			{
+				return;
+			}
+			final BulkList<BitmapIndex<E, ?>> resolved = BulkList.New();
+			for(final BitmapIndex<E, ?> identityIndex : this.identityIndices)
+			{
+				resolved.add(identityIndex == oldIndex ? newIndex : identityIndex);
+			}
+			this.internalSetIdentityIndices(ConstHashEnum.New(resolved));
+			this.markStateChangeInstance();
+		}
+
 		@Override
 		public final BitmapIndices<E> addAll(final Iterable<? extends Indexer<? super E, ?>> indexers)
 		{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -804,6 +804,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 			this.bitmapIndices.removeFor(name);
 			this.internalRemoveUniqueConstraint(index);
+			// release the dropped index' off-heap (Unsafe) memory immediately instead of waiting for the
+			// segments' cleaners to run on GC (see BitmapLevel2#release).
+			index.internalReleaseOffHeap();
 			if(rebuildCache)
 			{
 				this.rebuildCache();

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -450,7 +450,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * Get the registered identity indices used to identify entities during lookup and removal operations.
 	 * <p>
 	 * Note: Identity indices do not enforce uniqueness. To ensure that identity values are unique
-	 * across all entities, add a unique constraint via {@link #addUniqueConstraint(String, Indexer)}.
+	 * across all entities, add a unique constraint via {@link #addUniqueConstraint(Indexer)}.
 	 *
 	 * @return all registered identity indices, might be <code>null</code>
 	 */
@@ -461,7 +461,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * <p>
 	 * Identity indices define which fields are used to build internal queries for looking up
 	 * and removing entities. They do not enforce uniqueness. To ensure that no two entities
-	 * share the same identity value, add a unique constraint via {@link #addUniqueConstraint(String, Indexer)}.
+	 * share the same identity value, add a unique constraint via {@link #addUniqueConstraint(Indexer)}.
 	 *
 	 * @param identityIndices the new, non-empty, identity indices
 	 * @return this
@@ -473,7 +473,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * <p>
 	 * Identity indices define which fields are used to build internal queries for looking up
 	 * and removing entities. They do not enforce uniqueness. To ensure that no two entities
-	 * share the same identity value, add a unique constraint via {@link #addUniqueConstraint(String, Indexer)}.
+	 * share the same identity value, add a unique constraint via {@link #addUniqueConstraint(Indexer)}.
 	 *
 	 * @param identityIndices the new, non-empty, identity indices
 	 * @return this
@@ -1306,12 +1306,14 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			this.parent.internalReportIndexGroupStateChange(this);
 		}
 		
+		@Deprecated
 		@Override
 		public final UniqueConstraints<E> addUniqueConstraint(final String indexName, final Indexer<? super E, ?> indexer)
 		{
+			// note: indexName is ignored; the constraint is registered under the indexer's own name.
 			// validation and registering creates so many instances that this one detour instance does not matter.
 			this.addUniqueConstraints(X.Constant(indexer));
-			
+
 			return this;
 		}
 		
@@ -1339,10 +1341,27 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				}
 				this.rebuildCache();
 			}
-			
+
 			return this;
 		}
-		
+
+		@Override
+		public final UniqueConstraints<E> ensureUniqueConstraint(final Indexer<? super E, ?> indexer)
+		{
+			synchronized(this.parentMap())
+			{
+				// registry key is the indexer's name (a unique constraint is registered under index.name())
+				final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(indexer.name());
+				if(existing != null && this.uniqueConstraints != null && this.uniqueConstraints.contains(existing))
+				{
+					// already registered as a unique constraint -> idempotent no-op
+					return this;
+				}
+				// create + validate against existing data (throws if the name is taken by a non-unique index)
+				return this.addUniqueConstraint(indexer);
+			}
+		}
+
 		private void buildUniqueIndices(
 			final Iterable<? extends Indexer<? super E, ?>> indexers,
 			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -633,6 +633,22 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 	{
 		return ensureAddableLevel1SegmentForEntityId(this.level2Address, entityId, level3);
 	}
+
+	// Deterministically frees this segment's off-heap memory and neutralizes the Cleaner so it cannot
+	// double-free. Idempotent. Used when an index is dropped (see BitmapIndices#removeIndex / update) to
+	// release native memory immediately instead of waiting for the Cleaner to run on GC. Safe because the
+	// owning instance is still strongly reachable while this runs, so the Cleaner cannot fire concurrently.
+	final void release()
+	{
+		final long address = this.level2Address;
+		if(address == 0L)
+		{
+			return;
+		}
+		this.cleanup.address = 0L; // neutralize the Cleaner before freeing (volatile write)
+		this.level2Address   = 0L;
+		deallocate(address);
+	}
 	
 	// Holds the off-heap address for Cleaner-based release.
 	//

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel3.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel3.java
@@ -216,6 +216,22 @@ public class BitmapLevel3 extends AbstractStateChangeFlagged implements Unpersis
 		}
 	}
 	
+	// Deterministically frees the off-heap memory of all level2 segments below this level. Used when the
+	// owning index is dropped (see BitmapIndices#removeIndex / update) to release native memory immediately.
+	final void release()
+	{
+		final BitmapLevel2[] segments = this.segments;
+		for(int i = 0; i < segments.length; i++)
+		{
+			final BitmapLevel2 segment = segments[i];
+			if(segment != null)
+			{
+				segment.release();
+				segments[i] = null;
+			}
+		}
+	}
+
 	static BitmapLevel2[] createArray(final int length)
 	{
 		return new BitmapLevel2[length];

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
@@ -14,6 +14,7 @@ package org.eclipse.store.gigamap.types;
  * #L%
  */
 
+import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.EqHashTable;
 import org.eclipse.serializer.persistence.binary.types.BinaryTypeHandler;
 import org.eclipse.serializer.persistence.types.Storer;
@@ -63,6 +64,48 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 	 * @return the updated CustomConstraints instance with the new constraints added
 	 */
 	public CustomConstraints<E> addConstraints(Iterable<? extends CustomConstraint<? super E>> constraints);
+
+	/**
+	 * Ensures the given custom constraint exists (get-or-create).
+	 * <p>
+	 * For details see {@link #ensureConstraints(Iterable)}.
+	 *
+	 * @param constraint the constraint to ensure
+	 * @return this
+	 */
+	public default CustomConstraints<E> ensureConstraint(final CustomConstraint<? super E> constraint)
+	{
+		return this.ensureConstraints(X.List(constraint));
+	}
+
+	/**
+	 * Ensures the given custom constraints exist (get-or-create).
+	 * <p>
+	 * For details see {@link #ensureConstraints(Iterable)}.
+	 *
+	 * @param constraints the constraints to ensure
+	 * @return this
+	 */
+	@SuppressWarnings("unchecked")
+	public default CustomConstraints<E> ensureConstraints(final CustomConstraint<? super E>... constraints)
+	{
+		return this.ensureConstraints(X.List(constraints));
+	}
+
+	/**
+	 * Ensures the given custom constraints exist (get-or-create per constraint).
+	 * <p>
+	 * A constraint whose {@link CustomConstraint#name() name} is already registered is skipped (no-op),
+	 * and its newly passed logic is <b>not</b> applied; the remaining (new) constraints are added and
+	 * validated against all existing entities, exactly like {@link #addConstraints(Iterable)}.
+	 * <p>
+	 * This makes startup schema declaration idempotent: the same call can run on every boot, whether
+	 * the storage is new or already contains the constraints.
+	 *
+	 * @param constraints the constraints to ensure
+	 * @return this
+	 */
+	public CustomConstraints<E> ensureConstraints(Iterable<? extends CustomConstraint<? super E>> constraints);
 
 	/**
 	 * Removes the custom constraint registered under the given name, i.e. stops enforcing it.
@@ -211,6 +254,29 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 
 				this.markStateChangeInstance();
 				this.parent.internalReportConstraintsStateChange();
+			}
+
+			return this;
+		}
+
+		@Override
+		public final CustomConstraints<E> ensureConstraints(final Iterable<? extends CustomConstraint<? super E>> constraints)
+		{
+			synchronized(this.parentMap())
+			{
+				final BulkList<CustomConstraint<? super E>> toAdd = BulkList.New();
+				for(final CustomConstraint<? super E> constraint : constraints)
+				{
+					if(this.elements == null || this.elements.get(constraint.name()) == null)
+					{
+						toAdd.add(constraint);  // absent -> create
+					}
+					// else: already registered under that name -> idempotent no-op
+				}
+				if(!toAdd.isEmpty())
+				{
+					this.addConstraints(toAdd);  // validates only the new constraints against existing entities
+				}
 			}
 
 			return this;

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
@@ -236,6 +236,10 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		{
 			synchronized(this.parentMap())
 			{
+				if(this.parentMap().isReadOnly())
+				{
+					throw new IllegalStateException("Cannot add custom constraint(s): the parent GigaMap is read-only.");
+				}
 				for(final CustomConstraint<? super E> constraint : constraints)
 				{
 					this.validateConstraintToAdd(constraint.name(), constraint);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
@@ -63,9 +63,28 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 	 * @return the updated CustomConstraints instance with the new constraints added
 	 */
 	public CustomConstraints<E> addConstraints(Iterable<? extends CustomConstraint<? super E>> constraints);
-	
-		
-	
+
+	/**
+	 * Removes the custom constraint registered under the given name, i.e. stops enforcing it.
+	 *
+	 * @param name the {@link CustomConstraint#name() name} of the constraint to remove
+	 * @return {@code true} if a constraint with that name existed and was removed, {@code false} otherwise
+	 */
+	public boolean removeConstraint(String name);
+
+	/**
+	 * Removes the given custom constraint, identified by its {@link CustomConstraint#name() name}.
+	 * <p>
+	 * For details see {@link #removeConstraint(String)}.
+	 *
+	 * @param constraint the constraint whose name identifies the constraint to remove
+	 * @return {@code true} if a constraint with that name existed and was removed, {@code false} otherwise
+	 */
+	public default boolean removeConstraint(final CustomConstraint<? super E> constraint)
+	{
+		return this.removeConstraint(constraint.name());
+	}
+
 	public final class Default<E> extends AbstractStateChangeFlagged implements CustomConstraints<E>
 	{
 		///////////////////////////////////////////////////////////////////////////
@@ -196,7 +215,26 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 
 			return this;
 		}
-		
+
+		@Override
+		public final boolean removeConstraint(final String name)
+		{
+			synchronized(this.parentMap())
+			{
+				if(this.elements == null)
+				{
+					return false;
+				}
+				if(this.elements.removeFor(name) == null)
+				{
+					return false;
+				}
+				this.markStateChangeInstance();
+				this.parent.internalReportConstraintsStateChange();
+				return true;
+			}
+		}
+
 		private void validateForExistingEntities(final Iterable<? extends CustomConstraint<? super E>> constraints)
 		{
 			this.parent.iterateIndexed((final long entityId, final E entity) ->

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
@@ -221,6 +221,12 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		{
 			synchronized(this.parentMap())
 			{
+				if(this.parentMap().isReadOnly())
+				{
+					throw new IllegalStateException(
+						"Cannot remove custom constraint \"" + name + "\": the parent GigaMap is read-only."
+					);
+				}
 				if(this.elements == null)
 				{
 					return false;

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -401,6 +401,12 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 		{
 			synchronized(this.parentMap())
 			{
+				if(this.parent.isReadOnly())
+				{
+					throw new IllegalStateException(
+						"Cannot register an index group: the GigaMap is read-only."
+					);
+				}
 				final IndexGroup.Internal<E> indexGroup = category.createIndexGroup(this.parent);
 				
 				@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -18,6 +18,8 @@ import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.persistence.binary.types.BinaryTypeHandler;
 import org.eclipse.serializer.persistence.types.Storer;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.function.Function;
 
 import static org.eclipse.serializer.util.X.notNull;
@@ -106,7 +108,37 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 	 * @return the registered index group corresponding to the specified category
 	 */
 	public <I extends IndexGroup<E>> I register(IndexCategory<E, I> category);
-	
+
+	/**
+	 * Removes the index group of the given category from this {@link GigaMap}, dropping the whole
+	 * group and its data.
+	 * <p>
+	 * If the group implements {@link java.io.Closeable} (e.g. the Lucene full-text index), it is
+	 * closed first to release native resources such as file locks, readers and writers. Index data
+	 * held inside the object graph is reclaimed by the storage's garbage collection on the next
+	 * housekeeping cycle after the surrounding {@link GigaMap} is stored; index artifacts kept in an
+	 * external, application-managed directory on the file system are <b>not</b> deleted.
+	 * <p>
+	 * The core bitmap index group cannot be removed (it hosts the unique and custom constraints);
+	 * use {@link BitmapIndices#removeIndex(String)} to remove individual bitmap indices instead.
+	 *
+	 * @param category the category identifying the index group to remove
+	 * @return {@code true} if a matching group existed and was removed, {@code false} otherwise
+	 * @throws IllegalArgumentException if the targeted group is the core bitmap index group
+	 * @throws RuntimeException if the parent {@link GigaMap} is read-only
+	 */
+	public boolean remove(IndexCategory<E, ?> category);
+
+	/**
+	 * Removes the index group of the given type from this {@link GigaMap}.
+	 * <p>
+	 * For details see {@link #remove(IndexCategory)}.
+	 *
+	 * @param categoryType the type of the index group to remove
+	 * @return {@code true} if a matching group existed and was removed, {@code false} otherwise
+	 */
+	public boolean remove(Class<? extends IndexGroup<E>> categoryType);
+
 	/**
 	 * The Internals interface extends the GigaIndices interface to provide additional functionality
 	 * specifically related to managing internal operations and indices. This interface is meant
@@ -380,8 +412,83 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 				
 				this.indexGroups.add(indexGroup);
 				this.markStateChangeInstance();
-				
+
 				return category.indexType().cast(indexGroup);
+			}
+		}
+
+		@Override
+		public final boolean remove(final IndexCategory<E, ?> category)
+		{
+			return this.internalRemoveGroup(category.indexType());
+		}
+
+		@Override
+		public final boolean remove(final Class<? extends IndexGroup<E>> categoryType)
+		{
+			return this.internalRemoveGroup(categoryType);
+		}
+
+		private boolean internalRemoveGroup(final Class<?> categoryType)
+		{
+			synchronized(this.parentMap())
+			{
+				if(this.parent.isReadOnly())
+				{
+					throw new IllegalStateException(
+						"Cannot remove index group \"" + categoryType.getName() + "\": the GigaMap is read-only."
+					);
+				}
+
+				IndexGroup.Internal<E> found = null;
+				// exact class match is checked first, then the general (e.g. interface) type, mirroring #get.
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					if(indexGroup.getClass() == categoryType)
+					{
+						found = indexGroup;
+						break;
+					}
+				}
+				if(found == null)
+				{
+					for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+					{
+						if(categoryType.isAssignableFrom(indexGroup.getClass()))
+						{
+							found = indexGroup;
+							break;
+						}
+					}
+				}
+				if(found == null)
+				{
+					return false;
+				}
+				if(found instanceof BitmapIndices)
+				{
+					throw new IllegalArgumentException(
+						"The bitmap index group cannot be removed (it hosts the unique and custom constraints); "
+						+ "use BitmapIndices#removeIndex(String) to remove individual bitmap indices."
+					);
+				}
+
+				// release resources
+				if(found instanceof Closeable)
+				{
+					try
+					{
+						((Closeable)found).close();
+					}
+					catch(final IOException e)
+					{
+						throw new RuntimeException(e);
+					}
+				}
+
+				this.indexGroups.removeOne(found);
+				this.markStateChangeInstance();
+				return true;
 			}
 		}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -482,7 +482,11 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 					}
 					catch(final IOException e)
 					{
-						throw new RuntimeException(e);
+						throw new RuntimeException(
+							"Failed to close index group \"" + found.getClass().getName()
+							+ "\" while removing it.",
+							e
+						);
 					}
 				}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -890,7 +890,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				// more than one with...Index method.
 				if(!this.uniqueIndices.isEmpty())
 				{
-					indices.addUniqueConstraints(this.uniqueIndices);
+					indices.ensureUniqueConstraints(this.uniqueIndices);
 				}
 				if(!this.bitmapIndices.isEmpty())
 				{
@@ -903,7 +903,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				}
 				if(!this.customConstraints.isEmpty())
 				{
-					gigaMap.constraints().custom().addConstraints(this.customConstraints);
+					gigaMap.constraints().custom().ensureConstraints(this.customConstraints);
 				}
 
 				return gigaMap;

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
@@ -30,14 +30,17 @@ public interface UniqueConstraints<E> extends GigaConstraints.Category<E>
 {
 	/**
 	 * Adds a unique constraint to the current set of constraints using the provided index name and indexer.
-	 * This constraint ensures that the indexed values for the specified property are unique across all elements.
 	 *
 	 * @param indexName the name of the unique index to be created
 	 * @param indexer the indexer used to extract the property from elements for indexing
 	 * @return the updated instance of {@code UniqueConstraints<E>} with the new unique constraint applied
+	 * @deprecated The {@code indexName} is ignored: a unique constraint is always registered under the
+	 *             indexer's own {@link Indexer#name() name}, consistent with index registration
+	 *             ({@link BitmapIndices#add(Indexer)}). Use {@link #addUniqueConstraint(Indexer)} instead.
 	 */
+	@Deprecated
 	public UniqueConstraints<E> addUniqueConstraint(String indexName, Indexer<? super E, ?> indexer);
-	
+
 	/**
 	 * Adds a unique constraint to the current set of constraints using the given indexer.
 	 * This method ensures that the indexed values for the specified property are unique
@@ -48,7 +51,7 @@ public interface UniqueConstraints<E> extends GigaConstraints.Category<E>
 	 */
 	public default UniqueConstraints<E> addUniqueConstraint(final Indexer<? super E, ?> indexer)
 	{
-		return this.addUniqueConstraint(indexer.name(), indexer);
+		return this.addUniqueConstraints(X.List(indexer));
 	}
 	
 	/**
@@ -76,6 +79,55 @@ public interface UniqueConstraints<E> extends GigaConstraints.Category<E>
 	public UniqueConstraints<E> addUniqueConstraints(Iterable<? extends Indexer<? super E, ?>> indexers);
 
 	/**
+	 * Ensures a unique constraint for the given indexer exists (get-or-create), keyed by the indexer's
+	 * {@link Indexer#name() name}.
+	 * <p>
+	 * If a unique constraint with that name is already registered, this is a no-op and the newly passed
+	 * indexer logic is <b>not</b> applied (consistent with {@link BitmapIndices#ensure(Indexer)}); to
+	 * change the logic, remove it via {@link BitmapIndices#removeIndex(String)} and add it anew.
+	 * Otherwise the constraint is created and validated against all existing entities, exactly like
+	 * {@link #addUniqueConstraint(Indexer)}.
+	 * <p>
+	 * This makes startup schema declaration idempotent: the same call can run on every boot, whether
+	 * the storage is new or already contains the constraint.
+	 *
+	 * @param indexer the indexer used to extract the property from elements for indexing
+	 * @return this
+	 */
+	public UniqueConstraints<E> ensureUniqueConstraint(Indexer<? super E, ?> indexer);
+
+	/**
+	 * Ensures unique constraints for all given indexers exist (get-or-create per indexer).
+	 * <p>
+	 * For details see {@link #ensureUniqueConstraint(Indexer)}.
+	 *
+	 * @param indexers the indexers used to extract properties from elements for indexing
+	 * @return this
+	 */
+	@SuppressWarnings("unchecked")
+	public default UniqueConstraints<E> ensureUniqueConstraints(final Indexer<? super E, ?>... indexers)
+	{
+		return this.ensureUniqueConstraints(X.List(indexers));
+	}
+
+	/**
+	 * Ensures unique constraints for all given indexers exist (get-or-create per indexer).
+	 * <p>
+	 * For details see {@link #ensureUniqueConstraint(Indexer)}.
+	 *
+	 * @param indexers the indexers used to extract properties from elements for indexing
+	 * @return this
+	 */
+	public default UniqueConstraints<E> ensureUniqueConstraints(final Iterable<? extends Indexer<? super E, ?>> indexers)
+	{
+		for(final Indexer<? super E, ?> indexer : indexers)
+		{
+			this.ensureUniqueConstraint(indexer);
+		}
+		return this;
+	}
+
+	/**
 	 * Removes the unique constraint registered under the given index name, i.e. stops enforcing
 	 * uniqueness for that index.
 	 * <p>
@@ -83,7 +135,7 @@ public interface UniqueConstraints<E> extends GigaConstraints.Category<E>
 	 * bitmap index. To remove the index itself, use {@link BitmapIndices#removeIndex(String)}.
 	 * <p>
 	 * Because the demoted index keeps its name, it cannot be re-promoted directly via
-	 * {@link #addUniqueConstraint(String, Indexer)} (that would fail on the already-registered name);
+	 * {@link #addUniqueConstraint(Indexer)} (that would fail on the already-registered name);
 	 * remove the index first with {@link BitmapIndices#removeIndex(String)}, then add the unique
 	 * constraint anew (which re-validates the current data).
 	 *

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
@@ -74,7 +74,40 @@ public interface UniqueConstraints<E> extends GigaConstraints.Category<E>
 	 * @return the updated instance of {@code UniqueConstraints<E>} with the new unique constraints applied
 	 */
 	public UniqueConstraints<E> addUniqueConstraints(Iterable<? extends Indexer<? super E, ?>> indexers);
-	
+
+	/**
+	 * Removes the unique constraint registered under the given index name, i.e. stops enforcing
+	 * uniqueness for that index.
+	 * <p>
+	 * The underlying index is <b>not</b> removed: it remains registered as a regular, queryable
+	 * bitmap index. To remove the index itself, use {@link BitmapIndices#removeIndex(String)}.
+	 * <p>
+	 * Because the demoted index keeps its name, it cannot be re-promoted directly via
+	 * {@link #addUniqueConstraint(String, Indexer)} (that would fail on the already-registered name);
+	 * remove the index first with {@link BitmapIndices#removeIndex(String)}, then add the unique
+	 * constraint anew (which re-validates the current data).
+	 *
+	 * @param indexName the name of the unique constraint to remove
+	 * @return {@code true} if a unique constraint with that name existed and was removed,
+	 *         {@code false} otherwise
+	 */
+	public boolean removeUniqueConstraint(String indexName);
+
+	/**
+	 * Removes the unique constraint registered under the {@link Indexer#name() name} of the given
+	 * indexer.
+	 * <p>
+	 * For details see {@link #removeUniqueConstraint(String)}.
+	 *
+	 * @param indexer the indexer whose name identifies the unique constraint to remove
+	 * @return {@code true} if a unique constraint with that name existed and was removed,
+	 *         {@code false} otherwise
+	 */
+	public default boolean removeUniqueConstraint(final Indexer<? super E, ?> indexer)
+	{
+		return this.removeUniqueConstraint(indexer.name());
+	}
+
 	/**
 	 * Applies the provided logic to each unique constraint in the current category.
 	 * The unique constraints are represented as instances of {@code XImmutableEnum} containing

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintEnsureTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintEnsureTest.java
@@ -211,6 +211,41 @@ public class ConstraintEnsureTest
 	}
 
 	@Test
+	void ensureAndAdd_onReadOnlyMap_throwWhenCreating()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.markReadOnly();
+
+		// creating structure on a read-only map is rejected (consistent with the remove/update guards)
+		assertThrows(RuntimeException.class, () -> map.constraints().unique().ensureUniqueConstraint(UNAME));
+		assertThrows(RuntimeException.class, () -> map.constraints().unique().addUniqueConstraint(UNAME));
+		assertThrows(RuntimeException.class, () -> map.constraints().custom().ensureConstraint(new NoBad()));
+		assertThrows(RuntimeException.class, () -> map.constraints().custom().addConstraint(new NoBad()));
+		assertThrows(RuntimeException.class, () -> map.index().bitmap().add(PLAIN_X));
+
+		map.unmarkReadOnly();
+	}
+
+	@Test
+	void ensure_onReadOnlyMap_noOpWhenAlreadyPresent()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+		map.constraints().custom().addConstraint(new NoBad());
+		map.markReadOnly();
+
+		// an already-satisfied ensure must not mutate -> no-op, no throw (lets a read-only replica run
+		// the identical startup schema declaration)
+		assertDoesNotThrow(() ->
+		{
+			map.constraints().unique().ensureUniqueConstraint(UNAME);
+			map.constraints().custom().ensureConstraint(new NoBad());
+		});
+
+		map.unmarkReadOnly();
+	}
+
+	@Test
 	void ensure_isIdempotentAcrossManyCalls()
 	{
 		final GigaMap<Person> map = GigaMap.New();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintEnsureTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/ConstraintEnsureTest.java
@@ -1,0 +1,231 @@
+package org.eclipse.store.gigamap.constraint;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.CustomConstraint;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers the idempotent {@code ensure*} APIs for unique and custom constraints
+ * ({@link org.eclipse.store.gigamap.types.UniqueConstraints#ensureUniqueConstraint},
+ * {@link org.eclipse.store.gigamap.types.CustomConstraints#ensureConstraint}) — the get-or-create
+ * behaviour that lets startup schema declaration run unchanged on every boot.
+ */
+public class ConstraintEnsureTest
+{
+	static class Person
+	{
+		String name;
+
+		Person()
+		{
+			// for deserialization
+		}
+
+		Person(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	static final BinaryIndexerString<Person> UNAME = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "uname";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	// a plain (non-unique) hashing index and a unique binary index that share the name "x"
+	static final IndexerString<Person> PLAIN_X = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "x";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	static final BinaryIndexerString<Person> UNIQUE_X = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "x";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	// CustomConstraint.AbstractBase#name() is final -> registered under "NoBad"
+	static class NoBad extends CustomConstraint.AbstractSimple<Person>
+	{
+		@Override
+		public boolean isViolated(final Person entity)
+		{
+			return entity.name.contains("BAD");
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Person> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Person>)m.root();
+	}
+
+	@Test
+	void ensureUniqueConstraint_createsThenNoOps()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().ensureUniqueConstraint(UNAME);
+		map.add(new Person("alice"));
+
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("alice")));
+
+		// second ensure is a no-op: must not throw, constraint stays in force
+		assertDoesNotThrow(() -> map.constraints().unique().ensureUniqueConstraint(UNAME));
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("alice")));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	void ensureConstraint_createsThenNoOps()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().custom().ensureConstraint(new NoBad());
+
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("xBADx")));
+
+		assertDoesNotThrow(() -> map.constraints().custom().ensureConstraint(new NoBad()));
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("xBADx")));
+	}
+
+	/**
+	 * The headline restart-safety guarantee: declaring the same schema via {@code ensure*} after a
+	 * reload (where the constraints already exist) must not throw, and the constraints stay enforced.
+	 */
+	@Test
+	void ensure_afterReload_doesNotThrow(@TempDir final Path dir)
+	{
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> map = GigaMap.New();
+			m.setRoot(map);
+			map.constraints().unique().addUniqueConstraint(UNAME);
+			map.constraints().custom().addConstraint(new NoBad());
+			map.add(new Person("alice"));
+			m.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> map = reload(m);
+
+			// unconditional startup declaration against an existing storage -> idempotent, no throw
+			assertDoesNotThrow(() ->
+			{
+				map.constraints().unique().ensureUniqueConstraint(UNAME);
+				map.constraints().custom().ensureConstraint(new NoBad());
+			});
+
+			// both constraints still enforced
+			assertThrows(ConstraintViolationException.class, () -> map.add(new Person("alice")));
+			assertThrows(ConstraintViolationException.class, () -> map.add(new Person("xBADx")));
+		}
+	}
+
+	@Test
+	void ensure_newConstraintOnReloadedPopulatedMap(@TempDir final Path dir)
+	{
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> map = GigaMap.New();
+			m.setRoot(map);
+			map.add(new Person("alice"));
+			map.add(new Person("bob"));
+			m.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> map = reload(m);
+
+			// constraint did not exist before: ensure creates it, validating + indexing existing data
+			map.constraints().unique().ensureUniqueConstraint(UNAME);
+
+			assertThrows(ConstraintViolationException.class, () -> map.add(new Person("alice")));
+			assertEquals(2, map.size());
+		}
+	}
+
+	@Test
+	void ensureUniqueConstraint_existingPlainIndexSameName_throws()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(PLAIN_X); // plain (non-unique) index named "x"
+
+		// ensuring a unique constraint under a name already taken by a non-unique index is a real conflict
+		assertThrows(RuntimeException.class, () -> map.constraints().unique().ensureUniqueConstraint(UNIQUE_X));
+	}
+
+	@Test
+	void ensure_isIdempotentAcrossManyCalls()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		for(int i = 0; i < 3; i++)
+		{
+			map.constraints().unique().ensureUniqueConstraint(UNAME);
+			map.constraints().custom().ensureConstraint(new NoBad());
+		}
+
+		// exactly one unique constraint registered
+		final long[] uniqueCount = {0};
+		map.index().bitmap().accessUniqueConstraints(e -> uniqueCount[0] = e.size());
+		assertEquals(1L, uniqueCount[0]);
+
+		// custom constraint enforced exactly once (no duplicate-name failure occurred above)
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("xBADx")));
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/CustomConstraintRemovalTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/CustomConstraintRemovalTest.java
@@ -1,0 +1,181 @@
+package org.eclipse.store.gigamap.constraint;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.CustomConstraint;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@link org.eclipse.store.gigamap.types.CustomConstraints#removeConstraint(String)} and, via the
+ * reload tests, the durability of custom-constraint structural changes (the {@code elements} table must be
+ * stored eagerly so post-first-store mutations persist).
+ */
+public class CustomConstraintRemovalTest
+{
+	static class Person
+	{
+		String name;
+
+		Person()
+		{
+			// required for deserialization
+		}
+
+		Person(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	// CustomConstraint.AbstractBase#name() is final and returns getClass().getSimpleName(),
+	// so these constraints are registered under "NoBad" / "NoUgly".
+	static class NoBad extends CustomConstraint.AbstractSimple<Person>
+	{
+		@Override
+		public boolean isViolated(final Person entity)
+		{
+			return entity.name.contains("BAD");
+		}
+	}
+
+	static class NoUgly extends CustomConstraint.AbstractSimple<Person>
+	{
+		@Override
+		public boolean isViolated(final Person entity)
+		{
+			return entity.name.contains("UGLY");
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Person> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Person>)m.root();
+	}
+
+	@Test
+	void removeConstraint_previouslyRejectedNowAccepted()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().custom().addConstraint(new NoBad());
+
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("xBADx")));
+
+		assertTrue(map.constraints().custom().removeConstraint("NoBad"));
+
+		map.add(new Person("xBADx")); // now accepted
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	void removeConstraint_unknownName_returnsFalse()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().custom().addConstraint(new NoBad());
+
+		assertFalse(map.constraints().custom().removeConstraint("does-not-exist"));
+	}
+
+	@Test
+	void removeConstraint_isIdempotent()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().custom().addConstraint(new NoBad());
+
+		assertTrue(map.constraints().custom().removeConstraint("NoBad"));
+		assertFalse(map.constraints().custom().removeConstraint("NoBad"));
+	}
+
+	@Test
+	void removeConstraint_oneOfMany_othersStillEnforced()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().custom().addConstraints(new NoBad(), new NoUgly());
+
+		map.constraints().custom().removeConstraint("NoBad");
+
+		map.add(new Person("xBADx")); // no longer rejected
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("xUGLYx")));
+	}
+
+	/**
+	 * Primary regression guard for the eager-store fix: a constraint added before a store and then
+	 * removed after a reload must stay removed across a second reload.
+	 */
+	@Test
+	void removeConstraint_afterReload(@TempDir final Path dir)
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().custom().addConstraint(new NoBad());
+		map.add(new Person("ok"));
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(map, dir))
+		{
+			// stored on close
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			assertTrue(reloaded.constraints().custom().removeConstraint("NoBad"));
+			reloaded.store();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			reloaded.add(new Person("xBADx")); // constraint must stay removed
+			assertEquals(2, reloaded.size());
+		}
+	}
+
+	/**
+	 * Independent guard on the add path: a constraint added <em>after</em> the first store must be
+	 * persisted (this relies on the {@code elements} table being stored eagerly).
+	 */
+	@Test
+	void addConstraint_afterInitialStore_persists(@TempDir final Path dir)
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(map, dir))
+		{
+			// empty map stored on close
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			reloaded.constraints().custom().addConstraint(new NoBad());
+			reloaded.store();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			assertThrows(ConstraintViolationException.class, () -> reloaded.add(new Person("xBADx")));
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/StructuralLifecycleIntegrationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/StructuralLifecycleIntegrationTest.java
@@ -1,0 +1,219 @@
+package org.eclipse.store.gigamap.constraint;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerInteger;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * End-to-end coherence check: a single map carrying several index families, a unique constraint, an
+ * identity index and a custom constraint is mutated structurally (remove / redefine / demote /
+ * removeConstraint) with a store+reload between every step, asserting the surviving structure and
+ * entity data stay correct.
+ */
+public class StructuralLifecycleIntegrationTest
+{
+	static class Person
+	{
+		String name;
+		String email;
+		int    age;
+
+		Person()
+		{
+			// required for deserialization
+		}
+
+		Person(final String name, final String email, final int age)
+		{
+			this.name  = name;
+			this.email = email;
+			this.age   = age;
+		}
+	}
+
+	static final IndexerString<Person> NAME_FIRST_LETTER = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "name";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name.substring(0, 1);
+		}
+	};
+
+	static final IndexerString<Person> NAME_FULL = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "name";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	static final IndexerInteger<Person> AGE = new IndexerInteger.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "age";
+		}
+
+		@Override
+		protected Integer getInteger(final Person e)
+		{
+			return e.age;
+		}
+	};
+
+	static final BinaryIndexerString<Person> EMAIL = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "email";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.email;
+		}
+	};
+
+	static class NoBad extends org.eclipse.store.gigamap.types.CustomConstraint.AbstractSimple<Person>
+	{
+		@Override
+		public boolean isViolated(final Person entity)
+		{
+			return entity.name.contains("BAD");
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Person> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Person>)m.root();
+	}
+
+	@Test
+	void fullStructuralLifecycleAcrossReloads(@TempDir final Path dir)
+	{
+		// 0) initial structure: name (first-letter) + age indexes, unique+identity email, NoBad constraint
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME_FIRST_LETTER);
+		map.index().bitmap().add(AGE);
+		map.index().bitmap().addUniqueConstraint(EMAIL);
+		map.index().bitmap().setIdentityIndices(EMAIL);
+		map.constraints().custom().addConstraint(new NoBad());
+		map.add(new Person("alice", "alice@x.com", 30));
+		map.add(new Person("anna", "anna@x.com", 30));
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(map, dir))
+		{
+			// stored on close
+		}
+
+		// constraints are active right away
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("bob", "alice@x.com", 1))); // dup email
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("xBADx", "bad@x.com", 1))); // NoBad
+
+		// 1) remove the age index
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			r.index().bitmap().removeIndex("age");
+			r.store();
+		}
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			assertNull(r.index().bitmap().get(Integer.class, "age"));
+			assertNotNull(r.index().bitmap().get("name"));
+			assertEquals(2, r.size());
+			assertEquals(2, r.query(NAME_FIRST_LETTER.is("a")).count());
+		}
+
+		// 2) redefine the name index from first-letter to full-name
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			r.index().bitmap().update(NAME_FULL);
+			r.store();
+		}
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			assertEquals(1, r.query(NAME_FULL.is("alice")).count());
+			assertEquals(0, r.query(NAME_FIRST_LETTER.is("a")).count());
+			// email unique constraint still enforced after the unrelated redefine
+			assertThrows(ConstraintViolationException.class, () -> r.add(new Person("zoe", "alice@x.com", 9)));
+		}
+
+		// 3) demote the email unique constraint (still an identity index, still queryable)
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			r.constraints().unique().removeUniqueConstraint("email");
+			r.store();
+		}
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			r.add(new Person("zoe", "alice@x.com", 9)); // duplicate email now allowed
+			assertEquals(3, r.size());
+			assertEquals(2, r.query(EMAIL.is("alice@x.com")).count());
+			r.store();
+		}
+
+		// 4) remove the custom constraint
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			r.constraints().custom().removeConstraint("NoBad");
+			r.store();
+		}
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> r = reload(m);
+			r.add(new Person("xBADx", "bad@x.com", 1)); // NoBad no longer enforced
+			assertEquals(4, r.size());
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/UniqueConstraintRemovalTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/constraint/UniqueConstraintRemovalTest.java
@@ -1,0 +1,206 @@
+package org.eclipse.store.gigamap.constraint;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@link org.eclipse.store.gigamap.types.UniqueConstraints#removeUniqueConstraint(String)}:
+ * demoting a unique index to a plain queryable index (uniqueness no longer enforced, index retained).
+ */
+public class UniqueConstraintRemovalTest
+{
+	static class Person
+	{
+		String name;
+
+		Person()
+		{
+			// required for deserialization
+		}
+
+		Person(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	static final BinaryIndexerString<Person> UNAME = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "uname";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	static final IndexerString<Person> PLAIN = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "plain";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Person> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Person>)m.root();
+	}
+
+	@Test
+	void removeUniqueConstraint_allowsDuplicatesAfterward()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+		map.add(new Person("alice"));
+
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("alice")));
+
+		assertTrue(map.constraints().unique().removeUniqueConstraint("uname"));
+
+		map.add(new Person("alice")); // now allowed
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	void removeUniqueConstraint_indexRemainsQueryable()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+		map.add(new Person("alice"));
+
+		map.constraints().unique().removeUniqueConstraint("uname");
+		map.add(new Person("alice"));
+
+		// the demoted index is still a regular queryable index
+		assertEquals(2, map.query(UNAME.is("alice")).count());
+	}
+
+	@Test
+	void removeUniqueConstraint_unknownName_returnsFalse()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+
+		assertFalse(map.constraints().unique().removeUniqueConstraint("does-not-exist"));
+	}
+
+	@Test
+	void removeUniqueConstraint_nonUniqueIndex_returnsFalse()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(PLAIN); // plain index, not a unique constraint
+
+		assertFalse(map.constraints().unique().removeUniqueConstraint("plain"));
+	}
+
+	@Test
+	void removeUniqueConstraint_isIdempotent()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+
+		assertTrue(map.constraints().unique().removeUniqueConstraint("uname"));
+		assertFalse(map.constraints().unique().removeUniqueConstraint("uname"));
+	}
+
+	@Test
+	void removeUniqueConstraint_lastConstraint_emptiesRegistry()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+
+		map.constraints().unique().removeUniqueConstraint("uname");
+
+		assertTrue(map.index().bitmap().uniqueConstraints() == null
+			|| map.index().bitmap().uniqueConstraints().isEmpty());
+	}
+
+	@Test
+	void removeIndex_thenRePromote_reEnforcesUniqueness()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+		map.add(new Person("alice"));
+
+		// demote, add a duplicate (now allowed)
+		map.constraints().unique().removeUniqueConstraint("uname");
+		map.add(new Person("alice"));
+
+		// re-promoting the still-registered index by the same name is rejected (name already taken);
+		// the index must be removed first, then re-added as a unique constraint.
+		assertThrows(RuntimeException.class, () -> map.constraints().unique().addUniqueConstraint(UNAME));
+
+		map.index().bitmap().removeIndex("uname");
+		// now there are two "alice" entities -> promotion must fail on the existing duplicate
+		assertThrows(ConstraintViolationException.class, () -> map.constraints().unique().addUniqueConstraint(UNAME));
+	}
+
+	@Test
+	void removeUniqueConstraint_afterReload(@TempDir final Path dir)
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.constraints().unique().addUniqueConstraint(UNAME);
+		map.add(new Person("alice"));
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(map, dir))
+		{
+			// stored on close
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			assertTrue(reloaded.constraints().unique().removeUniqueConstraint("uname"));
+			reloaded.store();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			// demotion persisted: duplicate now allowed, index still queryable
+			reloaded.add(new Person("alice"));
+			assertEquals(2, reloaded.size());
+			assertEquals(2, reloaded.query(UNAME.is("alice")).count());
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IndexRemovalTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IndexRemovalTest.java
@@ -1,0 +1,254 @@
+package org.eclipse.store.gigamap.indexer;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the structural removal of a registered bitmap index via {@link org.eclipse.store.gigamap.types.BitmapIndices#removeIndex(String)}.
+ */
+public class IndexRemovalTest
+{
+	static class Person
+	{
+		String name;
+		String city;
+
+		Person()
+		{
+			// required for deserialization
+		}
+
+		Person(final String name, final String city)
+		{
+			this.name = name;
+			this.city = city;
+		}
+	}
+
+	static final IndexerString<Person> NAME = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "name";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	static final IndexerString<Person> CITY = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "city";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.city;
+		}
+	};
+
+	// binary string index -> backing index is suitable as a unique constraint
+	static final BinaryIndexerString<Person> UNAME = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "uname";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Person> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Person>)m.root();
+	}
+
+	@Test
+	void removeIndex_returnsTrue_andIndexGone()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.add(new Person("alice", "NYC"));
+
+		assertNotNull(map.index().bitmap().get("name"));
+		assertTrue(map.index().bitmap().removeIndex("name"));
+		assertNull(map.index().bitmap().get("name"));
+	}
+
+	@Test
+	void removeIndex_unknownName_returnsFalse()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+
+		assertFalse(map.index().bitmap().removeIndex("does-not-exist"));
+	}
+
+	@Test
+	void removeIndex_isIdempotent()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+
+		assertTrue(map.index().bitmap().removeIndex("name"));
+		assertFalse(map.index().bitmap().removeIndex("name"));
+	}
+
+	@Test
+	void removeIndex_siblingIndexesUnaffected()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(CITY);
+		map.add(new Person("alice", "NYC"));
+		map.add(new Person("bob", "NYC"));
+
+		map.index().bitmap().removeIndex("name");
+
+		assertNull(map.index().bitmap().get("name"));
+		assertNotNull(map.index().bitmap().get("city"));
+		assertEquals(2, map.query(CITY.is("NYC")).count());
+	}
+
+	@Test
+	void removeIndex_entitiesIntact()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.add(new Person("alice", "NYC"));
+		map.add(new Person("bob", "LA"));
+
+		map.index().bitmap().removeIndex("name");
+
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	void removeIndex_identityIndex_throws()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().setIdentityIndices(NAME);
+		map.add(new Person("alice", "NYC"));
+
+		assertThrows(RuntimeException.class, () -> map.index().bitmap().removeIndex("name"));
+		assertNotNull(map.index().bitmap().get("name"));
+	}
+
+	@Test
+	void removeIndex_uniqueIndex_alsoLiftsUniqueness()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().addUniqueConstraint(UNAME);
+		map.add(new Person("alice", "NYC"));
+
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("alice", "LA")));
+
+		assertTrue(map.index().bitmap().removeIndex("uname"));
+		assertTrue(map.index().bitmap().uniqueConstraints() == null || map.index().bitmap().uniqueConstraints().isEmpty());
+
+		// duplicate is now allowed
+		map.add(new Person("alice", "LA"));
+		assertEquals(2, map.size());
+	}
+
+	@Test
+	void removeIndex_thenReAddSameName_backfillsExisting()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.add(new Person("alice", "NYC"));
+
+		map.index().bitmap().removeIndex("name");
+		map.index().bitmap().add(NAME); // name freed; re-add must back-fill existing entities
+
+		assertEquals(1, map.query(NAME.is("alice")).count());
+	}
+
+	@Test
+	void removeIndex_readOnly_throws()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.add(new Person("alice", "NYC"));
+		map.markReadOnly();
+
+		assertThrows(RuntimeException.class, () -> map.index().bitmap().removeIndex("name"));
+		assertNotNull(map.index().bitmap().get("name"));
+
+		map.unmarkReadOnly();
+	}
+
+	@Test
+	void removeIndex_afterReload(@TempDir final Path dir)
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(CITY);
+		map.add(new Person("alice", "NYC"));
+		map.add(new Person("bob", "NYC"));
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(map, dir))
+		{
+			// initial state stored on close
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			assertTrue(reloaded.index().bitmap().removeIndex("name"));
+			reloaded.store();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			assertNull(reloaded.index().bitmap().get("name"));
+			assertNotNull(reloaded.index().bitmap().get("city"));
+			assertEquals(2, reloaded.query(CITY.is("NYC")).count());
+			assertEquals(2, reloaded.size());
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IndexerRedefinitionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IndexerRedefinitionTest.java
@@ -309,6 +309,27 @@ public class IndexerRedefinitionTest
 	}
 
 	@Test
+	void repeatedUpdateReleasesOffHeapWithoutCorruption()
+	{
+		// Each update() drops the previous index and deterministically frees its off-heap bitmap memory.
+		// Repeating it over a populated index would crash (double-free / use-after-free) if that release
+		// were wrong, and must keep producing correct query results.
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(FULL_NAME);
+		for(int i = 0; i < 300; i++)
+		{
+			map.add(new Person("name" + i));
+		}
+
+		for(int cycle = 0; cycle < 30; cycle++)
+		{
+			map.index().bitmap().update(FULL_NAME);
+			assertEquals(1, map.query(FULL_NAME.is("name123")).count());
+		}
+		assertEquals(300, map.size());
+	}
+
+	@Test
 	void ensure_doesNotUpdateLogic()
 	{
 		final GigaMap<Person> map = GigaMap.New();

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IndexerRedefinitionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/IndexerRedefinitionTest.java
@@ -1,0 +1,326 @@
+package org.eclipse.store.gigamap.indexer;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerInteger;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers {@link org.eclipse.store.gigamap.types.BitmapIndices#update(org.eclipse.store.gigamap.types.Indexer)}:
+ * replacing an existing index' logic and rebuilding its data from all current entities, including
+ * unique-constraint and identity-index preservation.
+ */
+public class IndexerRedefinitionTest
+{
+	static class Person
+	{
+		String name;
+
+		Person()
+		{
+			// required for deserialization
+		}
+
+		Person(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	// two indexers registered under the SAME name "key", but different logic
+	static final IndexerString<Person> FIRST_LETTER = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "key";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name.substring(0, 1);
+		}
+	};
+
+	static final IndexerString<Person> FULL_NAME = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "key";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	static final IndexerInteger<Person> NAME_LENGTH = new IndexerInteger.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "key";
+		}
+
+		@Override
+		protected Integer getInteger(final Person e)
+		{
+			return e.name.length();
+		}
+	};
+
+	// case-sensitive vs case-folding binary string indexers, both named "u" (suitable as unique)
+	static final BinaryIndexerString<Person> U_CASE_SENSITIVE = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "u";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	static final BinaryIndexerString<Person> U_LOWERCASE = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "u";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name.toLowerCase();
+		}
+	};
+
+	static final IndexerString<Person> NAME_IDENTITY = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "name";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	static final IndexerString<Person> NAME_IDENTITY_2 = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "name";
+		}
+
+		@Override
+		protected String getString(final Person e)
+		{
+			return e.name;
+		}
+	};
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Person> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Person>)m.root();
+	}
+
+	@Test
+	void update_rebuildsAllExistingEntities()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(FIRST_LETTER);
+		map.add(new Person("alice"));
+		map.add(new Person("anna"));
+		map.add(new Person("bob"));
+
+		assertEquals(2, map.query(FIRST_LETTER.is("a")).count());
+
+		map.index().bitmap().update(FULL_NAME);
+
+		// data was rebuilt under the new (full-name) logic
+		assertEquals(1, map.query(FULL_NAME.is("alice")).count());
+		assertEquals(1, map.query(FULL_NAME.is("anna")).count());
+		assertEquals(0, map.query(FIRST_LETTER.is("a")).count()); // no entity's full name is "a"
+	}
+
+	@Test
+	void update_emptyMap_swapsLogic()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(FIRST_LETTER);
+
+		map.index().bitmap().update(FULL_NAME);
+		map.add(new Person("alice"));
+
+		assertEquals(1, map.query(FULL_NAME.is("alice")).count());
+	}
+
+	@Test
+	void update_unknownName_throws()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+
+		assertThrows(RuntimeException.class, () -> map.index().bitmap().update(FULL_NAME));
+	}
+
+	@Test
+	void update_preservesUniqueConstraint()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().addUniqueConstraint(U_CASE_SENSITIVE);
+		map.add(new Person("alice"));
+		map.add(new Person("bob"));
+
+		map.index().bitmap().update(U_LOWERCASE);
+
+		// uniqueness is still enforced under the new logic
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("ALICE")));
+		assertEquals(1, map.index().bitmap().uniqueConstraints().size());
+	}
+
+	@Test
+	void update_uniqueViolationDuringRebuild_throws_andKeepsOldIndex()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().addUniqueConstraint(U_CASE_SENSITIVE);
+		map.add(new Person("Alice"));
+		map.add(new Person("alice")); // distinct under case-sensitive logic
+
+		// under the lowercase logic both collapse to "alice" -> rebuild must fail
+		assertThrows(ConstraintViolationException.class, () -> map.index().bitmap().update(U_LOWERCASE));
+
+		// atomic failure: entities intact and the original (case-sensitive) constraint still enforced
+		assertEquals(2, map.size());
+		assertThrows(ConstraintViolationException.class, () -> map.add(new Person("Alice")));
+	}
+
+	@Test
+	void update_preservesIdentityIndex()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(NAME_IDENTITY);
+		map.index().bitmap().setIdentityIndices(NAME_IDENTITY);
+		map.add(new Person("alice"));
+
+		map.index().bitmap().update(NAME_IDENTITY_2);
+
+		// identity-based lookup (used by update) must resolve via the rebuilt index
+		final Person alice = map.query(NAME_IDENTITY.is("alice")).toList().get(0);
+		map.update(alice, p -> p.name = "alice2");
+
+		assertEquals(1, map.query(NAME_IDENTITY.is("alice2")).count());
+		assertEquals(0, map.query(NAME_IDENTITY.is("alice")).count());
+	}
+
+	@Test
+	void update_changedKeyType()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(FULL_NAME);
+		map.add(new Person("alice")); // length 5
+		map.add(new Person("bob"));   // length 3
+
+		map.index().bitmap().update(NAME_LENGTH);
+
+		assertEquals(1, map.query(NAME_LENGTH.is(5)).count());
+		assertEquals(1, map.query(NAME_LENGTH.is(3)).count());
+	}
+
+	@Test
+	void update_readOnly_throws()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(FIRST_LETTER);
+		map.add(new Person("alice"));
+		map.markReadOnly();
+
+		assertThrows(RuntimeException.class, () -> map.index().bitmap().update(FULL_NAME));
+
+		map.unmarkReadOnly();
+	}
+
+	@Test
+	void update_afterReload(@TempDir final Path dir)
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(FIRST_LETTER);
+		map.add(new Person("alice"));
+		map.add(new Person("anna"));
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(map, dir))
+		{
+			// stored on close
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			reloaded.index().bitmap().update(FULL_NAME);
+			reloaded.store();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Person> reloaded = reload(m);
+			assertEquals(1, reloaded.query(FULL_NAME.is("alice")).count());
+			assertEquals(1, reloaded.query(FULL_NAME.is("anna")).count());
+			assertEquals(0, reloaded.query(FIRST_LETTER.is("a")).count());
+		}
+	}
+
+	@Test
+	void ensure_doesNotUpdateLogic()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		map.index().bitmap().add(FIRST_LETTER);
+		map.add(new Person("alice"));
+		map.add(new Person("anna"));
+		map.add(new Person("bob"));
+
+		// ensure is get-or-create: it returns the existing index unchanged and ignores FULL_NAME's logic
+		assertNotNull(map.index().bitmap().ensure(FULL_NAME));
+
+		assertEquals(2, map.query(FIRST_LETTER.is("a")).count()); // still first-letter logic
+		assertEquals(0, map.query(FULL_NAME.is("alice")).count()); // logic was NOT switched
+	}
+}

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
@@ -283,6 +283,12 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
         {
             synchronized(this.parentMap())
             {
+                if(this.parent.isReadOnly())
+                {
+                    throw new IllegalStateException(
+                        "Cannot add vector index \"" + name + "\": the GigaMap is read-only."
+                    );
+                }
                 this.validateIndexToAdd(name);
 
                 final VectorIndex.Internal<E> index = new VectorIndex.Default<>(

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
@@ -22,6 +22,7 @@ import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.serializer.typing.KeyValue;
 import org.eclipse.store.gigamap.types.*;
 
+import java.io.Closeable;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
@@ -74,6 +75,20 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
      * @return the found index or {@code null}
      */
     public VectorIndex<E> get(String name);
+
+    /**
+     * Removes the vector index registered under the given name, dropping it and its data.
+     * <p>
+     * The index is {@link VectorIndex#close() closed} first to release its background, search and
+     * (if any) disk resources. Vector data held inside the object graph is reclaimed by the storage's
+     * garbage collection on the next housekeeping cycle after the surrounding {@link GigaMap} is
+     * stored; index artifacts kept in an external, application-managed directory are not deleted.
+     *
+     * @param name the name of the index to remove
+     * @return {@code true} if an index with that name existed and was removed, {@code false} otherwise
+     * @throws RuntimeException if the parent {@link GigaMap} is read-only
+     */
+    public boolean removeIndex(String name);
 
     /**
      * Accesses the indices table.
@@ -130,7 +145,7 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
     }
 
 
-    public final class Default<E> extends AbstractStateChangeFlagged implements Internal<E>
+    public final class Default<E> extends AbstractStateChangeFlagged implements Internal<E>, Closeable
     {
         static BinaryTypeHandler<Default<?>> provideTypeHandler()
         {
@@ -304,6 +319,46 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
             synchronized(this.parentMap())
             {
                 return this.internalGet(name);
+            }
+        }
+
+        @Override
+        public boolean removeIndex(final String name)
+        {
+            synchronized(this.parentMap())
+            {
+                if(this.parent.isReadOnly())
+                {
+                    throw new IllegalStateException(
+                        "Cannot remove vector index \"" + name + "\": the GigaMap is read-only."
+                    );
+                }
+                final VectorIndex.Internal<E> index = this.vectorIndices.get(name);
+                if(index == null)
+                {
+                    return false;
+                }
+                index.close(); // release background/disk/searcher resources before dropping the index
+                this.vectorIndices.removeFor(name);
+                this.markStateChangeInstance();
+                this.parent.internalReportIndexGroupStateChange(this);
+                return true;
+            }
+        }
+
+        /**
+         * Closes all contained vector indices, releasing their native resources. Invoked when the
+         * whole vector index group is removed via {@link GigaIndices#remove(IndexCategory)}.
+         */
+        @Override
+        public void close()
+        {
+            synchronized(this.parentMap())
+            {
+                for(final VectorIndex.Internal<E> index : this.vectorIndices.values())
+                {
+                    index.close();
+                }
             }
         }
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
@@ -1,0 +1,196 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexGroup;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the structural lifecycle of vector indices: {@link VectorIndices#removeIndex(String)},
+ * {@link VectorIndices#update(String, VectorIndexConfiguration, Vectorizer)} and whole-group removal
+ * via {@link org.eclipse.store.gigamap.types.GigaIndices#remove(org.eclipse.store.gigamap.types.IndexCategory)}.
+ */
+@Tag("slow")
+class VectorIndexLifecycleTest
+{
+	static final class Doc
+	{
+		final float[] embedding;
+
+		Doc()
+		{
+			this.embedding = null; // for deserialization
+		}
+
+		Doc(final float[] embedding)
+		{
+			this.embedding = embedding;
+		}
+	}
+
+	static class EmbeddingVectorizer extends Vectorizer<Doc>
+	{
+		@Override
+		public float[] vectorize(final Doc entity)
+		{
+			return entity.embedding;
+		}
+
+		@Override
+		public boolean isEmbedded()
+		{
+			return true;
+		}
+	}
+
+	private static VectorIndexConfiguration config()
+	{
+		return VectorIndexConfiguration.builder()
+			.dimension(3)
+			.similarityFunction(VectorSimilarityFunction.COSINE)
+			.build();
+	}
+
+	private static void addDocs(final GigaMap<Doc> map)
+	{
+		map.add(new Doc(new float[]{1.0f, 0.0f, 0.0f}));
+		map.add(new Doc(new float[]{0.0f, 1.0f, 0.0f}));
+		map.add(new Doc(new float[]{0.0f, 0.0f, 1.0f}));
+	}
+
+	@Test
+	void removeIndex_returnsTrue_andIndexGone()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+		vi.add("emb", config(), new EmbeddingVectorizer());
+		addDocs(map);
+
+		assertEquals(3, vi.get("emb").search(new float[]{1.0f, 0.0f, 0.0f}, 3).size());
+
+		assertTrue(vi.removeIndex("emb"));
+		assertNull(vi.get("emb"));
+		assertFalse(vi.removeIndex("emb")); // idempotent
+	}
+
+	@Test
+	void removeIndex_siblingIndexUnaffected()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+		vi.add("a", config(), new EmbeddingVectorizer());
+		vi.add("b", config(), new EmbeddingVectorizer());
+		addDocs(map);
+
+		vi.removeIndex("a");
+
+		assertNull(vi.get("a"));
+		assertNotNull(vi.get("b"));
+		assertEquals(3, vi.get("b").search(new float[]{1.0f, 0.0f, 0.0f}, 3).size());
+	}
+
+	@Test
+	void removeIndex_unknownName_returnsFalse()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+
+		assertFalse(vi.removeIndex("nope"));
+	}
+
+	@Test
+	void removeIndex_readOnly_throws()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+		vi.add("emb", config(), new EmbeddingVectorizer());
+		addDocs(map);
+		map.markReadOnly();
+
+		assertThrows(RuntimeException.class, () -> vi.removeIndex("emb"));
+		assertNotNull(vi.get("emb"));
+
+		map.unmarkReadOnly();
+	}
+
+	@Test
+	void removeWholeVectorGroup()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+		vi.add("emb", config(), new EmbeddingVectorizer());
+		addDocs(map);
+
+		assertTrue(map.index().remove(VectorIndices.Category())); // closes child indices
+		assertNull(map.index().get(VectorIndices.Category()));
+		assertFalse(map.index().remove(VectorIndices.Category())); // already gone
+	}
+
+	@Test
+	void removeBitmapGroup_throws()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		@SuppressWarnings("unchecked")
+		final Class<? extends IndexGroup<Doc>> bitmapType =
+			(Class<? extends IndexGroup<Doc>>)(Class<?>)BitmapIndices.class;
+
+		assertThrows(IllegalArgumentException.class, () -> map.index().remove(bitmapType));
+	}
+
+	@Test
+	void removeIndex_afterReload(@TempDir final Path dir)
+	{
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Doc> map = GigaMap.New();
+			storage.setRoot(map);
+			final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+			vi.add("emb", config(), new EmbeddingVectorizer());
+			addDocs(map);
+			storage.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Doc> map = storage.root();
+			final VectorIndices<Doc> vi = map.index().get(VectorIndices.Category());
+			assertTrue(vi.removeIndex("emb"));
+			storage.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Doc> map = storage.root();
+			final VectorIndices<Doc> vi = map.index().get(VectorIndices.Category());
+			assertNull(vi.get("emb"));   // removal persisted
+			assertEquals(3, map.size()); // entity data intact
+		}
+	}
+}

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
@@ -33,9 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Covers the structural lifecycle of vector indices: {@link VectorIndices#removeIndex(String)},
- * {@link VectorIndices#update(String, VectorIndexConfiguration, Vectorizer)} and whole-group removal
- * via {@link org.eclipse.store.gigamap.types.GigaIndices#remove(org.eclipse.store.gigamap.types.IndexCategory)}.
+ * Covers the structural lifecycle of vector indices: {@link VectorIndices#removeIndex(String)} and
+ * whole-group removal via
+ * {@link org.eclipse.store.gigamap.types.GigaIndices#remove(org.eclipse.store.gigamap.types.IndexCategory)}.
  */
 @Tag("slow")
 class VectorIndexLifecycleTest

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleRemovalTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleRemovalTest.java
@@ -1,0 +1,153 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.apache.lucene.document.Document;
+import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexGroup;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers structural lifecycle of the Lucene full-text index group: whole-group removal via
+ * {@link org.eclipse.store.gigamap.types.GigaIndices#remove(org.eclipse.store.gigamap.types.IndexCategory)}
+ * and redefinition via {@link LuceneIndex#update(LuceneContext)}.
+ */
+public class LuceneLifecycleRemovalTest
+{
+	static class Article
+	{
+		String title;
+		String content;
+
+		Article()
+		{
+			// for deserialization
+		}
+
+		Article(final String title, final String content)
+		{
+			this.title   = title;
+			this.content = content;
+		}
+	}
+
+	/** Indexes the title only. */
+	static class TitleOnlyPopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			document.add(createTextField("title", entity.title));
+		}
+	}
+
+	// GraphDirectory context (data lives inside the GigaMap, so it survives EmbeddedStorage reload)
+	private static LuceneContext<Article> titleOnly()
+	{
+		return LuceneContext.New(new TitleOnlyPopulator());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Article> reload(final EmbeddedStorageManager m)
+	{
+		return (GigaMap<Article>)m.root();
+	}
+
+	@Test
+	void removeWholeLuceneGroup()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(titleOnly()));
+		map.add(new Article("eclipse", "persistent"));
+		assertEquals(1, idx.query("title:eclipse").size());
+
+		assertTrue(map.index().remove(LuceneIndex.Category(titleOnly())));
+		assertNull(map.index().get(LuceneIndex.Category(titleOnly())));
+
+		// the lock was released: a fresh group can be registered again
+		assertNotNull(map.index().register(LuceneIndex.Category(titleOnly())));
+	}
+
+	@Test
+	void removeLuceneGroup_unknown_returnsFalse()
+	{
+		final GigaMap<Article> map = GigaMap.New(); // no lucene group registered
+		assertFalse(map.index().remove(LuceneIndex.Category(titleOnly())));
+	}
+
+	@Test
+	void removeLuceneGroup_readOnly_throws()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		map.index().register(LuceneIndex.Category(titleOnly()));
+		map.markReadOnly();
+
+		assertThrows(RuntimeException.class, () -> map.index().remove(LuceneIndex.Category(titleOnly())));
+		assertNotNull(map.index().get(LuceneIndex.Category(titleOnly())));
+
+		map.unmarkReadOnly();
+	}
+
+	@Test
+	void removeBitmapGroup_throws()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		@SuppressWarnings("unchecked")
+		final Class<? extends IndexGroup<Article>> bitmapType =
+			(Class<? extends IndexGroup<Article>>)(Class<?>)BitmapIndices.class;
+
+		assertThrows(IllegalArgumentException.class, () -> map.index().remove(bitmapType));
+	}
+
+	@Test
+	void removeLuceneGroup_afterReload(@TempDir final Path dir)
+	{
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Article> map = GigaMap.New();
+			m.setRoot(map);
+			map.index().register(LuceneIndex.Category(titleOnly()));
+			map.add(new Article("eclipse", "persistent"));
+			m.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Article> map = reload(m);
+			assertTrue(map.index().remove(LuceneIndex.Category(titleOnly())));
+			m.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager m = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Article> map = reload(m);
+			assertNull(map.index().get(LuceneIndex.Category(titleOnly()))); // removal persisted
+			assertEquals(1, map.size());                                    // entity data intact
+		}
+	}
+}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleRemovalTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleRemovalTest.java
@@ -34,8 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Covers structural lifecycle of the Lucene full-text index group: whole-group removal via
- * {@link org.eclipse.store.gigamap.types.GigaIndices#remove(org.eclipse.store.gigamap.types.IndexCategory)}
- * and redefinition via {@link LuceneIndex#update(LuceneContext)}.
+ * {@link org.eclipse.store.gigamap.types.GigaIndices#remove(org.eclipse.store.gigamap.types.IndexCategory)}.
  */
 public class LuceneLifecycleRemovalTest
 {


### PR DESCRIPTION
## Summary

The GigaMap index/constraint management API was **append-only** — once registered, an index, constraint, or index group could never be removed, and there was no way to change an index's logic. This PR adds the missing structural lifecycle operations as the counterpart to registration, across the bitmap, vector, and Lucene families.

It is the structural-API follow-up to the data-path indexer fixes in #685–#693.

## Commits

1. **Add structural lifecycle API for GigaMap indexers and constraints** — bitmap-family removal + redefinition, constraint removal, eager-store persistence fix.
2. **Support removing index groups and vector indices from GigaMap** — generic index-group removal (covers Lucene) and named vector-index removal.

## What's included

### Bitmap indices & constraints (`gigamap`)
- `BitmapIndices.removeIndex(String | IndexIdentifier)` — drop an index and its data; lifts uniqueness if it was a unique constraint; rejects removing an active identity index.
- `BitmapIndices.update(Indexer)` — replace an existing index's logic and rebuild it from all current entities, preserving unique-constraint / identity-index membership (uniqueness is re-validated *before* the old index is dropped, so a violation leaves it intact).
- `UniqueConstraints.removeUniqueConstraint(String | Indexer)` — demote a unique index to a plain queryable index.
- `CustomConstraints.removeConstraint(String | CustomConstraint)`.
- Clarified `ensure(...)` Javadoc (get-or-create; never updates logic — use `update`).
- Persistence fix: `BinaryHandlerCustomConstraintsDefault` now stores the constraint table eagerly, so post-first-store constraint changes survive reload.

### Index groups, vector & Lucene
- `GigaIndices.remove(IndexCategory | Class)` — remove a whole index group. Closes the group if `Closeable` (releasing Lucene directory/writer locks); rejects removing the core bitmap group (it hosts the constraints); read-only-guarded. This is the removal mechanism for the single-group Lucene full-text index.
- `VectorIndices.removeIndex(String)` — close and drop a named vector index; `VectorIndices` is now `Closeable` so whole-group removal releases all child indices' resources.

## Semantics & design

- Every operation mirrors an existing `add`/`register` path in reverse: mutate the registry → mark state change → on the next `store()` the smaller graph is persisted and the orphaned subgraph is reclaimed by storage GC. All operations lock on the parent map.
- Removals return `boolean` (idempotent, `false` = nothing to remove); `update` throws if the target doesn't exist.
- "Close handles only": native resources are closed, in-graph data is GC-reclaimed, but externally managed on-disk directories (vector `DiskIndexManager`, Lucene `MMapDirectory`) are **not** deleted.

## Not included (follow-up)

Redefining (rebuilding) an existing **vector** or **Lucene** index is intentionally **deferred**.
Unlike bitmap indices, these carry engine-internal state that the tear-down/rebuild fights: jvector's named on-disk HNSW graph (a same-named rebuild reloads the prior graph and collides on node ids) and Lucene's GraphDirectory segment persistence (a rebuilt index doesn't survive a subsequent reload). Removal works cleanly for both; redefinition needs dedicated engine-specific work and is tracked separately.

## Testing

New tests cover in-memory + store/reload round-trips: per-name and whole-group removal, sibling isolation, unknown/idempotent returns, read-only and bitmap-group guards, unique demotion, custom constraint removal (incl. eager-store durability guards), and bitmap redefinition (rebuild, unique/identity preservation, atomic-failure).
