### PR TITLE
update AFS dep

### DIFF
--- a/afs/aws/pom.xml
+++ b/afs/aws/pom.xml
@@ -21,7 +21,7 @@
 	<url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <aws.sdk.version>2.42.4</aws.sdk.version>
+        <aws.sdk.version>2.46.11</aws.sdk.version>
     </properties>
 
 	<modules>

--- a/afs/azure/storage/pom.xml
+++ b/afs/azure/storage/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>com.azure</groupId>
 			<artifactId>azure-storage-blob</artifactId>
-            <version>12.33.2</version>
+            <version>12.35.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/googlecloud/firestore/pom.xml
+++ b/afs/googlecloud/firestore/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-firestore</artifactId>
-            <version>3.38.0</version>
+            <version>3.43.1</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/kafka/pom.xml
+++ b/afs/kafka/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>4.2.0</version>
+			<version>4.3.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/oraclecloud/objectstorage/pom.xml
+++ b/afs/oraclecloud/objectstorage/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.oracle.oci.sdk</groupId>
 			<artifactId>oci-java-sdk-objectstorage</artifactId>
-            <version>3.80.3</version>
+            <version>3.89.1</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/afs/redis/pom.xml
+++ b/afs/redis/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>io.lettuce</groupId>
 			<artifactId>lettuce-core</artifactId>
-			<version>7.5.0.RELEASE</version>
+			<version>7.6.0.RELEASE</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
This pull request updates several dependencies across different modules to their latest versions. These changes ensure that the project uses up-to-date libraries, which can bring in bug fixes, security patches, and new features.

Dependency version updates:

**Cloud provider SDKs:**
* Updated AWS SDK version from `2.42.4` to `2.46.11` in `afs/aws/pom.xml`
* Updated Azure Storage Blob SDK from `12.33.2` to `12.35.0` in `afs/azure/storage/pom.xml`
* Updated Google Cloud Firestore SDK from `3.38.0` to `3.43.1` in `afs/googlecloud/firestore/pom.xml`
* Updated Oracle OCI Object Storage SDK from `3.80.3` to `3.89.1` in `afs/oraclecloud/objectstorage/pom.xml`

**Other dependencies:**
* Updated Kafka clients from `4.2.0` to `4.3.0` in `afs/kafka/pom.xml`
* Updated Lettuce Redis client from `7.5.0.RELEASE` to `7.6.0.RELEASE` in `afs/redis/pom.xml`