### PR TITLE
writing truncation log entry in case of truncation after failing a write

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -659,7 +659,18 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		@Override
 		public final void rollbackWrite()
 		{
-			this.writer.truncate(this.headFile, this.headFile.totalLength(), this.fileProvider);
+			// only roll back if an uncommitted write actually happened (size grew past the committed length).
+			// channels that wrote nothing (e.g. empty chunk) must not accrue a spurious truncation entry.
+			if(this.headFile.totalLength() != this.headFile.size())
+			{
+				final long timestamp = this.timestampProvider.currentNanoTimestamp();
+
+				// write truncation entry (BEFORE the actual truncate), mirroring handleLastFile, so the
+				// transaction log and the data file stay consistent after a rolled-back partial store.
+				this.writeTransactionsEntryFileTruncation(this.headFile, timestamp, this.headFile.totalLength());
+
+				this.writer.truncate(this.headFile, this.headFile.totalLength(), this.fileProvider);
+			}
 		}
 
 		@Override


### PR DESCRIPTION
Log a truncation entry when rolling back a partial store.

  When one channel's write fails mid-store while a sibling channel already wrote its slice, the engine rolls back the successful channel by truncating its data file. Previously StorageFileManager.rollbackWrite truncated
  the file but never recorded a matching truncation entry in the transaction log — so the store entry written earlier kept claiming the larger, pre-rollback length. On the next start, validateStorageDataFilesLength saw
  a data file shorter than its logged length and threw StorageExceptionConsistency, leaving the storage permanently un-openable.

  The fix makes rollbackWrite write a FILE_TRUNCATION transaction entry before truncating (mirroring handleLastFile), keeping the transaction log and the data file consistent. A totalLength() != size() guard ensures
  only channels that actually wrote uncommitted data emit an entry. On restart, the recovery analysis resolves the store-then-truncate pair to the rolled-back length and reopens cleanly to the last consistent state —
  the truncation case the transaction analysis was already designed to handle.