### PR TITLE
bump spring boot version to 3.5.14

### DIFF
--- a/integrations/itest/pom.xml
+++ b/integrations/itest/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.5.13</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.14</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3-console/pom.xml
+++ b/integrations/spring-boot3-console/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.5.13</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.14</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3/pom.xml
+++ b/integrations/spring-boot3/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.5.13</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.14</org.springframework.boot.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request updates the Spring Boot dependency version across multiple integration modules to ensure consistency and to include the latest bug fixes and improvements.

Dependency version updates:

* Bumped the `org.springframework.boot.version` property from `3.5.13` to `3.5.14` in the following `pom.xml` files:
  - `integrations/itest/pom.xml`
  - `integrations/spring-boot3-console/pom.xml`
  - `integrations/spring-boot3/pom.xml`