### PR TITLE
Update GitHub Actions versions: checkout@v6 and setup-java@v5

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: windows-latest
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_converter.yml
+++ b/.github/workflows/maven_converter.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_deploy_snapshot.yml
+++ b/.github/workflows/maven_deploy_snapshot.yml
@@ -16,9 +16,9 @@ jobs:
     if: github.repository == 'eclipse-store/store'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java for publishing to Maven Central Snapshot Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven_deploy_snapshot_dev.yml
+++ b/.github/workflows/maven_deploy_snapshot_dev.yml
@@ -14,9 +14,9 @@ jobs:
     if: github.repository == 'eclipse-store/store'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java for publishing to Maven Central Snapshot Repository
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_licence_check.yml
+++ b/.github/workflows/maven_licence_check.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -12,9 +12,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven_slow_test.yml
+++ b/.github/workflows/maven_slow_test.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       #Build with java 17
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for building, testing, and deploying the project. The main focus is upgrading the versions of the `actions/checkout` and `actions/setup-java` actions to improve security, compatibility, and maintainability across all CI/CD pipelines.

**CI/CD Workflow Upgrades:**

* Upgraded `actions/checkout` to version `v6` in all workflow files to ensure the latest features and security patches are used. [[1]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L18-R20) [[2]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L18-R20) [[3]](diffhunk://#diff-78ec4836e8c0653030b3d3a7cf36ff43c53aeecd17784becf8fb1453033d15a6L18-R20) [[4]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L19-R21) [[5]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L17-R19) [[6]](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L18-R20) [[7]](diffhunk://#diff-64392646b49a1d14736c149a4698977a54bfb6c569f9f623ca6cd4c3d1658c95L20-R22) [[8]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L15-R17) [[9]](diffhunk://#diff-77e0dfc1dd68b5122b990fdb8b9972bda0bacb60646105d9d9ab0186a5ba5ccbL22-R24)
* Upgraded `actions/setup-java` to version `v5` in all workflow files for setting up JDK 17, ensuring consistency and access to the latest improvements. [[1]](diffhunk://#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764L18-R20) [[2]](diffhunk://#diff-e77b56b9896f79686ebc79a8aa2f9a3504f3a42badbb6f53e667642a68fa6259L18-R20) [[3]](diffhunk://#diff-78ec4836e8c0653030b3d3a7cf36ff43c53aeecd17784becf8fb1453033d15a6L18-R20) [[4]](diffhunk://#diff-90e483e757fc53fb36f9124261704451c10f53e476a7e4b1580f52c8a4ea20c0L19-R21) [[5]](diffhunk://#diff-1bd6a250b0687be2e84d36516305bd217ea856858e767d20d34c03c645973e98L17-R19) [[6]](diffhunk://#diff-013a2ec5c7db633eb7cfe5ed77d6536fed02843f4d5c253f059e2728751b3e16L18-R20) [[7]](diffhunk://#diff-64392646b49a1d14736c149a4698977a54bfb6c569f9f623ca6cd4c3d1658c95L20-R22) [[8]](diffhunk://#diff-81f8c014d70e0efb7dd886d9353bd9f2d694907253e3abdfa029f9cdb3c9fba1L15-R17) [[9]](diffhunk://#diff-77e0dfc1dd68b5122b990fdb8b9972bda0bacb60646105d9d9ab0186a5ba5ccbL22-R24)