### PR TITLE
GigaMap: fix iteration read-lock leaks & deadlocks, enforce the iteration contract (#697)

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIterator.java
@@ -111,19 +111,28 @@ public final class BitmapIterator<E> extends AbstractBitmapIterating<E> implemen
 	{
 		synchronized(this.parent())
 		{
-			final E next;
-			if(this.next != null)
+			// must close on any throwable (no more elements or a failure during entity resolution).
+			try
 			{
-				// #hasNext already had the next element prepared, so just consume it.
-				next = this.next;
-				this.next = null;
+				final E next;
+				if(this.next != null)
+				{
+					// #hasNext already had the next element prepared, so just consume it.
+					next = this.next;
+					this.next = null;
+				}
+				else if((next = this.scrollToNextNonNullElement()) == null)
+				{
+					// no element and no more data to get the next one, hence exception
+					throw new NoSuchElementException();
+				}
+				return next;
 			}
-			else if((next = this.scrollToNextNonNullElement()) == null)
+			catch(final Throwable t)
 			{
-				// no element and no more data to get the next one, hence exception
-				throw new NoSuchElementException();
+				this.close();
+				throw t;
 			}
-			return next;
 		}
 	}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIterator.java
@@ -41,8 +41,9 @@ public final class BitmapIterator<E> extends AbstractBitmapIterating<E> implemen
 	////////////////////
 
 	// parent must be referenced separately because resolver might not use/reference it at all.
-	private final GigaMap.Default<E> parent  ;
-	private final EntityResolver<E>  resolver;
+	private final GigaMap.Default<E> parent      ;
+	private final EntityResolver<E>  resolver    ;
+	private final Thread             owningThread = Thread.currentThread();
 
 	private boolean isActive = true;
 
@@ -80,6 +81,12 @@ public final class BitmapIterator<E> extends AbstractBitmapIterating<E> implemen
 	public final GigaMap.Default<E> parent()
 	{
 		return this.parent;
+	}
+
+	@Override
+	public final Thread owningThread()
+	{
+		return this.owningThread;
 	}
 
 	@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIterator.java
@@ -93,9 +93,10 @@ public interface GigaIterator<E> extends Iterator<E>, AutoCloseable
 		////////////////////
 		
 		// parent must be referenced separately because resolver might not use/reference it at all.
-		private final GigaMap.Default<E> parent    ;
-		private final ResultIdIterator   idIterator;
-		private final EntityResolver<E>  resolver  ;
+		private final GigaMap.Default<E> parent      ;
+		private final ResultIdIterator   idIterator  ;
+		private final EntityResolver<E>  resolver    ;
+		private final Thread             owningThread = Thread.currentThread();
 
 		private Entry<E> next = null;
 		
@@ -127,6 +128,12 @@ public interface GigaIterator<E> extends Iterator<E>, AutoCloseable
 		public GigaMap<?> parent()
 		{
 			return this.idIterator.parent();
+		}
+
+		@Override
+		public Thread owningThread()
+		{
+			return this.owningThread;
 		}
 
 		@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIterator.java
@@ -132,15 +132,24 @@ public interface GigaIterator<E> extends Iterator<E>, AutoCloseable
 		@Override
 		public final boolean hasNext()
 		{
-			if(this.next != null || (this.next = this.scrollToNextNonNullElement()) != null)
+			// must close in any and all cases where next is null. Including no elements and any throwable.
+			try
 			{
-				return true;
+				if(this.next != null || (this.next = this.scrollToNextNonNullElement()) != null)
+				{
+					return true;
+				}
+
+				// must close at the end to unregister from the parent GigaMap.
+				this.close();
+
+				return false;
 			}
-
-			// must close at the end to unregister from the parent GigaMap.
-			this.close();
-
-			return false;
+			catch(final Throwable t)
+			{
+				this.close();
+				throw t;
+			}
 		}
 
 		@Override
@@ -158,19 +167,28 @@ public interface GigaIterator<E> extends Iterator<E>, AutoCloseable
 		
 		private Entry<E> nextEntry()
 		{
-			final Entry<E> next;
-			if(this.next != null)
+			// must close on any throwable (no more elements or a failure during entity resolution).
+			try
 			{
-				// #hasNext already had the next element prepared, so just consume it.
-				next = this.next;
-				this.next = null;
+				final Entry<E> next;
+				if(this.next != null)
+				{
+					// #hasNext already had the next element prepared, so just consume it.
+					next = this.next;
+					this.next = null;
+				}
+				else if((next = this.scrollToNextNonNullElement()) == null)
+				{
+					// no element and no more data to get the next one, hence exception
+					throw new NoSuchElementException();
+				}
+				return next;
 			}
-			else if((next = this.scrollToNextNonNullElement()) == null)
+			catch(final Throwable t)
 			{
-				// no element and no more data to get the next one, hence exception
-				throw new NoSuchElementException();
+				this.close();
+				throw t;
 			}
-			return next;
 		}
 		
 		private Entry<E> scrollToNextNonNullElement()

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -224,24 +224,33 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public boolean isReadOnly();
 	
 	/**
-	 * Marks this {@link GigaMap} as read-only, indicating that
-	 * it cannot be modified further.
+	 * Marks this {@link GigaMap} as read-only, indicating that it cannot be modified further until a
+	 * matching {@link #unmarkReadOnly()} is issued.
+	 * <p>
+	 * Read-only marks are <strong>reference-counted</strong>: nesting is allowed, but every
+	 * {@code markReadOnly()} must be paired with exactly one {@link #unmarkReadOnly()}.
+	 * <p>
+	 * <strong>Warning:</strong> this is a low-level toggle that shares its counter with the read-lock
+	 * mechanism guarding in-progress iterations and queries. Do <strong>not</strong> call it (nor
+	 * {@link #unmarkReadOnly()}) from within an {@link #iterate(Consumer)} / {@link #forEach(Consumer)} /
+	 * {@code query(...)} consumer: doing so corrupts the read-only count that protects the running
+	 * iteration and results in undefined behavior. Imbalanced calls can leave the map permanently
+	 * non-mutable.
 	 */
 	public void markReadOnly();
-	
+
 	/**
-	 * Removes the read-only status from this {@link GigaMap}.
+	 * Removes one read-only mark previously set via {@link #markReadOnly()}; the map becomes mutable
+	 * again once the last mark is removed.
+	 * <p>
+	 * <strong>Warning:</strong> must be balanced with {@link #markReadOnly()}. Calling it more often than
+	 * {@code markReadOnly()} throws an {@link IllegalStateException} (it would otherwise drive the
+	 * read-only count negative and leave the map permanently non-mutable). See {@link #markReadOnly()} for
+	 * why this must never be called from within an iteration/query consumer.
+	 *
+	 * @throws IllegalStateException if called without a matching {@link #markReadOnly()}
 	 */
 	public void unmarkReadOnly();
-	
-	/**
-	 * Removes all read-only marks currently set.
-	 * This operation is intended to reset or clear any read-only status
-	 * that may have been applied to this {@link GigaMap}.
-	 *
-	 * @return true if the read-only marks were successfully cleared, false otherwise
-	 */
-	public boolean clearReadOnlyMarks();
 	
 	/**
 	 * Replaces an entity if present in this collection, updates the indices accordingly,
@@ -1249,8 +1258,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		// Uses WeakReferences so removed entities can be garbage-collected.
 		private transient BulkList<WeakReference<E>> pendingEntityStores;
 		
+		// Internal, transient read-only hold count: incremented by active readers (iterators), in-progress
+		// iterate()/iterateIndexed() and query execution. NOT touched by the public markReadOnly() API, so
+		// that public misuse cannot lift the protection of a running iteration.
 		private transient int readOnlyCount;
 		private transient int activeReaderCount;
+		// Public, explicit read-only mode count, controlled solely by markReadOnly()/unmarkReadOnly().
+		private transient int explicitReadOnlyCount;
 		private final transient BulkList<Reading> activeReaders;
 							
 		
@@ -1311,8 +1325,9 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			
 			this.initializeConfiguration();
 			
-			this.readOnlyCount       = 0;
-			this.activeReaderCount = 0;
+			this.readOnlyCount         = 0;
+			this.activeReaderCount     = 0;
+			this.explicitReadOnlyCount = 0;
 			this.activeReaders = BulkList.New();
 
 			if(createInstances)
@@ -1625,10 +1640,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			
 			this.initializeConfiguration();
 			
-			this.readOnlyCount       = 0;
-			this.activeReaderCount = 0;
+			this.readOnlyCount         = 0;
+			this.activeReaderCount     = 0;
+			this.explicitReadOnlyCount = 0;
 			this.activeReaders.clear();
-			
+
 			for(final Lazy<?> e : this.level3.segments)
 			{
 				if(e != null)
@@ -1976,8 +1992,9 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			
 			this.initializeConfiguration();
 			
-			this.readOnlyCount       = 0;
-			this.activeReaderCount = 0;
+			this.readOnlyCount         = 0;
+			this.activeReaderCount     = 0;
+			this.explicitReadOnlyCount = 0;
 			this.activeReaders.clear();
 		}
 		
@@ -2186,7 +2203,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			// Mark read-only for the duration of the traversal so that a reentrant mutation from the
 			// consumer fails fast (in #ensureMutability) instead of corrupting the structure being
 			// walked. Structural modification during iteration is not supported.
-			this.markReadOnly();
+			this.enterReadOnly();
 			try
 			{
 				final Lazy<GigaLevel2<E>>[] level3 = this.level3.segments;
@@ -2209,7 +2226,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			}
 			finally
 			{
-				this.unmarkReadOnly();
+				this.exitReadOnly();
 			}
 
 			return iterator;
@@ -2244,7 +2261,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		public final synchronized <I extends EntryConsumer<? super E>> I iterateIndexed(final I consumer)
 		{
 			// see #iterate(Consumer): read-only for the duration so reentrant mutation fails fast.
-			this.markReadOnly();
+			this.enterReadOnly();
 			try
 			{
 				final int level1p2Pow2 = this.level2TotalLengthExp;
@@ -2269,7 +2286,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			}
 			finally
 			{
-				this.unmarkReadOnly();
+				this.exitReadOnly();
 			}
 
 			return consumer;
@@ -2418,7 +2435,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 			this.activeReaders.add(reading);
 			this.activeReaderCount++;
-			this.markReadOnly();
+			this.enterReadOnly();
 
 			return iterator;
 		}
@@ -2534,54 +2551,83 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			}
 			finally
 			{
-				this.unmarkReadOnly();
+				this.exitReadOnly();
 			}
 		}
 		
 		private boolean checkingIsReadOnly()
 		{
+			// Explicit (public) read-only mode: reject mutation immediately.
+			if(this.explicitReadOnlyCount != 0)
+			{
+				throw new IllegalStateException(XChars.systemString(this) + " is in read only mode.");
+			}
+
 			if(this.readOnlyCount == 0)
 			{
 				return false;
 			}
-			
+
+			// A read-only hold that does not stem from an active reader means an iterate()/iterateIndexed()
+			// or query execution is in progress: structural modification during iteration is not supported.
 			if(this.readOnlyCount > this.activeReaderCount)
 			{
-				throw new IllegalStateException(XChars.systemString(this) + " is in read only mode.");
+				throw new IllegalStateException(
+					XChars.systemString(this) + " must not be structurally modified during iteration."
+				);
 			}
-			
+
+			// Only active readers hold the map read-only: a mutation must wait until they are closed
+			// (the reader may be driven by another thread; #checkSelfHeldReader guards the same-thread case).
 			return true;
 		}
-				
-		@Override
-		public final synchronized boolean isReadOnly()
-		{
-			return this.readOnlyCount != 0;
-		}
-					
-		@Override
-		public final synchronized void markReadOnly()
+
+		/**
+		 * Internal read-only hold for active readers, in-progress iterations and query execution. Distinct
+		 * from the public {@link #markReadOnly()} so that public misuse cannot lift an iteration's hold.
+		 */
+		private synchronized void enterReadOnly()
 		{
 			this.readOnlyCount++;
 		}
-		
-		@Override
-		public final synchronized void unmarkReadOnly()
+
+		private synchronized void exitReadOnly()
 		{
 			if(--this.readOnlyCount == 0)
 			{
-				// notify threads waiting for gigamap instance to become mutable again
+				// notify threads waiting for the gigamap instance to become mutable again
 				this.notifyAll();
 			}
 		}
-		
+
 		@Override
-		public final synchronized boolean clearReadOnlyMarks()
+		public final synchronized boolean isReadOnly()
 		{
-			final boolean result = this.readOnlyCount > this.activeReaderCount;
-			this.readOnlyCount = this.activeReaderCount;
-			
-			return result;
+			return this.explicitReadOnlyCount != 0 || this.readOnlyCount != 0;
+		}
+
+		@Override
+		public final synchronized void markReadOnly()
+		{
+			this.explicitReadOnlyCount++;
+		}
+
+		@Override
+		public final synchronized void unmarkReadOnly()
+		{
+			if(this.explicitReadOnlyCount <= 0)
+			{
+				// Fail fast instead of driving the count negative: a negative count would make
+				// #checkingIsReadOnly report read-only forever, permanently blocking every mutation.
+				throw new IllegalStateException(
+					XChars.systemString(this) + " unmarkReadOnly() called without a matching markReadOnly()."
+				);
+			}
+			if(--this.explicitReadOnlyCount == 0)
+			{
+				// notify threads waiting for the gigamap instance to become mutable again
+				this.notifyAll();
+			}
 		}
 
 		final void executeInReadOnlyMode(
@@ -2594,12 +2640,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		{
 			try
 			{
-				this.markReadOnly();
+				this.enterReadOnly();
 				this.executeReadOnly(condition, idStart, idBound, idMatcher, consumer);
 			}
 			finally
 			{
-				this.unmarkReadOnly();
+				this.exitReadOnly();
 			}
 		}
 		
@@ -2802,7 +2848,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			this.activeReaders.add(iterator);
 			this.activeReaderCount++;
 			
-			this.markReadOnly();
+			this.enterReadOnly();
 			
 			return iterator;
 		}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -412,7 +412,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	@Override
 	public default void forEach(final Consumer<? super E> action)
 	{
-		this.iterate(action);
+		this.iterate(notNull(action));
 	}
 
 	/**

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -38,6 +38,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -412,6 +413,21 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public default void forEach(final Consumer<? super E> action)
 	{
 		this.iterate(action);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * <strong>
+	 * Important: a directly-obtained spliterator holds the GigaMap read-lock and provides no close
+	 * handle. Either consume it fully (the underlying {@link GigaIterator} self-closes on exhaustion)
+	 * or, preferably, use {@link #iterate(Consumer)} or a try-with-resources around {@link #iterator()}.
+	 * </strong>
+	 */
+	@Override
+	public default Spliterator<E> spliterator()
+	{
+		return Iterable.super.spliterator();
 	}
 
 	/**

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -1872,6 +1872,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		{
 			while(this.checkingIsReadOnly())
 			{
+				this.checkSelfHeldReader();
 				try
 				{
 					this.wait();
@@ -1881,6 +1882,26 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 					throw new IllegalStateException(
 						XChars.systemString(this) + " is not mutable. (readOnlyCount " + this.readOnlyCount + ")",
 						e
+					);
+				}
+			}
+		}
+
+		private void checkSelfHeldReader()
+		{
+			// If the current thread itself holds an open reader, waiting for mutability would block
+			// forever (the blocked thread is the only one that would close its own reader). Fail fast
+			// with a clear error instead of deadlocking. Only reached when a mutation would block.
+			final Thread current = Thread.currentThread();
+			for(final Reading reader : this.activeReaders)
+			{
+				if(reader.owningThread() == current)
+				{
+					throw new IllegalStateException(
+						"Self-deadlock detected: the current thread holds an open read iterator on this "
+						+ GigaMap.class.getSimpleName() + " and cannot mutate it until that iterator is closed. "
+						+ "Close the iterator (e.g. via try-with-resources) before mutating, or iterate and "
+						+ "mutate on separate threads."
 					);
 				}
 			}
@@ -2939,17 +2960,18 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		////////////////////
 		
 		private final GigaMap.Default<E> parent;
+		private final Thread             owningThread = Thread.currentThread();
 		long currentEntityId = -1;
 		E currentEntity = null;
-		
+
 		boolean isActive = true;
-		
-		
-		
+
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
-		
+
 		Itr(final GigaMap.Default<E> parent)
 		{
 			super();
@@ -3013,19 +3035,25 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		{
 			return this.parent;
 		}
-		
+
+		@Override
+		public final Thread owningThread()
+		{
+			return this.owningThread;
+		}
+
 		@Override
 		public final boolean isClosed()
 		{
 			return !this.isActive;
 		}
-		
+
 		@Override
 		public final void setInactive()
 		{
 			this.isActive = false;
 		}
-		
+
 		@Override
 		public final void close()
 		{
@@ -3044,13 +3072,29 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public interface Reading
 	{
 		public void close();
-		
+
 		public boolean isClosed();
-		
+
 		public GigaMap<?> parent();
-		
+
 		public void setInactive();
-				
+
+		/**
+		 * Returns the thread that opened this reader (and therefore holds the parent
+		 * {@link GigaMap}'s read-lock), or {@code null} if unknown.
+		 * <p>
+		 * Used to detect self-deadlocks: a thread that still holds an open reader and then tries to
+		 * mutate the same GigaMap on that same thread would wait forever for its own reader to close.
+		 * The ownership reflects the <em>creating</em> thread; the supported usage model is that an
+		 * iterator is driven and closed by the same thread that created it.
+		 *
+		 * @return the owning thread, or {@code null} if unknown
+		 */
+		public default Thread owningThread()
+		{
+			return null;
+		}
+
 	}
 	
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -402,6 +402,19 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public <I extends Consumer<? super E>> I iterate(I iterator);
 
 	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * Overrides the default {@link Iterable#forEach(Consumer)} to delegate to {@link #iterate(Consumer)},
+	 * which traverses the elements without leaving a read-lock open if {@code action} throws. The inherited
+	 * default implementation obtains a {@link GigaIterator} but never closes it.
+	 */
+	@Override
+	public default void forEach(final Consumer<? super E> action)
+	{
+		this.iterate(action);
+	}
+
+	/**
 	 * Iterates over all elements, handing over the entity ids as well.
 	 * <p>
 	 * Keep in mind that this can result in a very expensive operation, depending on the overall count of elements.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -394,7 +394,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Iterates over all elements.
 	 * <p>
 	 * Keep in mind that this can result in a very expensive operation, depending on the overall count of elements.
-	 * 
+	 * <p>
+	 * The map is held read-only for the duration of the iteration: structurally modifying it from within
+	 * {@code iterator} (e.g. {@code add}, {@code remove}, {@code update}/{@code apply}, {@code store}) is not
+	 * supported and throws an {@link IllegalStateException}. To mutate based on a scan, collect first (e.g.
+	 * into a separate {@link java.util.List}) and mutate afterwards.
+	 *
 	 * @param <I> type of iterator
 	 * @param iterator the consumer of elements
 	 * @return the given iterator
@@ -408,6 +413,9 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Overrides the default {@link Iterable#forEach(Consumer)} to delegate to {@link #iterate(Consumer)},
 	 * which traverses the elements without leaving a read-lock open if {@code action} throws. The inherited
 	 * default implementation obtains a {@link GigaIterator} but never closes it.
+	 * <p>
+	 * As with {@link #iterate(Consumer)}, structurally modifying the map from within {@code action} is not
+	 * supported and throws an {@link IllegalStateException}.
 	 */
 	@Override
 	public default void forEach(final Consumer<? super E> action)
@@ -434,7 +442,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Iterates over all elements, handing over the entity ids as well.
 	 * <p>
 	 * Keep in mind that this can result in a very expensive operation, depending on the overall count of elements.
-	 * 
+	 * <p>
+	 * As with {@link #iterate(Consumer)}, the map is held read-only for the duration of the iteration:
+	 * structurally modifying it from within {@code consumer} is not supported and throws an
+	 * {@link IllegalStateException}.
+	 *
 	 * @param <I> type of consumer
 	 * @param consumer the consumer of elements
 	 * @return the given consumer
@@ -2170,24 +2182,35 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		@Override
 		public final synchronized <I extends Consumer<? super E>> I iterate(final I iterator)
 		{
-			final Lazy<GigaLevel2<E>>[] level3 = this.level3.segments;
-			for(final Lazy<GigaLevel2<E>> level2Root : level3)
+			// Mark read-only for the duration of the traversal so that a reentrant mutation from the
+			// consumer fails fast (in #ensureMutability) instead of corrupting the structure being
+			// walked. Structural modification during iteration is not supported.
+			this.markReadOnly();
+			try
 			{
-				if(level2Root == null)
+				final Lazy<GigaLevel2<E>>[] level3 = this.level3.segments;
+				for(final Lazy<GigaLevel2<E>> level2Root : level3)
 				{
-					continue;
-				}
-				final Lazy<GigaLevel1<E>>[] level2 = level2Root.get().segments;
-				try
-				{
-					iterate(level2, iterator);
-				}
-				catch(final ThrowBreak b)
-				{
-					break;
+					if(level2Root == null)
+					{
+						continue;
+					}
+					final Lazy<GigaLevel1<E>>[] level2 = level2Root.get().segments;
+					try
+					{
+						iterate(level2, iterator);
+					}
+					catch(final ThrowBreak b)
+					{
+						break;
+					}
 				}
 			}
-			
+			finally
+			{
+				this.unmarkReadOnly();
+			}
+
 			return iterator;
 		}
 				
@@ -2219,26 +2242,35 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		@Override
 		public final synchronized <I extends EntryConsumer<? super E>> I iterateIndexed(final I consumer)
 		{
-			final int level1p2Pow2 = this.level2TotalLengthExp;
-			final Lazy<GigaLevel2<E>>[] level3 = this.level3.segments;
-			for(int i = 0; i < level3.length; i++)
+			// see #iterate(Consumer): read-only for the duration so reentrant mutation fails fast.
+			this.markReadOnly();
+			try
 			{
-				final Lazy<GigaLevel2<E>> level2Root;
-				if((level2Root = level3[i]) == null)
+				final int level1p2Pow2 = this.level2TotalLengthExp;
+				final Lazy<GigaLevel2<E>>[] level3 = this.level3.segments;
+				for(int i = 0; i < level3.length; i++)
 				{
-					continue;
-				}
-				final GigaLevel2<E> level2 = level2Root.get();
-				try
-				{
-					this.iterate(level2, i<<level1p2Pow2, consumer);
-				}
-				catch(final ThrowBreak b)
-				{
-					break;
+					final Lazy<GigaLevel2<E>> level2Root;
+					if((level2Root = level3[i]) == null)
+					{
+						continue;
+					}
+					final GigaLevel2<E> level2 = level2Root.get();
+					try
+					{
+						this.iterate(level2, i<<level1p2Pow2, consumer);
+					}
+					catch(final ThrowBreak b)
+					{
+						break;
+					}
 				}
 			}
-			
+			finally
+			{
+				this.unmarkReadOnly();
+			}
+
 			return consumer;
 		}
 		

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -396,9 +396,10 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Keep in mind that this can result in a very expensive operation, depending on the overall count of elements.
 	 * <p>
 	 * The map is held read-only for the duration of the iteration: structurally modifying it from within
-	 * {@code iterator} (e.g. {@code add}, {@code remove}, {@code update}/{@code apply}, {@code store}) is not
-	 * supported and throws an {@link IllegalStateException}. To mutate based on a scan, collect first (e.g.
-	 * into a separate {@link java.util.List}) and mutate afterwards.
+	 * {@code iterator} (e.g. {@code add}, {@code remove}, {@code update}/{@code apply}) is not supported and
+	 * throws an {@link IllegalStateException}. To mutate based on a scan, collect first (e.g. into a separate
+	 * {@link java.util.List}) and mutate afterwards. (Calling {@code store()} during iteration is allowed —
+	 * it persists the graph without structurally modifying the map.)
 	 *
 	 * @param <I> type of iterator
 	 * @param iterator the consumer of elements

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
@@ -14,6 +14,7 @@ package org.eclipse.store.gigamap.types;
  * #L%
  */
 
+import org.eclipse.serializer.branching.ThrowBreak;
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.XArrays;
 import org.eclipse.serializer.collections.types.XIterable;
@@ -75,6 +76,11 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 				procedure.accept(it.next());
 			}
 		}
+		catch(final ThrowBreak b)
+		{
+			// X.BREAK() signals a controlled early exit per the XIterable contract; absorb it.
+			// (The iterator is already closed by the try-with-resources, releasing the read-lock.)
+		}
 		return procedure;
 	}
 
@@ -130,6 +136,11 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 			{
 				it.nextIndexed(consumer);
 			}
+		}
+		catch(final ThrowBreak b)
+		{
+			// X.BREAK() signals a controlled early exit; absorb it, mirroring iterate(Consumer) and
+			// GigaMap.iterateIndexed(). (The iterator is already closed, releasing the read-lock.)
 		}
 		return consumer;
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
@@ -17,12 +17,15 @@ package org.eclipse.store.gigamap.types;
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.XArrays;
 import org.eclipse.serializer.collections.types.XIterable;
+import org.eclipse.serializer.util.X;
 
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static org.eclipse.serializer.util.X.notNull;
 
 
 /**
@@ -78,7 +81,7 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 	@Override
 	public default void forEach(final Consumer<? super E> action)
 	{
-		this.iterate(action);
+		this.iterate(notNull(action));
 	}
 
 	/**

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
@@ -80,6 +80,22 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 	{
 		this.iterate(action);
 	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * <strong>
+	 * Important: a directly-obtained spliterator holds the GigaMap read-lock and provides no close
+	 * handle. Either consume it fully (the underlying {@link GigaIterator} self-closes on exhaustion)
+	 * or, preferably, use {@link #stream()} (which releases the read-lock via {@code onClose}) or
+	 * {@link #iterate(Consumer)}.
+	 * </strong>
+	 */
+	@Override
+	public default Spliterator<E> spliterator()
+	{
+		return Iterable.super.spliterator();
+	}
 	
 	/**
 	 * Iterates over the results of this query with their corresponding id

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
@@ -67,6 +67,19 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 		}
 		return procedure;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * Overrides the default {@link Iterable#forEach(Consumer)} to ensure the underlying
+	 * {@link GigaIterator} (and thus the GigaMap read-lock) is closed even if {@code action}
+	 * throws. The inherited default implementation does not close the iterator.
+	 */
+	@Override
+	public default void forEach(final Consumer<? super E> action)
+	{
+		this.iterate(action);
+	}
 	
 	/**
 	 * Iterates over the results of this query with their corresponding id

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
@@ -53,6 +53,12 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 	
 	/**
 	 * Iterates over the results of this query using the provided {@code Consumer} procedure.
+	 * <p>
+	 * The backing {@link GigaMap} is held read-only for the duration of the iteration: structurally
+	 * modifying it from within {@code procedure} (e.g. {@code add}, {@code remove},
+	 * {@code update}/{@code apply}, {@code store}) is not supported and throws an
+	 * {@link IllegalStateException}. To mutate based on a query, collect first (e.g. via
+	 * {@link #toList()}) and mutate afterwards.
 	 *
 	 * @param <P> the type of the {@code Consumer} that will process the elements
 	 * @param procedure the {@code Consumer} instance that processes elements
@@ -77,6 +83,9 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 	 * Overrides the default {@link Iterable#forEach(Consumer)} to ensure the underlying
 	 * {@link GigaIterator} (and thus the GigaMap read-lock) is closed even if {@code action}
 	 * throws. The inherited default implementation does not close the iterator.
+	 * <p>
+	 * As with {@link #iterate(Consumer)}, structurally modifying the backing map from within
+	 * {@code action} is not supported and throws an {@link IllegalStateException}.
 	 */
 	@Override
 	public default void forEach(final Consumer<? super E> action)
@@ -103,6 +112,10 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 	/**
 	 * Iterates over the results of this query with their corresponding id
 	 * and applies the given consumer to each element.
+	 * <p>
+	 * As with {@link #iterate(Consumer)}, the backing map is held read-only for the duration of the
+	 * iteration: structurally modifying it from within {@code consumer} is not supported and throws an
+	 * {@link IllegalStateException}.
 	 *
 	 * @param <I> The type of the consumer that will process each element and its id.
 	 * @param consumer The consumer that processes each element and its id during iteration.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
@@ -56,9 +56,10 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 	 * <p>
 	 * The backing {@link GigaMap} is held read-only for the duration of the iteration: structurally
 	 * modifying it from within {@code procedure} (e.g. {@code add}, {@code remove},
-	 * {@code update}/{@code apply}, {@code store}) is not supported and throws an
-	 * {@link IllegalStateException}. To mutate based on a query, collect first (e.g. via
-	 * {@link #toList()}) and mutate afterwards.
+	 * {@code update}/{@code apply}) is not supported and throws an {@link IllegalStateException}. To mutate
+	 * based on a query, collect first (e.g. via {@link #toList()}) and mutate afterwards. (Calling
+	 * {@code store()} during iteration is allowed — it persists the graph without structurally modifying
+	 * the map.)
 	 *
 	 * @param <P> the type of the {@code Consumer} that will process the elements
 	 * @param procedure the {@code Consumer} instance that processes elements

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/ReadOnlyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/ReadOnlyTest.java
@@ -157,4 +157,52 @@ public class ReadOnlyTest
 		map.add(Entity.Random().setWord("x"));
 		assertEquals(1, map.size());
 	}
+
+	@Test
+	void unmarkReadOnly_withoutMatchingMark_throws()
+	{
+		final GigaMap<Entity> map = GigaMap.New();
+		map.index().bitmap().ensure(Entity.wordIndex);
+
+		// An unbalanced unmark must fail fast rather than drive readOnlyCount negative, which would
+		// leave the map permanently non-mutable (a silent deadlock for every future mutation).
+		assertThrows(IllegalStateException.class, map::unmarkReadOnly);
+
+		// The map must still be mutable afterwards.
+		map.add(Entity.Random().setWord("x"));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	void unmarkReadOnly_oneTooMany_throws()
+	{
+		final GigaMap<Entity> map = GigaMap.New();
+		map.index().bitmap().ensure(Entity.wordIndex);
+
+		map.markReadOnly();
+		map.unmarkReadOnly();
+		assertThrows(IllegalStateException.class, map::unmarkReadOnly);
+
+		map.add(Entity.Random().setWord("x"));
+		assertEquals(1, map.size());
+	}
+
+	@Test
+	void unmarkReadOnly_fromWithinIteration_cannotLiftIterationGuard()
+	{
+		final GigaMap<Entity> map = GigaMap.New();
+		map.index().bitmap().ensure(Entity.wordIndex);
+		map.add(Entity.Random().setWord("a"));
+
+		// The public read-only API uses a counter separate from the iteration's internal read-lock.
+		// A consumer calling unmarkReadOnly() must therefore NOT be able to lift the protection of the
+		// running iteration; it fails fast (no matching markReadOnly()) instead.
+		assertThrows(IllegalStateException.class,
+			() -> map.forEach(e -> map.unmarkReadOnly()));
+
+		// The iteration released its own hold cleanly, so the map is mutable again afterwards.
+		assertFalse(map.isReadOnly());
+		map.add(Entity.Random().setWord("b"));
+		assertEquals(2, map.size());
+	}
 }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
@@ -14,9 +14,12 @@ package org.eclipse.store.gigamap.indexer.edge;
  * #L%
  */
 
+import org.eclipse.store.gigamap.types.EntityResolver;
 import org.eclipse.store.gigamap.types.GigaIterator;
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.GigaQuery;
 import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.gigamap.types.IterationThreadProvider;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -236,6 +239,140 @@ public class QueryIteratorCloseTest
         holder.join();
         assertNull(holderError.get());
         assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+
+    @Test
+    void threadedQueryForEachClosesIteratorOnException()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+        for (int i = 0; i < 99; i++)
+        {
+            gigaMap.add(new NamePerson("name1", i));
+        }
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            try
+            {
+                // A thread provider forces the multi-threaded GigaIterator.Wrapping instead of BitmapIterator.
+                gigaMap.query(threadProvider()).and(nameIndexer.is("name1")).forEach(p -> {
+                    throw new RuntimeException("boom");
+                });
+            }
+            catch (final RuntimeException expected)
+            {
+                // swallow: the consumer threw on purpose
+            }
+
+            // Must NOT deadlock: the read-lock has to be released even though the consumer threw.
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+    @Test
+    void threadedNextPastEndReleasesLockOnThrow()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+        gigaMap.add(new NamePerson("other", 2));
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            // Deliberately NOT closing the iterator: driving next() one past the end must release
+            // the read-lock itself when it throws NoSuchElementException (Wrapping.nextEntry guard).
+            final GigaIterator<NamePerson> it =
+                gigaMap.query(threadProvider()).and(nameIndexer.is("name1")).iterator();
+            it.hasNext();                                         // prepares the single match
+            it.next();                                           // consumes it, clearing the buffer
+            assertThrows(NoSuchElementException.class, it::next); // scrolls past end -> must self-close
+
+            // Must NOT deadlock: next() has to release the read-lock on throw.
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+    @Test
+    void threadedResolutionFailureInHasNextReleasesLock()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            // A failing resolver simulates an entity resolution error (e.g. lazy-load failure) on
+            // the normal iteration path: hasNext() itself throws and must release the read-lock
+            // (Wrapping.hasNext guard). Deliberately NOT closing the iterator.
+            final GigaQuery.Default<NamePerson> query =
+                (GigaQuery.Default<NamePerson>)gigaMap.query(threadProvider()).and(nameIndexer.is("name1"));
+            final GigaIterator<NamePerson> it = query.iterator(failingResolver(gigaMap));
+
+            final RuntimeException thrown = assertThrows(RuntimeException.class, it::hasNext);
+            assertEquals("simulated entity resolution failure", thrown.getMessage());
+
+            // Must NOT deadlock: hasNext() has to release the read-lock on throw.
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+    @Test
+    void resolutionFailureInNextReleasesLock()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            // Single-threaded path: calling next() without a prior hasNext() exercises the scroll
+            // branch inside BitmapIterator.next() itself, where the resolution failure must
+            // release the read-lock. Deliberately NOT closing the iterator.
+            final GigaQuery.Default<NamePerson> query =
+                (GigaQuery.Default<NamePerson>)gigaMap.query(nameIndexer.is("name1"));
+            final GigaIterator<NamePerson> it = query.iterator(failingResolver(gigaMap));
+
+            final RuntimeException thrown = assertThrows(RuntimeException.class, it::next);
+            assertEquals("simulated entity resolution failure", thrown.getMessage());
+
+            // Must NOT deadlock: next() has to release the read-lock on throw.
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+
+    static IterationThreadProvider threadProvider()
+    {
+        return IterationThreadProvider.Creating((parent, results) -> 4);
+    }
+
+    static EntityResolver<NamePerson> failingResolver(final GigaMap<NamePerson> parent)
+    {
+        return new EntityResolver<>()
+        {
+            @Override
+            public NamePerson get(final long entityId)
+            {
+                throw new RuntimeException("simulated entity resolution failure");
+            }
+
+            @Override
+            public GigaMap<NamePerson> parent()
+            {
+                return parent;
+            }
+        };
     }
 
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
@@ -23,9 +23,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
@@ -167,6 +171,70 @@ public class QueryIteratorCloseTest
             gigaMap.update(person, p -> p.setName("changed"));
         });
 
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+
+    @Test
+    void mutationWhileHoldingOwnIteratorThrows()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            // Open and hold a reader without exhausting/closing it.
+            final GigaIterator<NamePerson> it = gigaMap.query(nameIndexer.is("name1")).iterator();
+            it.hasNext();
+
+            // Mutating the same GigaMap on the same thread that holds the reader would deadlock;
+            // it must fail fast with IllegalStateException instead.
+            assertThrows(IllegalStateException.class,
+                () -> gigaMap.update(person, p -> p.setName("changed")));
+
+            it.close();
+        });
+    }
+
+    @Test
+    void mutationFromOtherThreadStillWaits() throws InterruptedException
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        final CountDownLatch readerOpened = new CountDownLatch(1);
+        final CountDownLatch releaseReader = new CountDownLatch(1);
+        final AtomicReference<Throwable> holderError = new AtomicReference<>();
+
+        // A different thread holds an open reader, then releases it on signal.
+        final Thread holder = new Thread(() -> {
+            try (final GigaIterator<NamePerson> it = gigaMap.query(nameIndexer.is("name1")).iterator())
+            {
+                it.hasNext();
+                readerOpened.countDown();
+                releaseReader.await(5, TimeUnit.SECONDS);
+            }
+            catch (final Throwable t)
+            {
+                holderError.set(t);
+            }
+        }, "reader-holder");
+        holder.start();
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            readerOpened.await();
+            // The mutating thread does NOT own the reader, so it must wait (not throw). Release the
+            // holder shortly after so the update can proceed once the foreign reader is closed.
+            final Thread releaser = new Thread(releaseReader::countDown, "releaser");
+            releaser.start();
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        holder.join();
+        assertNull(holderError.get());
         assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
@@ -14,6 +14,7 @@ package org.eclipse.store.gigamap.indexer.edge;
  * #L%
  */
 
+import org.eclipse.store.gigamap.types.GigaIterator;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerString;
 import org.junit.jupiter.api.Test;
@@ -21,9 +22,11 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class QueryIteratorCloseTest
@@ -134,6 +137,33 @@ public class QueryIteratorCloseTest
             }
 
             // Must NOT deadlock: forEach has to release the read-lock even though the consumer threw.
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+
+    @Test
+    void nextPastEndReleasesLockOnThrow()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            // A matching query yields a real BitmapIterator holding a read-lock (an empty query
+            // would return the always-safe GigaIterator.Empty and not exercise the guard).
+            // Deliberately NOT closing the iterator: driving next() one past the end must release
+            // the read-lock itself when it throws NoSuchElementException. A try-with-resources
+            // would mask the leak.
+            final GigaIterator<NamePerson> it = gigaMap.query(nameIndexer.is("name1")).iterator();
+            it.hasNext();                                         // prepares the single match
+            it.next();                                           // consumes it, clearing the buffer
+            assertThrows(NoSuchElementException.class, it::next); // scrolls past end -> must self-close
+
+            // Must NOT deadlock: next() has to release the read-lock on throw.
             gigaMap.update(person, p -> p.setName("changed"));
         });
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
@@ -18,11 +18,13 @@ import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerString;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class QueryIteratorCloseTest
 {
@@ -81,6 +83,61 @@ public class QueryIteratorCloseTest
 
         gigaMap.remove(namePerson);
 
+    }
+
+
+    @Test
+    void queryForEachClosesIteratorOnException()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            try
+            {
+                gigaMap.query(nameIndexer.is("name1")).forEach(p -> {
+                    throw new RuntimeException("boom");
+                });
+            }
+            catch (final RuntimeException expected)
+            {
+                // swallow: the consumer threw on purpose
+            }
+
+            // Must NOT deadlock: forEach has to release the read-lock even though the consumer threw.
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
+    }
+
+    @Test
+    void mapForEachClosesIteratorOnException()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            try
+            {
+                gigaMap.forEach(p -> {
+                    throw new RuntimeException("boom");
+                });
+            }
+            catch (final RuntimeException expected)
+            {
+                // swallow: the consumer threw on purpose
+            }
+
+            // Must NOT deadlock: forEach has to release the read-lock even though the consumer threw.
+            gigaMap.update(person, p -> p.setName("changed"));
+        });
+
+        assertEquals(1, gigaMap.query(nameIndexer.is("changed")).count());
     }
 
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/QueryIteratorCloseTest.java
@@ -376,6 +376,52 @@ public class QueryIteratorCloseTest
     }
 
 
+    @Test
+    void mapForEachMutationDuringIterationThrows()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        gigaMap.add(new NamePerson("name1", 1));
+        gigaMap.add(new NamePerson("name2", 2));
+
+        // Structurally modifying the map from within forEach is not supported and must fail fast
+        // (the map is held read-only for the duration of the iteration), not silently produce
+        // undefined results.
+        assertTimeoutPreemptively(Duration.ofSeconds(5),
+            () -> assertThrows(IllegalStateException.class,
+                () -> gigaMap.forEach(gigaMap::remove)));
+    }
+
+    @Test
+    void mapIterateMutationDuringIterationThrows()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        final NamePerson person = new NamePerson("name1", 1);
+        gigaMap.add(person);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5),
+            () -> assertThrows(IllegalStateException.class,
+                () -> gigaMap.iterate(p -> gigaMap.update(p, x -> x.setName("changed")))));
+    }
+
+    @Test
+    void collectThenMutateIsSupported()
+    {
+        final GigaMap<NamePerson> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(nameIndexer);
+        gigaMap.add(new NamePerson("name1", 1));
+        gigaMap.add(new NamePerson("name2", 2));
+
+        // Supported pattern: snapshot first, then mutate.
+        final List<NamePerson> snapshot = new ArrayList<>();
+        gigaMap.forEach(snapshot::add);
+        snapshot.forEach(gigaMap::remove);
+
+        assertEquals(0, gigaMap.size());
+    }
+
+
     static IndexerString<NamePerson> nameIndexer = new IndexerString.Abstract<>()
     {
         @Override

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/process/BreakContractTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/process/BreakContractTest.java
@@ -1,0 +1,63 @@
+package org.eclipse.store.gigamap.process;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.util.X;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * XIterable contract: iterate() absorbs X.BREAK() as a controlled early exit.
+ * GigaMap honors it, and GigaQuery (which extends XIterable) must too instead of
+ * letting the raw ThrowBreak escape to the caller.
+ */
+public class BreakContractTest
+{
+    private static GigaMap<Long> newMap()
+    {
+        final GigaMap<Long> map = GigaMap.New();
+        for (long i = 0; i < 10; i++)
+        {
+            map.add(i);
+        }
+        return map;
+    }
+
+    @Test
+    void mapForEachAbsorbsBreak()
+    {
+        assertDoesNotThrow(() -> newMap().forEach(e -> { throw X.BREAK(); }));
+    }
+
+    @Test
+    void queryIterateAbsorbsBreak()
+    {
+        assertDoesNotThrow(() -> newMap().query().iterate(e -> { throw X.BREAK(); }));
+    }
+
+    @Test
+    void queryForEachAbsorbsBreak()
+    {
+        assertDoesNotThrow(() -> newMap().query().forEach(e -> { throw X.BREAK(); }));
+    }
+
+    @Test
+    void queryIterateIndexedAbsorbsBreak()
+    {
+        assertDoesNotThrow(() -> newMap().query().iterateIndexed((id, e) -> { throw X.BREAK(); }));
+    }
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/process/StoreDuringIterationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/process/StoreDuringIterationTest.java
@@ -1,0 +1,46 @@
+package org.eclipse.store.gigamap.process;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class StoreDuringIterationTest
+{
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void storeDuringIterationIsAllowed()
+    {
+        final GigaMap<String> gigaMap = GigaMap.New();
+        gigaMap.add("entity");
+
+        try (EmbeddedStorageManager storage = EmbeddedStorage.start(gigaMap, this.tempDir))
+        {
+            // iterate()/forEach() hold the map read-only, so structural mutation (add/remove/update)
+            // throws. store() is NOT a structural modification — it persists the graph without changing
+            // the entity structure — so it is allowed during iteration and must not throw.
+            assertDoesNotThrow(() -> gigaMap.forEach(e -> gigaMap.store()));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [#697](https://github.com/eclipse-store/store/issues/697) and hardens the whole GigaMap iteration / read-lock model around it. A GigaMap read-lock is taken when an iterator registers as a reader and released only on `close()`. A lock that leaks — or is mismanaged — blocks every later mutation on that thread. This PR closes the leak paths, makes mutation-during-iteration fail fast and consistently, turns the remaining unavoidable self-deadlock into a clear exception, and fixes two `XIterable`/API contract violations uncovered along the way.

## What changed

### #697 — read-lock leaks on iteration
- **`forEach()` closes its iterator.** `GigaQuery`/`GigaMap` extend `Iterable`; the inherited `Iterable.forEach` never closed the iterator, so a throwing consumer leaked the read-lock and the next same-thread mutation deadlocked. Both now override `forEach` to the already-safe `iterate()` (and guard against a null action).
- **Uniform close-on-throw across all iterator implementations.** Audited every reader; `BitmapIterator.next()` and `GigaIterator.Wrapping` (the multi-threaded query path) didn't release the read-lock when entity resolution threw mid-iteration. All iterators now close on any throwable, matching the existing pattern. Added threaded-iterator close/lock-release tests (#703).
- Documented `spliterator()` on both types (no behavior change): a directly-obtained spliterator holds the read-lock with no close handle — use `stream()`/`iterate()`.

### Self-deadlock detection
- A thread that mutates the GigaMap while still holding its own open iterator would wait forever. `ensureMutability()` now throws `IllegalStateException` (tracking the reader's owning thread) instead of hanging. Mutations from *other* threads while a reader is held still wait normally.

### Mutation-during-iteration is unsupported and fails fast
- `GigaMap.forEach` delegated to the synchronized direct-walk `iterate()`, which held no reader — so mutating inside the consumer proceeded silently (reentrant) with undefined results, while `query.forEach` threw. `Default.iterate()`/`iterateIndexed()` now hold the map read-only for the traversal, so reentrant mutation throws consistently. Contract documented on `iterate`/`iterateIndexed`/`forEach`; collect-then-mutate is the supported pattern. (`store()` during iteration is *not* structural and remains allowed.)

### Read-only API hardening & decoupling
- The public `markReadOnly()`/`unmarkReadOnly()` shared one counter with the iteration read-lock, so an unbalanced `unmarkReadOnly()` (e.g. from a consumer) could lift a running iteration's protection, and one extra call drove the count negative → permanent silent deadlock. The counter is now split: an internal hold (readers/iterate/query-execution) vs. a public explicit-read-only count. `unmarkReadOnly()` fails fast on underflow; public misuse can no longer touch the iteration hold. `checkingIsReadOnly()`/`isReadOnly()` behavior is preserved exactly.
- Removed the unused, footgun `clearReadOnlyMarks()`.

### XIterable contract — `X.BREAK()`
- `GigaQuery.iterate()`/`iterateIndexed()` let a raw `ThrowBreak` escape instead of absorbing it as a controlled early exit. Now caught, mirroring `GigaMap.Default`.

## Breaking changes (changelog)
- `GigaMap.clearReadOnlyMarks()` removed.
- `unmarkReadOnly()` now throws `IllegalStateException` on unbalanced calls.
- Structurally modifying a GigaMap during `iterate()`/`iterateIndexed()`/`forEach()`/ a query consumer now throws IllegalStateException` instead of silently producing undefined results.

## Testing
New regression tests for each behavior (`QueryIteratorCloseTest`, `ReadOnlyTest`, `StoreDuringIterationTest`, `BreakContractTest`), each guarded by `assertTimeoutPreemptively` where a regression would otherwise hang. Each was confirmed to fail without its fix and pass with it.