### PR TITLE
GigaMap: compile-time index metamodel (annotation processor) with Lucene & JVector wiring

### DIFF
--- a/docs/modules/gigamap/pages/indexing/annotations.adoc
+++ b/docs/modules/gigamap/pages/indexing/annotations.adoc
@@ -105,9 +105,11 @@ gigaMap.index().get(VectorIndices.class).get("embedding").search(queryVector, 10
 
 The processor depends only on the GigaMap core and reads the `@FullText` / `@Vector` annotations by name, so bitmap-only projects do not pull the Lucene / JVector libraries onto the processor path; the generated code references those types, which are on your classpath whenever you use the annotations.
 
+A custom `@Index(creator = ...)` is wired up too: the processor generates a constant initialized from the creator and registers it (a plain creator via `new TheCreator().create()`; a `Creator.MemberAware` is handed the index name and the member first). Because the creator decides the indexer at runtime, the constant is typed `Indexer<Entity, K>` (the key type `K` is taken from the creator's `Creator<E,K>` binding when concrete, else a wildcard), which supports equality queries (`Entity_.code.is(value)`); flavor-specific methods are not exposed. The creator must be referenceable from the entity's package (a `public`, or same-package, class with an accessible no-argument constructor); otherwise the processor emits a note and leaves that index to the runtime generator.
+
 The metamodel name suffix (default `_`, e.g. `Person` \-> `Person_`) is configurable via the processor option `-Agigamap.metamodel.suffix=...`.
 
-NOTE: A custom `@Index(creator = ...)` and `@Vector(onDisk = true)` cannot be reproduced at compile time. The processor skips them with a compiler note; register those via the runtime `IndexerGenerator` / `VectorAnnotationHandler.New(Path)`. The compile-time metamodel complements the runtime generator rather than replacing it — both resolve indices by name, so they interoperate.
+NOTE: `@Vector(onDisk = true)` cannot be reproduced at compile time (it needs an index directory) and an inaccessible custom creator falls back to the runtime path; both are skipped with a compiler note — register those via the runtime `IndexerGenerator` / `VectorAnnotationHandler.New(Path)`. The compile-time metamodel complements the runtime generator rather than replacing it — both resolve indices by name, so they interoperate.
 
 NOTE: Because the generated code uses getters and package-accessible fields (never reflection), no JPMS `opens` is required for the compile-time path.
 

--- a/docs/modules/gigamap/pages/indexing/annotations.adoc
+++ b/docs/modules/gigamap/pages/indexing/annotations.adoc
@@ -111,7 +111,7 @@ The metamodel name suffix (default `_`, e.g. `Person` \-> `Person_`) is configur
 
 NOTE: `@Vector(onDisk = true)` cannot be reproduced at compile time (it needs an index directory) and an inaccessible custom creator falls back to the runtime path; both are skipped with a compiler note — register those via the runtime `IndexerGenerator` / `VectorAnnotationHandler.New(Path)`. The compile-time metamodel complements the runtime generator rather than replacing it — both resolve indices by name, so they interoperate.
 
-NOTE: Because the generated code uses getters and package-accessible fields (never reflection), no JPMS `opens` is required for the compile-time path.
+NOTE: The generated bitmap, spatial, full-text and vector reads use getters and package-accessible fields rather than reflection, so the compile-time path needs no JPMS `opens`. The one exception is a `Creator.MemberAware` creator, whose member is resolved with `getDeclaredField` / `getDeclaredMethod` — but that reflection targets the entity's own module, which is allowed without `opens`.
 
 == Adding your own annotation handler
 

--- a/docs/modules/gigamap/pages/indexing/annotations.adoc
+++ b/docs/modules/gigamap/pages/indexing/annotations.adoc
@@ -58,6 +58,59 @@ IndexerGenerator.generate(Article.class, gigaMap,
 
 Registration uses explicit handlers (no classpath scanning), so only the modules you depend on participate.
 
+== Compile-time metamodel (annotation processor)
+
+`IndexerGenerator` builds the indexers reflectively at runtime. As an alternative, the optional `gigamap-codegen` module is an annotation processor that, at *compile* time, generates a sibling metamodel class `+<Entity>_+` for each annotated entity — typed `public static final` indexer constants plus a `registerIndices(GigaMap)` helper. This gives you compile-time index names, IDE autocomplete and refactor-safety, and reads members through getters / accessible fields instead of reflection.
+
+Add the processor to the `maven-compiler-plugin` (it is only needed at compile time, not at runtime):
+
+[source, xml, subs=attributes+]
+----
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        <annotationProcessorPaths>
+            <path>
+                <groupId>org.eclipse.store</groupId>
+                <artifactId>gigamap-codegen</artifactId>
+                <version>{maven-version}</version>
+            </path>
+        </annotationProcessorPaths>
+    </configuration>
+</plugin>
+----
+
+For an annotated `Person`, the processor emits `Person_` (into `target/generated-sources/annotations`) with a typed constant per bitmap / spatial index and an idempotent registration helper. Query through the constants just like hand-written ones:
+
+[source, java]
+----
+GigaMap<Person> gigaMap = GigaMap.New();
+Person_.registerIndices(gigaMap);   // ensures all indices, unique constraints, identity indices
+
+gigaMap.query(Person_.firstName.startsWith("J"));
+gigaMap.query(Person_.score.between(10, 20));
+----
+
+`registerIndices(...)` is idempotent and reload-safe: call it on a freshly created map or re-run it on a map loaded from storage (re-registration is a no-op, like the runtime generator).
+
+`@FullText` and `@Vector` are wired up too, but — unlike bitmap indices — without a typed query constant, since a `LuceneIndex` / `VectorIndex` is a per-map runtime object. For these the processor generates a reflection-free `DocumentPopulator` / `Vectorizer` and registers the index inside `registerIndices(...)` (using in-graph / in-memory defaults); you still query through the runtime handle:
+
+[source, java]
+----
+Article_.registerIndices(gigaMap);
+gigaMap.index().get(LuceneIndex.class).query("title:gigamap");
+gigaMap.index().get(VectorIndices.class).get("embedding").search(queryVector, 10);
+----
+
+The processor depends only on the GigaMap core and reads the `@FullText` / `@Vector` annotations by name, so bitmap-only projects do not pull the Lucene / JVector libraries onto the processor path; the generated code references those types, which are on your classpath whenever you use the annotations.
+
+The metamodel name suffix (default `_`, e.g. `Person` \-> `Person_`) is configurable via the processor option `-Agigamap.metamodel.suffix=...`.
+
+NOTE: A custom `@Index(creator = ...)` and `@Vector(onDisk = true)` cannot be reproduced at compile time. The processor skips them with a compiler note; register those via the runtime `IndexerGenerator` / `VectorAnnotationHandler.New(Path)`. The compile-time metamodel complements the runtime generator rather than replacing it — both resolve indices by name, so they interoperate.
+
+NOTE: Because the generated code uses getters and package-accessible fields (never reflection), no JPMS `opens` is required for the compile-time path.
+
 == Adding your own annotation handler
 
 An index type outside the core module participates by implementing `GigaIndexAnnotationHandler`. The handler reflects over the entity type for the annotations it owns and registers the matching `IndexCategory` on the supplied `GigaIndices`; it must be a no-op when the type carries none of its annotations.

--- a/docs/modules/gigamap/pages/indexing/bitmap/defining.adoc
+++ b/docs/modules/gigamap/pages/indexing/bitmap/defining.adoc
@@ -244,6 +244,10 @@ For a `GigaMap` loaded from existing storage the indexers are already registered
 generation on the loaded map to obtain a fresh handle — re-registration is a no-op, and the returned indexers
 query correctly because they resolve against the registered index by name.
 
+TIP: To get typed constants at *compile* time instead of a runtime registry — `Person_.firstName.startsWith("J")`
+with IDE autocomplete and refactor-safe names — use the `gigamap-codegen` annotation processor (see
+xref:indexing/annotations.adoc#_compile_time_metamodel_annotation_processor[Compile-time metamodel]).
+
 Alternatively, retrieve an indexer directly from the `BitmapIndices` getter API by name:
 
 [source, java]

--- a/gigamap/codegen-test/LICENSE
+++ b/gigamap/codegen-test/LICENSE
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/gigamap/codegen-test/pom.xml
+++ b/gigamap/codegen-test/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.store</groupId>
+        <artifactId>gigamap-parent</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gigamap-codegen-test</artifactId>
+
+    <name>EclipseStore GigaMap Codegen Tests</name>
+    <description>Tests for the GigaMap index metamodel annotation processor (test sources only)</description>
+    <url>https://projects.eclipse.org/projects/technology.store</url>
+
+    <properties>
+        <!-- not published -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.store</groupId>
+            <artifactId>gigamap</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.store</groupId>
+            <artifactId>gigamap-codegen</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.store</groupId>
+            <artifactId>storage-embedded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <proc>full</proc>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.eclipse.store</groupId>
+                                    <artifactId>gigamap-codegen</artifactId>
+                                    <version>${project.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <annotationProcessors>
+                                <annotationProcessor>org.eclipse.store.gigamap.codegen.IndexMetamodelProcessor</annotationProcessor>
+                            </annotationProcessors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/gigamap/codegen-test/pom.xml
+++ b/gigamap/codegen-test/pom.xml
@@ -81,7 +81,6 @@
                     <execution>
                         <id>default-testCompile</id>
                         <configuration>
-                            <proc>full</proc>
                             <annotationProcessorPaths>
                                 <path>
                                     <groupId>org.eclipse.store</groupId>

--- a/gigamap/codegen-test/pom.xml
+++ b/gigamap/codegen-test/pom.xml
@@ -43,6 +43,33 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- integration modules whose @FullText / @Vector annotations the processor wires up -->
+        <dependency>
+            <groupId>org.eclipse.store</groupId>
+            <artifactId>gigamap-lucene</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.store</groupId>
+            <artifactId>gigamap-jvector</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Lucene is 'provided' in gigamap-lucene (not transitive), so pull it in for the tests -->
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>9.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+            <version>9.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Article.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Article.java
@@ -1,0 +1,29 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+
+/**
+ * Record entity: the index annotations sit on the components; the generated metamodel must read each
+ * value through the record's component accessor (the private backing field is not reachable).
+ */
+public record Article(
+	@Index String title,
+	@Index int views
+)
+{
+	// record
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/City.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/City.java
@@ -1,0 +1,60 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.annotations.SpatialIndex;
+import org.eclipse.store.gigamap.annotations.Unique;
+
+/**
+ * Type-level {@link SpatialIndex} built from two numeric coordinate members, plus a regular field
+ * index.
+ */
+@SpatialIndex(latitude = "lat", longitude = "lon")
+public class City
+{
+	@Unique
+	private String name;
+
+	private double lat;
+	private double lon;
+
+	public City()
+	{
+		super();
+	}
+
+	public City(final String name, final double lat, final double lon)
+	{
+		this.name = name;
+		this.lat  = lat;
+		this.lon  = lon;
+	}
+
+	public String getName()
+	{
+		return this.name;
+	}
+
+	public double getLat()
+	{
+		return this.lat;
+	}
+
+	public double getLon()
+	{
+		return this.lon;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Color.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Color.java
@@ -1,0 +1,20 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+public enum Color
+{
+	RED, GREEN, BLUE
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/CreatorBean.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/CreatorBean.java
@@ -1,0 +1,153 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.annotations.Unique;
+import org.eclipse.store.gigamap.types.BinaryIndexer;
+import org.eclipse.store.gigamap.types.Indexer;
+import org.eclipse.store.gigamap.types.IndexerString;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+
+/**
+ * Custom-creator test entity: a {@link Indexer.Creator.MemberAware MemberAware} creator (told the
+ * member, upper-cases its value), a plain creator, and a {@code @Unique} creator producing a binary
+ * index. The creators are {@code public static} so the generated metamodel can instantiate them.
+ */
+public class CreatorBean
+{
+	@Index(creator = UpperCaseCreator.class)
+	private String label;
+
+	@Index(creator = FixedNameCreator.class)
+	private String code;
+
+	@Unique
+	@Index(creator = IdCreator.class)
+	private long id;
+
+	public CreatorBean()
+	{
+		super();
+	}
+
+	public CreatorBean(final String label, final String code, final long id)
+	{
+		this.label = label;
+		this.code  = code;
+		this.id    = id;
+	}
+
+	public String getCode()
+	{
+		return this.code;
+	}
+
+	public long getId()
+	{
+		return this.id;
+	}
+
+	/** Member-aware creator: indexes the upper-cased value of whatever member it is given. */
+	public static final class UpperCaseCreator implements Indexer.Creator.MemberAware<CreatorBean, String>
+	{
+		private String name;
+		private Field  field;
+
+		@Override
+		public void initialize(final String indexName, final Member member)
+		{
+			this.name  = indexName;
+			this.field = (Field)member;
+		}
+
+		@Override
+		public Indexer<CreatorBean, String> create()
+		{
+			final String myName  = this.name;
+			final Field  myField = this.field;
+			return new IndexerString.Abstract<>()
+			{
+				@Override
+				public String name()
+				{
+					return myName;
+				}
+
+				@Override
+				protected String getString(final CreatorBean entity)
+				{
+					try
+					{
+						final Object value = myField.get(entity);
+						return value == null ? null : ((String)value).toUpperCase();
+					}
+					catch(final IllegalAccessException e)
+					{
+						throw new RuntimeException(e);
+					}
+				}
+			};
+		}
+	}
+
+	/** Plain creator returning a fixed indexer reading {@code code}. */
+	public static final class FixedNameCreator implements Indexer.Creator<CreatorBean, String>
+	{
+		@Override
+		public Indexer<CreatorBean, String> create()
+		{
+			return new IndexerString.Abstract<>()
+			{
+				@Override
+				public String name()
+				{
+					return "code";
+				}
+
+				@Override
+				protected String getString(final CreatorBean entity)
+				{
+					return entity.getCode();
+				}
+			};
+		}
+	}
+
+	/** Plain creator producing a binary index, suitable for the unique {@code id} constraint. */
+	public static final class IdCreator implements Indexer.Creator<CreatorBean, Long>
+	{
+		@Override
+		public Indexer<CreatorBean, Long> create()
+		{
+			return new BinaryIndexer.Abstract<CreatorBean>()
+			{
+				@Override
+				public String name()
+				{
+					return "id";
+				}
+
+				@Override
+				public long indexBinary(final CreatorBean entity)
+				{
+					return entity.getId();
+				}
+			};
+		}
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/CreatorMetamodelTest.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/CreatorMetamodelTest.java
@@ -1,0 +1,104 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationException;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@code @Index(creator = ...)} indices are generated into the metamodel: a typed
+ * {@code Indexer<E,K>} constant (member-aware and plain creators), unique-constraint wiring, parity
+ * with the runtime generator, and the inaccessible-creator fallback.
+ */
+public class CreatorMetamodelTest
+{
+	private static GigaMap<CreatorBean> beans()
+	{
+		final GigaMap<CreatorBean> map = GigaMap.New();
+		CreatorBean_.registerIndices(map);
+		map.add(new CreatorBean("hello", "X1", 1L));
+		map.add(new CreatorBean("world", "X2", 2L));
+		return map;
+	}
+
+	@Test
+	void memberAwareCreatorConstantQueries()
+	{
+		final GigaMap<CreatorBean> map = beans();
+
+		// UpperCaseCreator indexes the upper-cased value
+		assertEquals(1, map.query(CreatorBean_.label.is("HELLO")).toList().size());
+		assertEquals(0, map.query(CreatorBean_.label.is("hello")).toList().size());
+	}
+
+	@Test
+	void plainCreatorConstantQueries()
+	{
+		final GigaMap<CreatorBean> map = beans();
+		assertEquals(1, map.query(CreatorBean_.code.is("X1")).toList().size());
+	}
+
+	@Test
+	void uniqueCreatorIndexEnforcesConstraint()
+	{
+		final GigaMap<CreatorBean> map = beans();
+
+		assertEquals(1, map.query(CreatorBean_.id.is(1L)).toList().size());
+		assertThrows(
+			UniqueConstraintViolationException.class,
+			() -> map.add(new CreatorBean("other", "X9", 1L))
+		);
+	}
+
+	@Test
+	void matchesRuntimeGenerator()
+	{
+		final GigaMap<CreatorBean> runtime = GigaMap.New();
+		IndexerGenerator.AnnotationBased(CreatorBean.class).generateIndices(runtime);
+		final GigaMap<CreatorBean> generated = GigaMap.New();
+		CreatorBean_.registerIndices(generated);
+		for(final GigaMap<CreatorBean> m : java.util.List.of(runtime, generated))
+		{
+			m.add(new CreatorBean("hello", "X1", 1L));
+			m.add(new CreatorBean("world", "X2", 2L));
+		}
+
+		assertEquals(
+			runtime.query(runtime.index().bitmap().getIndexerString("label").is("HELLO")).toList().size(),
+			generated.query(CreatorBean_.label.is("HELLO")).toList().size()
+		);
+		assertEquals(
+			runtime.query(runtime.index().bitmap().getIndexerString("code").is("X2")).toList().size(),
+			generated.query(CreatorBean_.code.is("X2")).toList().size()
+		);
+	}
+
+	@Test
+	void inaccessibleCreatorFallsBackToRuntime()
+	{
+		// PrivateCreatorBean's creator is a private nested class: not wired at compile time.
+		final GigaMap<PrivateCreatorBean> map = GigaMap.New();
+		PrivateCreatorBean_.registerIndices(map); // generated, but empty for the skipped creator index
+		map.add(new PrivateCreatorBean("hidden"));
+
+		assertNull(map.index().bitmap().getIndexerString("secret"));
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Doc.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Doc.java
@@ -1,0 +1,51 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.lucene.annotations.FullText;
+
+/**
+ * Lucene full-text test entity: a tokenized field and an exact-match keyword field, both private and
+ * read through their getters.
+ */
+public class Doc
+{
+	@FullText
+	private String title;
+
+	@FullText(analyzed = false)
+	private String category;
+
+	public Doc()
+	{
+		super();
+	}
+
+	public Doc(final String title, final String category)
+	{
+		this.title    = title;
+		this.category = category;
+	}
+
+	public String getTitle()
+	{
+		return this.title;
+	}
+
+	public String getCategory()
+	{
+		return this.category;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/GeneratedLuceneVectorTest.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/GeneratedLuceneVectorTest.java
@@ -1,0 +1,174 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.jvector.VectorAnnotationHandler;
+import org.eclipse.store.gigamap.jvector.VectorIndices;
+import org.eclipse.store.gigamap.lucene.LuceneAnnotationHandler;
+import org.eclipse.store.gigamap.lucene.LuceneIndex;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerGenerator;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Verifies that the generated metamodels wire up Lucene full-text ({@code @FullText}) and JVector
+ * ({@code @Vector}) indices: their {@code registerIndices} create queryable indices, survive reload,
+ * and match the runtime annotation handlers.
+ */
+public class GeneratedLuceneVectorTest
+{
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void luceneFullTextViaGeneratedMetamodel()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		Doc_.registerIndices(map);
+		map.add(new Doc("hello world", "news"));
+		map.add(new Doc("another text", "blog"));
+
+		final LuceneIndex<Doc> index = map.index().get(LuceneIndex.class);
+		final List<Doc> hits = index.query("title:hello");
+		assertEquals(1, hits.size());
+		assertEquals("hello world", hits.get(0).getTitle());
+	}
+
+	@Test
+	void vectorSearchViaGeneratedMetamodel()
+	{
+		final GigaMap<VectorItem> map = GigaMap.New();
+		VectorItem_.registerIndices(map);
+		final long idA = map.add(new VectorItem(new float[]{1, 0, 0, 0}));
+		map.add(new VectorItem(new float[]{0, 1, 0, 0}));
+
+		assertEquals(idA, topId(map, new float[]{1, 0, 0, 0}));
+	}
+
+	@Test
+	void mixedMetamodelWiresBitmapFullTextAndVector()
+	{
+		final GigaMap<MixedDoc> map = GigaMap.New();
+		MixedDoc_.registerIndices(map);
+		map.add(new MixedDoc("A", "eclipse store gigamap", new float[]{1, 0, 0}));
+		map.add(new MixedDoc("B", "something else",        new float[]{0, 1, 0}));
+
+		assertEquals(1, map.query(MixedDoc_.category.is("A")).toList().size());
+		assertEquals(1, map.index().get(LuceneIndex.class).query("body:eclipse").size());
+		assertEquals(1, map.index().get(VectorIndices.class).get("embedding")
+			.search(new float[]{1, 0, 0}, 1).toList().size());
+	}
+
+	@Test
+	void onDiskVectorIsNotWired()
+	{
+		final GigaMap<OnDiskItem> map = GigaMap.New();
+		OnDiskItem_.registerIndices(map); // generated, but emits no vector registration
+		map.add(new OnDiskItem(new float[]{1, 0}));
+
+		assertNull(map.index().get(VectorIndices.class));
+	}
+
+	@Test
+	void luceneReloadSafe()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		Doc_.registerIndices(map);
+		map.add(new Doc("hello world", "news"));
+
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(map, this.tempDir))
+		{
+			// store
+		}
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(this.tempDir))
+		{
+			final GigaMap<Doc> reloaded = sm.root();
+			Doc_.registerIndices(reloaded); // idempotent on the reloaded, already-indexed map
+			assertEquals(1, reloaded.index().get(LuceneIndex.class).query("title:hello").size());
+		}
+	}
+
+	@Test
+	void vectorReloadSafe()
+	{
+		final GigaMap<VectorItem> map = GigaMap.New();
+		VectorItem_.registerIndices(map);
+		final long idA = map.add(new VectorItem(new float[]{1, 0, 0, 0}));
+
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(map, this.tempDir))
+		{
+			// store
+		}
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(this.tempDir))
+		{
+			final GigaMap<VectorItem> reloaded = sm.root();
+			VectorItem_.registerIndices(reloaded); // idempotent
+			assertEquals(idA, topId(reloaded, new float[]{1, 0, 0, 0}));
+		}
+	}
+
+	private static long topId(final GigaMap<VectorItem> map, final float[] query)
+	{
+		final VectorIndices<VectorItem> indices = map.index().get(VectorIndices.class);
+		return indices.get("embedding").search(query, 1).stream().findFirst().orElseThrow().entityId();
+	}
+
+	@Test
+	void matchesRuntimeHandlers()
+	{
+		// Lucene: generated registration vs runtime LuceneAnnotationHandler
+		final GigaMap<Doc> runtimeLucene = GigaMap.New();
+		IndexerGenerator.AnnotationBased(Doc.class)
+			.register(LuceneAnnotationHandler.New())
+			.generateIndices(runtimeLucene);
+		final GigaMap<Doc> genLucene = GigaMap.New();
+		Doc_.registerIndices(genLucene);
+		for(final GigaMap<Doc> m : List.of(runtimeLucene, genLucene))
+		{
+			m.add(new Doc("hello world", "news"));
+			m.add(new Doc("hello there", "blog"));
+		}
+		assertEquals(
+			runtimeLucene.index().get(LuceneIndex.class).query("title:hello").size(),
+			genLucene.index().get(LuceneIndex.class).query("title:hello").size()
+		);
+
+		// Vector: generated registration vs runtime VectorAnnotationHandler
+		final GigaMap<VectorItem> runtimeVector = GigaMap.New();
+		IndexerGenerator.AnnotationBased(VectorItem.class)
+			.register(VectorAnnotationHandler.New())
+			.generateIndices(runtimeVector);
+		final GigaMap<VectorItem> genVector = GigaMap.New();
+		VectorItem_.registerIndices(genVector);
+		for(final GigaMap<VectorItem> m : List.of(runtimeVector, genVector))
+		{
+			m.add(new VectorItem(new float[]{1, 0, 0, 0}));
+			m.add(new VectorItem(new float[]{0, 1, 0, 0}));
+		}
+		assertEquals(
+			topId(runtimeVector, new float[]{1, 0, 0, 0}),
+			topId(genVector, new float[]{1, 0, 0, 0})
+		);
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/GeneratedMetamodelTest.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/GeneratedMetamodelTest.java
@@ -1,0 +1,164 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexer;
+import org.eclipse.store.gigamap.types.ByteIndexerInteger;
+import org.eclipse.store.gigamap.types.GeneratedIndices;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.Indexer;
+import org.eclipse.store.gigamap.types.IndexerGenerator;
+import org.eclipse.store.gigamap.types.IndexerInteger;
+import org.eclipse.store.gigamap.types.IndexerMultiValue;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that the compile-time generated {@code <Entity>_} metamodels (produced by the
+ * {@code IndexMetamodelProcessor} during this module's test compilation) yield working indexer
+ * constants and a reload-safe {@code registerIndices}, and that their indexer flavors match the
+ * runtime {@code IndexerGenerator}.
+ */
+public class GeneratedMetamodelTest
+{
+	@TempDir
+	Path tempDir;
+
+	private static GigaMap<Person> people()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		Person_.registerIndices(map);
+		map.add(new Person("John", 30, 111L, 15, Color.RED , List.of("a", "b"), "john@x", "Johnny", "Berlin"));
+		map.add(new Person("Jane", 25, 222L,  5, Color.BLUE, List.of("b", "c"), "jane@x", "Janie" , "Hamburg"));
+		map.add(new Person("Bob" , 40, 333L, 50, Color.RED , List.of("c")     , "bob@x" , "Bobby" , "Berlin"));
+		return map;
+	}
+
+	@Test
+	void queryViaGeneratedConstants()
+	{
+		final GigaMap<Person> map = people();
+
+		assertEquals(1, map.query(Person_.firstName.startsWith("Jo")).toList().size());
+		assertEquals(1, map.query(Person_.age.is(30)).toList().size());
+		assertEquals(1, map.query(Person_.ssn.is(222L)).toList().size());
+		assertEquals(2, map.query(Person_.score.between(0, 20)).toList().size());
+		assertEquals(2, map.query(Person_.color.is(Color.RED)).toList().size());
+		assertEquals(2, map.query(Person_.tags.is("b")).toList().size());
+		assertEquals(1, map.query(Person_.email.is("bob@x")).toList().size());
+		assertEquals(1, map.query(Person_.nickname.is("Janie")).toList().size());
+		assertEquals(2, map.query(Person_.city.is("Berlin")).toList().size());
+	}
+
+	@Test
+	void recordMetamodel()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		Article_.registerIndices(map);
+		map.add(new Article("Hello", 100));
+		map.add(new Article("World", 200));
+
+		assertEquals(1, map.query(Article_.title.is("Hello")).toList().size());
+		assertEquals(1, map.query(Article_.views.is(200)).toList().size());
+	}
+
+	@Test
+	void spatialMetamodel()
+	{
+		final GigaMap<City> map = GigaMap.New();
+		City_.registerIndices(map);
+		map.add(new City("Berlin", 52.520, 13.405));
+		map.add(new City("Munich", 48.137, 11.575));
+
+		assertEquals(1, map.query(City_.spatial.near(52.5, 13.4, 50)).toList().size());
+		assertEquals(1, map.query(City_.name.is("Munich")).toList().size());
+	}
+
+	@Test
+	void registerIndicesIsIdempotentAndReloadSafe()
+	{
+		final GigaMap<Person> map = GigaMap.New();
+		Person_.registerIndices(map);
+		Person_.registerIndices(map); // second call must be a no-op, not fail on the unique constraint
+		map.add(new Person("John", 30, 111L, 15, Color.RED, List.of("a"), "john@x", "Johnny", "Berlin"));
+
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(map, this.tempDir))
+		{
+			// store
+		}
+
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(this.tempDir))
+		{
+			final GigaMap<Person> reloaded = sm.root();
+			Person_.registerIndices(reloaded); // idempotent on the reloaded, already-indexed map
+
+			assertEquals(1, reloaded.query(Person_.firstName.is("John")).toList().size());
+			assertEquals(1, reloaded.query(Person_.ssn.is(111L)).toList().size());
+			assertEquals(1, reloaded.query(Person_.score.between(10, 20)).toList().size());
+		}
+	}
+
+	@Test
+	void flavorsMatchRuntimeGenerator()
+	{
+		final GigaMap<Person> runtimeMap = GigaMap.New();
+		final GeneratedIndices<Person> gi =
+			IndexerGenerator.AnnotationBased(Person.class).generateIndices(runtimeMap);
+
+		assertEquals(flavor(gi.get("firstName")), flavor(Person_.firstName));
+		assertEquals(flavor(gi.get("age"))      , flavor(Person_.age));
+		assertEquals(flavor(gi.get("ssn"))      , flavor(Person_.ssn));
+		assertEquals(flavor(gi.get("score"))    , flavor(Person_.score));
+		assertEquals(flavor(gi.get("color"))    , flavor(Person_.color));
+		assertEquals(flavor(gi.get("tags"))     , flavor(Person_.tags));
+		assertEquals(flavor(gi.get("email"))    , flavor(Person_.email));
+		assertEquals(flavor(gi.get("nickname")) , flavor(Person_.nickname));
+		assertEquals(flavor(gi.get("city"))     , flavor(Person_.city));
+	}
+
+	/** Classifies an indexer by its most-specific GigaMap indexer interface (for parity comparison). */
+	private static String flavor(final Indexer<?, ?> indexer)
+	{
+		if(indexer instanceof ByteIndexerInteger)
+		{
+			return "ByteIndexerInteger";
+		}
+		if(indexer instanceof BinaryIndexer)
+		{
+			return "BinaryIndexer";
+		}
+		if(indexer instanceof IndexerMultiValue)
+		{
+			return "IndexerMultiValue:" + indexer.keyType().getName();
+		}
+		if(indexer instanceof IndexerString)
+		{
+			return "IndexerString";
+		}
+		if(indexer instanceof IndexerInteger)
+		{
+			return "IndexerInteger";
+		}
+		return "Indexer:" + indexer.keyType().getName();
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/GeoEntity.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/GeoEntity.java
@@ -1,0 +1,49 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.SpatialIndex;
+
+/**
+ * Spatial index whose name is not a valid Java identifier; the generated constant identifier must be
+ * sanitized (e.g. {@code geo-index} &rarr; {@code geo_index}).
+ */
+@SpatialIndex(name = "geo-index", latitude = "lat", longitude = "lon")
+public class GeoEntity
+{
+	private double lat;
+	private double lon;
+
+	public GeoEntity()
+	{
+		super();
+	}
+
+	public GeoEntity(final double lat, final double lon)
+	{
+		this.lat = lat;
+		this.lon = lon;
+	}
+
+	public double getLat()
+	{
+		return this.lat;
+	}
+
+	public double getLon()
+	{
+		return this.lon;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/InheritingEntity.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/InheritingEntity.java
@@ -1,0 +1,43 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.codegen.test.base.BaseEntity;
+
+/**
+ * Entity inheriting index-annotated members from a different-package {@link BaseEntity}, plus its own.
+ */
+public class InheritingEntity extends BaseEntity
+{
+	@Index
+	private String name;
+
+	public InheritingEntity()
+	{
+		super();
+	}
+
+	public InheritingEntity(final String region, final String tag, final String name)
+	{
+		super(region, tag);
+		this.name = name;
+	}
+
+	public String getName()
+	{
+		return this.name;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/MixedDoc.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/MixedDoc.java
@@ -1,0 +1,62 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.jvector.annotations.Vector;
+import org.eclipse.store.gigamap.lucene.annotations.FullText;
+
+/**
+ * Exercises all three families wired into a single generated metamodel: a bitmap index, a Lucene
+ * full-text field, and a JVector embedding.
+ */
+public class MixedDoc
+{
+	@Index
+	private String category;
+
+	@FullText
+	private String body;
+
+	@Vector(dimension = 3)
+	private float[] embedding;
+
+	public MixedDoc()
+	{
+		super();
+	}
+
+	public MixedDoc(final String category, final String body, final float[] embedding)
+	{
+		this.category  = category;
+		this.body      = body;
+		this.embedding = embedding;
+	}
+
+	public String getCategory()
+	{
+		return this.category;
+	}
+
+	public String getBody()
+	{
+		return this.body;
+	}
+
+	public float[] getEmbedding()
+	{
+		return this.embedding;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Nesting.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Nesting.java
@@ -1,0 +1,50 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+
+/**
+ * Holder for a nested entity. Its metamodel must be named {@code Nesting_Customer_} (qualified with
+ * the enclosing type) so it cannot shadow a same-named top-level entity's metamodel.
+ */
+public final class Nesting
+{
+	private Nesting()
+	{
+		// holder
+	}
+
+	public static class Customer
+	{
+		@Index
+		private String name;
+
+		public Customer()
+		{
+			super();
+		}
+
+		public Customer(final String name)
+		{
+			this.name = name;
+		}
+
+		public String getName()
+		{
+			return this.name;
+		}
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/OnDiskItem.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/OnDiskItem.java
@@ -1,0 +1,42 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.jvector.annotations.Vector;
+
+/**
+ * {@code @Vector(onDisk = true)} cannot be wired at compile time (it needs an index directory), so the
+ * processor emits a note and generates no vector registration for this entity.
+ */
+public class OnDiskItem
+{
+	@Vector(dimension = 2, onDisk = true)
+	private float[] embedding;
+
+	public OnDiskItem()
+	{
+		super();
+	}
+
+	public OnDiskItem(final float[] embedding)
+	{
+		this.embedding = embedding;
+	}
+
+	public float[] getEmbedding()
+	{
+		return this.embedding;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Person.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/Person.java
@@ -1,0 +1,136 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Identity;
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.annotations.IndexKind;
+import org.eclipse.store.gigamap.annotations.Unique;
+
+import java.util.List;
+
+/**
+ * Test entity exercising a representative spread of index kinds. All fields are private and reached
+ * through their getters:
+ * <ul>
+ *   <li>annotations on private fields, read through the matching getter,</li>
+ *   <li>an annotation on the getter rather than the field ({@code city}),</li>
+ *   <li>{@code @Unique} natural number (binary), {@code BIT_SLICED} numeric, enum and multi-value.</li>
+ * </ul>
+ */
+public class Person
+{
+	@Index
+	private String firstName;
+
+	@Index
+	private int age;
+
+	@Index
+	@Unique
+	private long ssn;
+
+	@Index(kind = IndexKind.BIT_SLICED)
+	private int score;
+
+	@Index
+	private Color color;
+
+	@Index
+	private List<String> tags;
+
+	@Index
+	@Identity
+	private String email;
+
+	@Index
+	private String nickname;
+
+	private String city;
+
+	public Person()
+	{
+		super();
+	}
+
+	public Person(
+		final String       firstName,
+		final int          age      ,
+		final long         ssn      ,
+		final int          score    ,
+		final Color        color    ,
+		final List<String> tags     ,
+		final String       email    ,
+		final String       nickname ,
+		final String       city
+	)
+	{
+		this.firstName = firstName;
+		this.age       = age;
+		this.ssn       = ssn;
+		this.score     = score;
+		this.color     = color;
+		this.tags      = tags;
+		this.email     = email;
+		this.nickname  = nickname;
+		this.city      = city;
+	}
+
+	public String getFirstName()
+	{
+		return this.firstName;
+	}
+
+	public int getAge()
+	{
+		return this.age;
+	}
+
+	public long getSsn()
+	{
+		return this.ssn;
+	}
+
+	public int getScore()
+	{
+		return this.score;
+	}
+
+	public Color getColor()
+	{
+		return this.color;
+	}
+
+	public List<String> getTags()
+	{
+		return this.tags;
+	}
+
+	public String getEmail()
+	{
+		return this.email;
+	}
+
+	public String getNickname()
+	{
+		return this.nickname;
+	}
+
+	@Index
+	public String getCity()
+	{
+		return this.city;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/PrivateCreatorBean.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/PrivateCreatorBean.java
@@ -1,0 +1,67 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.types.Indexer;
+import org.eclipse.store.gigamap.types.IndexerString;
+
+/**
+ * The creator is a {@code private} nested class: reachable for the annotation here, but not from the
+ * generated sibling metamodel. The processor must emit a note and skip it (runtime fallback), still
+ * producing a compilable {@code PrivateCreatorBean_}.
+ */
+public class PrivateCreatorBean
+{
+	@Index(creator = SecretCreator.class)
+	private String secret;
+
+	public PrivateCreatorBean()
+	{
+		super();
+	}
+
+	public PrivateCreatorBean(final String secret)
+	{
+		this.secret = secret;
+	}
+
+	public String getSecret()
+	{
+		return this.secret;
+	}
+
+	private static final class SecretCreator implements Indexer.Creator<PrivateCreatorBean, String>
+	{
+		@Override
+		public Indexer<PrivateCreatorBean, String> create()
+		{
+			return new IndexerString.Abstract<>()
+			{
+				@Override
+				public String name()
+				{
+					return "secret";
+				}
+
+				@Override
+				protected String getString(final PrivateCreatorBean entity)
+				{
+					return entity.getSecret();
+				}
+			};
+		}
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/ReviewFixesTest.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/ReviewFixesTest.java
@@ -1,0 +1,53 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for the PR review findings: an index name that is not a valid Java identifier must
+ * still produce a compilable, sanitized constant, and index-annotated members inherited from a
+ * different-package superclass must be read through accessible members.
+ */
+public class ReviewFixesTest
+{
+	@Test
+	void spatialIndexNameIsSanitizedToValidIdentifier()
+	{
+		final GigaMap<GeoEntity> map = GigaMap.New();
+		GeoEntity_.registerIndices(map);
+		map.add(new GeoEntity(52.520, 13.405));
+		map.add(new GeoEntity(48.137, 11.575));
+
+		// "geo-index" -> GeoEntity_.geo_index
+		assertEquals(1, map.query(GeoEntity_.geo_index.near(52.5, 13.4, 50)).toList().size());
+	}
+
+	@Test
+	void inheritedMembersFromAnotherPackageAreReadThroughAccessibleMembers()
+	{
+		final GigaMap<InheritingEntity> map = GigaMap.New();
+		InheritingEntity_.registerIndices(map);
+		map.add(new InheritingEntity("eu", "alpha", "first"));
+		map.add(new InheritingEntity("us", "beta", "second"));
+
+		assertEquals(1, map.query(InheritingEntity_.region.is("eu")).toList().size()); // public field, direct
+		assertEquals(1, map.query(InheritingEntity_.tag.is("beta")).toList().size());  // private field, via getter
+		assertEquals(1, map.query(InheritingEntity_.name.is("first")).toList().size()); // own field
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/ReviewFixesTest.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/ReviewFixesTest.java
@@ -50,4 +50,15 @@ public class ReviewFixesTest
 		assertEquals(1, map.query(InheritingEntity_.tag.is("beta")).toList().size());  // private field, via getter
 		assertEquals(1, map.query(InheritingEntity_.name.is("first")).toList().size()); // own field
 	}
+
+	@Test
+	void nestedEntityMetamodelIsQualifiedWithEnclosingType()
+	{
+		// Nesting.Customer -> Nesting_Customer_ (would shadow a top-level Customer_ if named Customer_)
+		final GigaMap<Nesting.Customer> map = GigaMap.New();
+		Nesting_Customer_.registerIndices(map);
+		map.add(new Nesting.Customer("acme"));
+
+		assertEquals(1, map.query(Nesting_Customer_.name.is("acme")).toList().size());
+	}
 }

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/VectorItem.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/VectorItem.java
@@ -1,0 +1,42 @@
+package org.eclipse.store.gigamap.codegen.test;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.jvector.annotations.Vector;
+import org.eclipse.store.gigamap.jvector.VectorSimilarityFunction;
+
+/**
+ * JVector test entity with a private {@code float[]} embedding read through its getter.
+ */
+public class VectorItem
+{
+	@Vector(dimension = 4, similarity = VectorSimilarityFunction.COSINE)
+	private float[] embedding;
+
+	public VectorItem()
+	{
+		super();
+	}
+
+	public VectorItem(final float[] embedding)
+	{
+		this.embedding = embedding;
+	}
+
+	public float[] getEmbedding()
+	{
+		return this.embedding;
+	}
+}

--- a/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/base/BaseEntity.java
+++ b/gigamap/codegen-test/src/test/java/org/eclipse/store/gigamap/codegen/test/base/BaseEntity.java
@@ -1,0 +1,47 @@
+package org.eclipse.store.gigamap.codegen.test.base;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.annotations.Index;
+
+/**
+ * Superclass in a <em>different package</em> than the entity that extends it, used to verify the
+ * generated metamodel only reaches members it actually can: a {@code public} field is read directly,
+ * a {@code private} field is read through its {@code public} getter.
+ */
+public class BaseEntity
+{
+	@Index
+	public String region;
+
+	@Index
+	private String tag;
+
+	protected BaseEntity()
+	{
+		super();
+	}
+
+	protected BaseEntity(final String region, final String tag)
+	{
+		this.region = region;
+		this.tag    = tag;
+	}
+
+	public String getTag()
+	{
+		return this.tag;
+	}
+}

--- a/gigamap/codegen/LICENSE
+++ b/gigamap/codegen/LICENSE
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/gigamap/codegen/pom.xml
+++ b/gigamap/codegen/pom.xml
@@ -26,4 +26,21 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <!--
+                    This module registers itself as an annotation processor via META-INF/services.
+                    Disable annotation processing while compiling the processor itself, otherwise a
+                    clean build discovers the (not-yet-compiled) processor and fails to load it.
+                -->
+                <configuration>
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/gigamap/codegen/pom.xml
+++ b/gigamap/codegen/pom.xml
@@ -8,24 +8,22 @@
 
     <parent>
         <groupId>org.eclipse.store</groupId>
-        <artifactId>store-parent</artifactId>
+        <artifactId>gigamap-parent</artifactId>
         <version>5.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>gigamap-parent</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>gigamap-codegen</artifactId>
 
-    <name>EclipseStore GigaMap Parent</name>
-    <description>EclipseStore GigaMap Project</description>
+    <name>EclipseStore GigaMap Codegen</name>
+    <description>EclipseStore GigaMap compile-time index metamodel generator (annotation processor)</description>
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
-    <modules>
-        <module>gigamap</module>
-        <module>codegen</module>
-        <module>codegen-test</module>
-        <module>lucene</module>
-        <module>jvector</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.store</groupId>
+            <artifactId>gigamap</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/gigamap/codegen/src/main/java/module-info.java
+++ b/gigamap/codegen/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+module org.eclipse.store.gigamap.codegen
+{
+	requires java.compiler;
+	requires org.eclipse.store.gigamap;
+
+	exports org.eclipse.store.gigamap.codegen;
+
+	provides javax.annotation.processing.Processor
+		with org.eclipse.store.gigamap.codegen.IndexMetamodelProcessor;
+}

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/Imports.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/Imports.java
@@ -1,0 +1,79 @@
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+package org.eclipse.store.gigamap.codegen;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Collects the type references used while building a single generated source file and hands back the
+ * simple name to print for each, registering an {@code import} where one is warranted. Types in
+ * {@code java.lang}, types in the file's own package, and primitives are referenced by their simple
+ * name without an import; the first type claiming a given simple name wins, later clashing types fall
+ * back to their fully qualified name.
+ */
+final class Imports
+{
+	private final String              packageName;
+	private final Map<String, String> bySimpleName = new TreeMap<>();
+
+	Imports(final String packageName)
+	{
+		this.packageName = packageName;
+	}
+
+	/**
+	 * Returns the source token to use for the given raw (generics-free) fully qualified type name,
+	 * registering an import if appropriate.
+	 */
+	String ref(final String fqn)
+	{
+		final int dot = fqn.lastIndexOf('.');
+		if(dot < 0)
+		{
+			return fqn; // primitive or wrapper passed as a bare simple name
+		}
+		final String simple = fqn.substring(dot + 1);
+		final String pkg    = fqn.substring(0, dot);
+		if(pkg.equals("java.lang") || pkg.equals(this.packageName))
+		{
+			return simple;
+		}
+		final String existing = this.bySimpleName.get(simple);
+		if(existing == null)
+		{
+			this.bySimpleName.put(simple, fqn);
+			return simple;
+		}
+		return existing.equals(fqn) ? simple : fqn;
+	}
+
+	/** The imported fully qualified names, ordered alphabetically. */
+	Collection<String> imported()
+	{
+		final List<String> names = new ArrayList<>(this.bySimpleName.values());
+		names.sort(null);
+		return names;
+	}
+
+	@Override
+	public String toString()
+	{
+		final List<String> names = new ArrayList<>(this.bySimpleName.values());
+		return String.join(", ", names);
+	}
+}

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
@@ -26,12 +26,15 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeKind;
@@ -48,7 +51,9 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Compile-time annotation processor that emits, for each entity carrying GigaMap index annotations
@@ -58,9 +63,18 @@ import java.util.Set;
  * <p>
  * This is the compile-time, reflection-free counterpart of the runtime
  * {@code IndexerGenerator.AnnotationBased}: the type/kind to indexer-flavor mapping is reproduced in
- * {@link IndexerEmitter}. Members carrying a custom {@code @Index(creator=...)}, and any full-text /
- * vector annotations, cannot be reproduced at compile time and are skipped with a note — those
- * entities must still use the runtime generator for the skipped indices.
+ * {@link IndexerEmitter}. Bitmap and spatial indices yield typed query constants. Full-text
+ * ({@code @FullText}, Lucene) and vector ({@code @Vector}, JVector) annotations are wired up too: the
+ * processor emits a reflection-free {@code DocumentPopulator} / {@code Vectorizer} and registration
+ * code in {@code registerIndices} (in-graph / in-memory defaults), but — unlike bitmap indices — no
+ * typed query handle, since those are per-map runtime objects. Members carrying a custom
+ * {@code @Index(creator=...)}, and {@code @Vector(onDisk=true)}, cannot be reproduced at compile time
+ * and are skipped with a note — those stay on the runtime generator.
+ * <p>
+ * The full-text / vector annotations are read via the {@code javax.lang.model} mirror API by fully
+ * qualified name, so this processor depends only on the GigaMap core (not the Lucene / JVector
+ * modules); the generated code references their types, which are on the user's classpath whenever the
+ * annotations are used.
  * <p>
  * The suffix appended to the entity's simple name to form the metamodel name (default {@code "_"},
  * e.g. {@code Person} &rarr; {@code Person_}) is configurable through the processor option
@@ -71,7 +85,9 @@ import java.util.Set;
 	"org.eclipse.store.gigamap.annotations.Unique",
 	"org.eclipse.store.gigamap.annotations.Identity",
 	"org.eclipse.store.gigamap.annotations.SpatialIndex",
-	"org.eclipse.store.gigamap.annotations.Indexed"
+	"org.eclipse.store.gigamap.annotations.Indexed",
+	"org.eclipse.store.gigamap.lucene.annotations.FullText",
+	"org.eclipse.store.gigamap.jvector.annotations.Vector"
 })
 @SupportedOptions(IndexMetamodelProcessor.SUFFIX_OPTION)
 public final class IndexMetamodelProcessor extends AbstractProcessor
@@ -81,6 +97,11 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 	static final String DEFAULT_SUFFIX = "_";
 
 	private static final String DUMMY_CREATOR = "org.eclipse.store.gigamap.types.Indexer.Creator.Dummy";
+
+	private static final String FULLTEXT_ANNOTATION = "org.eclipse.store.gigamap.lucene.annotations.FullText";
+	private static final String VECTOR_ANNOTATION   = "org.eclipse.store.gigamap.jvector.annotations.Vector";
+	private static final String FULLTEXT_POPULATOR  = "FullTextPopulator";
+	private static final String VECTORIZER_CLASS    = "EmbeddingVectorizer";
 
 	private Types             types;
 	private Elements          elements;
@@ -118,6 +139,8 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		this.collectEntities(roundEnv, Identity.class     , entities);
 		this.collectEntities(roundEnv, SpatialIndex.class , entities);
 		this.collectEntities(roundEnv, Indexed.class       , entities);
+		this.collectEntities(roundEnv, FULLTEXT_ANNOTATION, entities);
+		this.collectEntities(roundEnv, VECTOR_ANNOTATION  , entities);
 
 		for(final TypeElement entity : entities)
 		{
@@ -146,13 +169,40 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 	{
 		for(final Element e : roundEnv.getElementsAnnotatedWith(annotation))
 		{
-			final TypeElement entity = e.getKind().isClass() || e.getKind().isInterface()
-				? (TypeElement)e
-				: enclosingType(e);
-			if(entity != null && (entity.getKind() == ElementKind.CLASS || entity.getKind() == ElementKind.RECORD))
-			{
-				entities.add(entity);
-			}
+			addEntity(e, entities);
+		}
+	}
+
+	/**
+	 * Like {@link #collectEntities(RoundEnvironment, Class, Set)} but resolves the annotation by name,
+	 * so it works for the Lucene / JVector annotations that are not on this processor's classpath. A
+	 * no-op when the annotation type is absent from the compilation (then no entity uses it).
+	 */
+	private void collectEntities(
+		final RoundEnvironment roundEnv      ,
+		final String           annotationFqn ,
+		final Set<TypeElement> entities
+	)
+	{
+		final TypeElement annotation = this.elements.getTypeElement(annotationFqn);
+		if(annotation == null)
+		{
+			return;
+		}
+		for(final Element e : roundEnv.getElementsAnnotatedWith(annotation))
+		{
+			addEntity(e, entities);
+		}
+	}
+
+	private static void addEntity(final Element e, final Set<TypeElement> entities)
+	{
+		final TypeElement entity = e.getKind().isClass() || e.getKind().isInterface()
+			? (TypeElement)e
+			: enclosingType(e);
+		if(entity != null && (entity.getKind() == ElementKind.CLASS || entity.getKind() == ElementKind.RECORD))
+		{
+			entities.add(entity);
 		}
 	}
 
@@ -234,7 +284,99 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 
 		this.addSpatial(entity, entityRef, emitter, indexNames, constants);
 
-		this.writeSource(entity, pkg, metamodelName, entityRef, imports, constants);
+		final FullTextPlan fullText = this.buildFullText(entity, entityRef, emitter);
+		final VectorPlan   vector   = this.buildVector(entity, entityRef, emitter, metamodelName);
+
+		this.writeSource(entity, pkg, metamodelName, entityRef, imports, constants, fullText, vector);
+	}
+
+	/** Builds the {@code @FullText} populator plan, or {@code null} if the entity has no full-text members. */
+	private FullTextPlan buildFullText(final TypeElement entity, final String entityRef, final IndexerEmitter emitter)
+	{
+		final List<Member> members = this.collectMembers(entity, e -> findMirror(e, FULLTEXT_ANNOTATION) != null);
+		if(members.isEmpty())
+		{
+			return null;
+		}
+		final List<IndexerEmitter.FullTextField> fields = new ArrayList<>();
+		for(final Member member : members)
+		{
+			final String readExpr = this.readExpression(entity, member);
+			if(readExpr == null)
+			{
+				continue; // diagnostic already emitted
+			}
+			final AnnotationMirror am = findMirror(member.element, FULLTEXT_ANNOTATION);
+			fields.add(new IndexerEmitter.FullTextField(
+				nonEmpty(stringValue(am, "name"), member.propertyName),
+				readExpr,
+				boolValue(am, "analyzed", true),
+				boolValue(am, "store", true)
+			));
+		}
+		if(fields.isEmpty())
+		{
+			return null;
+		}
+		return new FullTextPlan(emitter.fullTextPopulator(entityRef, FULLTEXT_POPULATOR, fields));
+	}
+
+	/** Builds the {@code @Vector} vectorizer plan, or {@code null} if absent / not generatable. */
+	private VectorPlan buildVector(
+		final TypeElement    entity,
+		final String         entityRef,
+		final IndexerEmitter emitter,
+		final String         metamodelName
+	)
+	{
+		final List<Member> members = this.collectMembers(entity, e -> findMirror(e, VECTOR_ANNOTATION) != null);
+		if(members.isEmpty())
+		{
+			return null;
+		}
+		if(members.size() > 1)
+		{
+			this.error(entity, "Multiple @Vector members in " + entity.getQualifiedName()
+				+ "; only one vector index per entity is supported");
+			return null;
+		}
+		final Member member = members.get(0);
+		if(isIndexAnnotated(member.element))
+		{
+			this.error(member.element, "A @Vector member must not also carry @Index / @Unique / @Identity");
+			return null;
+		}
+		if(!isFloatArray(member.type))
+		{
+			this.error(member.element, "A @Vector member must be of type float[]");
+			return null;
+		}
+
+		final AnnotationMirror am = findMirror(member.element, VECTOR_ANNOTATION);
+		final int dimension = intValue(am, "dimension", 0);
+		if(dimension <= 0)
+		{
+			this.error(member.element, "@Vector requires a positive dimension");
+			return null;
+		}
+		if(boolValue(am, "onDisk", false))
+		{
+			this.note(member.element, "@Vector(onDisk = true) needs an index directory and is not generated into "
+				+ metamodelName + "; register it via the runtime VectorAnnotationHandler.New(Path).");
+			return null;
+		}
+
+		final String readExpr = this.readExpression(entity, member);
+		if(readExpr == null)
+		{
+			return null; // diagnostic already emitted
+		}
+		return new VectorPlan(
+			emitter.vectorizer(entityRef, VECTORIZER_CLASS, readExpr),
+			nonEmpty(stringValue(am, "name"), member.propertyName),
+			dimension,
+			enumValue(am, "similarity", "COSINE")
+		);
 	}
 
 	private void addSpatial(
@@ -293,6 +435,16 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 	 */
 	private List<Member> collectAnnotatedMembers(final TypeElement entity)
 	{
+		return this.collectMembers(entity, IndexMetamodelProcessor::isIndexAnnotated);
+	}
+
+	/**
+	 * Collects instance members (fields, then no-argument getters) matching {@code annotated} across
+	 * the superclass chain; fields take precedence over getters of the same property
+	 * (case-insensitive).
+	 */
+	private List<Member> collectMembers(final TypeElement entity, final Predicate<Element> annotated)
+	{
 		final List<Member> result    = new ArrayList<>();
 		final Set<String>  seenProps = new HashSet<>();
 
@@ -300,7 +452,7 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		{
 			for(final VariableElement field : fieldsOf(t))
 			{
-				if(!field.getModifiers().contains(Modifier.STATIC) && isIndexAnnotated(field))
+				if(!field.getModifiers().contains(Modifier.STATIC) && annotated.test(field))
 				{
 					final String prop = field.getSimpleName().toString();
 					if(seenProps.add(normalize(prop)))
@@ -321,7 +473,7 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 				{
 					continue;
 				}
-				if(isIndexAnnotated(method))
+				if(annotated.test(method))
 				{
 					final String prop = derivePropertyName(method);
 					if(seenProps.add(normalize(prop)))
@@ -464,7 +616,9 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		final String                  metamodelName,
 		final String                  entityRef,
 		final Imports                 imports,
-		final List<GeneratedConstant> constants
+		final List<GeneratedConstant> constants,
+		final FullTextPlan            fullText,
+		final VectorPlan              vector
 	) throws IOException
 	{
 		// resolve the remaining references (these register their imports) before emitting the header
@@ -481,7 +635,16 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 				.append(" =\n\t\t").append(c.initializer).append(";\n\n");
 		}
 
-		this.appendRegisterIndices(body, entityRef, imports, constants);
+		this.appendRegisterIndices(body, entityRef, imports, constants, fullText, vector);
+
+		if(fullText != null)
+		{
+			body.append("\n").append(fullText.source);
+		}
+		if(vector != null)
+		{
+			body.append("\n").append(vector.source);
+		}
 
 		body.append("\n\tprivate ").append(metamodelName).append("()\n\t{\n")
 			.append("\t\t// static metamodel; not instantiable\n\t}\n");
@@ -515,7 +678,9 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		final StringBuilder           b,
 		final String                  entityRef,
 		final Imports                 imports,
-		final List<GeneratedConstant> constants
+		final List<GeneratedConstant> constants,
+		final FullTextPlan            fullText,
+		final VectorPlan              vector
 	)
 	{
 		final List<GeneratedConstant> nonUnique = new ArrayList<>();
@@ -529,9 +694,9 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 				identity.add(c);
 			}
 		}
+		final boolean hasBitmap = !constants.isEmpty();
 
 		final String gigaMap = imports.ref(IndexerEmitter.TYPES + "GigaMap");
-		final String bitmaps = imports.ref(IndexerEmitter.TYPES + "BitmapIndices");
 
 		b.append("\t/**\n");
 		b.append("\t * Idempotently registers all generated indices on the given map; safe to call on a\n");
@@ -539,38 +704,67 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		b.append("\t */\n");
 		b.append("\tpublic static void registerIndices(final ").append(gigaMap).append("<")
 			.append(entityRef).append("> map)\n\t{\n");
-		b.append("\t\tfinal ").append(bitmaps).append("<").append(entityRef)
-			.append("> bitmap = map.index().bitmap();\n");
 
-		if(!nonUnique.isEmpty())
+		if(hasBitmap)
 		{
-			b.append("\t\tbitmap.ensureAll(").append(joinIdentifiers(nonUnique)).append(");\n");
-		}
+			final String bitmaps = imports.ref(IndexerEmitter.TYPES + "BitmapIndices");
+			b.append("\t\tfinal ").append(bitmaps).append("<").append(entityRef)
+				.append("> bitmap = map.index().bitmap();\n");
 
-		if(!unique.isEmpty())
-		{
-			final String set      = imports.ref("java.util.Set");
-			final String hashSet  = imports.ref("java.util.HashSet");
-			final String list     = imports.ref("java.util.List");
-			final String arrayList = imports.ref("java.util.ArrayList");
-			final String indexer  = imports.ref(IndexerEmitter.TYPES + "Indexer");
-
-			b.append("\t\tfinal ").append(set).append("<String> existingUnique = new ").append(hashSet).append("<>();\n");
-			b.append("\t\tbitmap.accessUniqueConstraints(cs -> cs.forEach(c -> existingUnique.add(c.name())));\n");
-			b.append("\t\tfinal ").append(list).append("<").append(indexer).append("<? super ")
-				.append(entityRef).append(", ?>> newUnique = new ").append(arrayList).append("<>();\n");
-			for(final GeneratedConstant c : unique)
+			if(!nonUnique.isEmpty())
 			{
-				b.append("\t\tif(!existingUnique.contains(").append(c.identifier).append(".name()))\n\t\t{\n")
-					.append("\t\t\tnewUnique.add(").append(c.identifier).append(");\n\t\t}\n");
+				b.append("\t\tbitmap.ensureAll(").append(joinIdentifiers(nonUnique)).append(");\n");
 			}
-			b.append("\t\tif(!newUnique.isEmpty())\n\t\t{\n");
-			b.append("\t\t\tbitmap.addUniqueConstraints(newUnique);\n\t\t}\n");
+
+			if(!unique.isEmpty())
+			{
+				final String set      = imports.ref("java.util.Set");
+				final String hashSet  = imports.ref("java.util.HashSet");
+				final String list     = imports.ref("java.util.List");
+				final String arrayList = imports.ref("java.util.ArrayList");
+				final String indexer  = imports.ref(IndexerEmitter.TYPES + "Indexer");
+
+				b.append("\t\tfinal ").append(set).append("<String> existingUnique = new ").append(hashSet).append("<>();\n");
+				b.append("\t\tbitmap.accessUniqueConstraints(cs -> cs.forEach(c -> existingUnique.add(c.name())));\n");
+				b.append("\t\tfinal ").append(list).append("<").append(indexer).append("<? super ")
+					.append(entityRef).append(", ?>> newUnique = new ").append(arrayList).append("<>();\n");
+				for(final GeneratedConstant c : unique)
+				{
+					b.append("\t\tif(!existingUnique.contains(").append(c.identifier).append(".name()))\n\t\t{\n")
+						.append("\t\t\tnewUnique.add(").append(c.identifier).append(");\n\t\t}\n");
+				}
+				b.append("\t\tif(!newUnique.isEmpty())\n\t\t{\n");
+				b.append("\t\t\tbitmap.addUniqueConstraints(newUnique);\n\t\t}\n");
+			}
+
+			if(!identity.isEmpty())
+			{
+				b.append("\t\tbitmap.setIdentityIndices(").append(joinIdentifiers(identity)).append(");\n");
+			}
 		}
 
-		if(!identity.isEmpty())
+		if(fullText != null)
 		{
-			b.append("\t\tbitmap.setIdentityIndices(").append(joinIdentifiers(identity)).append(");\n");
+			final String luceneIndex   = imports.ref("org.eclipse.store.gigamap.lucene.LuceneIndex");
+			final String luceneContext = imports.ref("org.eclipse.store.gigamap.lucene.LuceneContext");
+			// register() returns null if already present (reloaded map) — that is intentionally ignored
+			b.append("\t\tmap.index().register(").append(luceneIndex).append(".Category(")
+				.append(luceneContext).append(".New(new ").append(FULLTEXT_POPULATOR).append("())));\n");
+		}
+
+		if(vector != null)
+		{
+			final String vectorIndices = imports.ref("org.eclipse.store.gigamap.jvector.VectorIndices");
+			final String vectorConfig  = imports.ref("org.eclipse.store.gigamap.jvector.VectorIndexConfiguration");
+			final String similarity    = imports.ref("org.eclipse.store.gigamap.jvector.VectorSimilarityFunction");
+			b.append("\t\t").append(vectorIndices).append("<").append(entityRef)
+				.append("> vectorIndices = map.index().register(").append(vectorIndices).append(".Category());\n");
+			b.append("\t\tif(vectorIndices == null)\n\t\t{\n");
+			b.append("\t\t\tvectorIndices = map.index().get(").append(vectorIndices).append(".class);\n\t\t}\n");
+			b.append("\t\tvectorIndices.ensure(\"").append(quote(vector.name)).append("\", ")
+				.append(vectorConfig).append(".builder().dimension(").append(vector.dimension)
+				.append(").similarityFunction(").append(similarity).append(".").append(vector.similarity)
+				.append(").onDisk(false).build(), new ").append(VECTORIZER_CLASS).append("());\n");
 		}
 
 		b.append("\t}\n");
@@ -610,6 +804,74 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		{
 			return e.getTypeMirror().toString().equals(DUMMY_CREATOR);
 		}
+	}
+
+	// ---- annotation mirror reading (for the off-classpath Lucene / JVector annotations) ---------
+
+	private static AnnotationMirror findMirror(final Element element, final String annotationFqn)
+	{
+		for(final AnnotationMirror am : element.getAnnotationMirrors())
+		{
+			if(am.getAnnotationType().toString().equals(annotationFqn))
+			{
+				return am;
+			}
+		}
+		return null;
+	}
+
+	/** The explicitly-set value of an annotation attribute, or {@code null} (then the default applies). */
+	private static Object rawValue(final AnnotationMirror am, final String attribute)
+	{
+		for(final Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> e : am.getElementValues().entrySet())
+		{
+			if(e.getKey().getSimpleName().contentEquals(attribute))
+			{
+				return e.getValue().getValue();
+			}
+		}
+		return null;
+	}
+
+	private static String stringValue(final AnnotationMirror am, final String attribute)
+	{
+		final Object v = rawValue(am, attribute);
+		return v == null ? "" : (String)v;
+	}
+
+	private static boolean boolValue(final AnnotationMirror am, final String attribute, final boolean def)
+	{
+		final Object v = rawValue(am, attribute);
+		return v == null ? def : (Boolean)v;
+	}
+
+	private static int intValue(final AnnotationMirror am, final String attribute, final int def)
+	{
+		final Object v = rawValue(am, attribute);
+		return v == null ? def : ((Number)v).intValue();
+	}
+
+	/** The simple name of an enum-valued attribute (e.g. {@code COSINE}), or {@code def} if unset. */
+	private static String enumValue(final AnnotationMirror am, final String attribute, final String def)
+	{
+		final Object v = rawValue(am, attribute);
+		return v instanceof VariableElement ? ((VariableElement)v).getSimpleName().toString() : def;
+	}
+
+	private static String nonEmpty(final String value, final String fallback)
+	{
+		return value == null || value.isEmpty() ? fallback : value;
+	}
+
+	private static boolean isFloatArray(final TypeMirror type)
+	{
+		return type.getKind() == TypeKind.ARRAY
+			&& ((ArrayType)type).getComponentType().getKind() == TypeKind.FLOAT;
+	}
+
+	private static String quote(final String s)
+	{
+		return s.replace("\\", "\\\\").replace("\"", "\\\"");
 	}
 
 	private static List<VariableElement> fieldsOf(final TypeElement t)
@@ -746,6 +1008,34 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 			this.initializer  = initializer;
 			this.unique       = unique;
 			this.identity     = identity;
+		}
+	}
+
+	/** A generated Lucene full-text populator (nested class source) to embed and register. */
+	private static final class FullTextPlan
+	{
+		final String source;
+
+		FullTextPlan(final String source)
+		{
+			this.source = source;
+		}
+	}
+
+	/** A generated JVector vectorizer (nested class source) plus the index config from {@code @Vector}. */
+	private static final class VectorPlan
+	{
+		final String source;
+		final String name;
+		final int    dimension;
+		final String similarity;
+
+		VectorPlan(final String source, final String name, final int dimension, final String similarity)
+		{
+			this.source     = source;
+			this.name       = name;
+			this.dimension  = dimension;
+			this.similarity = similarity;
 		}
 	}
 }

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
@@ -1,0 +1,751 @@
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+package org.eclipse.store.gigamap.codegen;
+
+import org.eclipse.store.gigamap.annotations.Identity;
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.annotations.Indexed;
+import org.eclipse.store.gigamap.annotations.SpatialIndex;
+import org.eclipse.store.gigamap.annotations.Unique;
+import org.eclipse.store.gigamap.codegen.IndexerEmitter.IndexerCode;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Compile-time annotation processor that emits, for each entity carrying GigaMap index annotations
+ * ({@link Index}, {@link Unique}, {@link Identity}, {@link SpatialIndex} or the {@link Indexed}
+ * marker), a sibling {@code <Entity>_} metamodel class of typed {@code public static final} indexer
+ * constants plus a {@code registerIndices(GigaMap)} helper.
+ * <p>
+ * This is the compile-time, reflection-free counterpart of the runtime
+ * {@code IndexerGenerator.AnnotationBased}: the type/kind to indexer-flavor mapping is reproduced in
+ * {@link IndexerEmitter}. Members carrying a custom {@code @Index(creator=...)}, and any full-text /
+ * vector annotations, cannot be reproduced at compile time and are skipped with a note — those
+ * entities must still use the runtime generator for the skipped indices.
+ * <p>
+ * The suffix appended to the entity's simple name to form the metamodel name (default {@code "_"},
+ * e.g. {@code Person} &rarr; {@code Person_}) is configurable through the processor option
+ * {@value #SUFFIX_OPTION}, for example {@code -Agigamap.metamodel.suffix=Meta}.
+ */
+@SupportedAnnotationTypes({
+	"org.eclipse.store.gigamap.annotations.Index",
+	"org.eclipse.store.gigamap.annotations.Unique",
+	"org.eclipse.store.gigamap.annotations.Identity",
+	"org.eclipse.store.gigamap.annotations.SpatialIndex",
+	"org.eclipse.store.gigamap.annotations.Indexed"
+})
+@SupportedOptions(IndexMetamodelProcessor.SUFFIX_OPTION)
+public final class IndexMetamodelProcessor extends AbstractProcessor
+{
+	/** Processor option selecting the metamodel type-name suffix; defaults to {@value #DEFAULT_SUFFIX}. */
+	static final String SUFFIX_OPTION  = "gigamap.metamodel.suffix";
+	static final String DEFAULT_SUFFIX = "_";
+
+	private static final String DUMMY_CREATOR = "org.eclipse.store.gigamap.types.Indexer.Creator.Dummy";
+
+	private Types             types;
+	private Elements          elements;
+	private String            suffix;
+	private final Set<String> processed = new HashSet<>();
+
+	@Override
+	public SourceVersion getSupportedSourceVersion()
+	{
+		return SourceVersion.latestSupported();
+	}
+
+	@Override
+	public synchronized void init(final ProcessingEnvironment env)
+	{
+		super.init(env);
+		this.types    = env.getTypeUtils();
+		this.elements = env.getElementUtils();
+
+		final String configured = env.getOptions().get(SUFFIX_OPTION);
+		this.suffix = configured == null || configured.isEmpty() ? DEFAULT_SUFFIX : configured;
+	}
+
+	@Override
+	public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv)
+	{
+		if(roundEnv.processingOver())
+		{
+			return false;
+		}
+
+		final Set<TypeElement> entities = new LinkedHashSet<>();
+		this.collectEntities(roundEnv, Index.class       , entities);
+		this.collectEntities(roundEnv, Unique.class       , entities);
+		this.collectEntities(roundEnv, Identity.class     , entities);
+		this.collectEntities(roundEnv, SpatialIndex.class , entities);
+		this.collectEntities(roundEnv, Indexed.class       , entities);
+
+		for(final TypeElement entity : entities)
+		{
+			final String fqn = entity.getQualifiedName().toString();
+			if(this.processed.add(fqn))
+			{
+				try
+				{
+					this.generate(entity);
+				}
+				catch(final IOException e)
+				{
+					this.error(entity, "Failed to write index metamodel: " + e.getMessage());
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private void collectEntities(
+		final RoundEnvironment            roundEnv  ,
+		final Class<? extends Annotation> annotation,
+		final Set<TypeElement>            entities
+	)
+	{
+		for(final Element e : roundEnv.getElementsAnnotatedWith(annotation))
+		{
+			final TypeElement entity = e.getKind().isClass() || e.getKind().isInterface()
+				? (TypeElement)e
+				: enclosingType(e);
+			if(entity != null && (entity.getKind() == ElementKind.CLASS || entity.getKind() == ElementKind.RECORD))
+			{
+				entities.add(entity);
+			}
+		}
+	}
+
+	private static TypeElement enclosingType(final Element e)
+	{
+		for(Element c = e.getEnclosingElement(); c != null; c = c.getEnclosingElement())
+		{
+			if(c instanceof TypeElement)
+			{
+				return (TypeElement)c;
+			}
+		}
+		return null;
+	}
+
+	// ---- model building ------------------------------------------------------------------------
+
+	private void generate(final TypeElement entity) throws IOException
+	{
+		final String entityFqn     = entity.getQualifiedName().toString();
+		final String pkg           = this.elements.getPackageOf(entity).getQualifiedName().toString();
+		final String metamodelName = entity.getSimpleName().toString() + this.suffix;
+
+		final Imports        imports   = new Imports(pkg);
+		final String         entityRef = imports.ref(entityFqn);
+		final IndexerEmitter emitter   = new IndexerEmitter(this.types, this.elements, imports);
+
+		final List<GeneratedConstant> constants  = new ArrayList<>();
+		final Set<String>             indexNames = new HashSet<>();
+
+		for(final Member member : this.collectAnnotatedMembers(entity))
+		{
+			final Index    index    = member.element.getAnnotation(Index.class);
+			final boolean  unique   = member.element.getAnnotation(Unique.class)   != null;
+			final boolean  identity = member.element.getAnnotation(Identity.class) != null;
+
+			final String indexName = index != null && !index.name().isEmpty()
+				? index.name()
+				: member.propertyName;
+
+			if(!indexNames.add(indexName))
+			{
+				this.error(member.element, "Double index name '" + indexName + "' in " + entityFqn);
+				continue;
+			}
+
+			if(index != null && !isDummyCreator(index))
+			{
+				this.note(member.element,
+					"Index '" + indexName + "' uses a custom creator and is not generated into "
+					+ metamodelName + "; register it via the runtime IndexerGenerator.");
+				continue;
+			}
+
+			final String readExpr = this.readExpression(entity, member);
+			if(readExpr == null)
+			{
+				continue; // diagnostic already emitted
+			}
+
+			final IndexerCode code = emitter.emit(
+				entityRef, indexName, readExpr, member.type, index, unique
+			);
+			if(code == null)
+			{
+				this.error(member.element,
+					"Unsupported field type for annotation based index generation: " + member.type);
+				continue;
+			}
+
+			constants.add(new GeneratedConstant(
+				this.identifier(member.propertyName, constants),
+				code.declaredType,
+				code.initializer,
+				unique,
+				identity
+			));
+		}
+
+		this.addSpatial(entity, entityRef, emitter, indexNames, constants);
+
+		this.writeSource(entity, pkg, metamodelName, entityRef, imports, constants);
+	}
+
+	private void addSpatial(
+		final TypeElement             entity,
+		final String                  entityRef,
+		final IndexerEmitter          emitter,
+		final Set<String>             indexNames,
+		final List<GeneratedConstant> constants
+	)
+	{
+		final SpatialIndex spatial = entity.getAnnotation(SpatialIndex.class);
+		if(spatial == null)
+		{
+			return;
+		}
+		final String name = spatial.name().isEmpty() ? "spatial" : spatial.name();
+		if(!indexNames.add(name))
+		{
+			this.error(entity, "Double index name '" + name + "' in " + entity.getQualifiedName());
+			return;
+		}
+
+		final Member lat = this.resolveMember(entity, spatial.latitude());
+		final Member lon = this.resolveMember(entity, spatial.longitude());
+		if(lat == null || lon == null)
+		{
+			return; // diagnostic already emitted
+		}
+		if(!emitter.isNumericCoordinate(lat.type) || !emitter.isNumericCoordinate(lon.type))
+		{
+			this.error(entity, "Spatial index '" + name + "' coordinate members must be numeric");
+			return;
+		}
+
+		final String latRead = this.readExpression(entity, lat);
+		final String lonRead = this.readExpression(entity, lon);
+		if(latRead == null || lonRead == null)
+		{
+			return;
+		}
+
+		final IndexerCode code = emitter.spatial(entityRef, name, latRead, lonRead);
+		constants.add(new GeneratedConstant(
+			this.identifier(name, constants),
+			code.declaredType,
+			code.initializer,
+			false,
+			false
+		));
+	}
+
+	/**
+	 * Mirrors {@code IndexerGenerator.AnnotationBased.collectAnnotatedMembers}: index-annotated
+	 * instance fields take precedence over getters of the same property (case-insensitive); both are
+	 * collected across the superclass chain.
+	 */
+	private List<Member> collectAnnotatedMembers(final TypeElement entity)
+	{
+		final List<Member> result    = new ArrayList<>();
+		final Set<String>  seenProps = new HashSet<>();
+
+		for(final TypeElement t : this.hierarchy(entity))
+		{
+			for(final VariableElement field : fieldsOf(t))
+			{
+				if(!field.getModifiers().contains(Modifier.STATIC) && isIndexAnnotated(field))
+				{
+					final String prop = field.getSimpleName().toString();
+					if(seenProps.add(normalize(prop)))
+					{
+						result.add(new Member(field, field.asType(), prop));
+					}
+				}
+			}
+		}
+
+		for(final TypeElement t : this.hierarchy(entity))
+		{
+			for(final ExecutableElement method : methodsOf(t))
+			{
+				if(method.getModifiers().contains(Modifier.STATIC)
+					|| !method.getParameters().isEmpty()
+					|| method.getReturnType().getKind() == TypeKind.VOID)
+				{
+					continue;
+				}
+				if(isIndexAnnotated(method))
+				{
+					final String prop = derivePropertyName(method);
+					if(seenProps.add(normalize(prop)))
+					{
+						result.add(new Member(method, method.getReturnType(), prop));
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private List<TypeElement> hierarchy(final TypeElement entity)
+	{
+		final List<TypeElement> chain = new ArrayList<>();
+		for(TypeElement t = entity; t != null && !isObject(t); )
+		{
+			chain.add(t);
+			final TypeMirror sup = t.getSuperclass();
+			t = sup.getKind() == TypeKind.DECLARED ? (TypeElement)((DeclaredType)sup).asElement() : null;
+		}
+		return chain;
+	}
+
+	private static boolean isObject(final TypeElement t)
+	{
+		return t.getQualifiedName().contentEquals("java.lang.Object");
+	}
+
+	/**
+	 * Resolves a spatial coordinate member referenced by name: a field by exact name, or a method by
+	 * exact name or derived property name (mirrors {@code AnnotationBased.resolveMember}).
+	 */
+	private Member resolveMember(final TypeElement entity, final String propertyName)
+	{
+		for(final TypeElement t : this.hierarchy(entity))
+		{
+			for(final VariableElement field : fieldsOf(t))
+			{
+				if(!field.getModifiers().contains(Modifier.STATIC)
+					&& field.getSimpleName().contentEquals(propertyName))
+				{
+					return new Member(field, field.asType(), propertyName);
+				}
+			}
+		}
+		for(final TypeElement t : this.hierarchy(entity))
+		{
+			for(final ExecutableElement method : methodsOf(t))
+			{
+				if(method.getModifiers().contains(Modifier.STATIC)
+					|| !method.getParameters().isEmpty()
+					|| method.getReturnType().getKind() == TypeKind.VOID)
+				{
+					continue;
+				}
+				if(method.getSimpleName().contentEquals(propertyName)
+					|| derivePropertyName(method).equals(propertyName))
+				{
+					return new Member(method, method.getReturnType(), derivePropertyName(method));
+				}
+			}
+		}
+		this.error(entity, "No field or getter '" + propertyName + "' found in " + entity.getQualifiedName());
+		return null;
+	}
+
+	// ---- accessor (read expression) selection --------------------------------------------------
+
+	/**
+	 * The source expression reading {@code member} off a parameter {@code e}: a direct field access
+	 * when reachable from the same package (non-private field), otherwise an accessible getter call.
+	 * Methods are called directly when non-private.
+	 */
+	private String readExpression(final TypeElement entity, final Member member)
+	{
+		if(member.element.getKind() == ElementKind.METHOD)
+		{
+			if(member.element.getModifiers().contains(Modifier.PRIVATE))
+			{
+				this.error(member.element, "Indexed accessor '" + member.element.getSimpleName()
+					+ "' must not be private to be reachable from the generated metamodel");
+				return null;
+			}
+			return "e." + member.element.getSimpleName() + "()";
+		}
+
+		// field
+		if(!member.element.getModifiers().contains(Modifier.PRIVATE))
+		{
+			return "e." + member.element.getSimpleName();
+		}
+		final ExecutableElement getter = this.findGetter(entity, member);
+		if(getter != null)
+		{
+			return "e." + getter.getSimpleName() + "()";
+		}
+		this.error(member.element, "Indexed private field '" + member.element.getSimpleName()
+			+ "' has no accessible getter reachable from the generated metamodel");
+		return null;
+	}
+
+	private ExecutableElement findGetter(final TypeElement entity, final Member field)
+	{
+		final String prop    = field.propertyName;
+		final String cap     = Character.toUpperCase(prop.charAt(0)) + prop.substring(1);
+		final boolean isBool = field.type.getKind() == TypeKind.BOOLEAN
+			|| (field.type.getKind() == TypeKind.DECLARED
+				&& ((DeclaredType)field.type).asElement().getSimpleName().contentEquals("Boolean"));
+
+		for(final TypeElement t : this.hierarchy(entity))
+		{
+			for(final ExecutableElement method : methodsOf(t))
+			{
+				if(method.getModifiers().contains(Modifier.STATIC)
+					|| method.getModifiers().contains(Modifier.PRIVATE)
+					|| !method.getParameters().isEmpty()
+					|| method.getReturnType().getKind() == TypeKind.VOID)
+				{
+					continue;
+				}
+				final String n = method.getSimpleName().toString();
+				if(n.equals("get" + cap)
+					|| (isBool && n.equals("is" + cap))
+					|| n.equals(prop)) // record component accessor
+				{
+					return method;
+				}
+			}
+		}
+		return null;
+	}
+
+	// ---- source emission -----------------------------------------------------------------------
+
+	private void writeSource(
+		final TypeElement             entity,
+		final String                  pkg,
+		final String                  metamodelName,
+		final String                  entityRef,
+		final Imports                 imports,
+		final List<GeneratedConstant> constants
+	) throws IOException
+	{
+		// resolve the remaining references (these register their imports) before emitting the header
+		final String generatedRef = imports.ref("javax.annotation.processing.Generated");
+
+		final StringBuilder body = new StringBuilder();
+		body.append("@").append(generatedRef).append("(\"")
+			.append(IndexMetamodelProcessor.class.getName()).append("\")\n");
+		body.append("public final class ").append(metamodelName).append("\n{\n");
+
+		for(final GeneratedConstant c : constants)
+		{
+			body.append("\tpublic static final ").append(c.declaredType).append(' ').append(c.identifier)
+				.append(" =\n\t\t").append(c.initializer).append(";\n\n");
+		}
+
+		this.appendRegisterIndices(body, entityRef, imports, constants);
+
+		body.append("\n\tprivate ").append(metamodelName).append("()\n\t{\n")
+			.append("\t\t// static metamodel; not instantiable\n\t}\n");
+		body.append("}\n");
+
+		final String qualified = pkg.isEmpty() ? metamodelName : pkg + "." + metamodelName;
+		final JavaFileObject file = this.processingEnv.getFiler().createSourceFile(qualified, entity);
+		try(final Writer w = file.openWriter())
+		{
+			final StringBuilder out = new StringBuilder();
+			if(!pkg.isEmpty())
+			{
+				out.append("package ").append(pkg).append(";\n\n");
+			}
+			boolean anyImport = false;
+			for(final String name : imports.imported())
+			{
+				out.append("import ").append(name).append(";\n");
+				anyImport = true;
+			}
+			if(anyImport)
+			{
+				out.append("\n");
+			}
+			out.append(body);
+			w.write(out.toString());
+		}
+	}
+
+	private void appendRegisterIndices(
+		final StringBuilder           b,
+		final String                  entityRef,
+		final Imports                 imports,
+		final List<GeneratedConstant> constants
+	)
+	{
+		final List<GeneratedConstant> nonUnique = new ArrayList<>();
+		final List<GeneratedConstant> unique    = new ArrayList<>();
+		final List<GeneratedConstant> identity  = new ArrayList<>();
+		for(final GeneratedConstant c : constants)
+		{
+			(c.unique ? unique : nonUnique).add(c);
+			if(c.identity)
+			{
+				identity.add(c);
+			}
+		}
+
+		final String gigaMap = imports.ref(IndexerEmitter.TYPES + "GigaMap");
+		final String bitmaps = imports.ref(IndexerEmitter.TYPES + "BitmapIndices");
+
+		b.append("\t/**\n");
+		b.append("\t * Idempotently registers all generated indices on the given map; safe to call on a\n");
+		b.append("\t * freshly created or a reloaded {@link ").append(gigaMap).append("}.\n");
+		b.append("\t */\n");
+		b.append("\tpublic static void registerIndices(final ").append(gigaMap).append("<")
+			.append(entityRef).append("> map)\n\t{\n");
+		b.append("\t\tfinal ").append(bitmaps).append("<").append(entityRef)
+			.append("> bitmap = map.index().bitmap();\n");
+
+		if(!nonUnique.isEmpty())
+		{
+			b.append("\t\tbitmap.ensureAll(").append(joinIdentifiers(nonUnique)).append(");\n");
+		}
+
+		if(!unique.isEmpty())
+		{
+			final String set      = imports.ref("java.util.Set");
+			final String hashSet  = imports.ref("java.util.HashSet");
+			final String list     = imports.ref("java.util.List");
+			final String arrayList = imports.ref("java.util.ArrayList");
+			final String indexer  = imports.ref(IndexerEmitter.TYPES + "Indexer");
+
+			b.append("\t\tfinal ").append(set).append("<String> existingUnique = new ").append(hashSet).append("<>();\n");
+			b.append("\t\tbitmap.accessUniqueConstraints(cs -> cs.forEach(c -> existingUnique.add(c.name())));\n");
+			b.append("\t\tfinal ").append(list).append("<").append(indexer).append("<? super ")
+				.append(entityRef).append(", ?>> newUnique = new ").append(arrayList).append("<>();\n");
+			for(final GeneratedConstant c : unique)
+			{
+				b.append("\t\tif(!existingUnique.contains(").append(c.identifier).append(".name()))\n\t\t{\n")
+					.append("\t\t\tnewUnique.add(").append(c.identifier).append(");\n\t\t}\n");
+			}
+			b.append("\t\tif(!newUnique.isEmpty())\n\t\t{\n");
+			b.append("\t\t\tbitmap.addUniqueConstraints(newUnique);\n\t\t}\n");
+		}
+
+		if(!identity.isEmpty())
+		{
+			b.append("\t\tbitmap.setIdentityIndices(").append(joinIdentifiers(identity)).append(");\n");
+		}
+
+		b.append("\t}\n");
+	}
+
+	private static String joinIdentifiers(final List<GeneratedConstant> constants)
+	{
+		final StringBuilder b = new StringBuilder();
+		for(int i = 0; i < constants.size(); i++)
+		{
+			if(i > 0)
+			{
+				b.append(", ");
+			}
+			b.append(constants.get(i).identifier);
+		}
+		return b.toString();
+	}
+
+	// ---- helpers -------------------------------------------------------------------------------
+
+	private static boolean isIndexAnnotated(final Element element)
+	{
+		return element.getAnnotation(Index.class) != null
+			|| element.getAnnotation(Unique.class) != null
+			|| element.getAnnotation(Identity.class) != null;
+	}
+
+	private static boolean isDummyCreator(final Index index)
+	{
+		try
+		{
+			index.creator();
+			return false; // unreachable: accessing a Class-valued member throws
+		}
+		catch(final MirroredTypeException e)
+		{
+			return e.getTypeMirror().toString().equals(DUMMY_CREATOR);
+		}
+	}
+
+	private static List<VariableElement> fieldsOf(final TypeElement t)
+	{
+		final List<VariableElement> fields = new ArrayList<>();
+		for(final Element e : t.getEnclosedElements())
+		{
+			if(e.getKind() == ElementKind.FIELD)
+			{
+				fields.add((VariableElement)e);
+			}
+		}
+		return fields;
+	}
+
+	private static List<ExecutableElement> methodsOf(final TypeElement t)
+	{
+		final List<ExecutableElement> methods = new ArrayList<>();
+		for(final Element e : t.getEnclosedElements())
+		{
+			if(e.getKind() == ElementKind.METHOD)
+			{
+				methods.add((ExecutableElement)e);
+			}
+		}
+		return methods;
+	}
+
+	private static String derivePropertyName(final ExecutableElement method)
+	{
+		final String name = method.getSimpleName().toString();
+		final boolean bool = method.getReturnType().getKind() == TypeKind.BOOLEAN
+			|| (method.getReturnType().getKind() == TypeKind.DECLARED
+				&& ((DeclaredType)method.getReturnType()).asElement().getSimpleName().contentEquals("Boolean"));
+		if(name.startsWith("get") && name.length() > 3)
+		{
+			return decapitalize(name.substring(3));
+		}
+		if(name.startsWith("is") && name.length() > 2 && bool)
+		{
+			return decapitalize(name.substring(2));
+		}
+		return name;
+	}
+
+	private static String decapitalize(final String s)
+	{
+		if(s.isEmpty())
+		{
+			return s;
+		}
+		if(s.length() > 1 && Character.isUpperCase(s.charAt(0)) && Character.isUpperCase(s.charAt(1)))
+		{
+			return s;
+		}
+		final char[] chars = s.toCharArray();
+		chars[0] = Character.toLowerCase(chars[0]);
+		return new String(chars);
+	}
+
+	private static String normalize(final String propertyName)
+	{
+		return propertyName.toLowerCase(Locale.ROOT);
+	}
+
+	/** A Java identifier for a constant, kept unique within the metamodel. */
+	private String identifier(final String propertyName, final List<GeneratedConstant> existing)
+	{
+		String id = propertyName;
+		if(SourceVersion.isKeyword(id) || !SourceVersion.isIdentifier(id))
+		{
+			id = "_" + id;
+		}
+		String candidate = id;
+		int n = 1;
+		while(containsIdentifier(existing, candidate))
+		{
+			candidate = id + "_" + (++n);
+		}
+		return candidate;
+	}
+
+	private static boolean containsIdentifier(final List<GeneratedConstant> existing, final String id)
+	{
+		for(final GeneratedConstant c : existing)
+		{
+			if(c.identifier.equals(id))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void error(final Element e, final String message)
+	{
+		this.processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, e);
+	}
+
+	private void note(final Element e, final String message)
+	{
+		this.processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, message, e);
+	}
+
+	private static final class Member
+	{
+		final Element    element;
+		final TypeMirror type;
+		final String     propertyName;
+
+		Member(final Element element, final TypeMirror type, final String propertyName)
+		{
+			this.element      = element;
+			this.type         = type;
+			this.propertyName = propertyName;
+		}
+	}
+
+	private static final class GeneratedConstant
+	{
+		final String  identifier;
+		final String  declaredType;
+		final String  initializer;
+		final boolean unique;
+		final boolean identity;
+
+		GeneratedConstant(
+			final String identifier, final String declaredType, final String initializer,
+			final boolean unique, final boolean identity
+		)
+		{
+			this.identifier   = identifier;
+			this.declaredType = declaredType;
+			this.initializer  = initializer;
+			this.unique       = unique;
+			this.identity     = identity;
+		}
+	}
+}

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
@@ -230,8 +230,9 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		final String         entityRef = imports.ref(entityFqn);
 		final IndexerEmitter emitter   = new IndexerEmitter(this.types, this.elements, imports);
 
-		final List<GeneratedConstant> constants  = new ArrayList<>();
-		final Set<String>             indexNames = new HashSet<>();
+		final List<GeneratedConstant> constants     = new ArrayList<>();
+		final Set<String>             indexNames    = new HashSet<>();
+		final List<String>            helperMethods = new ArrayList<>();
 
 		for(final Member member : this.collectAnnotatedMembers(entity))
 		{
@@ -249,12 +250,21 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 				continue;
 			}
 
-			if(index != null && !isDummyCreator(index))
+			if(index != null)
 			{
-				this.note(member.element,
-					"Index '" + indexName + "' uses a custom creator and is not generated into "
-					+ metamodelName + "; register it via the runtime IndexerGenerator.");
-				continue;
+				final TypeMirror creator = creatorType(index);
+				if(creator != null)
+				{
+					final String id = this.identifier(member.propertyName, constants);
+					final IndexerEmitter.CreatorCode cc =
+						this.buildCreator(entity, entityRef, emitter, member, indexName, id, creator);
+					if(cc != null)
+					{
+						helperMethods.add(cc.helperMethod);
+						constants.add(new GeneratedConstant(id, cc.declaredType, cc.initializer, unique, identity));
+					}
+					continue; // generated, or NOTE + skip (falls back to the runtime generator)
+				}
 			}
 
 			final String readExpr = this.readExpression(entity, member);
@@ -287,7 +297,7 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		final FullTextPlan fullText = this.buildFullText(entity, entityRef, emitter);
 		final VectorPlan   vector   = this.buildVector(entity, entityRef, emitter, metamodelName);
 
-		this.writeSource(entity, pkg, metamodelName, entityRef, imports, constants, fullText, vector);
+		this.writeSource(entity, pkg, metamodelName, entityRef, imports, constants, helperMethods, fullText, vector);
 	}
 
 	/** Builds the {@code @FullText} populator plan, or {@code null} if the entity has no full-text members. */
@@ -617,6 +627,7 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		final String                  entityRef,
 		final Imports                 imports,
 		final List<GeneratedConstant> constants,
+		final List<String>            helperMethods,
 		final FullTextPlan            fullText,
 		final VectorPlan              vector
 	) throws IOException
@@ -636,6 +647,11 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		}
 
 		this.appendRegisterIndices(body, entityRef, imports, constants, fullText, vector);
+
+		for(final String helper : helperMethods)
+		{
+			body.append("\n").append(helper);
+		}
 
 		if(fullText != null)
 		{
@@ -793,17 +809,157 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 			|| element.getAnnotation(Identity.class) != null;
 	}
 
-	private static boolean isDummyCreator(final Index index)
+	/** The custom {@code Indexer.Creator} type of an {@code @Index}, or {@code null} for the default. */
+	private static TypeMirror creatorType(final Index index)
 	{
 		try
 		{
 			index.creator();
-			return false; // unreachable: accessing a Class-valued member throws
+			return null; // unreachable: accessing a Class-valued member throws
 		}
 		catch(final MirroredTypeException e)
 		{
-			return e.getTypeMirror().toString().equals(DUMMY_CREATOR);
+			final TypeMirror creator = e.getTypeMirror();
+			return creator.toString().equals(DUMMY_CREATOR) ? null : creator;
 		}
+	}
+
+	/**
+	 * Builds a constant backed by a custom creator, or {@code null} (with a NOTE) when the creator is not
+	 * referenceable from generated code — then the index falls back to the runtime generator.
+	 */
+	private IndexerEmitter.CreatorCode buildCreator(
+		final TypeElement    entity,
+		final String         entityRef,
+		final IndexerEmitter emitter,
+		final Member         member,
+		final String         indexName,
+		final String         identifier,
+		final TypeMirror     creatorMirror
+	)
+	{
+		if(creatorMirror.getKind() != TypeKind.DECLARED)
+		{
+			return null;
+		}
+		final TypeElement creatorElement = (TypeElement)((DeclaredType)creatorMirror).asElement();
+		if(!this.isReferenceableCreator(creatorElement, entity))
+		{
+			this.note(member.element, "Index '" + indexName + "' creator " + creatorElement.getQualifiedName()
+				+ " is not accessible for compile-time wiring; register it via the runtime IndexerGenerator.");
+			return null;
+		}
+
+		final TypeMirror keyType   = this.creatorKeyType(creatorMirror);
+		final String     keyRawFqn = keyType != null && keyType.getKind() == TypeKind.DECLARED
+			? this.types.erasure(keyType).toString()
+			: null;
+		final TypeElement declaring = (TypeElement)member.element.getEnclosingElement();
+
+		return emitter.creator(
+			entityRef,
+			identifier + "__creator",
+			creatorElement.getQualifiedName().toString(),
+			keyRawFqn,
+			this.isMemberAware(creatorMirror),
+			declaring.getQualifiedName().toString(),
+			member.element.getKind() == ElementKind.METHOD,
+			member.element.getSimpleName().toString(),
+			indexName
+		);
+	}
+
+	/** Whether a creator class can be referenced and {@code new}-ed from generated code in the entity's package. */
+	private boolean isReferenceableCreator(final TypeElement creator, final TypeElement entity)
+	{
+		final Set<Modifier> modifiers = creator.getModifiers();
+		if(modifiers.contains(Modifier.PRIVATE))
+		{
+			return false;
+		}
+		final Element enclosing = creator.getEnclosingElement();
+		final boolean nested = enclosing != null
+			&& (enclosing.getKind().isClass() || enclosing.getKind().isInterface());
+		if(nested && !modifiers.contains(Modifier.STATIC))
+		{
+			return false;
+		}
+		final boolean samePackage = this.elements.getPackageOf(creator)
+			.equals(this.elements.getPackageOf(entity));
+		if(!modifiers.contains(Modifier.PUBLIC) && !samePackage)
+		{
+			return false;
+		}
+		return hasAccessibleNoArgConstructor(creator, samePackage);
+	}
+
+	private static boolean hasAccessibleNoArgConstructor(final TypeElement type, final boolean samePackage)
+	{
+		boolean anyConstructor = false;
+		for(final Element e : type.getEnclosedElements())
+		{
+			if(e.getKind() != ElementKind.CONSTRUCTOR)
+			{
+				continue;
+			}
+			anyConstructor = true;
+			final ExecutableElement constructor = (ExecutableElement)e;
+			if(constructor.getParameters().isEmpty())
+			{
+				final Set<Modifier> m = constructor.getModifiers();
+				return !m.contains(Modifier.PRIVATE) && (m.contains(Modifier.PUBLIC) || samePackage);
+			}
+		}
+		// no explicit constructors -> implicit default ctor with the class's (already checked) visibility
+		return !anyConstructor;
+	}
+
+	private boolean isMemberAware(final TypeMirror creatorMirror)
+	{
+		final TypeElement memberAware =
+			this.elements.getTypeElement("org.eclipse.store.gigamap.types.Indexer.Creator.MemberAware");
+		return memberAware != null
+			&& this.types.isAssignable(creatorMirror, this.types.erasure(memberAware.asType()));
+	}
+
+	/** The {@code K} of the creator's {@code Indexer.Creator<E,K>} binding, or {@code null} if not concrete. */
+	private TypeMirror creatorKeyType(final TypeMirror creatorMirror)
+	{
+		final TypeElement creator =
+			this.elements.getTypeElement("org.eclipse.store.gigamap.types.Indexer.Creator");
+		return creator == null ? null : this.findTypeArgument(creatorMirror, creator, 1, new HashSet<>());
+	}
+
+	private TypeMirror findTypeArgument(
+		final TypeMirror  type,
+		final TypeElement target,
+		final int         index,
+		final Set<String> seen
+	)
+	{
+		if(type.getKind() != TypeKind.DECLARED)
+		{
+			return null;
+		}
+		final DeclaredType declared = (DeclaredType)type;
+		if(((TypeElement)declared.asElement()).getQualifiedName().contentEquals(target.getQualifiedName()))
+		{
+			final List<? extends TypeMirror> args = declared.getTypeArguments();
+			return args.size() > index ? args.get(index) : null;
+		}
+		if(!seen.add(declared.asElement().toString()))
+		{
+			return null;
+		}
+		for(final TypeMirror supertype : this.types.directSupertypes(type))
+		{
+			final TypeMirror found = this.findTypeArgument(supertype, target, index, seen);
+			if(found != null)
+			{
+				return found;
+			}
+		}
+		return null;
 	}
 
 	// ---- annotation mirror reading (for the off-classpath Lucene / JVector annotations) ---------

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
@@ -556,24 +556,25 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 
 	/**
 	 * The source expression reading {@code member} off a parameter {@code e}: a direct field access
-	 * when reachable from the same package (non-private field), otherwise an accessible getter call.
-	 * Methods are called directly when non-private.
+	 * when the field is accessible from the generated metamodel, otherwise an accessible getter call.
+	 * The metamodel sits in the entity's package and is not a subclass, so a member is reachable only
+	 * when it is {@code public} or declared in the entity's package (see {@link #isAccessibleFrom}).
 	 */
 	private String readExpression(final TypeElement entity, final Member member)
 	{
 		if(member.element.getKind() == ElementKind.METHOD)
 		{
-			if(member.element.getModifiers().contains(Modifier.PRIVATE))
+			if(this.isAccessibleFrom(member.element, entity))
 			{
-				this.error(member.element, "Indexed accessor '" + member.element.getSimpleName()
-					+ "' must not be private to be reachable from the generated metamodel");
-				return null;
+				return "e." + member.element.getSimpleName() + "()";
 			}
-			return "e." + member.element.getSimpleName() + "()";
+			this.error(member.element, "Indexed accessor '" + member.element.getSimpleName()
+				+ "' is not accessible from the generated metamodel (must be public or in the entity's package)");
+			return null;
 		}
 
 		// field
-		if(!member.element.getModifiers().contains(Modifier.PRIVATE))
+		if(this.isAccessibleFrom(member.element, entity))
 		{
 			return "e." + member.element.getSimpleName();
 		}
@@ -582,9 +583,28 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		{
 			return "e." + getter.getSimpleName() + "()";
 		}
-		this.error(member.element, "Indexed private field '" + member.element.getSimpleName()
-			+ "' has no accessible getter reachable from the generated metamodel");
+		this.error(member.element, "Indexed field '" + member.element.getSimpleName()
+			+ "' is not accessible and has no accessible getter reachable from the generated metamodel");
 		return null;
+	}
+
+	/**
+	 * Whether {@code member} can be referenced from a generated class in the entity's package. The
+	 * metamodel is not a subclass of the member's declaring type, so {@code protected} only helps when
+	 * the declaring type is in the entity's package; {@code private} is never reachable.
+	 */
+	private boolean isAccessibleFrom(final Element member, final TypeElement entity)
+	{
+		final Set<Modifier> modifiers = member.getModifiers();
+		if(modifiers.contains(Modifier.PRIVATE))
+		{
+			return false;
+		}
+		if(modifiers.contains(Modifier.PUBLIC))
+		{
+			return true;
+		}
+		return this.elements.getPackageOf(member).equals(this.elements.getPackageOf(entity));
 	}
 
 	private ExecutableElement findGetter(final TypeElement entity, final Member field)
@@ -607,9 +627,10 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 					continue;
 				}
 				final String n = method.getSimpleName().toString();
-				if(n.equals("get" + cap)
+				if((n.equals("get" + cap)
 					|| (isBool && n.equals("is" + cap))
 					|| n.equals(prop)) // record component accessor
+					&& this.isAccessibleFrom(method, entity))
 				{
 					return method;
 				}
@@ -1093,14 +1114,10 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 		return propertyName.toLowerCase(Locale.ROOT);
 	}
 
-	/** A Java identifier for a constant, kept unique within the metamodel. */
-	private String identifier(final String propertyName, final List<GeneratedConstant> existing)
+	/** A valid, unique-within-the-metamodel Java identifier for a constant. */
+	private String identifier(final String raw, final List<GeneratedConstant> existing)
 	{
-		String id = propertyName;
-		if(SourceVersion.isKeyword(id) || !SourceVersion.isIdentifier(id))
-		{
-			id = "_" + id;
-		}
+		final String id = sanitizeIdentifier(raw);
 		String candidate = id;
 		int n = 1;
 		while(containsIdentifier(existing, candidate))
@@ -1108,6 +1125,27 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 			candidate = id + "_" + (++n);
 		}
 		return candidate;
+	}
+
+	/**
+	 * Turns an arbitrary string (a property name, or an arbitrary {@code @...(name = ...)} index name)
+	 * into a valid Java identifier: non-identifier characters become {@code _}, and a leading {@code _}
+	 * is prepended when the result is empty, starts with a non-identifier-start character, or is a
+	 * reserved word. Valid property names pass through unchanged.
+	 */
+	private static String sanitizeIdentifier(final String raw)
+	{
+		final StringBuilder b = new StringBuilder(raw.length());
+		for(int i = 0; i < raw.length(); i++)
+		{
+			final char c = raw.charAt(i);
+			b.append(Character.isJavaIdentifierPart(c) ? c : '_');
+		}
+		if(b.length() == 0 || !Character.isJavaIdentifierStart(b.charAt(0)) || SourceVersion.isKeyword(b.toString()))
+		{
+			b.insert(0, '_');
+		}
+		return b.toString();
 	}
 
 	private static boolean containsIdentifier(final List<GeneratedConstant> existing, final String id)

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexMetamodelProcessor.java
@@ -220,11 +220,26 @@ public final class IndexMetamodelProcessor extends AbstractProcessor
 
 	// ---- model building ------------------------------------------------------------------------
 
+	/**
+	 * The metamodel type name: the entity's simple name plus the configured suffix, qualified with the
+	 * enclosing type names for a nested entity (e.g. {@code Outer.Customer} &rarr; {@code Outer_Customer_})
+	 * so it cannot silently shadow a same-named top-level entity's metamodel in the same package.
+	 */
+	private String metamodelName(final TypeElement entity)
+	{
+		final List<String> parts = new ArrayList<>();
+		for(Element e = entity; e instanceof TypeElement; e = e.getEnclosingElement())
+		{
+			parts.add(0, e.getSimpleName().toString());
+		}
+		return String.join("_", parts) + this.suffix;
+	}
+
 	private void generate(final TypeElement entity) throws IOException
 	{
 		final String entityFqn     = entity.getQualifiedName().toString();
 		final String pkg           = this.elements.getPackageOf(entity).getQualifiedName().toString();
-		final String metamodelName = entity.getSimpleName().toString() + this.suffix;
+		final String metamodelName = this.metamodelName(entity);
 
 		final Imports        imports   = new Imports(pkg);
 		final String         entityRef = imports.ref(entityFqn);

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexerEmitter.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexerEmitter.java
@@ -1,0 +1,579 @@
+/*-
+ * #%L
+ * EclipseStore GigaMap Codegen
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+package org.eclipse.store.gigamap.codegen;
+
+import org.eclipse.store.gigamap.annotations.Index;
+import org.eclipse.store.gigamap.annotations.IndexKind;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import java.util.List;
+
+/**
+ * Compile-time counterpart of {@code IndexerGenerator.AnnotationBased.createIndexer}: maps a member's
+ * (type, {@link IndexKind kind}, binary / unique flags) to the matching {@code Indexer} flavor and
+ * emits the source of a typed {@code public static final} constant — an anonymous subclass of the
+ * corresponding {@code Indexer.Abstract} reading the member through {@code readExpr}.
+ * <p>
+ * The decision tree here mirrors the runtime generator one-for-one; the {@code flavorsMatchRuntime}
+ * test cross-checks the two paths to catch drift. Type references are routed through {@link Imports}
+ * so the generated source uses imported simple names rather than fully qualified names. One instance
+ * is used per generated file (it captures that file's {@link Imports}).
+ */
+final class IndexerEmitter
+{
+	static final String TYPES = "org.eclipse.store.gigamap.types.";
+
+	private final Types    types;
+	private final Elements elements;
+	private final Imports  imports;
+
+	IndexerEmitter(final Types types, final Elements elements, final Imports imports)
+	{
+		this.types    = types;
+		this.elements = elements;
+		this.imports  = imports;
+	}
+
+	/**
+	 * The generated source of a single indexer constant: its declared interface type (with generics)
+	 * and the {@code new ...Abstract<>(){ ... }} initializer (without a trailing semicolon).
+	 */
+	static final class IndexerCode
+	{
+		final String declaredType;
+		final String initializer;
+
+		IndexerCode(final String declaredType, final String initializer)
+		{
+			this.declaredType = declaredType;
+			this.initializer  = initializer;
+		}
+	}
+
+	/**
+	 * @return the constant source, or {@code null} if the member type is not supported for the
+	 *         requested kind (the caller reports the diagnostic).
+	 */
+	IndexerCode emit(
+		final String      entityRef ,
+		final String      indexName ,
+		final String      readExpr  ,
+		final TypeMirror  type      ,
+		final Index       annotation,
+		final boolean     unique
+	)
+	{
+		final IndexKind kind           = annotation != null ? annotation.kind() : IndexKind.AUTO;
+		final boolean   explicitBinary = kind == IndexKind.BINARY || (annotation != null && annotation.binary());
+		final boolean   preferBinary   = explicitBinary || (kind == IndexKind.AUTO && unique);
+
+		if(kind == IndexKind.BIT_SLICED)
+		{
+			return this.bitSliced(entityRef, indexName, readExpr, type);
+		}
+
+		if(preferBinary)
+		{
+			final IndexerCode binary = this.binary(entityRef, indexName, readExpr, type);
+			if(binary != null)
+			{
+				return binary;
+			}
+			if(explicitBinary)
+			{
+				return null;
+			}
+			// unique on a non-binary type: fall through to a standard indexer (used as unique constraint)
+		}
+
+		return this.standard(entityRef, indexName, readExpr, type);
+	}
+
+	private IndexerCode standard(
+		final String     entityRef,
+		final String     indexName,
+		final String     readExpr ,
+		final TypeMirror type
+	)
+	{
+		if(this.isType(type, "java.lang.String"))
+		{
+			return this.single("IndexerString", entityRef, indexName, "String", "getString", readExpr);
+		}
+		if(this.isCharacterType(type))
+		{
+			return this.single("IndexerCharacter", entityRef, indexName, "Character", "getCharacter", readExpr);
+		}
+		if(this.isIntegerType(type))
+		{
+			return this.single("IndexerInteger", entityRef, indexName, "Integer", "getInteger", readExpr);
+		}
+		if(this.isLongType(type))
+		{
+			return this.single("IndexerLong", entityRef, indexName, "Long", "getLong", readExpr);
+		}
+		if(this.isFloatType(type))
+		{
+			return this.single("IndexerFloat", entityRef, indexName, "Float", "getFloat", readExpr);
+		}
+		if(this.isDoubleType(type))
+		{
+			return this.single("IndexerDouble", entityRef, indexName, "Double", "getDouble", readExpr);
+		}
+		if(this.isByteType(type))
+		{
+			return this.single("IndexerByte", entityRef, indexName, "Byte", "getByte", readExpr);
+		}
+		if(this.isShortType(type))
+		{
+			return this.single("IndexerShort", entityRef, indexName, "Short", "getShort", readExpr);
+		}
+		if(this.isBooleanType(type))
+		{
+			return this.single("IndexerBoolean", entityRef, indexName, "Boolean", "getBoolean", readExpr);
+		}
+		if(this.isType(type, "java.time.LocalDate"))
+		{
+			return this.single("IndexerLocalDate", entityRef, indexName, "java.time.LocalDate", "getLocalDate", readExpr);
+		}
+		if(this.isType(type, "java.time.LocalTime"))
+		{
+			return this.single("IndexerLocalTime", entityRef, indexName, "java.time.LocalTime", "getLocalTime", readExpr);
+		}
+		if(this.isType(type, "java.time.LocalDateTime"))
+		{
+			return this.single("IndexerLocalDateTime", entityRef, indexName, "java.time.LocalDateTime", "getLocalDateTime", readExpr);
+		}
+		if(this.isType(type, "java.time.YearMonth"))
+		{
+			return this.single("IndexerYearMonth", entityRef, indexName, "java.time.YearMonth", "getYearMonth", readExpr);
+		}
+		if(this.isType(type, "java.time.Instant"))
+		{
+			return this.single("IndexerInstant", entityRef, indexName, "java.time.Instant", "getInstant", readExpr);
+		}
+		if(this.isType(type, "java.time.ZonedDateTime"))
+		{
+			return this.single("IndexerZonedDateTime", entityRef, indexName, "java.time.ZonedDateTime", "getZonedDateTime", readExpr);
+		}
+		if(this.isType(type, "java.util.UUID"))
+		{
+			return this.single("BinaryIndexerUUID", entityRef, indexName, "java.util.UUID", "getUUID", readExpr);
+		}
+		if(this.isEnum(type))
+		{
+			return this.keyed("Indexer", entityRef, this.refRaw(type), indexName, readExpr);
+		}
+		if(this.isIterable(type))
+		{
+			final String element = this.singleTypeArgument(type);
+			if(element == null)
+			{
+				return null;
+			}
+			return this.multiValue(entityRef, element, indexName, readExpr);
+		}
+		if(type.getKind() == TypeKind.ARRAY)
+		{
+			return this.multiValue(entityRef, this.box(((ArrayType)type).getComponentType()), indexName, readExpr);
+		}
+		if(this.isComparable(type))
+		{
+			return this.keyed("IndexerComparing", entityRef, this.refRaw(type), indexName, readExpr);
+		}
+		// custom: equality-only Indexer over the raw member type
+		return this.keyed("Indexer", entityRef, this.refRaw(type), indexName, readExpr);
+	}
+
+	private IndexerCode binary(
+		final String     entityRef,
+		final String     indexName,
+		final String     readExpr ,
+		final TypeMirror type
+	)
+	{
+		if(this.isNaturalNumberType(type))
+		{
+			final String base     = this.imports.ref(TYPES + "BinaryIndexer");
+			final String declared = base + "<" + entityRef + ">";
+			final StringBuilder b = new StringBuilder();
+			b.append("new ").append(base).append(".Abstract<").append(entityRef).append(">()\n");
+			b.append("\t{\n");
+			this.appendName(b, indexName);
+			b.append("\t\t@Override\n");
+			b.append("\t\tpublic long indexBinary(final ").append(entityRef).append(" e)\n");
+			b.append("\t\t{\n");
+			b.append("\t\t\tfinal Number key = ").append(readExpr).append(";\n");
+			b.append("\t\t\tif(key == null)\n");
+			b.append("\t\t\t{\n");
+			b.append("\t\t\t\tthrow new IllegalArgumentException(\"Null keys are not allowed in index ")
+				.append(escape(indexName)).append("\");\n");
+			b.append("\t\t\t}\n");
+			b.append("\t\t\treturn key.longValue();\n");
+			b.append("\t\t}\n");
+			b.append("\t}");
+			return new IndexerCode(declared, b.toString());
+		}
+		if(this.isFloatType(type))
+		{
+			return this.single("BinaryIndexerFloat", entityRef, indexName, "Float", "getFloat", readExpr);
+		}
+		if(this.isDoubleType(type))
+		{
+			return this.single("BinaryIndexerDouble", entityRef, indexName, "Double", "getDouble", readExpr);
+		}
+		if(this.isType(type, "java.lang.String"))
+		{
+			return this.single("BinaryIndexerString", entityRef, indexName, "String", "getString", readExpr);
+		}
+		if(this.isType(type, "java.util.UUID"))
+		{
+			return this.single("BinaryIndexerUUID", entityRef, indexName, "java.util.UUID", "getUUID", readExpr);
+		}
+		return null;
+	}
+
+	private IndexerCode bitSliced(
+		final String     entityRef,
+		final String     indexName,
+		final String     readExpr ,
+		final TypeMirror type
+	)
+	{
+		if(this.isIntegerType(type))
+		{
+			return this.single("ByteIndexerInteger", entityRef, indexName, "Integer", "getInteger", readExpr);
+		}
+		if(this.isLongType(type))
+		{
+			return this.single("ByteIndexerLong", entityRef, indexName, "Long", "getLong", readExpr);
+		}
+		if(this.isByteType(type))
+		{
+			return this.single("ByteIndexerByte", entityRef, indexName, "Byte", "getByte", readExpr);
+		}
+		if(this.isShortType(type))
+		{
+			return this.single("ByteIndexerShort", entityRef, indexName, "Short", "getShort", readExpr);
+		}
+		if(this.isFloatType(type))
+		{
+			return this.single("ByteIndexerFloat", entityRef, indexName, "Float", "getFloat", readExpr);
+		}
+		if(this.isDoubleType(type))
+		{
+			return this.single("ByteIndexerDouble", entityRef, indexName, "Double", "getDouble", readExpr);
+		}
+		if(this.isType(type, "java.time.Instant"))
+		{
+			return this.single("ByteIndexerInstant", entityRef, indexName, "java.time.Instant", "getInstant", readExpr);
+		}
+		return null;
+	}
+
+	/**
+	 * Emits the source of a {@code SpatialIndexer} constant reading two numeric coordinate members.
+	 */
+	IndexerCode spatial(
+		final String entityRef,
+		final String indexName,
+		final String latReadExpr,
+		final String lonReadExpr
+	)
+	{
+		final String base     = this.imports.ref(TYPES + "SpatialIndexer");
+		final String declared = base + "<" + entityRef + ">";
+		final StringBuilder b = new StringBuilder();
+		b.append("new ").append(base).append(".Abstract<").append(entityRef).append(">()\n");
+		b.append("\t{\n");
+		this.appendName(b, indexName);
+		this.appendCoordinate(b, entityRef, "getLatitude", "latitude", latReadExpr);
+		b.append("\n");
+		this.appendCoordinate(b, entityRef, "getLongitude", "longitude", lonReadExpr);
+		b.append("\t}");
+		return new IndexerCode(declared, b.toString());
+	}
+
+	private void appendCoordinate(
+		final StringBuilder b,
+		final String entityRef,
+		final String method,
+		final String axis,
+		final String readExpr
+	)
+	{
+		b.append("\t\t@Override\n");
+		b.append("\t\tprotected Double ").append(method).append("(final ").append(entityRef).append(" e)\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\tfinal Object value = ").append(readExpr).append(";\n");
+		b.append("\t\t\tif(value == null)\n");
+		b.append("\t\t\t{\n");
+		b.append("\t\t\t\treturn null;\n");
+		b.append("\t\t\t}\n");
+		b.append("\t\t\tif(value instanceof Number)\n");
+		b.append("\t\t\t{\n");
+		b.append("\t\t\t\treturn ((Number)value).doubleValue();\n");
+		b.append("\t\t\t}\n");
+		b.append("\t\t\tthrow new IllegalStateException(\"Spatial index ").append(escape(axis))
+			.append(" member must be numeric\");\n");
+		b.append("\t\t}\n");
+	}
+
+	// ---- shared constant templates -------------------------------------------------------------
+
+	/** A single-{@code E}-parameter indexer overriding {@code name()} and one protected getter. */
+	private IndexerCode single(
+		final String simpleType ,
+		final String entityRef  ,
+		final String indexName  ,
+		final String returnType ,
+		final String getter     ,
+		final String readExpr
+	)
+	{
+		final String base       = this.imports.ref(TYPES + simpleType);
+		final String returnRef  = this.imports.ref(returnType);
+		final String declared   = base + "<" + entityRef + ">";
+		final StringBuilder b = new StringBuilder();
+		b.append("new ").append(base).append(".Abstract<").append(entityRef).append(">()\n");
+		b.append("\t{\n");
+		this.appendName(b, indexName);
+		b.append("\t\t@Override\n");
+		b.append("\t\tprotected ").append(returnRef).append(" ").append(getter)
+			.append("(final ").append(entityRef).append(" e)\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn ").append(readExpr).append(";\n");
+		b.append("\t\t}\n");
+		b.append("\t}");
+		return new IndexerCode(declared, b.toString());
+	}
+
+	/** An {@code Indexer}/{@code IndexerComparing} keyed by {@code keyRef}, overriding name/keyType/index. */
+	private IndexerCode keyed(
+		final String simpleType,
+		final String entityRef ,
+		final String keyRef    ,
+		final String indexName ,
+		final String readExpr
+	)
+	{
+		final String base     = this.imports.ref(TYPES + simpleType);
+		final String declared = base + "<" + entityRef + ", " + keyRef + ">";
+		final StringBuilder b = new StringBuilder();
+		b.append("new ").append(base).append(".Abstract<").append(entityRef).append(", ").append(keyRef).append(">()\n");
+		b.append("\t{\n");
+		this.appendName(b, indexName);
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic Class<").append(keyRef).append("> keyType()\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn ").append(keyRef).append(".class;\n");
+		b.append("\t\t}\n\n");
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic ").append(keyRef).append(" index(final ").append(entityRef).append(" e)\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn ").append(readExpr).append(";\n");
+		b.append("\t\t}\n");
+		b.append("\t}");
+		return new IndexerCode(declared, b.toString());
+	}
+
+	private IndexerCode multiValue(
+		final String entityRef,
+		final String keyRef   ,
+		final String indexName,
+		final String readExpr
+	)
+	{
+		final String base     = this.imports.ref(TYPES + "IndexerMultiValue");
+		final String declared = base + "<" + entityRef + ", " + keyRef + ">";
+		final StringBuilder b = new StringBuilder();
+		b.append("new ").append(base).append(".Abstract<").append(entityRef).append(", ").append(keyRef).append(">()\n");
+		b.append("\t{\n");
+		this.appendName(b, indexName);
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic Class<").append(keyRef).append("> keyType()\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn ").append(keyRef).append(".class;\n");
+		b.append("\t\t}\n\n");
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic Iterable<? extends ").append(keyRef).append("> indexEntityMultiValue(final ")
+			.append(entityRef).append(" e)\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn ").append(readExpr).append(";\n");
+		b.append("\t\t}\n");
+		b.append("\t}");
+		return new IndexerCode(declared, b.toString());
+	}
+
+	private void appendName(final StringBuilder b, final String indexName)
+	{
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic String name()\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn \"").append(escape(indexName)).append("\";\n");
+		b.append("\t\t}\n\n");
+	}
+
+	// ---- type categories (mirror of XTypes) ----------------------------------------------------
+
+	boolean isNumericCoordinate(final TypeMirror t)
+	{
+		return this.isByteType(t) || this.isShortType(t) || this.isIntegerType(t) || this.isLongType(t)
+			|| this.isFloatType(t) || this.isDoubleType(t)
+			|| this.isAssignableTo(t, "java.lang.Number");
+	}
+
+	private boolean isType(final TypeMirror t, final String fqn)
+	{
+		return t.getKind() == TypeKind.DECLARED && this.rawName(t).equals(fqn);
+	}
+
+	private boolean isBooleanType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.BOOLEAN || this.isType(t, "java.lang.Boolean");
+	}
+
+	private boolean isByteType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.BYTE || this.isType(t, "java.lang.Byte");
+	}
+
+	private boolean isShortType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.SHORT || this.isType(t, "java.lang.Short");
+	}
+
+	private boolean isIntegerType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.INT || this.isType(t, "java.lang.Integer");
+	}
+
+	private boolean isLongType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.LONG || this.isType(t, "java.lang.Long");
+	}
+
+	private boolean isFloatType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.FLOAT || this.isType(t, "java.lang.Float");
+	}
+
+	private boolean isDoubleType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.DOUBLE || this.isType(t, "java.lang.Double");
+	}
+
+	private boolean isCharacterType(final TypeMirror t)
+	{
+		return t.getKind() == TypeKind.CHAR || this.isType(t, "java.lang.Character");
+	}
+
+	private boolean isNaturalNumberType(final TypeMirror t)
+	{
+		return this.isByteType(t) || this.isShortType(t) || this.isIntegerType(t) || this.isLongType(t)
+			|| this.isType(t, "java.math.BigInteger")
+			|| this.isType(t, "java.util.concurrent.atomic.AtomicInteger")
+			|| this.isType(t, "java.util.concurrent.atomic.AtomicLong");
+	}
+
+	private boolean isEnum(final TypeMirror t)
+	{
+		if(t.getKind() != TypeKind.DECLARED)
+		{
+			return false;
+		}
+		final Element e = ((DeclaredType)t).asElement();
+		return e.getKind() == ElementKind.ENUM;
+	}
+
+	private boolean isIterable(final TypeMirror t)
+	{
+		return this.isAssignableTo(t, "java.lang.Iterable");
+	}
+
+	private boolean isComparable(final TypeMirror t)
+	{
+		return this.isAssignableTo(t, "java.lang.Comparable");
+	}
+
+	private boolean isAssignableTo(final TypeMirror t, final String superFqn)
+	{
+		if(t.getKind() != TypeKind.DECLARED)
+		{
+			return false;
+		}
+		final TypeElement sup = this.elements.getTypeElement(superFqn);
+		if(sup == null)
+		{
+			return false;
+		}
+		return this.types.isAssignable(this.types.erasure(t), this.types.erasure(sup.asType()));
+	}
+
+	/** The single {@code Class} type argument of an {@code Iterable<X>}, import-resolved, or {@code null}. */
+	private String singleTypeArgument(final TypeMirror t)
+	{
+		if(t.getKind() != TypeKind.DECLARED)
+		{
+			return null;
+		}
+		final List<? extends TypeMirror> args = ((DeclaredType)t).getTypeArguments();
+		if(args.size() != 1 || args.get(0).getKind() != TypeKind.DECLARED)
+		{
+			return null;
+		}
+		return this.refRaw(args.get(0));
+	}
+
+	/** Import-resolved raw (erased) name, suitable for a {@code .class} literal and a type argument. */
+	private String refRaw(final TypeMirror t)
+	{
+		return this.imports.ref(this.rawName(t));
+	}
+
+	private String rawName(final TypeMirror t)
+	{
+		return this.types.erasure(t).toString();
+	}
+
+	/** Import-resolved boxed name for primitives; import-resolved raw name otherwise. */
+	private String box(final TypeMirror t)
+	{
+		switch(t.getKind())
+		{
+			case BOOLEAN: return "Boolean";
+			case BYTE   : return "Byte";
+			case SHORT  : return "Short";
+			case INT    : return "Integer";
+			case LONG   : return "Long";
+			case CHAR   : return "Character";
+			case FLOAT  : return "Float";
+			case DOUBLE : return "Double";
+			default     : return this.refRaw(t);
+		}
+	}
+
+	private static String escape(final String s)
+	{
+		return s.replace("\\", "\\\\").replace("\"", "\\\"");
+	}
+}

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexerEmitter.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexerEmitter.java
@@ -419,6 +419,79 @@ final class IndexerEmitter
 		return b.toString();
 	}
 
+	/** The generated source for a {@code @Index(creator=...)} constant plus its backing helper method. */
+	static final class CreatorCode
+	{
+		final String declaredType;
+		final String initializer;
+		final String helperMethod;
+
+		CreatorCode(final String declaredType, final String initializer, final String helperMethod)
+		{
+			this.declaredType = declaredType;
+			this.initializer  = initializer;
+			this.helperMethod = helperMethod;
+		}
+	}
+
+	/**
+	 * Emits a constant backed by a custom {@code Indexer.Creator}: a typed {@code Indexer<E, K>} (or
+	 * {@code Indexer<E, ?>} when {@code keyRawFqn} is {@code null}) initialized from a generated private
+	 * static helper. A plain creator is instantiated reflection-free ({@code new C().create()}); a
+	 * {@code MemberAware} creator additionally receives the resolved index name and the reflective
+	 * member (mirroring the runtime {@code IndexerGenerator.instantiateCreator}).
+	 */
+	CreatorCode creator(
+		final String  entityRef,
+		final String  helperName,
+		final String  creatorFqn,
+		final String  keyRawFqn,     // null -> wildcard
+		final boolean memberAware,
+		final String  declaringFqn,
+		final boolean methodMember,
+		final String  memberName,
+		final String  indexName
+	)
+	{
+		final String indexer    = this.imports.ref(TYPES + "Indexer");
+		final String creatorRef = this.imports.ref(creatorFqn);
+		final String keyRef     = keyRawFqn == null ? "?" : this.imports.ref(keyRawFqn);
+		final String declared   = indexer + "<" + entityRef + ", " + keyRef + ">";
+
+		final StringBuilder b = new StringBuilder();
+		b.append("\t@SuppressWarnings(\"unchecked\")\n");
+		b.append("\tprivate static ").append(declared).append(" ").append(helperName).append("()\n");
+		b.append("\t{\n");
+		if(memberAware)
+		{
+			final String declaringRef = this.imports.ref(declaringFqn);
+			final String memberType   = this.imports.ref(methodMember
+				? "java.lang.reflect.Method" : "java.lang.reflect.Field");
+			final String lookup       = methodMember ? "getDeclaredMethod" : "getDeclaredField";
+			final String checkedEx    = methodMember ? "NoSuchMethodException" : "NoSuchFieldException";
+
+			b.append("\t\tfinal ").append(creatorRef).append(" creator = new ").append(creatorRef).append("();\n");
+			b.append("\t\ttry\n\t\t{\n");
+			b.append("\t\t\tfinal ").append(memberType).append(" member = ").append(declaringRef)
+				.append(".class.").append(lookup).append("(\"").append(escape(memberName)).append("\");\n");
+			b.append("\t\t\tmember.trySetAccessible();\n");
+			b.append("\t\t\tcreator.initialize(\"").append(escape(indexName)).append("\", member);\n");
+			b.append("\t\t}\n");
+			b.append("\t\tcatch(final ").append(checkedEx).append(" e)\n\t\t{\n");
+			b.append("\t\t\tthrow new RuntimeException(e);\n\t\t}\n");
+			b.append("\t\treturn (").append(declared).append(")(").append(indexer)
+				.append("<?, ?>) creator.create();\n");
+		}
+		else
+		{
+			b.append("\t\treturn (").append(declared).append(")(").append(indexer)
+				.append("<?, ?>) new ").append(creatorRef).append("().create();\n");
+		}
+		b.append("\t}\n");
+
+		return new CreatorCode(declared, helperName + "()", b.toString());
+	}
+
 	// ---- shared constant templates -------------------------------------------------------------
 
 	/** A single-{@code E}-parameter indexer overriding {@code name()} and one protected getter. */

--- a/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexerEmitter.java
+++ b/gigamap/codegen/src/main/java/org/eclipse/store/gigamap/codegen/IndexerEmitter.java
@@ -338,6 +338,87 @@ final class IndexerEmitter
 		b.append("\t\t}\n");
 	}
 
+	/** A single {@code @FullText} document field: target Lucene field name, read expression, flags. */
+	static final class FullTextField
+	{
+		final String  fieldName;
+		final String  readExpr;
+		final boolean analyzed;
+		final boolean store;
+
+		FullTextField(final String fieldName, final String readExpr, final boolean analyzed, final boolean store)
+		{
+			this.fieldName = fieldName;
+			this.readExpr  = readExpr;
+			this.analyzed  = analyzed;
+			this.store     = store;
+		}
+	}
+
+	/**
+	 * Emits a nested {@code DocumentPopulator} subclass that maps each {@code @FullText} member into a
+	 * Lucene document field through {@code readExpr} (reflection-free, mirroring
+	 * {@code AnnotationDocumentPopulator}).
+	 */
+	String fullTextPopulator(final String entityRef, final String className, final List<FullTextField> fields)
+	{
+		final String base     = this.imports.ref("org.eclipse.store.gigamap.lucene.DocumentPopulator");
+		final String document = this.imports.ref("org.apache.lucene.document.Document");
+		final String store    = this.imports.ref("org.apache.lucene.document.Field.Store");
+
+		final StringBuilder b = new StringBuilder();
+		b.append("\tpublic static final class ").append(className)
+			.append(" extends ").append(base).append("<").append(entityRef).append(">\n");
+		b.append("\t{\n");
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic void populate(final ").append(document).append(" document, final ")
+			.append(entityRef).append(" e)\n");
+		b.append("\t\t{\n");
+		int i = 0;
+		for(final FullTextField f : fields)
+		{
+			final String fieldType = this.imports.ref(f.analyzed
+				? "org.apache.lucene.document.TextField"
+				: "org.apache.lucene.document.StringField");
+			final String local = "v" + i++;
+			b.append("\t\t\tfinal Object ").append(local).append(" = ").append(f.readExpr).append(";\n");
+			b.append("\t\t\tif(").append(local).append(" != null)\n\t\t\t{\n");
+			b.append("\t\t\t\tdocument.add(new ").append(fieldType).append("(\"").append(escape(f.fieldName))
+				.append("\", String.valueOf(").append(local).append("), ").append(store)
+				.append(f.store ? ".YES" : ".NO").append("));\n");
+			b.append("\t\t\t}\n");
+		}
+		b.append("\t\t}\n");
+		b.append("\t}\n");
+		return b.toString();
+	}
+
+	/**
+	 * Emits a nested {@code Vectorizer} subclass that reads the {@code @Vector float[]} member through
+	 * {@code readExpr} in embedded mode (reflection-free, mirroring {@code AnnotationVectorizer}).
+	 */
+	String vectorizer(final String entityRef, final String className, final String readExpr)
+	{
+		final String base = this.imports.ref("org.eclipse.store.gigamap.jvector.Vectorizer");
+
+		final StringBuilder b = new StringBuilder();
+		b.append("\tpublic static final class ").append(className)
+			.append(" extends ").append(base).append("<").append(entityRef).append(">\n");
+		b.append("\t{\n");
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic float[] vectorize(final ").append(entityRef).append(" e)\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn ").append(readExpr).append(";\n");
+		b.append("\t\t}\n\n");
+		b.append("\t\t@Override\n");
+		b.append("\t\tpublic boolean isEmbedded()\n");
+		b.append("\t\t{\n");
+		b.append("\t\t\treturn true;\n");
+		b.append("\t\t}\n");
+		b.append("\t}\n");
+		return b.toString();
+	}
+
 	// ---- shared constant templates -------------------------------------------------------------
 
 	/** A single-{@code E}-parameter indexer overriding {@code name()} and one protected getter. */

--- a/gigamap/codegen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/gigamap/codegen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.eclipse.store.gigamap.codegen.IndexMetamodelProcessor


### PR DESCRIPTION
## What

Introduces **`gigamap-codegen`** — an annotation processor that generates a compile-time index metamodel for GigaMap entities. For each annotated entity `Person`, it emits a sibling `Person_` with typed `public static final` indexer constants and an idempotent `registerIndices(GigaMap)` helper:

  ```java
  Person_.registerIndices(map);
  map.query(Person_.firstName.startsWith("J"));
  ```

It's the reflection-free, compile-time counterpart to the runtime `IndexerGenerator` — same indices, but with compile-time names, IDE autocomplete, and refactor-safety. Opt in by adding the processor to `maven-compiler-plugin` `annotationProcessorPaths` (compile-time only).

## Coverage

| Annotation | Generated |
  |---|---|
| `@Index` / `@Unique` / `@Identity` / `@SpatialIndex` | typed indexer constants (String, numeric, time, UUID, enum, `Comparable`, multi-value, binary, bit-sliced, spatial) + registration |
| `@FullText` (Lucene) | reflection-free `DocumentPopulator` + index registration |
| `@Vector` (JVector) | reflection-free `Vectorizer` + index registration |
| `@Index(creator = …)` | `Indexer<E,K>` from the creator (plain or `MemberAware`) + registration |

The processor depends only on the GigaMap core and reads the Lucene/JVector annotations by name, so bitmap-only projects don't pull those libraries onto the processor path.

## Notes

- Full-text/vector and creator indices have no typed compile-time *query* handle (their runtime flavor is opaque / they're per-map objects); query them via the runtime handle, or `Entity_.x.is(value)` for creators with a concrete key type.
- `@Vector(onDisk=true)` and creators not reachable from the entity's package are skipped with a note and left to the runtime path — the metamodel complements `IndexerGenerator`, both resolve indices by name and interoperate.
- Suffix configurable via `-Agigamap.metamodel.suffix=` (default `_`); builds clean on JDK 17–21+.

## Layout & tests

`gigamap-codegen` (the processor) + `gigamap-codegen-test` (test-only; Lucene/JVector test-scope). `mvn -pl gigamap/codegen install && mvn -pl gigamap/codegen-test clean test` → 17 tests green, covering query, reload, parity with the runtime generators/handlers, and the skip-fallbacks.
