### PR TITLE
Add null checks for current parameter in replace and apply methods

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -315,6 +315,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 */
 	public default E update(final E current, final Consumer<? super E> logic)
 	{
+		notNull(logic);
 		this.apply(current, e ->
 		{
 			logic.accept(e);
@@ -1811,12 +1812,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		@Override
 		public final synchronized long replace(final E current, final E replacement)
 		{
+			this.validateForCRUD(current);
+			this.validateForCRUD(replacement);
 			if(current == replacement)
 			{
 				throw new IllegalArgumentException("'current' and 'replacement' cannot be the same instance");
 			}
-			this.validateForCRUD(current);
-			this.validateForCRUD(replacement);
 			
 			this.ensureMutability();
 			
@@ -1862,6 +1863,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		public final synchronized <R> R apply(final E current, final Function<? super E, R> logic)
 		{
 			this.validateForCRUD(current);
+			notNull(logic);
 			this.ensureMutability();
 			
 			final long entityId = this.lookupEntityIdPeeking(current, this.determineIdentityLookupIndices());

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -1815,6 +1815,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			{
 				throw new IllegalArgumentException("'current' and 'replacement' cannot be the same instance");
 			}
+			this.validateForCRUD(current);
 			this.validateForCRUD(replacement);
 			
 			this.ensureMutability();
@@ -1860,6 +1861,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		@Override
 		public final synchronized <R> R apply(final E current, final Function<? super E, R> logic)
 		{
+			this.validateForCRUD(current);
 			this.ensureMutability();
 			
 			final long entityId = this.lookupEntityIdPeeking(current, this.determineIdentityLookupIndices());

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapUnitTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapUnitTest.java
@@ -92,6 +92,42 @@ public class GigaMapUnitTest
         }
     }
 
+    // dereferencing indexer: without the null-argument guard, replace(null, x) / apply(null, logic) NPE inside the indexer
+    static class LengthIndexer extends IndexerInteger.Abstract<String>
+    {
+        @Override
+        protected Integer getInteger(final String entity)
+        {
+            return entity.length();
+        }
+    }
+
+    @Test
+    void replaceNullCurrentTest()
+    {
+        final GigaMap<String> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(new LengthIndexer());
+        gigaMap.add("1000");
+        assertThrows(IllegalArgumentException.class, () -> gigaMap.replace(null, "1001"));
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(gigaMap, tempDir)) {
+            assertThrows(IllegalArgumentException.class, () -> gigaMap.replace(null, "1001"));
+        }
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
+            final GigaMap<String> gigaMap2 = manager.root();
+            assertThrows(IllegalArgumentException.class, () -> gigaMap2.replace(null, "1001"));
+        }
+    }
+
+    @Test
+    void applyNullCurrentTest()
+    {
+        final GigaMap<String> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(new LengthIndexer());
+        gigaMap.add("1000");
+        assertThrows(IllegalArgumentException.class, () -> gigaMap.apply(null, e -> e));
+        assertThrows(IllegalArgumentException.class, () -> gigaMap.update(null, e -> {}));
+    }
+
     @Test
     void setWithNull()
     {

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapUnitTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/GigaMapUnitTest.java
@@ -109,6 +109,11 @@ public class GigaMapUnitTest
         gigaMap.index().bitmap().add(new LengthIndexer());
         gigaMap.add("1000");
         assertThrows(IllegalArgumentException.class, () -> gigaMap.replace(null, "1001"));
+        // both null must be rejected as null arguments, not as "same instance"
+        final IllegalArgumentException bothNull = assertThrows(
+            IllegalArgumentException.class, () -> gigaMap.replace(null, null)
+        );
+        assertEquals("null entries are not allowed", bothNull.getMessage());
         try (EmbeddedStorageManager manager = EmbeddedStorage.start(gigaMap, tempDir)) {
             assertThrows(IllegalArgumentException.class, () -> gigaMap.replace(null, "1001"));
         }
@@ -123,9 +128,12 @@ public class GigaMapUnitTest
     {
         final GigaMap<String> gigaMap = GigaMap.New();
         gigaMap.index().bitmap().add(new LengthIndexer());
-        gigaMap.add("1000");
+        String s = "1000";
+        gigaMap.add(s);
         assertThrows(IllegalArgumentException.class, () -> gigaMap.apply(null, e -> e));
         assertThrows(IllegalArgumentException.class, () -> gigaMap.update(null, e -> {}));
+        assertThrows(NullPointerException.class, () -> gigaMap.apply(s, null));
+        assertThrows(NullPointerException.class, () -> gigaMap.update(s, null));
     }
 
     @Test


### PR DESCRIPTION
This pull request improves the robustness of the `GigaMap` class by adding additional argument validation to prevent null or invalid values from being used in key CRUD operations. It also introduces new unit tests to ensure these checks work as intended, especially when using custom indexers.

### Improved argument validation

* Added a call to `validateForCRUD(current)` in both the `replace` and `apply` methods of `GigaMap`, ensuring that the `current` argument is properly validated before proceeding. This helps prevent issues like `NullPointerException` when `null` is passed as the current entity. [[1]](diffhunk://#diff-1c02270344a1bc07f59563b4357cae134ce0f62196401b26a543f1c1f0cb0f99R1818) [[2]](diffhunk://#diff-1c02270344a1bc07f59563b4357cae134ce0f62196401b26a543f1c1f0cb0f99R1864)

### Enhanced test coverage

* Added new tests in `GigaMapUnitTest.java` to verify that passing `null` as the `current` argument to `replace`, `apply`, or `update` methods throws an `IllegalArgumentException`. These tests also cover scenarios with custom indexers to ensure the validation works in all cases.