### PR TITLE
GigaMap: fix IndexerGenerator restart idempotence for @Unique constraints

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerGenerator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerGenerator.java
@@ -227,7 +227,7 @@ public interface IndexerGenerator<E>
 			// Idempotent: skip unique constraints already registered and ensure (rather than add) the
 			// remaining indices, so the generator can run more than once on the same GigaMap without
 			// failing on already-present index names.
-			final XEnum<String> existingUnique = HashEnum.New();
+			final XEnum<String> existingUnique = EqHashEnum.New();
 			target.accessUniqueConstraints(constraints ->
 			{
 				for(final GigaIndex<E> constraint : constraints)

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/IdempotentGenerationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/annotation/IdempotentGenerationTest.java
@@ -21,7 +21,12 @@ import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationExceptionBi
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerGenerator;
 import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,6 +47,38 @@ public class IdempotentGenerationTest
 			this.name = name;
 			this.code = code;
 			this.id   = id;
+		}
+	}
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void generateIndicesIsIdempotentAcrossRestart()
+	{
+		final GigaMap<Entity> map = GigaMap.New();
+		IndexerGenerator.AnnotationBased(Entity.class).generateIndices(map);
+		map.add(new Entity("n1", "C1", 1));
+
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(map, this.tempDir))
+		{
+		}
+
+		try(final EmbeddedStorageManager sm = EmbeddedStorage.start(this.tempDir))
+		{
+			final GigaMap<Entity> reloaded = sm.root();
+
+			// before the fix this throws: BitmapIndex already registered for name "code".
+			IndexerGenerator.AnnotationBased(Entity.class).generateIndices(reloaded);
+
+			assertEquals(1, reloaded.size());
+
+			// unique constraint still enforced exactly once after re-generation
+			assertThrows(
+				UniqueConstraintViolationExceptionBitmap.class,
+				() -> reloaded.add(new Entity("n2", "C1", 2))
+			);
+			assertEquals(1, reloaded.size());
 		}
 	}
 


### PR DESCRIPTION
## Problem

Re-running the annotation-based `IndexerGenerator` on a **reloaded** `GigaMap` whose entity has a `@Unique` member fails with:

  ```
  RuntimeException: BitmapIndex already registered for name "id".
    at BitmapIndices$Default.validateIndexToAdd
    at BitmapIndices$Default.addUniqueConstraints
    at IndexerGenerator$AnnotationBased.generateBitmapIndices
  ```

`generateBitmapIndices` is meant to be idempotent: it collects the names of already-registered unique constraints and skips re-adding them. But that collection was built with an **identity-based** `HashEnum`. Within a single JVM run the constraint name and the regenerated indexer name are the *same interned `String` instance*, so the `==` check accidentally worked. After a storage reload the constraint name is a freshly deserialized `String`: the identity check misses it, the generator treats the constraint as new, and `addUniqueConstraints` throws.

In practice this breaks effectively every other application startup that re-runs `generateIndices` on a reloaded map with a `@Unique` field.

## Fix

One line in `IndexerGenerator.generateBitmapIndices` — use the value-based `EqHashEnum` (already imported) so deserialized names match by `equals`/`hashCode`:

  ```diff
  -final XEnum<String> existingUnique = HashEnum.New();
  +final XEnum<String> existingUnique = EqHashEnum.New();
  ```

The unrelated `identityIndices` enum (also `HashEnum`) is intentionally left as-is: it dedups freshly created `Indexer` instances within a single call and is not involved in any cross-reload comparison.

## Test

Added `generateIndicesIsIdempotentAcrossRestart` to `IdempotentGenerationTest`.
The existing test only covered the within-JVM case, which masked the bug. The new test stores, reloads via `EmbeddedStorage`, re-runs the generator, and asserts both that it does not throw and that the unique constraint is still enforced exactly once.

- **Before fix:** fails with `BitmapIndex already registered for name "code"`.
- **After fix:** green — `IdempotentGenerationTest`, `CarUniqueTest`, `UniqueStandaloneTest` all pass.
