### PR TITLE
Feature/storage check sums

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -54,6 +54,7 @@
 *** xref:storage:legacy-type-mapping/user-interaction.adoc[User Interaction]
 ** xref:storage:import-export.adoc[Import / Export]
 ** xref:storage:housekeeping.adoc[Housekeeping]
+** xref:storage:data-integrity.adoc[Data Integrity]
 ** Customizing
 *** xref:storage:customizing/custom-type-handler.adoc[Custom Type Handler]
 *** xref:storage:customizing/custom-legacy-type-handler.adoc[Custom Legacy Type Handler]

--- a/docs/modules/storage/pages/addendum/tools.adoc
+++ b/docs/modules/storage/pages/addendum/tools.adoc
@@ -86,7 +86,8 @@ This is useful for:
 
 * Changing the number of storage channels
 * Moving storage from local disk to a cloud storage target or vice-versa
-* Converting 
+* Converting the on-disk binary representation of persisted objects
+* Adding, changing, or removing chunk-checksum protection (see <<Chunk checksums>>)
 
 === Prerequisites
 
@@ -155,6 +156,98 @@ To move from local file system to a cloud storage target, configure the target `
 ====
 
 For more information see the https://github.com/eclipse-store/store/tree/main/storage/embedded-tools/storage-converter[readme file].
+
+
+=== Chunk checksums
+
+The converter is chunk-checksum aware. What it *writes* is governed by the **target** configuration's chunk-checksum provider, and what it *verifies* while reading is governed by the **source** configuration's provider — independently. A single conversion can therefore add, change, remove, or re-establish chunk-checksum protection.
+
+==== Output protection (target configuration)
+
+By default a converted storage is chunk-checksum-protected just like a storage freshly written by the engine: every target data file is written with a file header and covering chunk-checksum records, honoring the target `StorageDataFileEvaluator` (its file-maximum-size drives file rollover, its coalesce-chunk-target-size drives how often a checksum record is written).
+
+To produce an *unprotected* target (byte-shaped like a pre-feature storage), configure the target with the "none" provider:
+
+[source, java]
+----
+StorageConfiguration target = StorageConfiguration.Builder()
+	.setStorageFileProvider(...)
+	.setChunkChecksumProvider(StorageChunkChecksumProvider.NewNone()) // no checksums emitted
+	.createConfiguration();
+----
+
+A protected target reopens under any policy, including the strict one:
+
+[source, java]
+----
+foundation.setConfiguration(
+	StorageConfiguration.Builder()
+		.setStorageFileProvider(...)
+		.setChunkChecksumProvider(
+			StorageChunkChecksumProvider.NewSha256Chained(StorageChunkChecksumPolicy.NewStrict()))
+		.createConfiguration()
+);
+----
+
+==== Source verification
+
+When the source configuration's policy verifies, the converter recomputes and checks every chunk-checksum record in the source *as it reads*, before writing the target. Corruption is caught up front rather than being silently copied through: a verifying policy aborts the conversion on a mismatch, an observe (log) policy reports it and continues. A source without checksums (a legacy storage) simply has nothing to verify.
+
+==== Changing the checksum (re-keying)
+
+Because the source and target providers are independent, one conversion can:
+
+[cols="1,1,2", options="header"]
+|===
+|Source on disk |Target provider |Effect
+
+|none (legacy)      |an emitting provider   |*add* checksum protection
+|protected          |`NewNone()`            |*remove* protection
+|one algorithm      |a different algorithm  |*change* the algorithm
+|one algorithm      |the same algorithm     |*re-establish* full coverage
+|===
+
+For example, to switch a chained-SHA-256 store to CRC32C, verify the input with a chained-SHA-256 source provider and emit CRC32C on the target:
+
+[source, java]
+----
+StorageConfiguration source = StorageConfiguration.Builder()
+	.setStorageFileProvider(...)
+	.setChunkChecksumProvider(StorageChunkChecksumProvider.NewSha256Chained()) // verify the chained-SHA-256 input
+	.createConfiguration();
+
+StorageConfiguration target = StorageConfiguration.Builder()
+	.setStorageFileProvider(...)
+	.setChunkChecksumProvider(StorageChunkChecksumProvider.NewCrc32c()) // emit CRC32C
+	.createConfiguration();
+
+new StorageConverter(source, target).start();
+----
+
+To add protection to a legacy (unprotected) storage, use `NewNone()` for the source (nothing to verify) and an emitting provider for the target.
+
+==== Verify-only
+
+Construct the converter with a *single* source configuration (no target) to scan and verify a storage's chunk checksums without writing anything:
+
+[source, java]
+----
+new StorageConverter(source).start(); // verifies the source per its policy; writes nothing
+----
+
+On the command line, pass a single configuration file:
+
+[source, bash, subs=attributes+]
+----
+java -jar storage-embedded-tools-storage-converter-<version>-standalone.jar sourceConfig.xml
+----
+
+A verifying source policy exits with a non-zero status on the first mismatch; an observe policy reports and completes successfully.
+
+[NOTE]
+====
+The external configuration files do not (yet) carry a chunk-checksum setting. A conversion driven entirely by configuration files therefore uses the framework-default provider for both source and target — i.e. it is protected by default, but cannot be re-keyed from the command line. To choose a different target algorithm, the "none" provider, or an explicit source/target policy, use the `StorageConverter` Java API with hand-built `StorageConfiguration` instances.
+====
 
 
 === Converting binary data

--- a/docs/modules/storage/pages/data-integrity.adoc
+++ b/docs/modules/storage/pages/data-integrity.adoc
@@ -1,0 +1,303 @@
+= Data Integrity (Chunk Checksums)
+
+{product-name} can protect the data in its storage files with per-chunk integrity checksums.
+Each time a batch of data (a "chunk") is written, a checksum covering those bytes is stored alongside it.
+When the storage is started, every data file is walked and its checksums are recomputed and compared against the stored values, so silent on-disk corruption (bit-rot, a corrupted block, a damaged backup file) is detected before the data is used.
+
+By default this protection is *off*: no checksums are written, and data files stay byte-compatible with a pre-feature engine.
+Enable it by configuring a `StorageChunkChecksumProvider` (see <<_configuration>>) — for example chained SHA-256 or CRC32C.
+
+== How It Works
+
+Checksums are written into the regular `.dat` storage files, not into a side file:
+
+* Each data file begins with a small *file header* record that records which checksum algorithm the file uses.
+* Every committed chunk is followed by a *checksum record* covering the bytes that precede it.
+
+The checksum record is written in the same atomic write as the chunk it covers, so a chunk and its checksum can never get out of sync; the file header is written once, as a file's first entry, when the file is created.
+The records are encoded as storage "gaps", which means older {product-name} versions (and the housekeeping/garbage-collection logic) simply skip over them — a checksummed storage remains readable by an engine that does not know about the feature.
+
+Verification happens *once, at startup*, while the storage initializes and walks its files.
+It is not repeated for individual lazy or cache loads during normal operation.
+
+[NOTE]
+====
+Checksums protect the *data files on disk*. They detect corruption of persisted bytes; they are not a substitute for application-level validation of the objects themselves.
+====
+
+== Algorithms
+
+The algorithm used for *writing* is called the _primary_ algorithm.
+Alongside it, the engine keeps a set of _additional_ algorithms so that a file written by one algorithm can still be verified after the configured primary changes between runs.
+
+[cols="1,3"]
+|===
+| Algorithm | Description
+
+| `CRC32C`
+| Fast integrity checksum. Hardware-accelerated and zero-copy on direct buffers; detects accidental corruption such as bit-rot or a damaged block.
+
+| chained `SHA-256`
+| A 32-byte hash per chunk. Each chunk's hash folds in the previous chunk's hash, so within a file it detects not only single-chunk corruption but also reordering, insertion or deletion of whole chunks.
+
+| `None`
+| No checksum at all. Produces data files indistinguishable from those of a pre-feature engine. This is the sanctioned way to switch the feature *off*.
+|===
+
+[TIP]
+====
+Chaining is designed to detect accidental or partial corruption. What it can detect is bounded by housekeeping (see <<_chained_checksums_and_housekeeping>>).
+====
+
+== Policies and Profiles
+
+A _policy_ decides two things independently: whether to *emit* checksums on write, and whether to *verify* them on load.
+When verifying, each kind of anomaly the load walk can encounter is answered by a _reaction_:
+
+[cols="1,3"]
+|===
+| Reaction | Effect
+
+| `IGNORE` | Skip silently.
+| `LOG`    | Log a warning and continue.
+| `FAIL`   | Throw and abort the start.
+|===
+
+The anomaly categories are: a *checksum mismatch* (the stored bytes no longer match their recorded checksum), a *chunk-boundary mismatch* (a framing desync, where a corrupted entity length rerouted the load walk past a covering record), an *unknown record kind* (a removed or future algorithm), a *missing file header*, and *uncovered data* (data with no covering checksum where coverage was expected).
+
+Rather than assemble these by hand, pick a profile from `StorageChunkChecksumPolicy`:
+
+[cols="1,3"]
+|===
+| Profile | Behavior
+
+| `New()` (lenient)
+| The default *policy* once the feature is enabled: emit + verify, `FAIL` on a checksum mismatch, everything else `IGNORE`. Forward-compatible — unknown kinds and pre-existing legacy files are tolerated.
+
+| `NewOff()`
+| Emit nothing, verify nothing. Files are indistinguishable from a pre-feature engine.
+
+| `NewObserve()`
+| Emit + verify, every anomaly `LOG` (never fails). Learn about corruption, unknown kinds and coverage gaps from the log without risking a storage that refuses to start.
+
+| `NewStrict()`
+| Emit + verify, every anomaly `FAIL`, full and continuous coverage required. Zero-tolerance — use once a storage is fully migrated.
+
+| `NewStrictTolerateLegacy()`
+| Like `NewStrict()`, but pre-existing legacy coverage gaps are logged instead of fatal. The migrating-to-strict profile.
+
+| `NewCustom(...)`
+| Full control over both axes and all five reactions, with fail-early validation against contradictory combinations.
+|===
+
+== Configuration
+
+The feature is configured through a `StorageChunkChecksumProvider`, which carries the primary algorithm and the policy.
+Set it on the `StorageConfiguration`:
+
+[source, java]
+----
+NioFileSystem          fileSystem     = NioFileSystem.New();
+EmbeddedStorageManager storageManager = EmbeddedStorageFoundation.New()
+    .setConfiguration(
+        StorageConfiguration.Builder()
+            .setStorageFileProvider(
+                Storage.FileProviderBuilder(fileSystem)
+                    .setDirectory(fileSystem.ensureDirectoryPath("data"))
+                    .createFileProvider()
+            )
+            // chained SHA-256, emit + verify, fail on every anomaly, require full coverage
+            .setChunkChecksumProvider(
+                StorageChunkChecksumProvider.NewSha256Chained(StorageChunkChecksumPolicy.NewStrict())
+            )
+            .createConfiguration()
+    )
+    .createEmbeddedStorageManager();
+----
+
+`StorageChunkChecksumProvider` offers ready-made factories:
+
+[source, java]
+----
+// framework default: no checksum (the feature off) — identical to NewNone()
+StorageChunkChecksumProvider.New();
+
+// chained SHA-256, optionally with a chosen policy and initial chain seed
+StorageChunkChecksumProvider.NewSha256Chained();
+StorageChunkChecksumProvider.NewSha256Chained(StorageChunkChecksumPolicy.NewObserve());
+
+// CRC32C primary (still verifies chained-SHA-256 files written earlier)
+StorageChunkChecksumProvider.NewCrc32c();
+
+// switch the feature off explicitly
+StorageChunkChecksumProvider.NewNone();
+----
+
+The feature is off unless configured; `StorageChunkChecksumProvider.NewNone()` (or simply `New()`) expresses that explicitly.
+
+=== External Configuration
+
+The feature can also be configured declaratively — through external `.properties` / INI / XML files, Spring Boot, or CDI / MicroProfile — without writing foundation code.
+Setting any `chunk-checksum-*` key activates external configuration of the feature; leaving them all unset keeps the framework default (no checksum — the feature off).
+
+Almost all users need only the *simple* tier — pick an algorithm and a profile:
+
+[cols="2,3,1"]
+|===
+| Key | Values | Default
+
+| `chunk-checksum-algorithm`
+| `none` \| `crc32c` \| `sha256-chained`
+| `sha256-chained`
+
+| `chunk-checksum-profile`
+| `default` \| `off` \| `observe` \| `strict` \| `strict-tolerate-legacy`
+| `default`
+
+| `chunk-checksum-seed`
+| 64 hex chars (32 bytes), `sha256-chained` only
+| none
+|===
+
+.INI / properties
+[source, properties]
+----
+chunk-checksum-algorithm=crc32c
+chunk-checksum-profile=strict
+----
+
+.Spring Boot (`application.properties`)
+[source, properties]
+----
+org.eclipse.store.chunk-checksum.algorithm=crc32c
+org.eclipse.store.chunk-checksum.profile=strict
+----
+
+.MicroProfile / CDI
+[source, properties]
+----
+org.eclipse.store.chunk.checksum.algorithm=crc32c
+org.eclipse.store.chunk.checksum.profile=strict
+----
+
+[TIP]
+====
+*Expert tier.* The profile supplies a complete, coherent base policy; for fine-grained control each policy axis can be overridden individually with the keys below (each defaults to the profile's value when unset):
+`chunk-checksum-emit`, `chunk-checksum-verify`, `chunk-checksum-on-checksum-mismatch`, `chunk-checksum-on-boundary-mismatch`, `chunk-checksum-on-unknown-kind`, `chunk-checksum-on-missing-header`, `chunk-checksum-on-uncovered-data` (each `ignore` \| `log` \| `fail`), `chunk-checksum-require-coverage`, `chunk-checksum-continuous-coverage`.
+
+There is no separate sanity layer on the expert tier: the resulting policy is validated by `NewCustom(...)`, so a contradictory combination (for example `chunk-checksum-verify=false` together with a non-`ignore` reaction) is rejected. Two rules apply silently: `chunk-checksum-algorithm=none` forces the feature off (profile and overrides are ignored), and `chunk-checksum-seed` is used only by `sha256-chained`. The `sha256-chained` + emit + no-verify combination is not rejected at parse time — it surfaces when the storage starts.
+====
+
+Custom `Algorithm` implementations and custom verify sets remain Java-API only — there is no configuration token for them.
+
+== Existing Storages
+
+Opening a storage that was written *before* this feature existed is safe.
+Pre-feature data files carry no file header, so the engine treats them as legacy: it does not retro-fit checksums onto them, and a lenient policy ignores their missing coverage.
+Once the feature is enabled, newly created data files are written with checksums, so coverage grows naturally as the storage rolls over to new files.
+The two states coexist on disk without conflict.
+
+To assert that an *already fully migrated* storage has complete coverage, switch to `NewStrict()`.
+While migrating, `NewStrictTolerateLegacy()` enforces integrity on new writes while only logging the pre-existing gaps.
+
+== Custom Algorithms
+
+A custom checksum algorithm is an implementation of `StorageChunkChecksumCalculator.Algorithm`.
+Supply it as the primary (and/or among the additional algorithms) via a factory:
+
+[source, java]
+----
+StorageChunkChecksumProvider.New(MyAlgorithm::new);
+----
+
+An algorithm is supplied as a factory because each storage channel owns its own stateful instance.
+
+== Coalescing During Housekeeping
+
+When housekeeping cleans up storage files (see xref:housekeeping.adoc[Housekeeping]), it relocates the still-live data of a retired file into a new one.
+With checksums enabled, several small live runs are merged into a single coalesced chunk covered by one checksum, which keeps the checksum overhead of fragmented stores in check.
+
+The soft target size of a coalesced chunk defaults to 1 MB and can be tuned via the additional `StorageDataFileEvaluator` parameter:
+
+[source, java]
+----
+StorageDataFileEvaluator evaluator = Storage.DataFileEvaluator(
+    fileMinimumSize,
+    fileMaximumSize,
+    minimumUseRatio,
+    cleanUpHeadFile,
+    transactionFileMaximumSize,
+    coalesceChunkTargetBytes      // soft target per coalesced chunk, default 1 MB
+);
+----
+
+== On-demand Integrity Verification
+
+Chunk-checksum verification normally runs only at startup (during the load walk). To re-verify a *running* storage without restarting it, issue an on-demand integrity check on a `StorageConnection` (or the `StorageManager`, which is one):
+
+[source, java]
+----
+StorageIntegrityCheckResult result = storageManager.issueFullIntegrityCheck();
+if(!result.isClean())
+{
+    for(StorageIntegrityCheckResult.Finding finding : result.anomalies())
+    {
+        System.err.println(finding); // channel, data file, position, anomaly, expected vs actual
+    }
+}
+----
+
+The check re-walks the live data files of every channel, recomputes each chunk's checksum and compares it against the stored record. Unlike startup verification it *collects* every anomaly into the result instead of throwing, so a single call surfaces all corruption found across all channels without halting the storage. The chunk-checksum anomalies route through the configured `StorageChunkChecksumPolicy`: anomaly types whose reaction is `IGNORE` are not reported, and a policy that does not verify reports nothing.
+
+In addition, the budgeted variant verifies that the data files it snapshotted stay stable while it works: a sealed (non-head) file is immutable, so if its size changes between resume calls — truncation, growth or rewrite — that is reported as a `FILE_SIZE_CHANGED` anomaly (always, independent of the policy). Only the head file is exempt, since it legitimately grows.
+
+The check is an issued operation, so it is serialized with stores like any other (see xref:housekeeping.adoc[Housekeeping]); stores are blocked for its duration. `issueFullIntegrityCheck()` runs to completion in a single call and sees a consistent, complete set of files as of the moment it runs. Each channel's head file is verified up to its committed length at that moment (append-only data beyond that point is out of scope and is covered at the next startup or check).
+
+A budgeted variant yields between calls so a long scan need not block stores for its whole duration:
+
+[source, java]
+----
+StorageIntegrityCheckResult result;
+do
+{
+    result = storageManager.issueIntegrityCheck(timeBudgetNanos);
+    // ... inspect result.anomalies() ...
+}
+while(!result.isComplete());
+----
+
+The verification scope is snapshotted at the start of the scan. Because housekeeping may delete or relocate whole data files between budgeted calls, a file dissolved in the meantime is skipped (no false positive) but its relocated data is not re-checked in that run; budgeted coverage is therefore best-effort. For a guaranteed complete, consistent snapshot, use `issueFullIntegrityCheck()`.
+
+The verification pass is side-effect-free: it never alters the running write state (the head file's chain tip and header are left untouched), so it is safe to run at any time.
+
+== Chained Checksums and Housekeeping
+
+The chained `SHA-256` algorithm links each chunk's hash to the previous one, which makes reordering, insertion or deletion of chunks within a file detectable.
+This linkage is bounded by {product-name}'s normal housekeeping, and the boundary matters when reasoning about what corruption the chain can detect.
+
+Housekeeping routinely *deletes whole storage files*: garbage collection retires a file once all of its entities have become unreachable, and file cleanup retires under-utilized files, relocating their still-live data into new files (see xref:housekeeping.adoc[Housekeeping]).
+Two consequences follow:
+
+* *Verification is per file.* On start, each file's chain is recomputed from the chain seed stored in that file's own header; the engine does not check that one file's seed continues the previous file's final value, and it keeps no record of how many files should exist. A surviving file therefore always verifies on its own.
+* *Relocation re-seeds the chain.* When live data is relocated and coalesced into a new file, it is re-hashed under that file's chain rather than its original one. The on-disk chain is thus not a single continuous lineage spanning the whole history of the storage; it is reset at file boundaries and after relocation.
+
+[WARNING]
+====
+Because deleting and relocating whole files is a legitimate, routine housekeeping operation, the *removal of an entire data file is indistinguishable from a housekeeping deletion and is not detected* by chained checksums.
+The chain detects corruption *within* a surviving file; it does not span the whole store.
+
+Chunk checksums are designed to detect accidental or partial corruption of persisted bytes; for that purpose this limitation does not apply.
+====
+
+== Failure Handling
+
+If verification finds a corrupted chunk under a `FAIL` reaction, the start aborts with a `StorageExceptionChunkChecksumMismatch`, which reports the affected file, the chunk position and the expected versus actual hash. (The on-demand integrity check never throws; it collects anomalies into its result instead — see <<_on_demand_integrity_verification>>.)
+
+Off-line repair tooling that writes into a checksum-protected storage but cannot produce a compliant covered file (for example, configured with a mismatching algorithm) fails loudly with a `StorageExceptionChunkChecksumUnavailable` rather than silently appending unprotected data.
+
+== Limitations
+
+* Verification runs automatically only at startup; it does not re-check individual lazy/cache loads during normal operation. A running storage can be re-verified explicitly with an on-demand integrity check (see <<_on_demand_integrity_verification>>).
+* The `CRC32C` algorithm detects accidental corruption (bit-rot, damaged blocks) and is the fastest option.
+* Chained `SHA-256` detects corruption within a file, including reordering, insertion or deletion of chunks. Because housekeeping deletes and relocates whole storage files, the chain does not span the whole store and does not detect the removal of an entire data file (see <<_chained_checksums_and_housekeeping>>).
+* Custom `Algorithm` implementations and custom verify sets are configurable through the Java API only, not through external text configuration.

--- a/integration-tests/src/test/java/test/eclipse/store/checksum/ChunkChecksumRegressionTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/checksum/ChunkChecksumRegressionTest.java
@@ -1,0 +1,407 @@
+package test.eclipse.store.checksum;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.eclipse.serializer.configuration.types.ByteSize;
+import org.eclipse.serializer.configuration.types.ByteUnit;
+import org.eclipse.store.storage.embedded.configuration.types.EmbeddedStorageConfigurationBuilder;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult.Anomaly;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult.Finding;
+import org.eclipse.store.storage.types.StorageWriteControllerReadOnlyMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Regression tests for fixes made to the storage chunk-checksum feature (PR #717 review).
+ * Each test pins a specific behavioral fix so a future change that reintroduces the bug fails here.
+ */
+class ChunkChecksumRegressionTest
+{
+	///////////////////////////////////////////////////////////////////////////
+	// #1 -- checksum-mismatch offset is the chunk's FILE OFFSET, not its byte length
+	/////////////////////////////////////////////////////////////////////////////
+
+	/**
+	 * A checksum mismatch must report the corrupted chunk's <em>file offset</em>, not its byte length.
+	 * <p>
+	 * The fixed bug passed {@code address - chunkStart} (the chunk's byte length) where every consumer
+	 * treats the value as a file offset. We store a single large object (one covered chunk that starts a
+	 * few dozen bytes into the file, right after the {@code FileHeaderV1}), corrupt a byte deep inside it,
+	 * then assert the reported position is that small chunk-start offset &mdash; it must be at or before the
+	 * corrupted byte, whereas the bug reported the chunk length (which exceeds the file midpoint).
+	 */
+	@Test
+	void checksumMismatchReportsChunkFileOffsetNotByteLength(@TempDir final Path workDir) throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final int    payloadSize = 200_000;
+		final byte[] payload     = new byte[payloadSize];
+		for(int i = 0; i < payloadSize; i++)
+		{
+			payload[i] = (byte)(i * 31 + 7);
+		}
+
+		// session 1: write with checksums emitting + verifying (observe = emit+verify, all anomalies LOG)
+		try(final EmbeddedStorageManager mgr = checksumConfig(storageDir, "observe", "crc32c")
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(payload)
+			.start())
+		{
+			mgr.storeRoot();
+		}
+
+		// corrupt one byte deep inside the chunk (file midpoint is well past the header, inside the data)
+		final Path dataFile  = largestDataFile(storageDir);
+		final long fileSize  = Files.size(dataFile);
+		final long corruptAt = fileSize / 2;
+		flipByte(dataFile, corruptAt);
+
+		// session 2: reopen and scan; observe logs the mismatch on load (no throw), the on-demand check collects it
+		final StorageIntegrityCheckResult result;
+		try(final EmbeddedStorageManager mgr = checksumConfig(storageDir, "observe", "crc32c")
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			result = mgr.issueFullIntegrityCheck();
+		}
+
+		assertFalse(result.isClean(), "on-disk corruption of a covered chunk must be detected");
+
+		final Finding mismatch = firstOf(result, Anomaly.CHECKSUM_MISMATCH);
+		assertNotNull(mismatch, "expected a CHECKSUM_MISMATCH finding, got: " + result);
+
+		assertTrue(mismatch.position() >= 0L, "offset must be non-negative, got " + mismatch.position());
+		assertTrue(
+			mismatch.position() <= corruptAt,
+			"checksum-mismatch position must be the chunk's FILE OFFSET (<= the corrupted byte at "
+				+ corruptAt + "), not its byte length; got " + mismatch.position()
+				+ " (a value > " + corruptAt + " indicates the reverted bug that reported chunk length)"
+		);
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// #5 -- read-only open with continuousCoverage must not write at startup
+	/////////////////////////////////////////////////////////////////////////
+
+	/**
+	 * Opening an existing legacy (un-checksummed) store <em>read-only</em> with a {@code continuousCoverage}
+	 * profile must not write at startup. The fixed bug unconditionally rolled the head file over (writing a
+	 * {@code FileHeaderV1} + transaction-log entry) when the head was not covered, which throws under a
+	 * disabled {@link StorageWriteControllerReadOnlyMode}. We assert the read-only open succeeds, the data is
+	 * readable, and no new data file was written.
+	 */
+	@Test
+	void readOnlyOpenWithContinuousCoverageOverLegacyStoreDoesNotWrite(@TempDir final Path workDir) throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final ArrayList<String> root = new ArrayList<>(List.of("alpha", "beta", "gamma"));
+
+		// session 1: legacy store -- no chunk-checksum property set, so the engine default (off) is used
+		try(final EmbeddedStorageManager mgr = EmbeddedStorageConfigurationBuilder.New()
+			.setStorageDirectory(storageDir.toString())
+			.setChannelCount(1)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(root)
+			.start())
+		{
+			mgr.storeRoot();
+		}
+
+		final Map<String, Long> dataFilesBefore = dataFileSizes(storageDir);
+
+		// session 2: reopen READ-ONLY with strict-tolerate-legacy (continuousCoverage = true, legacy tolerated)
+		final EmbeddedStorageFoundation<?> foundation =
+			checksumConfig(storageDir, "strict-tolerate-legacy", "sha256-chained")
+				.createEmbeddedStorageFoundation();
+		final StorageWriteControllerReadOnlyMode readOnly =
+			new StorageWriteControllerReadOnlyMode(foundation.getWriteController());
+		readOnly.setReadOnly(true);
+		foundation.setWriteController(readOnly);
+
+		final Object loadedRoot;
+		try(final EmbeddedStorageManager mgr = foundation.createEmbeddedStorageManager().start())
+		{
+			// reaching here at all is the core assertion: before the fix start() threw AfsExceptionReadOnly
+			loadedRoot = mgr.root();
+		}
+
+		assertNotNull(loadedRoot, "root must be loadable after a read-only reopen");
+		assertEquals(root, loadedRoot, "legacy data must be intact after a read-only reopen");
+		assertEquals(
+			dataFilesBefore, dataFileSizes(storageDir),
+			"read-only open with continuousCoverage must not have written or rolled over a data file"
+		);
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// #4 -- bounded streaming verify for files larger than the integrity-check buffer cap
+	///////////////////////////////////////////////////////////////////////////////////////
+
+	// Mirrors StorageFileManager.INTEGRITY_VERIFY_BUFFER_LIMIT (package-private): files above this are verified
+	// via the windowed streaming walk instead of being read whole.
+	private static final int STREAMING_CAP = 8 * 1024 * 1024;
+
+	/**
+	 * A data file larger than the 8 MiB integrity-check buffer must be verified by the windowed streaming walk
+	 * (StorageChunkChecksumCalculator.verifyDataFileStreaming) without reading the whole file resident. This
+	 * stores a single ~20 MiB object, so its one covered chunk is larger than the window and is hashed
+	 * incrementally across windows. Asserts the intact file verifies clean and that corrupting a byte deep past
+	 * the first window is detected with the chunk's file offset (not its byte length). Run for both algorithms;
+	 * sha256-chained additionally exercises the running tip across windows.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {"crc32c", "sha256-chained"})
+	void largeSingleChunkIsStreamedVerifiedAndCorruptionDetected(final String algorithm, @TempDir final Path workDir)
+		throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final int    payloadSize = 20 * 1024 * 1024; // > 8 MiB window: one chunk spanning multiple windows
+		final byte[] payload     = new byte[payloadSize];
+		for(int i = 0; i < payloadSize; i++)
+		{
+			payload[i] = (byte)(i * 31 + 7);
+		}
+
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(payload)
+			.start())
+		{
+			mgr.storeRoot();
+		}
+
+		final Path dataFile = largestDataFile(storageDir);
+		final long fileSize = Files.size(dataFile);
+		assertTrue(
+			fileSize > STREAMING_CAP,
+			"test must produce a data file larger than the streaming cap to exercise streaming; got " + fileSize
+		);
+
+		// intact: the streaming walk must report clean (no false anomalies across window boundaries)
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			final StorageIntegrityCheckResult clean = mgr.issueFullIntegrityCheck();
+			assertTrue(clean.isClean(), "intact large file must verify clean via streaming; got: " + clean);
+		}
+
+		// corrupt a byte at the file midpoint (well past the 8 MiB window -> a later window is exercised)
+		final long corruptAt = fileSize / 2;
+		flipByte(dataFile, corruptAt);
+
+		final StorageIntegrityCheckResult result;
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			result = mgr.issueFullIntegrityCheck();
+		}
+
+		assertFalse(result.isClean(), "corruption in a streamed large file must be detected");
+		final Finding mismatch = firstOf(result, Anomaly.CHECKSUM_MISMATCH);
+		assertNotNull(mismatch, "expected a CHECKSUM_MISMATCH finding, got: " + result);
+		assertTrue(
+			mismatch.position() >= 0L && mismatch.position() <= corruptAt,
+			"mismatch position must be the chunk's file offset (<= corrupted byte " + corruptAt + "), got "
+				+ mismatch.position()
+		);
+	}
+
+	/**
+	 * A large file made of several chunks (separate commits) exercises the streaming walk crossing window
+	 * boundaries at real chunk boundaries and, for sha256-chained, carrying the running tip from one chunk to the
+	 * next across windows. Asserts the intact file verifies clean, then that corruption in a later chunk is
+	 * detected.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {"crc32c", "sha256-chained"})
+	void largeMultiChunkFileIsStreamedVerified(final String algorithm, @TempDir final Path workDir)
+		throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final int chunkPayload = 6 * 1024 * 1024; // 6 MiB per commit
+		final int commits      = 4;               // ~24 MiB across 4 chunks -> file > 8 MiB window
+
+		final ArrayList<byte[]> root = new ArrayList<>();
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(root)
+			.start())
+		{
+			mgr.storeRoot();
+			for(int c = 0; c < commits; c++)
+			{
+				final byte[] arr = new byte[chunkPayload];
+				for(int i = 0; i < chunkPayload; i++)
+				{
+					arr[i] = (byte)(i + c);
+				}
+				// keep each array reachable from the root so housekeeping GC cannot dissolve its data file
+				// between sessions; storing the updated root in its own commit yields one chunk + covering record
+				// per array (so the file ends up with several chunks spread across the streaming windows).
+				root.add(arr);
+				mgr.store(root);
+			}
+		}
+
+		final Path dataFile = largestDataFile(storageDir);
+		assertTrue(
+			Files.size(dataFile) > STREAMING_CAP,
+			"expected a data file larger than the streaming cap, got " + Files.size(dataFile)
+		);
+
+		// many covering records spread across windows must verify clean (tip carried across windows for chained)
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			final StorageIntegrityCheckResult clean = mgr.issueFullIntegrityCheck();
+			assertTrue(clean.isClean(), "intact multi-chunk large file must verify clean via streaming; got: " + clean);
+		}
+
+		// corrupt a byte inside the last chunk (a later window) and assert detection
+		final long corruptAt = Files.size(dataFile) - chunkPayload / 2;
+		flipByte(dataFile, corruptAt);
+
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			final StorageIntegrityCheckResult result = mgr.issueFullIntegrityCheck();
+			assertFalse(result.isClean(), "corruption in a later chunk of a streamed file must be detected");
+			assertNotNull(firstOf(result, Anomaly.CHECKSUM_MISMATCH), "expected a CHECKSUM_MISMATCH finding, got: " + result);
+		}
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// helpers //
+	////////////
+
+	// Config with a large data-file maximum so a single growing head file exceeds the 8 MiB streaming cap.
+	private static EmbeddedStorageConfigurationBuilder largeFileConfig(
+		final Path   storageDir,
+		final String profile   ,
+		final String algorithm
+	)
+	{
+		return EmbeddedStorageConfigurationBuilder.New()
+			.setStorageDirectory(storageDir.toString())
+			.setChannelCount(1)
+			.setChunkChecksumProfile(profile)
+			.setChunkChecksumAlgorithm(algorithm)
+			.setDataFileMaximumSize(ByteSize.New(64, ByteUnit.MB));
+	}
+
+	private static EmbeddedStorageConfigurationBuilder checksumConfig(
+		final Path   storageDir,
+		final String profile   ,
+		final String algorithm
+	)
+	{
+		return EmbeddedStorageConfigurationBuilder.New()
+			.setStorageDirectory(storageDir.toString())
+			.setChannelCount(1)
+			.setChunkChecksumProfile(profile)
+			.setChunkChecksumAlgorithm(algorithm);
+	}
+
+	private static Path largestDataFile(final Path storageDir) throws IOException
+	{
+		try(final Stream<Path> stream = Files.walk(storageDir))
+		{
+			return stream
+				.filter(Files::isRegularFile)
+				.filter(p -> p.getFileName().toString().endsWith(".dat"))
+				.max(Comparator.comparingLong(ChunkChecksumRegressionTest::sizeOf))
+				.orElseThrow(() -> new IllegalStateException("no .dat data file under " + storageDir));
+		}
+	}
+
+	private static long sizeOf(final Path p)
+	{
+		try
+		{
+			return Files.size(p);
+		}
+		catch(final IOException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static void flipByte(final Path file, final long index) throws IOException
+	{
+		final byte[] bytes = Files.readAllBytes(file);
+		final int    i     = Math.toIntExact(index);
+		bytes[i] = (byte)(bytes[i] ^ 0xFF);
+		Files.write(file, bytes);
+	}
+
+	private static Map<String, Long> dataFileSizes(final Path storageDir) throws IOException
+	{
+		final Map<String, Long> result = new LinkedHashMap<>();
+		try(final Stream<Path> stream = Files.walk(storageDir))
+		{
+			stream
+				.filter(Files::isRegularFile)
+				.filter(p -> p.getFileName().toString().endsWith(".dat"))
+				.sorted(Comparator.comparing(Path::toString))
+				.forEach(p -> result.put(storageDir.relativize(p).toString(), sizeOf(p)));
+		}
+		return result;
+	}
+
+	private static Finding firstOf(final StorageIntegrityCheckResult result, final Anomaly anomaly)
+	{
+		for(final Finding f : result.anomalies())
+		{
+			if(f.anomaly() == anomaly)
+			{
+				return f;
+			}
+		}
+		return null;
+	}
+}

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
@@ -219,6 +219,102 @@ public enum ConfigurationCoreProperties
 	DATA_FILE_CLEANUP_HEAD_FILE(
 			Constants.PREFIX + "data.file.cleanup.head.file",
 			EmbeddedStorageConfigurationPropertyNames.DATA_FILE_CLEANUP_HEAD_FILE
+	),
+
+	/**
+	 * Primary chunk-checksum algorithm: none, crc32c or sha256-chained. Default sha256-chained.
+	 */
+	CHUNK_CHECKSUM_ALGORITHM(
+			Constants.PREFIX + "chunk.checksum.algorithm",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ALGORITHM
+	),
+
+	/**
+	 * Chunk-checksum base policy profile: default, off, observe, strict or strict-tolerate-legacy. Default default.
+	 */
+	CHUNK_CHECKSUM_PROFILE(
+			Constants.PREFIX + "chunk.checksum.profile",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_PROFILE
+	),
+
+	/**
+	 * Initial chain seed (hex, 64 chars = 32 bytes) for the sha256-chained algorithm; unused otherwise.
+	 */
+	CHUNK_CHECKSUM_SEED(
+			Constants.PREFIX + "chunk.checksum.seed",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_SEED
+	),
+
+	/**
+	 * Expert override: whether to emit checksum records on write. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_EMIT(
+			Constants.PREFIX + "chunk.checksum.emit",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_EMIT
+	),
+
+	/**
+	 * Expert override: whether to recompute and check checksum records on load. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_VERIFY(
+			Constants.PREFIX + "chunk.checksum.verify",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_VERIFY
+	),
+
+	/**
+	 * Expert override: reaction (ignore / log / fail) to a checksum mismatch. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH(
+			Constants.PREFIX + "chunk.checksum.on.checksum.mismatch",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH
+	),
+
+	/**
+	 * Expert override: reaction (ignore / log / fail) to a chunk-boundary mismatch. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH(
+			Constants.PREFIX + "chunk.checksum.on.boundary.mismatch",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH
+	),
+
+	/**
+	 * Expert override: reaction (ignore / log / fail) to an unknown record kind. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_ON_UNKNOWN_KIND(
+			Constants.PREFIX + "chunk.checksum.on.unknown.kind",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_UNKNOWN_KIND
+	),
+
+	/**
+	 * Expert override: reaction (ignore / log / fail) to a missing file header. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_ON_MISSING_HEADER(
+			Constants.PREFIX + "chunk.checksum.on.missing.header",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_MISSING_HEADER
+	),
+
+	/**
+	 * Expert override: reaction (ignore / log / fail) to uncovered data. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_ON_UNCOVERED_DATA(
+			Constants.PREFIX + "chunk.checksum.on.uncovered.data",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_UNCOVERED_DATA
+	),
+
+	/**
+	 * Expert override: whether missing/uncovered files are raised as anomalies. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_REQUIRE_COVERAGE(
+			Constants.PREFIX + "chunk.checksum.require.coverage",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_REQUIRE_COVERAGE
+	),
+
+	/**
+	 * Expert override: whether enabling emit forces an immediately-covered head file. Defaults to the profile's value.
+	 */
+	CHUNK_CHECKSUM_CONTINUOUS_COVERAGE(
+			Constants.PREFIX + "chunk.checksum.continuous.coverage",
+			EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_CONTINUOUS_COVERAGE
 	);
 
 	private final String microProfile;

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
@@ -43,6 +43,7 @@ import org.eclipse.store.storage.types.StorageEntityCacheEvaluator;
 import org.eclipse.store.storage.types.StorageEntityTypeExportFileProvider;
 import org.eclipse.store.storage.types.StorageEntityTypeExportStatistics;
 import org.eclipse.store.storage.types.StorageEntityTypeHandler;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult;
 import org.eclipse.store.storage.types.StorageLiveFileProvider;
 import org.eclipse.store.storage.types.StorageManager;
 import org.eclipse.store.storage.types.StorageRawFileStatistics;
@@ -235,6 +236,12 @@ public class StorageManagerProxy extends UsageMarkable.Default implements Storag
     public boolean issueFileCheck(final long nanoTimeBudget)
     {
         return this.getStorageManager().issueFileCheck(nanoTimeBudget);
+    }
+
+    @Override
+    public StorageIntegrityCheckResult issueIntegrityCheck(final long nanoTimeBudget)
+    {
+        return this.getStorageManager().issueIntegrityCheck(nanoTimeBudget);
     }
 
     @Override

--- a/integrations/cdi4/src/test/java/org/eclipse/store/integrations/cdi/types/ConfigurationCorePropertiesTest.java
+++ b/integrations/cdi4/src/test/java/org/eclipse/store/integrations/cdi/types/ConfigurationCorePropertiesTest.java
@@ -164,6 +164,27 @@ class ConfigurationCorePropertiesTest
 	}
 
 	@Test
+	void shouldMapChunkChecksumAlgorithm()
+	{
+		final String keyMicroProfile = PREFIX + "chunk.checksum.algorithm";
+		final Optional<ConfigurationCoreProperties> property = ConfigurationCoreProperties.get(keyMicroProfile);
+		Assertions.assertTrue(property.isPresent());
+		Assertions.assertEquals(ConfigurationCoreProperties.CHUNK_CHECKSUM_ALGORITHM, property.get());
+		Assertions.assertEquals("chunk-checksum-algorithm", property.get().getEclipseStore(keyMicroProfile));
+	}
+
+	@Test
+	void shouldMapChunkChecksumReactionKey()
+	{
+		// a dotted reaction key must translate to the flat kebab-case core key
+		final String keyMicroProfile = PREFIX + "chunk.checksum.on.checksum.mismatch";
+		final Optional<ConfigurationCoreProperties> property = ConfigurationCoreProperties.get(keyMicroProfile);
+		Assertions.assertTrue(property.isPresent());
+		Assertions.assertEquals(ConfigurationCoreProperties.CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH, property.get());
+		Assertions.assertEquals("chunk-checksum-on-checksum-mismatch", property.get().getEclipseStore(keyMicroProfile));
+	}
+
+	@Test
 	void findEnumValue()
 	{
 		// Not using CDI

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/ChunkChecksum.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/ChunkChecksum.java
@@ -1,0 +1,208 @@
+package org.eclipse.store.integrations.spring.boot.types.configuration;
+
+/*-
+ * #%L
+ * EclipseStore Integrations SpringBoot
+ * %%
+ * Copyright (C) 2023 - 2024 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * Configuration of the per-chunk data-integrity checksum feature.
+ *
+ * <p>The simple tier ({@link #algorithm}, {@link #profile}, {@link #seed}) is sufficient for almost all
+ * users; the remaining per-axis fields are an expert tier that overrides individual axes of the profile.
+ * The boolean overrides are {@link Boolean} (not primitive) so that an unset value stays distinct from an
+ * explicit {@code false} and the profile's value is used when absent.</p>
+ */
+public class ChunkChecksum
+{
+    /**
+     * Primary algorithm: {@code none}, {@code crc32c} or {@code sha256-chained}.
+     * Default {@code sha256-chained}.
+     */
+    private String algorithm;
+
+    /**
+     * Base policy profile: {@code default}, {@code off}, {@code observe}, {@code strict} or
+     * {@code strict-tolerate-legacy}. Default {@code default}.
+     */
+    private String profile;
+
+    /**
+     * Initial chain seed (hex, 64 chars = 32 bytes) for {@code sha256-chained}; unused otherwise.
+     */
+    private String seed;
+
+    /**
+     * Expert override: whether to emit checksum records on write. Defaults to the profile's value.
+     */
+    private Boolean emit;
+
+    /**
+     * Expert override: whether to recompute and check on load. Defaults to the profile's value.
+     */
+    private Boolean verify;
+
+    /**
+     * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a checksum mismatch.
+     */
+    private String onChecksumMismatch;
+
+    /**
+     * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a chunk-boundary mismatch.
+     */
+    private String onBoundaryMismatch;
+
+    /**
+     * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to an unknown record kind.
+     */
+    private String onUnknownKind;
+
+    /**
+     * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a missing file header.
+     */
+    private String onMissingHeader;
+
+    /**
+     * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to uncovered data.
+     */
+    private String onUncoveredData;
+
+    /**
+     * Expert override: whether missing/uncovered files are raised as anomalies. Defaults to the profile's value.
+     */
+    private Boolean requireCoverage;
+
+    /**
+     * Expert override: whether enabling emit forces an immediately-covered head file. Defaults to the profile's value.
+     */
+    private Boolean continuousCoverage;
+
+    public String getAlgorithm()
+    {
+        return this.algorithm;
+    }
+
+    public void setAlgorithm(final String algorithm)
+    {
+        this.algorithm = algorithm;
+    }
+
+    public String getProfile()
+    {
+        return this.profile;
+    }
+
+    public void setProfile(final String profile)
+    {
+        this.profile = profile;
+    }
+
+    public String getSeed()
+    {
+        return this.seed;
+    }
+
+    public void setSeed(final String seed)
+    {
+        this.seed = seed;
+    }
+
+    public Boolean getEmit()
+    {
+        return this.emit;
+    }
+
+    public void setEmit(final Boolean emit)
+    {
+        this.emit = emit;
+    }
+
+    public Boolean getVerify()
+    {
+        return this.verify;
+    }
+
+    public void setVerify(final Boolean verify)
+    {
+        this.verify = verify;
+    }
+
+    public String getOnChecksumMismatch()
+    {
+        return this.onChecksumMismatch;
+    }
+
+    public void setOnChecksumMismatch(final String onChecksumMismatch)
+    {
+        this.onChecksumMismatch = onChecksumMismatch;
+    }
+
+    public String getOnBoundaryMismatch()
+    {
+        return this.onBoundaryMismatch;
+    }
+
+    public void setOnBoundaryMismatch(final String onBoundaryMismatch)
+    {
+        this.onBoundaryMismatch = onBoundaryMismatch;
+    }
+
+    public String getOnUnknownKind()
+    {
+        return this.onUnknownKind;
+    }
+
+    public void setOnUnknownKind(final String onUnknownKind)
+    {
+        this.onUnknownKind = onUnknownKind;
+    }
+
+    public String getOnMissingHeader()
+    {
+        return this.onMissingHeader;
+    }
+
+    public void setOnMissingHeader(final String onMissingHeader)
+    {
+        this.onMissingHeader = onMissingHeader;
+    }
+
+    public String getOnUncoveredData()
+    {
+        return this.onUncoveredData;
+    }
+
+    public void setOnUncoveredData(final String onUncoveredData)
+    {
+        this.onUncoveredData = onUncoveredData;
+    }
+
+    public Boolean getRequireCoverage()
+    {
+        return this.requireCoverage;
+    }
+
+    public void setRequireCoverage(final Boolean requireCoverage)
+    {
+        this.requireCoverage = requireCoverage;
+    }
+
+    public Boolean getContinuousCoverage()
+    {
+        return this.continuousCoverage;
+    }
+
+    public void setContinuousCoverage(final Boolean continuousCoverage)
+    {
+        this.continuousCoverage = continuousCoverage;
+    }
+}

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -181,6 +181,12 @@ public class EclipseStoreProperties
     private String dataFileCleanupHeadFile;
 
     /**
+     * Per-chunk data-integrity checksum configuration. Bound from {@code org.eclipse.store.chunk-checksum.*}.
+     */
+    @NestedConfigurationProperty
+    private ChunkChecksum chunkChecksum;
+
+    /**
      * Is the {@code StorageManager} started when the CDI bean for the instance is created or not.
      * Be aware that when you don't rely on the autostart of the StorageManager, you are responsible for starting it
      * and might result in Exceptions when code is executed that relies on a started StorageManager.
@@ -498,6 +504,16 @@ public class EclipseStoreProperties
     public void setDataFileCleanupHeadFile(final String dataFileCleanupHeadFile)
     {
         this.dataFileCleanupHeadFile = dataFileCleanupHeadFile;
+    }
+
+    public ChunkChecksum getChunkChecksum()
+    {
+        return this.chunkChecksum;
+    }
+
+    public void setChunkChecksum(final ChunkChecksum chunkChecksum)
+    {
+        this.chunkChecksum = chunkChecksum;
     }
 
     public boolean isAutoStart()

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.store.integrations.spring.boot.types.configuration.ChunkChecksum;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.configuration.StorageFilesystem;
 import org.eclipse.store.integrations.spring.boot.types.configuration.aws.AbstractAwsProperties;
@@ -81,6 +82,20 @@ public class EclipseStoreConfigConverter
     protected static final String DATA_FILE_MINIMUM_USE_RATIO = EmbeddedStorageConfigurationPropertyNames.DATA_FILE_MINIMUM_USE_RATIO;
     protected static final String DATA_FILE_CLEANUP_HEAD_FILE = EmbeddedStorageConfigurationPropertyNames.DATA_FILE_CLEANUP_HEAD_FILE;
 
+    // Fields for the chunk-checksum (data integrity) configuration
+    protected static final String CHUNK_CHECKSUM_ALGORITHM = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ALGORITHM;
+    protected static final String CHUNK_CHECKSUM_PROFILE = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_PROFILE;
+    protected static final String CHUNK_CHECKSUM_SEED = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_SEED;
+    protected static final String CHUNK_CHECKSUM_EMIT = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_EMIT;
+    protected static final String CHUNK_CHECKSUM_VERIFY = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_VERIFY;
+    protected static final String CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH;
+    protected static final String CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH;
+    protected static final String CHUNK_CHECKSUM_ON_UNKNOWN_KIND = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_UNKNOWN_KIND;
+    protected static final String CHUNK_CHECKSUM_ON_MISSING_HEADER = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_MISSING_HEADER;
+    protected static final String CHUNK_CHECKSUM_ON_UNCOVERED_DATA = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ON_UNCOVERED_DATA;
+    protected static final String CHUNK_CHECKSUM_REQUIRE_COVERAGE = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_REQUIRE_COVERAGE;
+    protected static final String CHUNK_CHECKSUM_CONTINUOUS_COVERAGE = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_CONTINUOUS_COVERAGE;
+
 
     /**
      * Converts the provided Eclipse Store properties into a map.
@@ -132,12 +147,35 @@ public class EclipseStoreConfigConverter
         configValues.put(DATA_FILE_MINIMUM_USE_RATIO, properties.getDataFileMinimumUseRatio());
         configValues.put(DATA_FILE_CLEANUP_HEAD_FILE, properties.getDataFileCleanupHeadFile());
 
+        if (properties.getChunkChecksum() != null)
+        {
+            configValues.putAll(this.prepareChunkChecksum(properties.getChunkChecksum()));
+        }
+
 
         //remove keys with null value
         configValues.values().removeIf(Objects::isNull);
 
 
         return configValues;
+    }
+
+    private Map<String, String> prepareChunkChecksum(final ChunkChecksum properties)
+    {
+        final Map<String, String> values = new HashMap<>();
+        values.put(CHUNK_CHECKSUM_ALGORITHM, properties.getAlgorithm());
+        values.put(CHUNK_CHECKSUM_PROFILE, properties.getProfile());
+        values.put(CHUNK_CHECKSUM_SEED, properties.getSeed());
+        values.put(CHUNK_CHECKSUM_EMIT, properties.getEmit() == null ? null : properties.getEmit().toString());
+        values.put(CHUNK_CHECKSUM_VERIFY, properties.getVerify() == null ? null : properties.getVerify().toString());
+        values.put(CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH, properties.getOnChecksumMismatch());
+        values.put(CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH, properties.getOnBoundaryMismatch());
+        values.put(CHUNK_CHECKSUM_ON_UNKNOWN_KIND, properties.getOnUnknownKind());
+        values.put(CHUNK_CHECKSUM_ON_MISSING_HEADER, properties.getOnMissingHeader());
+        values.put(CHUNK_CHECKSUM_ON_UNCOVERED_DATA, properties.getOnUncoveredData());
+        values.put(CHUNK_CHECKSUM_REQUIRE_COVERAGE, properties.getRequireCoverage() == null ? null : properties.getRequireCoverage().toString());
+        values.put(CHUNK_CHECKSUM_CONTINUOUS_COVERAGE, properties.getContinuousCoverage() == null ? null : properties.getContinuousCoverage().toString());
+        return values;
     }
 
     private Map<String, String> prepareFileSystem(final StorageFilesystem properties, final String key)

--- a/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java
+++ b/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
  * #L%
  */
 
+import org.eclipse.store.integrations.spring.boot.types.configuration.ChunkChecksum;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.configuration.StorageFilesystem;
 import org.eclipse.store.integrations.spring.boot.types.configuration.googlecloud.Googlecloud;
@@ -107,6 +108,30 @@ class EclipseStoreConfigConverterTest
     {
         final String result = this.converter.composeKey("prefix", "suffix");
         assertEquals("prefix.suffix", result);
+    }
+
+    @Test
+    void testChunkChecksumConversion()
+    {
+        final ChunkChecksum chunkChecksum = new ChunkChecksum();
+        chunkChecksum.setAlgorithm("crc32c");
+        chunkChecksum.setProfile("strict");
+        chunkChecksum.setVerify(Boolean.FALSE);
+        chunkChecksum.setOnChecksumMismatch("log");
+
+        final EclipseStoreProperties properties = new EclipseStoreProperties();
+        properties.setChunkChecksum(chunkChecksum);
+
+        final Map<String, String> result = this.converter.convertConfigurationToMap(properties);
+
+        assertEquals("crc32c", result.get(EclipseStoreConfigConverter.CHUNK_CHECKSUM_ALGORITHM));
+        assertEquals("strict", result.get(EclipseStoreConfigConverter.CHUNK_CHECKSUM_PROFILE));
+        assertEquals("false", result.get(EclipseStoreConfigConverter.CHUNK_CHECKSUM_VERIFY));
+        assertEquals("log", result.get(EclipseStoreConfigConverter.CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH));
+        // unset fields (including the not-set Boolean overrides) must not appear
+        assertNull(result.get(EclipseStoreConfigConverter.CHUNK_CHECKSUM_SEED));
+        assertNull(result.get(EclipseStoreConfigConverter.CHUNK_CHECKSUM_EMIT));
+        assertNull(result.get(EclipseStoreConfigConverter.CHUNK_CHECKSUM_REQUIRE_COVERAGE));
     }
 
     @Test

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
@@ -333,7 +333,113 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 	 * @return this
 	 */
 	public EmbeddedStorageConfigurationBuilder setTransactionFileMaximumSize(ByteSize transactionFileMaximumSize);
-	
+
+	/**
+	 * The primary chunk-checksum algorithm: {@code none}, {@code crc32c}, {@code sha256} or
+	 * {@code sha256-chained}. Default is {@code sha256}. Setting any {@code chunk-checksum-*} property
+	 * activates declarative configuration of the feature; leaving them all unset keeps the framework default.
+	 *
+	 * @param chunkChecksumAlgorithm the algorithm token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumAlgorithm(String chunkChecksumAlgorithm);
+
+	/**
+	 * The chunk-checksum base policy profile: {@code default}, {@code off}, {@code observe}, {@code strict}
+	 * or {@code strict-tolerate-legacy}. Default is {@code default}.
+	 *
+	 * @param chunkChecksumProfile the profile token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumProfile(String chunkChecksumProfile);
+
+	/**
+	 * The initial chain seed for the {@code sha256-chained} algorithm, as a hex string (64 chars = 32 bytes).
+	 * Unused by any other algorithm.
+	 *
+	 * @param chunkChecksumSeed the seed as a hex string
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumSeed(String chunkChecksumSeed);
+
+	/**
+	 * Expert override: whether to emit checksum records on write. Defaults to the profile's value.
+	 *
+	 * @param chunkChecksumEmit whether to emit
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumEmit(boolean chunkChecksumEmit);
+
+	/**
+	 * Expert override: whether to recompute and check checksum records on load. Defaults to the profile's value.
+	 *
+	 * @param chunkChecksumVerify whether to verify
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumVerify(boolean chunkChecksumVerify);
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a checksum mismatch.
+	 * Defaults to the profile's value.
+	 *
+	 * @param reaction the reaction token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumOnChecksumMismatch(String reaction);
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a chunk-boundary mismatch.
+	 * Defaults to the profile's value.
+	 *
+	 * @param reaction the reaction token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumOnBoundaryMismatch(String reaction);
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to an unknown record kind.
+	 * Defaults to the profile's value.
+	 *
+	 * @param reaction the reaction token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumOnUnknownKind(String reaction);
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a missing file header.
+	 * Defaults to the profile's value.
+	 *
+	 * @param reaction the reaction token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumOnMissingHeader(String reaction);
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to uncovered data.
+	 * Defaults to the profile's value.
+	 *
+	 * @param reaction the reaction token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumOnUncoveredData(String reaction);
+
+	/**
+	 * Expert override: whether missing/uncovered files are raised as anomalies. Defaults to the profile's value.
+	 *
+	 * @param chunkChecksumRequireCoverage whether coverage is required
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumRequireCoverage(boolean chunkChecksumRequireCoverage);
+
+	/**
+	 * Expert override: whether enabling emit forces an immediately-covered head file. Defaults to the
+	 * profile's value.
+	 *
+	 * @param chunkChecksumContinuousCoverage whether coverage is continuous
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setChunkChecksumContinuousCoverage(boolean chunkChecksumContinuousCoverage);
+
 	/**
 	 * Creates an {@link EmbeddedStorageFoundation} based on the settings of this builder.
 	 *
@@ -663,6 +769,102 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 		)
 		{
 			return this.set(TRANSACTION_FILE_MAXIMUM_SIZE, transactionFileMaximumSize.toString());
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumAlgorithm(
+			final String chunkChecksumAlgorithm
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_ALGORITHM, chunkChecksumAlgorithm);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumProfile(
+			final String chunkChecksumProfile
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_PROFILE, chunkChecksumProfile);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumSeed(
+			final String chunkChecksumSeed
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_SEED, chunkChecksumSeed);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumEmit(
+			final boolean chunkChecksumEmit
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_EMIT, Boolean.toString(chunkChecksumEmit));
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumVerify(
+			final boolean chunkChecksumVerify
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_VERIFY, Boolean.toString(chunkChecksumVerify));
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumOnChecksumMismatch(
+			final String reaction
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH, reaction);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumOnBoundaryMismatch(
+			final String reaction
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH, reaction);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumOnUnknownKind(
+			final String reaction
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_ON_UNKNOWN_KIND, reaction);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumOnMissingHeader(
+			final String reaction
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_ON_MISSING_HEADER, reaction);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumOnUncoveredData(
+			final String reaction
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_ON_UNCOVERED_DATA, reaction);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumRequireCoverage(
+			final boolean chunkChecksumRequireCoverage
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_REQUIRE_COVERAGE, Boolean.toString(chunkChecksumRequireCoverage));
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setChunkChecksumContinuousCoverage(
+			final boolean chunkChecksumContinuousCoverage
+		)
+		{
+			return this.set(CHUNK_CHECKSUM_CONTINUOUS_COVERAGE, Boolean.toString(chunkChecksumContinuousCoverage));
 		}
 
 	}

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
@@ -335,8 +335,8 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 	public EmbeddedStorageConfigurationBuilder setTransactionFileMaximumSize(ByteSize transactionFileMaximumSize);
 
 	/**
-	 * The primary chunk-checksum algorithm: {@code none}, {@code crc32c}, {@code sha256} or
-	 * {@code sha256-chained}. Default is {@code sha256}. Setting any {@code chunk-checksum-*} property
+	 * The primary chunk-checksum algorithm: {@code none}, {@code crc32c} or
+	 * {@code sha256-chained}. Default is {@code sha256-chained}. Setting any {@code chunk-checksum-*} property
 	 * activates declarative configuration of the feature; leaving them all unset keeps the framework default.
 	 *
 	 * @param chunkChecksumAlgorithm the algorithm token

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
@@ -175,4 +175,97 @@ public interface EmbeddedStorageConfigurationPropertyNames
 	 */
 	public final static String DATA_FILE_CLEANUP_HEAD_FILE   = "data-file-cleanup-head-file";
 
+	/**
+	 * Primary chunk-checksum algorithm: {@code none}, {@code crc32c}, {@code sha256} or
+	 * {@code sha256-chained}. Default (unset) is {@code sha256}.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumAlgorithm(String)
+	 */
+	public final static String CHUNK_CHECKSUM_ALGORITHM            = "chunk-checksum-algorithm";
+
+	/**
+	 * Chunk-checksum base policy profile: {@code default}, {@code off}, {@code observe}, {@code strict} or
+	 * {@code strict-tolerate-legacy}. Default (unset) is {@code default}.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumProfile(String)
+	 */
+	public final static String CHUNK_CHECKSUM_PROFILE             = "chunk-checksum-profile";
+
+	/**
+	 * Initial chain seed for the {@code sha256-chained} algorithm as a hex string (64 chars = 32 bytes);
+	 * unused by any other algorithm.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumSeed(String)
+	 */
+	public final static String CHUNK_CHECKSUM_SEED               = "chunk-checksum-seed";
+
+	/**
+	 * Expert override: whether to emit checksum records on write. Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumEmit(boolean)
+	 */
+	public final static String CHUNK_CHECKSUM_EMIT               = "chunk-checksum-emit";
+
+	/**
+	 * Expert override: whether to recompute and check checksum records on load. Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumVerify(boolean)
+	 */
+	public final static String CHUNK_CHECKSUM_VERIFY             = "chunk-checksum-verify";
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a checksum mismatch.
+	 * Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumOnChecksumMismatch(String)
+	 */
+	public final static String CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH = "chunk-checksum-on-checksum-mismatch";
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a chunk-boundary mismatch.
+	 * Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumOnBoundaryMismatch(String)
+	 */
+	public final static String CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH = "chunk-checksum-on-boundary-mismatch";
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to an unknown record kind.
+	 * Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumOnUnknownKind(String)
+	 */
+	public final static String CHUNK_CHECKSUM_ON_UNKNOWN_KIND     = "chunk-checksum-on-unknown-kind";
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to a missing file header.
+	 * Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumOnMissingHeader(String)
+	 */
+	public final static String CHUNK_CHECKSUM_ON_MISSING_HEADER   = "chunk-checksum-on-missing-header";
+
+	/**
+	 * Expert override: reaction ({@code ignore} / {@code log} / {@code fail}) to uncovered data.
+	 * Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumOnUncoveredData(String)
+	 */
+	public final static String CHUNK_CHECKSUM_ON_UNCOVERED_DATA   = "chunk-checksum-on-uncovered-data";
+
+	/**
+	 * Expert override: whether missing/uncovered files are raised as anomalies. Defaults to the profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumRequireCoverage(boolean)
+	 */
+	public final static String CHUNK_CHECKSUM_REQUIRE_COVERAGE    = "chunk-checksum-require-coverage";
+
+	/**
+	 * Expert override: whether enabling emit forces an immediately-covered head file. Defaults to the
+	 * profile's value.
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumContinuousCoverage(boolean)
+	 */
+	public final static String CHUNK_CHECKSUM_CONTINUOUS_COVERAGE = "chunk-checksum-continuous-coverage";
+
 }

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
@@ -176,8 +176,10 @@ public interface EmbeddedStorageConfigurationPropertyNames
 	public final static String DATA_FILE_CLEANUP_HEAD_FILE   = "data-file-cleanup-head-file";
 
 	/**
-	 * Primary chunk-checksum algorithm: {@code none}, {@code crc32c}, {@code sha256} or
-	 * {@code sha256-chained}. Default (unset) is {@code sha256}.
+	 * Primary chunk-checksum algorithm: {@code none}, {@code crc32c} or
+	 * {@code sha256-chained}. When this key is unset but another {@code chunk-checksum-*} key is present,
+	 * the default is {@code sha256-chained}; setting no {@code chunk-checksum-*} key at all keeps the
+	 * framework default (no checksum &mdash; the feature off).
 	 *
 	 * @see EmbeddedStorageConfigurationBuilder#setChunkChecksumAlgorithm(String)
 	 */

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -31,6 +31,10 @@ import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
 import org.eclipse.store.storage.types.Storage;
 import org.eclipse.store.storage.types.StorageChannelCountProvider;
+import org.eclipse.store.storage.types.StorageChunkChecksumPolicy;
+import org.eclipse.store.storage.types.StorageChunkChecksumPolicy.Anomaly;
+import org.eclipse.store.storage.types.StorageChunkChecksumPolicy.Reaction;
+import org.eclipse.store.storage.types.StorageChunkChecksumProvider;
 import org.eclipse.store.storage.types.StorageConfiguration;
 import org.eclipse.store.storage.types.StorageDataFileEvaluator;
 import org.eclipse.store.storage.types.StorageEntityCacheEvaluator;
@@ -142,8 +146,14 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 				})
 			;
 
+			final StorageChunkChecksumProvider ccp = this.createChunkChecksumProvider();
+			if(ccp != null)
+			{
+				configBuilder.setChunkChecksumProvider(ccp);
+			}
+
 			foundation.setConfiguration(configBuilder.createConfiguration());
-			
+
 			return foundation;
 		}
 		
@@ -304,7 +314,149 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 					.orElse(StorageEntityCacheEvaluator.Defaults.defaultCacheThreshold())
 			);
 		}
-		
+
+		/**
+		 * Builds a {@link StorageChunkChecksumProvider} from the {@code chunk-checksum-*} properties, or returns
+		 * {@code null} (the sentinel telling the caller to skip the setter and keep the framework default) when
+		 * none is present. The profile supplies a coherent base policy; any present per-axis override replaces
+		 * that axis and the result is handed to {@link StorageChunkChecksumPolicy#NewCustom} &mdash; whose own
+		 * fail-early validation is the only policy guard (no bespoke sanity layer). Two documented silent rules:
+		 * {@code algorithm=none} forces an off policy (profile / overrides ignored), and {@code seed} is unused
+		 * by any algorithm other than {@code sha256-chained}.
+		 */
+		private StorageChunkChecksumProvider createChunkChecksumProvider()
+		{
+			if(!this.hasAnyChunkChecksumProperty())
+			{
+				return null;
+			}
+
+			final String algorithm = this.configuration.opt(CHUNK_CHECKSUM_ALGORITHM).orElse("sha256-chained").trim().toLowerCase();
+
+			// none => off, regardless of profile / overrides (documented silent rule); short-circuit so a
+			// discarded policy can never throw.
+			if("none".equals(algorithm))
+			{
+				return StorageChunkChecksumProvider.NewNone();
+			}
+
+			final StorageChunkChecksumPolicy policy = this.createChunkChecksumPolicy();
+
+			switch(algorithm)
+			{
+				case "crc32c":
+					return StorageChunkChecksumProvider.NewCrc32c(policy);
+				case "sha256-chained":
+					return StorageChunkChecksumProvider.NewSha256Chained(
+						policy,
+						this.configuration.opt(CHUNK_CHECKSUM_SEED).map(this::parseChunkChecksumSeed).orElse(null)
+					);
+				default:
+					throw new ConfigurationException(
+						this.configuration,
+						"Unknown " + CHUNK_CHECKSUM_ALGORITHM + ": '" + algorithm
+						+ "' (expected none, crc32c or sha256-chained)."
+					);
+			}
+		}
+
+		private boolean hasAnyChunkChecksumProperty()
+		{
+			for(final String key : this.configuration.keys())
+			{
+				if(key.startsWith("chunk-checksum-"))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private StorageChunkChecksumPolicy createChunkChecksumPolicy()
+		{
+			final StorageChunkChecksumPolicy base = this.chunkChecksumProfile();
+
+			// Each axis defaults off the profile base; any present key overrides it. NewCustom re-validates the
+			// resulting tuple and throws on a contradiction (the only policy guard) — wrapped as a
+			// ConfigurationException by createEmbeddedStorageFoundation().
+			return StorageChunkChecksumPolicy.NewCustom(
+				this.configuration.optBoolean(CHUNK_CHECKSUM_EMIT)              .orElse(base.emit())              ,
+				this.configuration.optBoolean(CHUNK_CHECKSUM_VERIFY)            .orElse(base.verify())            ,
+				this.chunkChecksumReaction(CHUNK_CHECKSUM_ON_CHECKSUM_MISMATCH, base.reactionTo(Anomaly.CHECKSUM_MISMATCH))      ,
+				this.chunkChecksumReaction(CHUNK_CHECKSUM_ON_BOUNDARY_MISMATCH, base.reactionTo(Anomaly.CHUNK_BOUNDARY_MISMATCH)),
+				this.chunkChecksumReaction(CHUNK_CHECKSUM_ON_UNKNOWN_KIND     , base.reactionTo(Anomaly.UNKNOWN_KIND))           ,
+				this.chunkChecksumReaction(CHUNK_CHECKSUM_ON_MISSING_HEADER   , base.reactionTo(Anomaly.MISSING_HEADER))         ,
+				this.chunkChecksumReaction(CHUNK_CHECKSUM_ON_UNCOVERED_DATA   , base.reactionTo(Anomaly.UNCOVERED_DATA))         ,
+				this.configuration.optBoolean(CHUNK_CHECKSUM_REQUIRE_COVERAGE)   .orElse(base.requireCoverage())   ,
+				this.configuration.optBoolean(CHUNK_CHECKSUM_CONTINUOUS_COVERAGE).orElse(base.continuousCoverage())
+			);
+		}
+
+		private StorageChunkChecksumPolicy chunkChecksumProfile()
+		{
+			final String profile = this.configuration.opt(CHUNK_CHECKSUM_PROFILE).orElse("default").trim().toLowerCase();
+			switch(profile)
+			{
+				case "default":                return StorageChunkChecksumPolicy.New()                    ;
+				case "off":                    return StorageChunkChecksumPolicy.NewOff()                 ;
+				case "observe":                return StorageChunkChecksumPolicy.NewObserve()             ;
+				case "strict":                 return StorageChunkChecksumPolicy.NewStrict()              ;
+				case "strict-tolerate-legacy": return StorageChunkChecksumPolicy.NewStrictTolerateLegacy();
+				default:
+					throw new ConfigurationException(
+						this.configuration,
+						"Unknown " + CHUNK_CHECKSUM_PROFILE + ": '" + profile
+						+ "' (expected default, off, observe, strict or strict-tolerate-legacy)."
+					);
+			}
+		}
+
+		private Reaction chunkChecksumReaction(final String key, final Reaction defaultReaction)
+		{
+			return this.configuration.opt(key)
+				.map(token -> this.parseChunkChecksumReaction(key, token))
+				.orElse(defaultReaction);
+		}
+
+		private Reaction parseChunkChecksumReaction(final String key, final String token)
+		{
+			switch(token.trim().toLowerCase())
+			{
+				case "ignore": return Reaction.IGNORE;
+				case "log":    return Reaction.LOG   ;
+				case "fail":   return Reaction.FAIL  ;
+				default:
+					throw new ConfigurationException(
+						this.configuration,
+						"Unknown reaction for " + key + ": '" + token + "' (expected ignore, log or fail)."
+					);
+			}
+		}
+
+		private byte[] parseChunkChecksumSeed(final String hex)
+		{
+			final String s = hex.trim();
+			if((s.length() & 1) != 0)
+			{
+				throw new ConfigurationException(
+					this.configuration,
+					CHUNK_CHECKSUM_SEED + " must be an even-length hex string (64 chars = 32 bytes), got length " + s.length() + "."
+				);
+			}
+			final byte[] out = new byte[s.length() / 2];
+			for(int i = 0; i < out.length; i++)
+			{
+				final int hi = Character.digit(s.charAt(i << 1)      , 16);
+				final int lo = Character.digit(s.charAt((i << 1) + 1), 16);
+				if(hi < 0 || lo < 0)
+				{
+					throw new ConfigurationException(this.configuration, CHUNK_CHECKSUM_SEED + " is not a valid hex string.");
+				}
+				out[i] = (byte)((hi << 4) | lo);
+			}
+			return out;
+		}
+
 	}
 	
 }

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -436,11 +436,11 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 		private byte[] parseChunkChecksumSeed(final String hex)
 		{
 			final String s = hex.trim();
-			if((s.length() & 1) != 0)
+			if(s.length() != 64)
 			{
 				throw new ConfigurationException(
 					this.configuration,
-					CHUNK_CHECKSUM_SEED + " must be an even-length hex string (64 chars = 32 bytes), got length " + s.length() + "."
+					CHUNK_CHECKSUM_SEED + " must be a 64-character hex string (32 bytes), got length " + s.length() + "."
 				);
 			}
 			final byte[] out = new byte[s.length() / 2];

--- a/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/MainUtilStorageConverter.java
+++ b/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/MainUtilStorageConverter.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.store.storage.embedded.configuration.types.EmbeddedStorageConfiguration;
+import org.eclipse.store.storage.types.StorageChunkChecksumPolicy;
+import org.eclipse.store.storage.types.StorageChunkChecksumProvider;
 import org.eclipse.store.storage.types.StorageConfiguration;
 
 /**
@@ -50,6 +52,11 @@ public class MainUtilStorageConverter
 		+ "\"-c binaryConverter1, binaryConverter2\""
 		+ "It is import to have the \"-c\" inside the quotation marks, "
 		+ "the converters must be specified using the full class name"
+		+ "\n\n"
+		+ "Verify-only: provide a single source config (no target) to scan and verify the source\n"
+		+ "storage's chunk checksums without writing anything: \n"
+		+ "\n"
+		+ "MainUtilStorageConverter sourceConfig.ini"
 		;
 
 	/**
@@ -69,16 +76,32 @@ public class MainUtilStorageConverter
 	public static void main(final String[] args)
 	{
 		verifyArguments(args);
-		
+
 		final String srcConfigFile = args[0];
+		final StorageConfiguration sourceConfig = loadConfiguration(srcConfigFile);
+
+		// Verify-only mode: a single source config, no target — scan and verify, write nothing.
+		if(args.length == 1)
+		{
+			System.out.println("Source storage configuration: " + srcConfigFile);
+			System.out.println("Source checksum policy: " + describe(sourceConfig.chunkChecksumProvider()));
+			System.out.println("Verify-only mode: no target configured; scanning source, writing nothing.");
+			try
+			{
+				new StorageConverter(sourceConfig).start();
+				System.out.println("Source verification completed (no fatal anomaly).");
+			}
+			catch(final Throwable t)
+			{
+				System.err.println("Source verification FAILED: " + t);
+				System.exit(1);
+			}
+			return;
+		}
+
 		final String dstConfigFile = args[1];
-		
-		final StorageConfiguration sourceConfig = EmbeddedStorageConfiguration.load(srcConfigFile)
-			.createEmbeddedStorageFoundation().getConfiguration();
-		
-		final StorageConfiguration targetConfig = EmbeddedStorageConfiguration.load(dstConfigFile)
-			.createEmbeddedStorageFoundation().getConfiguration();
-		
+		final StorageConfiguration targetConfig = loadConfiguration(dstConfigFile);
+
 		String[] binaryConverters = {};
 		if(args.length > 2)
 		{
@@ -90,15 +113,43 @@ public class MainUtilStorageConverter
 				}
 			}
 		}
-		
+
 		System.out.println("Source storage configuration: " + srcConfigFile);
 		System.out.println("Target storage configuration: " + dstConfigFile);
+		System.out.println("Source checksum policy: " + describe(sourceConfig.chunkChecksumProvider()));
+		System.out.println("Target checksum policy: " + describe(targetConfig.chunkChecksumProvider()));
 		System.out.println("Binary format converters: " + Arrays.toString(binaryConverters));
-		
+
 		final StorageConverter storageConverter = new StorageConverter(sourceConfig, targetConfig, binaryConverters);
 		storageConverter.start();
-		
+
 		System.out.println("Storage conversion finished!");
+	}
+
+	private static StorageConfiguration loadConfiguration(final String configFile)
+	{
+		return EmbeddedStorageConfiguration.load(configFile)
+			.createEmbeddedStorageFoundation().getConfiguration();
+	}
+
+	/**
+	 * Human-readable summary of a checksum provider's effective behavior. Note: the external configuration
+	 * format has no checksum-provider key, so a config-file-driven run reflects the framework default.
+	 */
+	private static String describe(final StorageChunkChecksumProvider provider)
+	{
+		final StorageChunkChecksumPolicy policy = provider.policy();
+		if(!policy.emit() && !policy.verify())
+		{
+			return "off (no emit, no verify)";
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append("emit=").append(policy.emit()).append(", verify=").append(policy.verify());
+		if(policy.emit())
+		{
+			sb.append(", writeKind=0x").append(Long.toHexString(provider.chunkChecksumKind()));
+		}
+		return sb.toString();
 	}
 
 	private static String[] parseBinaryConverters(String[] args, int startIndex)
@@ -121,13 +172,17 @@ public class MainUtilStorageConverter
 
 	private static void verifyArguments(final String[] args)
 	{
-		if(args.length >= 2)
+		if(args.length >= 1)
 		{
 			if(new File(args[0]).canRead())
 			{
+				if(args.length == 1)
+				{
+					return; // verify-only: source config alone
+				}
 				if(new File(args[1]).canRead())
 				{
-					return;
+					return; // conversion: source + target config
 				}
 				else
 				{
@@ -143,7 +198,7 @@ public class MainUtilStorageConverter
 		{
 			System.err.println("Invalid number of arguments.");
 		}
-		
+
 		System.out.println(HELP);
 		System.exit(-1);
 	}

--- a/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
+++ b/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
@@ -226,8 +226,7 @@ public class StorageConverter
 			}
 			finally
 			{
-				// always release the target's off-heap buffers (per-channel chunk buffers + header/record
-				// buffers) even if conversion throws partway; StorageConverterTarget.close() is exception-safe.
+				// release the target's buffers even if conversion throws.
 				this.close();
 			}
 		}
@@ -262,9 +261,7 @@ public class StorageConverter
 			}
 			finally
 			{
-				// the converter hands ownership of a fresh direct buffer and transferBytes only copies it,
-				// so free it now instead of leaving each per-entity buffer to the Cleaner. Guard against a
-				// converter that returns bufferIn unchanged (that one is owned/freed by processFile).
+				// free the converter's fresh buffer; skip bufferIn (freed by processFile).
 				if(converted != this.bufferIn)
 				{
 					XMemory.deallocateDirectByteBuffer(converted);
@@ -346,9 +343,7 @@ public class StorageConverter
 		}
 		finally
 		{
-			// Release the per-file off-heap buffer in every exit path (the verify-only return included)
-			// instead of leaving it for the Cleaner, so a long run over many files does not accumulate
-			// direct buffers.
+			// release the per-file buffer on every exit path (verify-only return included).
 			XMemory.deallocateDirectByteBuffer(this.bufferIn);
 			this.bufferIn = null;
 		}

--- a/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
+++ b/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
@@ -15,9 +15,11 @@ package org.eclipse.store.storage.embedded.tools.storage.converter;
  */
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 
 import org.eclipse.serializer.collections.EqHashTable;
 import org.eclipse.serializer.collections.XSort;
@@ -26,10 +28,14 @@ import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+import org.eclipse.store.storage.types.StorageChecksumAnomalyReporter;
+import org.eclipse.store.storage.types.StorageChunkChecksumCalculator;
+import org.eclipse.store.storage.types.StorageChunkChecksumProvider;
 import org.eclipse.store.storage.types.StorageConfiguration;
 import org.eclipse.store.storage.types.StorageDataInventoryFile;
 import org.eclipse.store.storage.types.StorageInventory;
 import org.eclipse.store.storage.types.StorageLiveFileProvider;
+import org.eclipse.store.storage.types.StorageMetaRecord;
 import org.slf4j.Logger;
 
 /**
@@ -70,6 +76,13 @@ public class StorageConverter
 	
 	private final BinaryConverterSelector   binaryConverterSelector;
 	private final ConverterTypeDictionary   converterTypeDictionary;
+
+	// Source-side chunk-checksum verification (driven by the source policy): recompute and compare every
+	// chunk-checksum record while reading, so corruption is caught before it propagates into the target.
+	// null when not verifying.
+	private final boolean                                              sourceVerifying;
+	private final Map<Long, StorageChunkChecksumCalculator.Algorithm>  verifyAlgorithms;
+	private final StorageChecksumAnomalyReporter                       anomalyReporter;
 
 	/**
 	 * Helper class describing a single entity in the current processed file
@@ -113,7 +126,12 @@ public class StorageConverter
 		this.processedIds            = new HashSet<>();
 		this.currentFileEntities     = new HashMap<>();
 
-		this.target                  = new StorageConverterTarget(targetStorageConfiguration);
+		this.target                  = StorageConverterTarget.New(targetStorageConfiguration);
+
+		final StorageChunkChecksumProvider srcProvider = sourceStorageConfiguration.chunkChecksumProvider();
+		this.sourceVerifying  = srcProvider.policy().verify();
+		this.verifyAlgorithms = this.sourceVerifying ? srcProvider.createAlgorithmsByKind()                  : null;
+		this.anomalyReporter  = this.sourceVerifying ? StorageChecksumAnomalyReporter.New(srcProvider.policy()) : null;
 	}
 
 	/**
@@ -144,22 +162,67 @@ public class StorageConverter
 		this.processedIds            = new HashSet<>();
 		this.currentFileEntities     = new HashMap<>();
 
-		this.target                  = new StorageConverterTarget(targetStorageConfiguration);
+		this.target                  = StorageConverterTarget.New(targetStorageConfiguration);
+
+		final StorageChunkChecksumProvider srcProvider = sourceStorageConfiguration.chunkChecksumProvider();
+		this.sourceVerifying  = srcProvider.policy().verify();
+		this.verifyAlgorithms = this.sourceVerifying ? srcProvider.createAlgorithmsByKind()                  : null;
+		this.anomalyReporter  = this.sourceVerifying ? StorageChecksumAnomalyReporter.New(srcProvider.policy()) : null;
 	}
-	
+
+	/**
+	 * Creates a <b>verify-only</b> converter: it walks the source storage and verifies its chunk checksums
+	 * according to the source configuration's {@link StorageChunkChecksumProvider} policy, but writes nothing
+	 * (no target storage is created). Anomalies react per the source policy. A non-verifying source policy
+	 * makes this a no-op scan.
+	 *
+	 * @param sourceStorageConfiguration configuration for the storage to be verified.
+	 */
+	public StorageConverter(final StorageConfiguration sourceStorageConfiguration)
+	{
+		this.srcFileProvider         = sourceStorageConfiguration.fileProvider();
+		this.srcChannelCount         = sourceStorageConfiguration.channelCountProvider().getChannelCount();
+
+		this.converterTypeDictionary = new ConverterTypeDictionary(this.srcFileProvider.provideTypeDictionaryIoHandler().loadTypeDictionary());
+		this.binaryConverterSelector = new BinaryConverterSelector(this.converterTypeDictionary);
+
+		this.srcInventories          = this.createChannelInventories();
+		this.processedIds            = new HashSet<>();
+		this.currentFileEntities     = new HashMap<>();
+
+		this.target                  = null; // verify-only: no target, nothing is written
+
+		final StorageChunkChecksumProvider srcProvider = sourceStorageConfiguration.chunkChecksumProvider();
+		this.sourceVerifying  = srcProvider.policy().verify();
+		this.verifyAlgorithms = this.sourceVerifying ? srcProvider.createAlgorithmsByKind()                  : null;
+		this.anomalyReporter  = this.sourceVerifying ? StorageChecksumAnomalyReporter.New(srcProvider.policy()) : null;
+	}
+
 
 	///////////////////////////////////////////////////////////////////////////
 	// methods //
 	////////////
-	
+
 	/**
-	 * Execute the conversion.
+	 * Execute the conversion, or &mdash; when constructed without a target &mdash; the verify-only scan.
 	 */
 	public void start()
 	{
-		this.copyTypeDictionary();
-		this.convertStorage();
-		this.close();
+		if(this.target == null)
+		{
+			// verify-only: walk and verify the source, write nothing.
+			if(!this.sourceVerifying)
+			{
+				logger.warn("Verify-only run, but the source policy does not verify; nothing will be checked.");
+			}
+			this.convertStorage();
+		}
+		else
+		{
+			this.copyTypeDictionary();
+			this.convertStorage();
+			this.close();
+		}
 	}
 
 	private void copyTypeDictionary()
@@ -212,6 +275,19 @@ public class StorageConverter
 		final long bufferStartAddress = XMemory.getDirectByteBufferAddress(this.bufferIn);
 		final long bufferBoundAddress = bufferStartAddress + this.bufferIn.limit();
 
+		if (this.sourceVerifying)
+		{
+			// verify the source's own chunk checksums before any entity is transferred, so a FAIL reaction
+			// aborts the conversion instead of copying corruption into the target.
+			this.verifyFile(storageDataInventoryFile, bufferStartAddress, bufferBoundAddress);
+		}
+
+		if (this.target == null)
+		{
+			// verify-only: the file has been verified above; nothing is registered or transferred.
+			return;
+		}
+
 		long currentItemLength;
 		long offset = 0;
 
@@ -244,6 +320,181 @@ public class StorageConverter
 
 		logger.trace("Clearing current file entities.");
 		this.currentFileEntities.clear();
+	}
+
+	/**
+	 * Verifies the source file's own chunk-checksum records, mirroring the engine's load-time walk
+	 * ({@code StorageChunkChecksumCalculator.ChunkChecksumHandler.onLoad}) but off-line: it tracks the chunk
+	 * boundary, parses a {@code FileHeaderV1} to seed the chain tip, and on each chunk-checksum record
+	 * recomputes the covered bytes {@code [chunkStart, recordAddress)} with the {@link
+	 * StorageChunkChecksumCalculator.Algorithm} dispatched by the record's on-disk KIND, comparing against the
+	 * stored hash. Anomalies are routed to {@link #anomalyReporter}. The whole file is already resident in
+	 * {@link #bufferIn}, so the chunk slices are taken in place.
+	 */
+	private void verifyFile(
+		final StorageDataInventoryFile storageDataInventoryFile,
+		final long                     bufferStartAddress      ,
+		final long                     bufferBoundAddress
+	)
+	{
+		final long fileNumber = storageDataInventoryFile.number();
+
+		long    chunkStart      = bufferStartAddress; // start of the bytes the next record will cover
+		byte[]  chainTip        = null;               // seeded from FileHeaderV1.chainRoot for chained kinds
+		boolean headerSeen      = false;
+		boolean dataSinceRecord = false;              // live data not yet covered by a record
+
+		for (long address = bufferStartAddress; address < bufferBoundAddress;)
+		{
+			// the 8-byte length field must be fully resident before it is read; a trailing remnant shorter than
+			// a length field cannot be a valid entry, so stop the walk. Only fires on a truncated/corrupt file.
+			if (address + Long.BYTES > bufferBoundAddress)
+			{
+				break;
+			}
+
+			final long rawLength = Binary.getEntityLengthRawValue(address);
+
+			if (rawLength > 0)
+			{
+				// live entity: part of the current chunk's byte range. chunkStart is unchanged.
+				dataSinceRecord = true;
+				address += rawLength;
+			}
+			else if (rawLength < 0)
+			{
+				final long entryLength = -rawLength;
+
+				// the 12-byte envelope (LENGTH + META_MARKER + KIND) must be resident before the marker/KIND are
+				// read; otherwise this negative-length entry cannot be a structured meta record — treat it as an
+				// opaque gap (chunkStart unchanged), mirroring StorageMetaRecordRegistry.dispatch.
+				if (address + StorageMetaRecord.OFFSET_PAYLOAD <= bufferBoundAddress
+					&& StorageMetaRecord.isMetaRecord(address))
+				{
+					final long kind = StorageMetaRecord.kindOf(address);
+					if (kind == StorageMetaRecord.KIND_FileHeaderV1)
+					{
+						if (address + StorageMetaRecord.LENGTH_FILEHEADERV1 > bufferBoundAddress)
+						{
+							// truncated header: its chain root runs past the resident bytes. Report and skip,
+							// mirroring StorageChunkChecksumCalculator.FileHeaderV1Handler.onLoad.
+							this.anomalyReporter.onUnknownKind(fileNumber, StorageMetaRecord.KIND_FileHeaderV1);
+						}
+						else
+						{
+							final StorageMetaRecord.FileHeaderV1Payload header = StorageMetaRecord.readFileHeaderV1(address);
+							chainTip        = header.chainRoot();
+							headerSeen      = true;
+							chunkStart      = address + entryLength;
+							dataSinceRecord = false;
+						}
+					}
+					else
+					{
+						final StorageChunkChecksumCalculator.Algorithm verifier = this.verifyAlgorithms.get(kind);
+						if (verifier == null)
+						{
+							// a meta record whose KIND we cannot verify (removed/future/custom not in the
+							// source provider's verify set): report and skip; chunkStart is unchanged.
+							this.anomalyReporter.onUnknownKind(fileNumber, kind);
+						}
+						else if (address + verifier.recordLength() > bufferBoundAddress)
+						{
+							// truncated covering record: its stored hash runs past the resident bytes. Report and
+							// skip, mirroring StorageChunkChecksumCalculator.ChunkChecksumHandler.onLoad.
+							this.anomalyReporter.onUnknownKind(fileNumber, kind);
+						}
+						else
+						{
+							chainTip        = this.verifyChunk(verifier, fileNumber, chunkStart, address, chainTip);
+							chunkStart      = address + entryLength;
+							dataSinceRecord = false;
+						}
+					}
+				}
+				// else: a plain gap/tombstone (or a sub-envelope remnant) is part of the current chunk's byte
+				// range; chunkStart is unchanged, matching the load walk's [chunkStart, recordAddress) slice.
+
+				address += entryLength;
+			}
+			else
+			{
+				throw new StorageExceptionConsistency("Zero length data item.");
+			}
+		}
+
+		// coverage anomalies: live data left uncovered at end of file. The reporter no-ops these unless the
+		// source policy requires coverage. No header at all => unprotected legacy file (MISSING_HEADER);
+		// data after the last covering record => UNCOVERED_DATA.
+		if (dataSinceRecord)
+		{
+			if (headerSeen)
+			{
+				this.anomalyReporter.onUncoveredData(fileNumber, chunkStart - bufferStartAddress);
+			}
+			else
+			{
+				this.anomalyReporter.onMissingHeader(fileNumber);
+			}
+		}
+
+		this.anomalyReporter.onFileWalkComplete(fileNumber);
+	}
+
+	/**
+	 * Recomputes and compares one chunk-checksum record. Returns the chain tip to carry forward (the stored
+	 * hash for chained kinds &mdash; equal to the recomputed hash on a match, and on a tolerated mismatch the
+	 * basis the writer chained from; {@code null}/unchanged for non-chained kinds).
+	 */
+	private byte[] verifyChunk(
+		final StorageChunkChecksumCalculator.Algorithm verifier     ,
+		final long                                      fileNumber   ,
+		final long                                      chunkStart   ,
+		final long                                      recordAddress,
+		final byte[]                                    chainTip
+	)
+	{
+		if (verifier.isChained() && chainTip == null)
+		{
+			// a chained record with no FileHeaderV1 seed cannot be verified; report the missing header and
+			// skip rather than fold a null tip into the digest.
+			this.anomalyReporter.onMissingHeader(fileNumber);
+			return null;
+		}
+
+		final long bufferStartAddress = XMemory.getDirectByteBufferAddress(this.bufferIn);
+
+		// framing cross-check (mirrors ChunkChecksumHandler.onLoad): if the record's stored chunk start disagrees
+		// with the boundary this walk reconstructed, a corrupted LENGTH rerouted the walk past a record. Report
+		// and skip the hash (the range is wrong); the caller re-anchors past this record.
+		final int  storedChunkStart = StorageMetaRecord.readChunkChecksumChunkStart(recordAddress);
+		final long walkerChunkStart = chunkStart - bufferStartAddress;
+		if(storedChunkStart != walkerChunkStart)
+		{
+			this.anomalyReporter.onChunkBoundaryMismatch(
+				fileNumber, recordAddress - bufferStartAddress, storedChunkStart, walkerChunkStart
+			);
+			// re-anchor the chain to the on-disk record (chained): continue from its stored tip.
+			return verifier.isChained() ? verifier.readStoredChecksumBytes(recordAddress) : chainTip;
+		}
+
+		final long       chunkLength        = recordAddress - chunkStart;
+		final ByteBuffer chunk              = XMemory.slice(this.bufferIn, chunkStart - bufferStartAddress, chunkLength);
+
+		final byte[] expected = verifier.readStoredChecksumBytes(recordAddress);
+		if (verifier.isChained())
+		{
+			verifier.setChainTip(chainTip);
+		}
+		final byte[] actual = verifier.computeChecksumBytes(chunk);
+
+		if (!Arrays.equals(actual, expected))
+		{
+			this.anomalyReporter.onChecksumMismatch(fileNumber, chunkStart - bufferStartAddress, verifier.kind(), expected, actual);
+		}
+
+		// continue a chain from the stored tip (== actual on a match); for non-chained kinds the tip is unused.
+		return verifier.isChained() ? expected : chainTip;
 	}
 
 	private void transferRegisteredEntities()

--- a/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
+++ b/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
@@ -265,61 +265,72 @@ public class StorageConverter
 		
 		try
 		{
-			storageDataInventoryFile.readBytes(this.bufferIn);
+			try
+			{
+				storageDataInventoryFile.readBytes(this.bufferIn);
+			}
+			finally
+			{
+				storageDataInventoryFile.close();
+			}
+
+			final long bufferStartAddress = XMemory.getDirectByteBufferAddress(this.bufferIn);
+			final long bufferBoundAddress = bufferStartAddress + this.bufferIn.limit();
+
+			if (this.sourceVerifying)
+			{
+				// verify the source's own chunk checksums before any entity is transferred, so a FAIL reaction
+				// aborts the conversion instead of copying corruption into the target.
+				this.verifyFile(storageDataInventoryFile, bufferStartAddress, bufferBoundAddress);
+			}
+
+			if (this.target == null)
+			{
+				// verify-only: the file has been verified above; nothing is registered or transferred.
+				return;
+			}
+
+			long currentItemLength;
+			long offset = 0;
+
+			for (long address = bufferStartAddress; address < bufferBoundAddress;)
+			{
+				currentItemLength = Binary.getEntityLengthRawValue(address);
+
+				if (currentItemLength > 0)
+				{
+					this.registerFileEntity(address, offset, currentItemLength);
+
+					address += currentItemLength;
+					offset += currentItemLength;
+				}
+				else if (currentItemLength < 0)
+				{
+					// comments (indicated by negative length) just get skipped.
+					// note that gap length gets registered for the file at the end arithmetically
+					address -= currentItemLength;
+					offset -= currentItemLength;
+				}
+				else
+				{
+					// entity length may never be 0 or the iteration will hang forever
+					throw new StorageExceptionConsistency("Zero length data item.");
+				}
+			}
+
+			this.transferRegisteredEntities();
+
+			logger.trace("Clearing current file entities.");
+			this.currentFileEntities.clear();
 		}
 		finally
 		{
-			storageDataInventoryFile.close();
+			// Release the per-file off-heap buffer in every exit path (the verify-only return included)
+			// instead of leaving it for the Cleaner, so a long run over many files does not accumulate
+			// direct buffers.
+			XMemory.deallocateDirectByteBuffer(this.bufferIn);
+			this.bufferIn = null;
 		}
-
-		final long bufferStartAddress = XMemory.getDirectByteBufferAddress(this.bufferIn);
-		final long bufferBoundAddress = bufferStartAddress + this.bufferIn.limit();
-
-		if (this.sourceVerifying)
-		{
-			// verify the source's own chunk checksums before any entity is transferred, so a FAIL reaction
-			// aborts the conversion instead of copying corruption into the target.
-			this.verifyFile(storageDataInventoryFile, bufferStartAddress, bufferBoundAddress);
-		}
-
-		if (this.target == null)
-		{
-			// verify-only: the file has been verified above; nothing is registered or transferred.
-			return;
-		}
-
-		long currentItemLength;
-		long offset = 0;
-
-		for (long address = bufferStartAddress; address < bufferBoundAddress;)
-		{
-			currentItemLength = Binary.getEntityLengthRawValue(address);
-
-			if (currentItemLength > 0)
-			{
-				this.registerFileEntity(address, offset, currentItemLength);
-
-				address += currentItemLength;
-				offset += currentItemLength;
-			}
-			else if (currentItemLength < 0)
-			{
-				// comments (indicated by negative length) just get skipped.
-				// note that gap length gets registered for the file at the end arithmetically
-				address -= currentItemLength;
-				offset -= currentItemLength;
-			}
-			else
-			{
-				// entity length may never be 0 or the iteration will hang forever
-				throw new StorageExceptionConsistency("Zero length data item.");
-			}
-		}
-
-		this.transferRegisteredEntities();
-
-		logger.trace("Clearing current file entities.");
-		this.currentFileEntities.clear();
 	}
 
 	/**

--- a/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
+++ b/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverter.java
@@ -219,9 +219,17 @@ public class StorageConverter
 		}
 		else
 		{
-			this.copyTypeDictionary();
-			this.convertStorage();
-			this.close();
+			try
+			{
+				this.copyTypeDictionary();
+				this.convertStorage();
+			}
+			finally
+			{
+				// always release the target's off-heap buffers (per-channel chunk buffers + header/record
+				// buffers) even if conversion throws partway; StorageConverterTarget.close() is exception-safe.
+				this.close();
+			}
 		}
 	}
 
@@ -247,8 +255,21 @@ public class StorageConverter
 		BinaryConverter converter = this.binaryConverterSelector.get(tid);
 		if(converter!=null)
 		{
-			ByteBuffer converted = converter.convert(this.bufferIn);
-			this.target.transferBytes(converted, oid);
+			final ByteBuffer converted = converter.convert(this.bufferIn);
+			try
+			{
+				this.target.transferBytes(converted, oid);
+			}
+			finally
+			{
+				// the converter hands ownership of a fresh direct buffer and transferBytes only copies it,
+				// so free it now instead of leaving each per-entity buffer to the Cleaner. Guard against a
+				// converter that returns bufferIn unchanged (that one is owned/freed by processFile).
+				if(converted != this.bufferIn)
+				{
+					XMemory.deallocateDirectByteBuffer(converted);
+				}
+			}
 		}
 		else
 		{

--- a/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverterTarget.java
+++ b/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverterTarget.java
@@ -9,7 +9,7 @@ package org.eclipse.store.storage.embedded.tools.storage.converter;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
@@ -18,128 +18,413 @@ import java.io.Closeable;
 import java.nio.ByteBuffer;
 
 import org.eclipse.serializer.afs.types.AWritableFile;
+import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.util.logging.Logging;
+import org.eclipse.store.storage.exceptions.StorageException;
+import org.eclipse.store.storage.types.StorageChunkChecksumCalculator.Algorithm;
+import org.eclipse.store.storage.types.StorageChunkChecksumProvider;
 import org.eclipse.store.storage.types.StorageConfiguration;
 import org.eclipse.store.storage.types.StorageDataFileEvaluator;
 import org.eclipse.store.storage.types.StorageLiveFileProvider;
+import org.eclipse.store.storage.types.StorageMetaRecord;
 import org.slf4j.Logger;
 
 
 /**
- * Handle everything related to the "Target Storage" of the storage converter.
- * 
+ * Handles everything related to the "Target Storage" of the storage converter.
+ * <p>
+ * Two strategies, selected once by {@link #New(StorageConfiguration)} from the target configuration's
+ * {@link StorageChunkChecksumProvider}:
+ * <ul>
+ *   <li>{@link NotChecksummed} &mdash; raw-streaming: entities are written verbatim and files roll over at
+ *       {@link StorageDataFileEvaluator#fileMaximumSize()}. Used when the provider does not emit.</li>
+ *   <li>{@link Checksummed} &mdash; mirrors the engine's coalescing-dissolution write: each file opens with a
+ *       {@code FileHeaderV1}, live entities are coalesced into chunks of about
+ *       {@link StorageDataFileEvaluator#coalesceChunkTargetBytes()} bytes each followed by a covering
+ *       chunk-checksum record, and the chained tip threads across a channel's files.</li>
+ * </ul>
  */
-public class StorageConverterTarget implements Closeable
+public interface StorageConverterTarget extends Closeable
 {
-	private final static Logger logger = Logging.getLogger(StorageConverterTarget.class);
-	
-	
-	///////////////////////////////////////////////////////////////////////////
-	// instance fields //
-	////////////////////
-	
-	private final StorageLiveFileProvider      fileProvider;
-	private final int                          channelCount;
-
-	private final StorageConverterTargetFile[] files;
-	private final StorageDataFileEvaluator     storageDataFileEvaluator;
-
-	
-	///////////////////////////////////////////////////////////////////////////
-	// constructors //
-	/////////////////
-		
 	/**
-	 * Creates a {@link StorageConverterTarget} instance based on the supplied
-	 * Storage configuration.
-	 * 
-	 * @param storageConfiguration {@link StorageConfiguration}
-	 */
-	public StorageConverterTarget(final StorageConfiguration storageConfiguration)
-	{
-		super();
-		this.fileProvider             = storageConfiguration.fileProvider();
-		this.channelCount             = storageConfiguration.channelCountProvider().getChannelCount();
-		this.storageDataFileEvaluator = storageConfiguration.dataFileEvaluator();
-		this.files                    = this.createTargetDataFiles();
-	}
-
-	
-	///////////////////////////////////////////////////////////////////////////
-	// methods //
-	////////////
-	
-	@Override
-	public void close()
-	{
-		for (final StorageConverterTargetFile file : this.files)
-		{
-			file.release();
-		}
-	}
-
-	/**
-	 * Write the supplied TypeDictionary String as the new targets TypeDictionary
-	 * 
+	 * Write the supplied TypeDictionary String as the new target's TypeDictionary.
+	 *
 	 * @param srcTypeDictionary the source type dictionary as String
 	 */
-	public void storeTypeDictionary(final String srcTypeDictionary)
-	{
-		logger.debug("Transferring type dictionary to target.");
-		
-		this.fileProvider.provideTypeDictionaryIoHandler().storeTypeDictionary(srcTypeDictionary);
-	}
-	
+	void storeTypeDictionary(String srcTypeDictionary);
+
 	/**
-	 * Write the content of the supplied ByteBuffer
-	 * to the targets' storage system.
-	 * 
+	 * Write the content of the supplied ByteBuffer to the target's storage system.
+	 *
 	 * @param buffer content to be transferred
-	 * @param oid object id
+	 * @param oid    object id (selects the target channel by {@code oid % channelCount})
 	 */
-	public void transferBytes(final ByteBuffer buffer, final long oid)
+	void transferBytes(ByteBuffer buffer, long oid);
+
+	@Override
+	void close();
+
+
+	/**
+	 * Creates the appropriate target for the supplied configuration: a {@link Checksummed} target when the
+	 * configured {@link StorageChunkChecksumProvider} emits, otherwise a {@link NotChecksummed} target. The
+	 * initial per-channel files are opened after construction (so a {@link Checksummed} target's header write
+	 * sees its fully initialized state).
+	 *
+	 * @param storageConfiguration the target {@link StorageConfiguration}
+	 * @return a ready-to-use {@link StorageConverterTarget}
+	 */
+	static StorageConverterTarget New(final StorageConfiguration storageConfiguration)
 	{
-		final int targetChannel = (int) (oid % this.channelCount);
-		
-		logger.trace("Transferring blob pos: {}, limit: {} to target channel {}.",
-				buffer.position(), buffer.limit(), targetChannel);
-		
-		this.transferBytesToChannel(buffer, targetChannel);
+		final StorageConverterTarget.Abstract target =
+			storageConfiguration.chunkChecksumProvider().policy().emit()
+				? new Checksummed(storageConfiguration)
+				: new NotChecksummed(storageConfiguration);
+		target.openInitialFiles();
+		return target;
 	}
 
-	private void transferBytesToChannel(final ByteBuffer buffer, final int channelIndex)
-	{
-		StorageConverterTargetFile file = this.files[channelIndex];
 
-		if (buffer.limit() - buffer.position() + file.size() > this.storageDataFileEvaluator.fileMaximumSize())
+	///////////////////////////////////////////////////////////////////////////
+	// shared base //
+	////////////////
+
+	/**
+	 * Shared state and file management for both target strategies: the file provider, channel count, data-file
+	 * evaluator, the per-channel target-file array and the type-dictionary write. Subclasses contribute the
+	 * write strategy ({@link #transferBytes}, {@link #close}) and an optional per-file-creation hook
+	 * ({@link #onFileCreated}).
+	 */
+	abstract class Abstract implements StorageConverterTarget
+	{
+		final static Logger logger = Logging.getLogger(StorageConverterTarget.class);
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		final StorageLiveFileProvider      fileProvider;
+		final int                          channelCount;
+		final StorageDataFileEvaluator     dataFileEvaluator;
+		final StorageConverterTargetFile[] files;
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Abstract(final StorageConfiguration storageConfiguration)
 		{
-			file.release();
-			file = this.createNewStorageFile(file.fileNumber() + 1, channelIndex);
-			this.files[channelIndex] = file;
+			super();
+			this.fileProvider      = storageConfiguration.fileProvider();
+			this.channelCount      = storageConfiguration.channelCountProvider().getChannelCount();
+			this.dataFileEvaluator = storageConfiguration.dataFileEvaluator();
+			this.files             = new StorageConverterTargetFile[this.channelCount];
 		}
 
-		this.files[channelIndex].writeBytes(buffer);
-	}
 
-	private StorageConverterTargetFile[] createTargetDataFiles()
-	{
-		final StorageConverterTargetFile[] files = new StorageConverterTargetFile[this.channelCount];
-		
-		for (int channelIndex = 0; channelIndex < this.channelCount; channelIndex++)
+		///////////////////////////////////////////////////////////////////////////
+		// methods //
+		////////////
+
+		/**
+		 * Opens the initial (number 0) file of every channel. Called by {@link #New(StorageConfiguration)}
+		 * <b>after</b> the instance is fully constructed, so a subclass's {@link #onFileCreated} hook sees its
+		 * own initialized state (it must not be called from a constructor).
+		 */
+		final void openInitialFiles()
 		{
-			files[channelIndex] = this.createNewStorageFile(0, channelIndex);
+			for (int channelIndex = 0; channelIndex < this.channelCount; channelIndex++)
+			{
+				this.files[channelIndex] = this.createNewStorageFile(0, channelIndex);
+			}
 		}
-		
-		return files;
+
+		final StorageConverterTargetFile createNewStorageFile(final long fileNumber, final int channelIndex)
+		{
+			logger.debug("Creating new storage file {} for channel {}.", fileNumber, channelIndex);
+
+			final AWritableFile file = this.fileProvider.provideDataFile(channelIndex, fileNumber).useWriting();
+			file.ensureExists();
+
+			final StorageConverterTargetFile targetFile = new StorageConverterTargetFile(file, fileNumber);
+			this.onFileCreated(targetFile, channelIndex);
+			return targetFile;
+		}
+
+		/**
+		 * Hook invoked right after a target file is created and ensured to exist. Default: no-op
+		 * ({@link NotChecksummed}). {@link Checksummed} overrides it to write the {@code FileHeaderV1}.
+		 */
+		void onFileCreated(final StorageConverterTargetFile file, final int channelIndex)
+		{
+			// no-op
+		}
+
+		@Override
+		public final void storeTypeDictionary(final String srcTypeDictionary)
+		{
+			logger.debug("Transferring type dictionary to target.");
+
+			this.fileProvider.provideTypeDictionaryIoHandler().storeTypeDictionary(srcTypeDictionary);
+		}
 	}
 
-	private StorageConverterTargetFile createNewStorageFile(final long fileNumber, final int channelIndex)
+
+	///////////////////////////////////////////////////////////////////////////
+	// no-checksum strategy //
+	/////////////////////////
+
+	/**
+	 * Raw-streaming target: writes entity bytes verbatim and rolls over at
+	 * {@link StorageDataFileEvaluator#fileMaximumSize()}.
+	 */
+	final class NotChecksummed extends Abstract
 	{
-		logger.debug("Creating new storage file {} for channel {}.", fileNumber, channelIndex);
-		
-		final AWritableFile file = this.fileProvider.provideDataFile(channelIndex, fileNumber).useWriting();
-		file.ensureExists();
-		
-		return new StorageConverterTargetFile(file, fileNumber);
+		NotChecksummed(final StorageConfiguration storageConfiguration)
+		{
+			super(storageConfiguration);
+		}
+
+		@Override
+		public void transferBytes(final ByteBuffer buffer, final long oid)
+		{
+			final int channelIndex = (int) (oid % this.channelCount);
+
+			logger.trace("Transferring blob pos: {}, limit: {} to target channel {}.",
+					buffer.position(), buffer.limit(), channelIndex);
+
+			StorageConverterTargetFile file = this.files[channelIndex];
+
+			if (buffer.limit() - buffer.position() + file.size() > this.dataFileEvaluator.fileMaximumSize())
+			{
+				file.release();
+				file = this.createNewStorageFile(file.fileNumber() + 1, channelIndex);
+				this.files[channelIndex] = file;
+			}
+
+			this.files[channelIndex].writeBytes(buffer);
+		}
+
+		@Override
+		public void close()
+		{
+			for (final StorageConverterTargetFile file : this.files)
+			{
+				file.release();
+			}
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// checksum strategy //
+	//////////////////////
+
+	/**
+	 * Chunk-checksum-emitting target: each file opens with a {@code FileHeaderV1}; live entities are coalesced
+	 * into chunks of about {@link StorageDataFileEvaluator#coalesceChunkTargetBytes()} bytes, each flushed with
+	 * a covering chunk-checksum record; files roll over at {@link StorageDataFileEvaluator#fileMaximumSize()}
+	 * (reserving the record). Each channel owns a stateful primary {@link Algorithm} whose chain tip threads
+	 * across that channel's files.
+	 */
+	final class Checksummed extends Abstract
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final long         coalesceChunkTargetBytes;
+		private final int          headerLength;
+		private final int          recordLength;
+		private final Algorithm[]  algorithms;   // per channel; chain tip threads across files
+		private final ByteBuffer[] chunkBuffers; // per channel; single-chunk accumulators
+		private final ByteBuffer   headerBuffer; // reused
+		private final ByteBuffer   recordBuffer; // reused
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Checksummed(final StorageConfiguration storageConfiguration)
+		{
+			super(storageConfiguration);
+
+			final StorageChunkChecksumProvider provider = storageConfiguration.chunkChecksumProvider();
+			this.coalesceChunkTargetBytes = this.dataFileEvaluator.coalesceChunkTargetBytes();
+			this.headerLength             = StorageMetaRecord.LENGTH_FILEHEADERV1;
+			this.algorithms               = new Algorithm[this.channelCount];
+			this.chunkBuffers             = new ByteBuffer[this.channelCount];
+
+			final int initialChunkCapacity = (int) Math.min(
+				Math.max(this.coalesceChunkTargetBytes, 4096L),
+				16L * 1024 * 1024
+			);
+			int algorithmRecordLength = 0;
+			for (int channelIndex = 0; channelIndex < this.channelCount; channelIndex++)
+			{
+				final Algorithm algorithm = provider.createPrimaryAlgorithm();
+				this.algorithms[channelIndex]   = algorithm;
+				this.chunkBuffers[channelIndex] = XMemory.allocateDirectNative(initialChunkCapacity);
+				algorithmRecordLength           = (int) algorithm.recordLength();
+			}
+			this.recordLength = algorithmRecordLength;
+			this.headerBuffer = XMemory.allocateDirectNative(this.headerLength);
+			this.recordBuffer = XMemory.allocateDirectNative(this.recordLength);
+		}
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// methods //
+		////////////
+
+		@Override
+		void onFileCreated(final StorageConverterTargetFile file, final int channelIndex)
+		{
+			// Write the FileHeaderV1 as the new file's first entry. The chain root snapshots the channel
+			// algorithm's current tip (the predecessor file's final tip, or the initial seed for the first
+			// file) so a chained file verifies self-contained; all-zero for a non-chained kind.
+			final Algorithm algorithm = this.algorithms[channelIndex];
+			final byte[]    chainRoot = algorithm.isChained()
+				? algorithm.chainTip()
+				: new byte[StorageMetaRecord.LENGTH_HASH_SHA256];
+
+			this.headerBuffer.clear();
+			StorageMetaRecord.writeFileHeaderV1(this.headerBuffer, algorithm.kind(), chainRoot);
+			this.headerBuffer.flip();
+			file.writeBytes(this.headerBuffer);
+		}
+
+		@Override
+		public void transferBytes(final ByteBuffer buffer, final long oid)
+		{
+			final int channelIndex = (int) (oid % this.channelCount);
+
+			logger.trace("Transferring blob pos: {}, limit: {} to target channel {}.",
+					buffer.position(), buffer.limit(), channelIndex);
+
+			this.accumulate(buffer, channelIndex);
+		}
+
+		/**
+		 * Appends an entity's bytes to the channel's chunk accumulator and flushes the chunk (data + covering
+		 * record) once it reaches {@code coalesceChunkTargetBytes} (a single entity larger than the target forms
+		 * its own chunk).
+		 */
+		private void accumulate(final ByteBuffer buffer, final int channelIndex)
+		{
+			ByteBuffer chunk = this.chunkBuffers[channelIndex];
+
+			final int incoming = buffer.limit() - buffer.position();
+			if (chunk.remaining() < incoming)
+			{
+				chunk = this.grow(chunk, incoming);
+				this.chunkBuffers[channelIndex] = chunk;
+			}
+			chunk.put(buffer);
+
+			if (chunk.position() >= this.coalesceChunkTargetBytes)
+			{
+				this.flushChunk(channelIndex);
+			}
+		}
+
+		/**
+		 * Writes the channel's pending chunk as {@code [data][covering record]}, rolling the file over first if
+		 * the chunk plus its record would exceed {@code fileMaximumSize} (unless the file holds only its header,
+		 * in which case an oversized single chunk is written into its own file). No-op when the accumulator is
+		 * empty.
+		 */
+		private void flushChunk(final int channelIndex)
+		{
+			final ByteBuffer chunk = this.chunkBuffers[channelIndex];
+			final int        used  = chunk.position();
+			if (used == 0)
+			{
+				return;
+			}
+			chunk.flip(); // [0, used]
+
+			StorageConverterTargetFile file = this.files[channelIndex];
+
+			final long projectedLength = file.size() + used + this.recordLength;
+			if (projectedLength > this.dataFileEvaluator.fileMaximumSize() && file.size() > this.headerLength)
+			{
+				file.release();
+				file = this.createNewStorageFile(file.fileNumber() + 1, channelIndex);
+				this.files[channelIndex] = file;
+			}
+
+			// a data file must stay loadable into a single direct buffer (< 2 GiB)
+			if ((long) this.headerLength + used + this.recordLength > Integer.MAX_VALUE)
+			{
+				throw new StorageException("Coalesced chunk too large for a single data file: " + used + " bytes.");
+			}
+
+			final Algorithm algorithm = this.algorithms[channelIndex];
+			this.recordBuffer.clear();
+			// the chunk is appended at the file's current size, so that is the chunk start the record stores. Fits
+			// an int: the file is bounded by fileMaximumSize (< 2 GiB), re-asserted by the guard above.
+			final int chunkStart = (int)file.size();
+			// computes the covering checksum over the chunk (read non-destructively); for a chained kind this
+			// folds and advances the channel's running tip, so the next chunk chains from it.
+			algorithm.writeRecord(this.recordBuffer, chunkStart, chunk);
+			this.recordBuffer.flip();
+
+			file.writeBytes(chunk);             // the entity bytes
+			file.writeBytes(this.recordBuffer); // its covering chunk-checksum record
+
+			chunk.clear();
+		}
+
+		/** Grows a chunk accumulator to hold at least {@code needed} more bytes, preserving its contents. */
+		private ByteBuffer grow(final ByteBuffer buffer, final int needed)
+		{
+			final int        used        = buffer.position();
+			final int        newCapacity = Math.max(used + needed, buffer.capacity() * 2);
+			final ByteBuffer bigger      = XMemory.allocateDirectNative(newCapacity);
+
+			buffer.flip();      // [0, used]
+			bigger.put(buffer); // copies used bytes; bigger.position == used
+			XMemory.deallocateDirectByteBuffer(buffer);
+			return bigger;
+		}
+
+		@Override
+		public void close()
+		{
+			// a flushChunk failure must not leak the remaining channels' files and off-heap buffers: release+free
+			// every channel regardless, and rethrow the first failure at the end.
+			RuntimeException flushFailure = null;
+			for (int channelIndex = 0; channelIndex < this.channelCount; channelIndex++)
+			{
+				try
+				{
+					this.flushChunk(channelIndex); // emit the final, partial chunk's covering record
+				}
+				catch (final RuntimeException e)
+				{
+					if (flushFailure == null)
+					{
+						flushFailure = e;
+					}
+					else
+					{
+						flushFailure.addSuppressed(e);
+					}
+				}
+				this.files[channelIndex].release();
+				XMemory.deallocateDirectByteBuffer(this.chunkBuffers[channelIndex]);
+			}
+			XMemory.deallocateDirectByteBuffer(this.headerBuffer);
+			XMemory.deallocateDirectByteBuffer(this.recordBuffer);
+
+			if (flushFailure != null)
+			{
+				throw flushFailure;
+			}
+		}
 	}
 }

--- a/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverterTarget.java
+++ b/storage/embedded-tools/storage-converter/src/main/java/org/eclipse/store/storage/embedded/tools/storage/converter/StorageConverterTarget.java
@@ -208,7 +208,7 @@ public interface StorageConverterTarget extends Closeable
 		}
 
 		@Override
-		public void close()
+		public void 	close()
 		{
 			for (final StorageConverterTargetFile file : this.files)
 			{

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
@@ -56,6 +56,7 @@ import org.eclipse.store.storage.types.StorageEntityTypeExportFileProvider;
 import org.eclipse.store.storage.types.StorageEntityTypeExportStatistics;
 import org.eclipse.store.storage.types.StorageEntityTypeHandler;
 import org.eclipse.store.storage.types.StorageIdAnalysis;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult;
 import org.eclipse.store.storage.types.StorageKillable;
 import org.eclipse.store.storage.types.StorageLiveFileProvider;
 import org.eclipse.store.storage.types.StorageManager;
@@ -567,6 +568,12 @@ public interface EmbeddedStorageManager extends StorageManager
 		public final boolean issueFileCheck(final long nanoTimeBudget)
 		{
 			return this.singletonConnection().issueFileCheck(nanoTimeBudget);
+		}
+
+		@Override
+		public final StorageIntegrityCheckResult issueIntegrityCheck(final long nanoTimeBudget)
+		{
+			return this.singletonConnection().issueIntegrityCheck(nanoTimeBudget);
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkBoundaryMismatch.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkBoundaryMismatch.java
@@ -1,0 +1,100 @@
+package org.eclipse.store.storage.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * Raised when a chunk-checksum meta record's stored chunk-start offset does not match the chunk boundary the
+ * load walk reconstructed by following entity LENGTH prefixes. Indicates a framing desync &mdash; a corrupted
+ * entity LENGTH rerouted the walker around a covering record &mdash; rather than bit-rot of a chunk's content
+ * (which surfaces as {@link StorageExceptionChunkChecksumMismatch}).
+ */
+public class StorageExceptionChunkBoundaryMismatch extends StorageExceptionConsistency
+{
+	///////////////////////////////////////////////////////////////////////////
+	// instance fields //
+	////////////////////
+
+	private final long fileNumber         ;
+	private final long recordPosition     ;
+	private final long expectedChunkStart ;
+	private final long actualChunkStart   ;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public StorageExceptionChunkBoundaryMismatch(
+		final long fileNumber         ,
+		final long recordPosition     ,
+		final long expectedChunkStart ,
+		final long actualChunkStart
+	)
+	{
+		super(buildMessage(fileNumber, recordPosition, expectedChunkStart, actualChunkStart));
+		this.fileNumber         = fileNumber        ;
+		this.recordPosition     = recordPosition    ;
+		this.expectedChunkStart = expectedChunkStart;
+		this.actualChunkStart   = actualChunkStart  ;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// getters //
+	////////////
+
+	public long fileNumber()
+	{
+		return this.fileNumber;
+	}
+
+	public long recordPosition()
+	{
+		return this.recordPosition;
+	}
+
+	public long expectedChunkStart()
+	{
+		return this.expectedChunkStart;
+	}
+
+	public long actualChunkStart()
+	{
+		return this.actualChunkStart;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+
+	private static String buildMessage(
+		final long fileNumber         ,
+		final long recordPosition     ,
+		final long expectedChunkStart ,
+		final long actualChunkStart
+	)
+	{
+		return "Chunk-boundary mismatch in data file #" + fileNumber
+			+ " at record position " + recordPosition
+			+ ": record covers chunk starting at " + expectedChunkStart
+			+ ", but the load walk reconstructed a chunk start of " + actualChunkStart
+			+ " (framing desync — a corrupted entity length rerouted the walk past a covering record)."
+		;
+	}
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumMismatch.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumMismatch.java
@@ -14,6 +14,8 @@ package org.eclipse.store.storage.exceptions;
  * #L%
  */
 
+import org.eclipse.serializer.chars.VarString;
+
 /**
  * Raised when a chunk-checksum meta record's stored hash does not match the checksum recomputed over the
  * chunk's preceding bytes during load-time verification. Indicates either bit-rot on the underlying
@@ -97,16 +99,8 @@ public class StorageExceptionChunkChecksumMismatch extends StorageExceptionConsi
 
 	private static String toHex(final byte[] bytes)
 	{
-		if(bytes == null)
-		{
-			return "(null)";
-		}
-		final StringBuilder sb = new StringBuilder(bytes.length * 2);
-		for(final byte b : bytes)
-		{
-			sb.append(Character.forDigit((b >> 4) & 0xF, 16))
-			  .append(Character.forDigit( b       & 0xF, 16));
-		}
-		return sb.toString();
+		return bytes == null
+			? "(null)"
+			: VarString.New().addHexDec(bytes).toString();
 	}
 }

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumMismatch.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumMismatch.java
@@ -1,0 +1,112 @@
+package org.eclipse.store.storage.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * Raised when a chunk-checksum meta record's stored hash does not match the checksum recomputed over the
+ * chunk's preceding bytes during load-time verification. Indicates either bit-rot on the underlying
+ * storage or a writer-side bug.
+ */
+public class StorageExceptionChunkChecksumMismatch extends StorageExceptionConsistency
+{
+	///////////////////////////////////////////////////////////////////////////
+	// instance fields //
+	////////////////////
+
+	private final long   fileNumber   ;
+	private final long   chunkPosition;
+	private final byte[] expectedHash ;
+	private final byte[] actualHash   ;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public StorageExceptionChunkChecksumMismatch(
+		final long   fileNumber   ,
+		final long   chunkPosition,
+		final byte[] expectedHash ,
+		final byte[] actualHash
+	)
+	{
+		super(buildMessage(fileNumber, chunkPosition, expectedHash, actualHash));
+		this.fileNumber    = fileNumber   ;
+		this.chunkPosition = chunkPosition;
+		this.expectedHash  = expectedHash ;
+		this.actualHash    = actualHash   ;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// getters //
+	////////////
+
+	public long fileNumber()
+	{
+		return this.fileNumber;
+	}
+
+	public long chunkPosition()
+	{
+		return this.chunkPosition;
+	}
+
+	public byte[] expectedHash()
+	{
+		return this.expectedHash;
+	}
+
+	public byte[] actualHash()
+	{
+		return this.actualHash;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+
+	private static String buildMessage(
+		final long   fileNumber   ,
+		final long   chunkPosition,
+		final byte[] expectedHash ,
+		final byte[] actualHash
+	)
+	{
+		return "ChunkChecksumV1 mismatch in data file #" + fileNumber
+			+ " at position " + chunkPosition
+			+ ": expected hash " + toHex(expectedHash)
+			+ ", actual hash "   + toHex(actualHash);
+	}
+
+	private static String toHex(final byte[] bytes)
+	{
+		if(bytes == null)
+		{
+			return "(null)";
+		}
+		final StringBuilder sb = new StringBuilder(bytes.length * 2);
+		for(final byte b : bytes)
+		{
+			sb.append(Character.forDigit((b >> 4) & 0xF, 16))
+			  .append(Character.forDigit( b       & 0xF, 16));
+		}
+		return sb.toString();
+	}
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumUnavailable.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumUnavailable.java
@@ -1,0 +1,86 @@
+package org.eclipse.store.storage.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * Raised by off-line repair tooling (e.g. {@code StorageObjectRestorer}) when the target store is
+ * chunk-checksum protected on disk but the tool cannot produce a compliant covered file &mdash; either
+ * because it was created without a {@code StorageConfiguration} (no chunk-checksum provider, hence no
+ * write algorithm), or because the configured provider's primary kind does not match the store's on-disk
+ * kind (writing a mismatched kind would manufacture a mixed store).
+ * <p>
+ * This turns an otherwise silent loss of integrity coverage into an actionable failure: reconstruct the
+ * tool with a configuration whose {@code chunkChecksumProvider} matches the store.
+ */
+public class StorageExceptionChunkChecksumUnavailable extends StorageException
+{
+	///////////////////////////////////////////////////////////////////////////
+	// instance fields //
+	////////////////////
+
+	private final long onDiskKind    ;
+	private final long configuredKind; // -1 when no provider was available at all
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public StorageExceptionChunkChecksumUnavailable(final long onDiskKind, final long configuredKind)
+	{
+		super(buildMessage(onDiskKind, configuredKind));
+		this.onDiskKind     = onDiskKind    ;
+		this.configuredKind = configuredKind;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// getters //
+	////////////
+
+	public long onDiskKind()
+	{
+		return this.onDiskKind;
+	}
+
+	/**
+	 * @return the configured provider's primary kind, or {@code -1} if no provider was available.
+	 */
+	public long configuredKind()
+	{
+		return this.configuredKind;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+
+	private static String buildMessage(final long onDiskKind, final long configuredKind)
+	{
+		if(configuredKind < 0L)
+		{
+			return "Store uses chunk-checksum kind 0x" + Long.toHexString(onDiskKind)
+				+ " but this restorer was created without a StorageConfiguration; reconstruct it with a"
+				+ " configuration whose chunkChecksumProvider matches the store.";
+		}
+		return "Store uses chunk-checksum kind 0x" + Long.toHexString(onDiskKind)
+			+ " but the configured provider writes kind 0x" + Long.toHexString(configuredKind)
+			+ "; configure a matching StorageChunkChecksumProvider.";
+	}
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/Storage.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/Storage.java
@@ -422,6 +422,34 @@ public final class Storage
 	}
 
 	/**
+	 * Creates a new default {@link StorageChunkChecksumPolicy} (the lenient {@code New()} default: emit + verify).
+	 * <p>
+	 * For a detailed explanation see {@link StorageChunkChecksumPolicy#New()}.
+	 *
+	 * @return a new {@link StorageChunkChecksumPolicy} instance.
+	 *
+	 * @see StorageChunkChecksumPolicy#New()
+	 */
+	public static final StorageChunkChecksumPolicy ChunkChecksumPolicy()
+	{
+		return StorageChunkChecksumPolicy.New();
+	}
+
+	/**
+	 * Creates a new default {@link StorageChunkChecksumProvider}: no checksum (the feature is off by default).
+	 * <p>
+	 * For a detailed explanation see {@link StorageChunkChecksumProvider#New()}.
+	 *
+	 * @return a new {@link StorageChunkChecksumProvider} instance.
+	 *
+	 * @see StorageChunkChecksumProvider#New()
+	 */
+	public static final StorageChunkChecksumProvider ChunkChecksumProvider()
+	{
+		return StorageChunkChecksumProvider.New();
+	}
+
+	/**
 	 * Creates a new {@link StorageDataFileEvaluator}.
 	 * <p>
 	 * For a detailed explanation see {@link StorageDataFileEvaluator#New(int, int)}.
@@ -578,7 +606,54 @@ public final class Storage
 			transactionFileMaximumSize
 		);
 	}
-	
+
+	/**
+	 * Creates a new {@link StorageDataFileEvaluator}.
+	 * <p>
+	 * For a detailed explanation see {@link StorageDataFileEvaluator#New(int, int, double, boolean, int, long)}.
+	 *
+	 * @param fileMinimumSize the minimum file size in bytes that a single storage file must have. Smaller files
+	 *        will be dissolved.
+	 *
+	 * @param fileMaximumSize the maximum file size in bytes that a single storage file may have. Larger files
+	 *        will be dissolved.<br>
+	 *        Note that a file can exceed this limit if it contains a single entity that already exceeds the limit.
+	 *
+	 * @param minimumUseRatio the ratio (value in ]0.0;1.0]) of non-gap data contained in a storage file to prevent
+	 *        the file from being dissolved.
+	 *
+	 * @param cleanUpHeadFile a flag defining whether the current head file (the only file actively written to)
+	 *        shall be subjected to file cleanups as well.
+	 *
+	 * @param transactionFileMaximumSize the maximum file size for transaction files. Lager files will
+	 *        be deleted and a new one will be created.
+	 *
+	 * @param coalesceChunkTargetBytes the soft target size in bytes for a single coalesced chunk produced by
+	 *        the dissolution transfer. See {@link StorageDataFileEvaluator#coalesceChunkTargetBytes()}.
+	 *
+	 * @return a new {@link StorageDataFileEvaluator} instance.
+	 *
+	 * @see StorageDataFileEvaluator#New(int, int, double, boolean, int, long)
+	 */
+	public static final StorageDataFileEvaluator DataFileEvaluator(
+		final int     fileMinimumSize           ,
+		final int     fileMaximumSize           ,
+		final double  minimumUseRatio           ,
+		final boolean cleanUpHeadFile           ,
+		final int     transactionFileMaximumSize,
+		final long    coalesceChunkTargetBytes
+	)
+	{
+		return StorageDataFileEvaluator.New(
+			fileMinimumSize,
+			fileMaximumSize,
+			minimumUseRatio,
+			cleanUpHeadFile,
+			transactionFileMaximumSize,
+			coalesceChunkTargetBytes
+		);
+	}
+
 	/**
 	 * Creates a new {@link StorageBackupSetup}.
 	 * <p>

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageAdjacencyDataExporter.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageAdjacencyDataExporter.java
@@ -159,6 +159,24 @@ public interface StorageAdjacencyDataExporter
 			{
 				address = startAddress + offset;
 				size = XMemory.get_long(address);
+
+				if(size < 0)
+				{
+					//skip metadata or gap
+					offset -= size;
+					continue;
+				}
+				else if(size == 0)
+				{
+					// zero-length entry: end of valid content (or a zeroed tail). Stop here;
+					// advancing by 0 would otherwise spin forever on the same offset.
+					break;
+				}
+				else
+				{
+					offset += size;
+				}
+
 				typeID = XMemory.get_long(address + 8);
 				objectID = XMemory.get_long(address + 16);
 								
@@ -171,7 +189,7 @@ public interface StorageAdjacencyDataExporter
 					refCount+=references.length;
 				}
 				
-				offset += size;
+
 			}
 										
 			XMemory.deallocateDirectByteBuffer(buffer);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -190,6 +190,18 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	public boolean issuedEntityCacheCheck(long nanoTimeBudget, StorageEntityCacheEvaluator entityEvaluator);
 
 	/**
+	 * Issues an on-demand chunk-checksum integrity check to this channel with the passed time budget,
+	 * returning this channel's collected anomalies and whether the scan completed within the budget.
+	 *
+	 * @param nanoTimeBudget the maximum amount of time, in nanoseconds, this channel is allowed to
+	 *                       spend on the integrity-check step.
+	 * @param freshScan      whether to start a new scan (vs resume the in-progress one).
+	 *
+	 * @return this channel's findings and completion state.
+	 */
+	public StorageIntegrityCheckResult issuedIntegrityCheck(long nanoTimeBudget, boolean freshScan);
+
+	/**
 	 * Issues a transactions-log cleanup pass to this channel.
 	 *
 	 * @return whether the cleanup pass completed; {@code true} if no further cleanup is currently
@@ -518,6 +530,17 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		}
 
 		@Override
+		public StorageIntegrityCheckResult performIssuedIntegrityCheck(final long nanoTimeBudget, final boolean freshScan)
+		{
+			logger.trace("StorageChannel#{} performing issued integrity check", this.channelIndex);
+
+			// turn budget into the budget bounding value for easier and faster checking
+			final long nanoTimeBudgetBound = XTime.calculateNanoTimeBudgetBound(nanoTimeBudget);
+
+			return this.fileManager.verifyChunkChecksums(nanoTimeBudgetBound, freshScan);
+		}
+
+		@Override
 		public final boolean performFileCleanupCheck(final long nanoTimeBudget)
 		{
 			if(!this.fileManager.isFileCleanupEnabled())
@@ -606,7 +629,13 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		{
 			return this.housekeepingBroker.performIssuedEntityCacheCheck(this, nanoTimeBudget, entityEvaluator);
 		}
-		
+
+		@Override
+		public StorageIntegrityCheckResult issuedIntegrityCheck(final long nanoTimeBudget, final boolean freshScan)
+		{
+			return this.housekeepingBroker.performIssuedIntegrityCheck(this, nanoTimeBudget, freshScan);
+		}
+
 		@Override
 		public boolean issuedTransactionsLogCleanup()
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelsCreator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelsCreator.java
@@ -31,6 +31,7 @@ public interface StorageChannelsCreator
 		StorageInitialDataFileNumberProvider       initialDataFileNumberProvider,
 		StorageExceptionHandler                    exceptionHandler             ,
 		StorageDataFileEvaluator                   fileDissolver                ,
+		StorageChunkChecksumProvider               chunkChecksumProvider        ,
 		StorageLiveFileProvider                    liveFileProvider             ,
 		StorageEntityCacheEvaluator                entityCacheEvaluator         ,
 		StorageTypeDictionary                      typeDictionary               ,
@@ -70,6 +71,7 @@ public interface StorageChannelsCreator
 			final StorageInitialDataFileNumberProvider       initialDataFileNumberProvider,
 			final StorageExceptionHandler                    exceptionHandler             ,
 			final StorageDataFileEvaluator                   dataFileEvaluator            ,
+			final StorageChunkChecksumProvider               chunkChecksumProvider        ,
 			final StorageLiveFileProvider                    liveFileProvider             ,
 			final StorageEntityCacheEvaluator                entityCacheEvaluator         ,
 			final StorageTypeDictionary                      typeDictionary               ,
@@ -142,18 +144,29 @@ public interface StorageChannelsCreator
 				cacheMonitors[i] = new EntityCacheMonitor(entityCache);
 				monitorManager.registerMonitor(cacheMonitors[i]);
 
+				// each channel owns its own meta-record registry; the chunk-checksum calculator registers its
+				// load-time handlers into it (any future meta-record feature registers into the same registry).
+				final StorageChunkChecksumCalculator chunkChecksumCalculator = chunkChecksumProvider.createCalculator();
+				final StorageChecksumAnomalyReporter reporter                = StorageChecksumAnomalyReporter.New(
+					chunkChecksumProvider.policy()
+				);
+				final StorageMetaRecordRegistry      metaRecordRegistry      = StorageMetaRecordRegistry.New(reporter);
+				chunkChecksumCalculator.registerMetaRecordHandlers(metaRecordRegistry, reporter);
+
 				// file manager to handle "file" IO (whatever "file" might be, might be a RDBMS binary table as well)
 				final StorageFileManager.Default fileManager = new StorageFileManager.Default(
-					i                               ,
-					initialDataFileNumberProvider   ,
-					timestampProvider               ,
-					liveFileProvider                ,
-					dataFileEvaluator               ,
-					entityCache                     ,
-					writeController                 ,
-					writerProvider.provideWriter(i) ,
-					readingDefaultBufferSizeProvider,
-					backupHandler                   ,
+					i                                       ,
+					initialDataFileNumberProvider           ,
+					timestampProvider                       ,
+					liveFileProvider                        ,
+					dataFileEvaluator                       ,
+					chunkChecksumCalculator                 ,
+					metaRecordRegistry                      ,
+					entityCache                             ,
+					writeController                         ,
+					writerProvider.provideWriter(i)         ,
+					readingDefaultBufferSizeProvider        ,
+					backupHandler                           ,
 					transactionFileCleanerCreator
 				);
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChecksumAnomalyReporter.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChecksumAnomalyReporter.java
@@ -1,0 +1,446 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.eclipse.serializer.util.X.notNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.eclipse.serializer.util.logging.Logging;
+import org.eclipse.store.storage.exceptions.StorageExceptionChunkBoundaryMismatch;
+import org.eclipse.store.storage.exceptions.StorageExceptionChunkChecksumMismatch;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+import org.eclipse.store.storage.types.StorageChunkChecksumPolicy.Anomaly;
+import org.eclipse.store.storage.types.StorageChunkChecksumPolicy.Reaction;
+import org.slf4j.Logger;
+
+/**
+ * Per-channel sink that applies the {@link StorageChunkChecksumPolicy}'s {@link Reaction} to each load-time
+ * {@link Anomaly}:
+ * <ul>
+ *   <li>gates behind {@link StorageChunkChecksumPolicy#verify()} (and, for {@link Anomaly#MISSING_HEADER},
+ *       additionally behind {@link StorageChunkChecksumPolicy#requireCoverage()}) &mdash; "not verifying"
+ *       reacts to nothing;</li>
+ *   <li>{@code IGNORE}: returns; {@code FAIL}: throws the anomaly's typed exception on the first occurrence;
+ *       {@code LOG}: warns once per {@code (file, anomaly, kind)} and counts the rest, surfaced as a
+ *       "+N more" summary at {@link #onFileWalkComplete(long)};</li>
+ *   <li>builds the failure exception and the log message <i>lazily</i>.</li>
+ * </ul>
+ * One instance per storage channel; the dedupe state needs no synchronization because the load walk is
+ * single-threaded per channel (matching the {@link StorageMetaRecordRegistry} contract).
+ */
+public interface StorageChecksumAnomalyReporter
+{
+	/**
+	 * Reports a chunk-checksum mismatch (recompute &ne; stored) at {@code offset} in file {@code fileNumber}.
+	 * No-op unless verifying; throws {@link StorageExceptionChunkChecksumMismatch} when the reaction is FAIL.
+	 */
+	public void onChecksumMismatch(long fileNumber, long offset, long kind, byte[] expected, byte[] actual);
+
+	/**
+	 * Reports a chunk-boundary mismatch: a covering record's stored chunk start ({@code expectedChunkStart})
+	 * disagrees with the boundary the load walk reconstructed ({@code actualChunkStart}) &mdash; a framing
+	 * desync. No-op unless verifying; throws {@link StorageExceptionChunkBoundaryMismatch} when the reaction is FAIL.
+	 */
+	public void onChunkBoundaryMismatch(long fileNumber, long recordOffset, long expectedChunkStart, long actualChunkStart);
+
+	/**
+	 * Reports a meta record whose KIND has no registered handler. No-op unless verifying; throws
+	 * {@link StorageExceptionConsistency} when the reaction is FAIL.
+	 */
+	public void onUnknownKind(long fileNumber, long kind);
+
+	/**
+	 * Reports a file that carries data but no {@code FileHeaderV1}. No-op unless verifying and coverage is
+	 * required; throws {@link StorageExceptionConsistency} when the reaction is FAIL.
+	 */
+	public void onMissingHeader(long fileNumber);
+
+	/**
+	 * Reports a covered file holding live content past its last chunk-checksum record (uncovered tail). Unlike
+	 * {@link #onMissingHeader(long)} this is <b>not</b> gated behind {@link StorageChunkChecksumPolicy#requireCoverage()}
+	 * &mdash; an uncovered tail on a covered file is corruption, not a legacy state. No-op unless verifying; throws
+	 * {@link StorageExceptionConsistency} when the reaction is FAIL.
+	 */
+	public void onUncoveredData(long fileNumber, long offset);
+
+	/**
+	 * Called by the walker after each file: emits any "+N more" summaries for {@code LOG}ged anomalies and
+	 * clears that file's dedupe state.
+	 */
+	public void onFileWalkComplete(long fileNumber);
+
+
+
+	public static StorageChecksumAnomalyReporter New(final StorageChunkChecksumPolicy policy)
+	{
+		return new Default(notNull(policy));
+	}
+
+	/**
+	 * Creates a non-throwing reporter for the on-demand integrity check: each non-{@code IGNORE} anomaly is
+	 * recorded into {@code sink} (tagged with {@code channelIndex}) instead of thrown or logged. The same
+	 * verify / requireCoverage gates as {@link Default} apply, so a verify-off policy collects nothing.
+	 *
+	 * @param policy       the configured policy (routes IGNORE vs collect); must be non-{@code null}.
+	 * @param channelIndex the channel this reporter collects for.
+	 * @param sink         the per-channel result to record findings into; must be non-{@code null}.
+	 * @return a new collecting {@link StorageChecksumAnomalyReporter}.
+	 */
+	public static StorageChecksumAnomalyReporter NewCollecting(
+		final StorageChunkChecksumPolicy        policy      ,
+		final int                               channelIndex,
+		final StorageIntegrityCheckResult.Default sink
+	)
+	{
+		return new Collecting(notNull(policy), channelIndex, notNull(sink));
+	}
+
+
+
+	public final class Default implements StorageChecksumAnomalyReporter
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// constants //
+		//////////////
+
+		private final static Logger logger = Logging.getLogger(StorageChecksumAnomalyReporter.class);
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final StorageChunkChecksumPolicy policy     ;
+		private       long                       currentFile = -1L;
+		private final HashMap<Long, long[]>      logCounts   = new HashMap<>(); // dedupe key -> {count}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(final StorageChunkChecksumPolicy policy)
+		{
+			super();
+			this.policy = policy;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// declared methods //
+		/////////////////////
+
+		private void apply(
+			final Anomaly                              anomaly   ,
+			final long                                 fileNumber,
+			final long                                 kind      ,
+			final Supplier<? extends RuntimeException> failure   ,
+			final Supplier<String>                     logMessage
+		)
+		{
+			final Reaction reaction = this.policy.reactionTo(anomaly);
+			if(reaction == Reaction.IGNORE)
+			{
+				return;
+			}
+			if(reaction == Reaction.FAIL)
+			{
+				throw failure.get(); // first occurrence — fail early, no accumulation
+			}
+
+			// LOG, deduped per (file, anomaly, kind). KIND fits 16 bits (enforced at
+			// StorageMetaRecordRegistry.register), so a 16-bit shift keeps the ordinal clear of the KIND.
+			this.rollFileIfChanged(fileNumber);
+			final long   key   = (kind << 16) | anomaly.ordinal();
+			final long[] count = this.logCounts.get(key);
+			if(count == null)
+			{
+				this.logCounts.put(key, new long[]{1L});
+				logger.warn(logMessage.get());
+			}
+			else
+			{
+				count[0]++; // suppressed; surfaced as "+N more" at onFileWalkComplete
+			}
+		}
+
+		private void rollFileIfChanged(final long fileNumber)
+		{
+			if(fileNumber != this.currentFile)
+			{
+				this.logCounts.clear();
+				this.currentFile = fileNumber;
+			}
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		public final void onChecksumMismatch(
+			final long   fileNumber,
+			final long   offset    ,
+			final long   kind      ,
+			final byte[] expected  ,
+			final byte[] actual
+		)
+		{
+			if(!this.policy.verify())
+			{
+				return;
+			}
+			this.apply(
+				Anomaly.CHECKSUM_MISMATCH, fileNumber, kind,
+				() -> new StorageExceptionChunkChecksumMismatch(fileNumber, offset, expected, actual),
+				() -> "Chunk-checksum mismatch in data file #" + fileNumber + " at offset " + offset
+			);
+		}
+
+		@Override
+		public final void onChunkBoundaryMismatch(
+			final long fileNumber        ,
+			final long recordOffset      ,
+			final long expectedChunkStart,
+			final long actualChunkStart
+		)
+		{
+			if(!this.policy.verify())
+			{
+				return;
+			}
+			this.apply(
+				Anomaly.CHUNK_BOUNDARY_MISMATCH, fileNumber, 0L,
+				() -> new StorageExceptionChunkBoundaryMismatch(
+					fileNumber, recordOffset, expectedChunkStart, actualChunkStart),
+				() -> "Chunk-boundary mismatch in data file #" + fileNumber + " at record offset " + recordOffset
+					+ " (record covers chunk start " + expectedChunkStart + ", walk reconstructed " + actualChunkStart + ")"
+			);
+		}
+
+		@Override
+		public final void onUnknownKind(final long fileNumber, final long kind)
+		{
+			if(!this.policy.verify())
+			{
+				return;
+			}
+			this.apply(
+				Anomaly.UNKNOWN_KIND, fileNumber, kind,
+				() -> new StorageExceptionConsistency(
+					"Unknown meta-record KIND 0x" + Long.toHexString(kind) + " in data file #" + fileNumber),
+				() -> "Skipping unknown meta-record KIND 0x" + Long.toHexString(kind)
+					+ " in data file #" + fileNumber + " (forward-compat)."
+			);
+		}
+
+		@Override
+		public final void onMissingHeader(final long fileNumber)
+		{
+			if(!this.policy.verify() || !this.policy.requireCoverage())
+			{
+				return;
+			}
+			this.apply(
+				Anomaly.MISSING_HEADER, fileNumber, 0L,
+				() -> new StorageExceptionConsistency(
+					"Missing FileHeaderV1 (unprotected legacy file) in data file #" + fileNumber),
+				() -> "Unprotected legacy file (no FileHeaderV1): data file #" + fileNumber
+			);
+		}
+
+		@Override
+		public final void onUncoveredData(final long fileNumber, final long offset)
+		{
+			// Verify-only gate (not requireCoverage, unlike onMissingHeader): a covered file always ends at a
+			// covering record after recovery, so a trailing uncovered region is corruption, not a legacy state.
+			if(!this.policy.verify())
+			{
+				return;
+			}
+			this.apply(
+				Anomaly.UNCOVERED_DATA, fileNumber, 0L,
+				() -> new StorageExceptionConsistency(
+					"Uncovered data (no chunk-checksum record) in data file #" + fileNumber + " at offset " + offset),
+				() -> "Uncovered data (no chunk-checksum record) in data file #" + fileNumber + " at offset " + offset
+			);
+		}
+
+		@Override
+		public final void onFileWalkComplete(final long fileNumber)
+		{
+			if(fileNumber != this.currentFile)
+			{
+				return;
+			}
+			for(final Map.Entry<Long, long[]> e : this.logCounts.entrySet())
+			{
+				final long extra = e.getValue()[0] - 1L;
+				if(extra > 0L)
+				{
+					logger.warn("... and {} more suppressed occurrence(s) in data file #{}.", extra, fileNumber);
+				}
+			}
+			this.logCounts.clear();
+			this.currentFile = -1L;
+		}
+
+	}
+
+
+
+	/**
+	 * Non-throwing reporter for the on-demand integrity check: same gates and IGNORE routing as {@link Default},
+	 * but records every non-ignored anomaly into a per-channel {@link StorageIntegrityCheckResult} instead of
+	 * throwing on FAIL or logging on LOG.
+	 */
+	public final class Collecting implements StorageChecksumAnomalyReporter
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final StorageChunkChecksumPolicy          policy      ;
+		private final int                                 channelIndex;
+		private final StorageIntegrityCheckResult.Default sink        ;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Collecting(
+			final StorageChunkChecksumPolicy          policy      ,
+			final int                                 channelIndex,
+			final StorageIntegrityCheckResult.Default sink
+		)
+		{
+			super();
+			this.policy       = policy      ;
+			this.channelIndex = channelIndex;
+			this.sink         = sink        ;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// declared methods //
+		/////////////////////
+
+		private boolean ignores(final Anomaly anomaly)
+		{
+			return this.policy.reactionTo(anomaly) == Reaction.IGNORE;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		public final void onChecksumMismatch(
+			final long   fileNumber,
+			final long   offset    ,
+			final long   kind      ,
+			final byte[] expected  ,
+			final byte[] actual
+		)
+		{
+			if(!this.policy.verify() || this.ignores(Anomaly.CHECKSUM_MISMATCH))
+			{
+				return;
+			}
+			this.sink.add(new StorageIntegrityCheckResult.Finding(
+				this.channelIndex, fileNumber, offset,
+				StorageIntegrityCheckResult.Anomaly.CHECKSUM_MISMATCH, kind, expected, actual
+			));
+		}
+
+		@Override
+		public final void onChunkBoundaryMismatch(
+			final long fileNumber        ,
+			final long recordOffset      ,
+			final long expectedChunkStart,
+			final long actualChunkStart
+		)
+		{
+			if(!this.policy.verify() || this.ignores(Anomaly.CHUNK_BOUNDARY_MISMATCH))
+			{
+				return;
+			}
+			this.sink.add(new StorageIntegrityCheckResult.Finding(
+				this.channelIndex, fileNumber, recordOffset,
+				StorageIntegrityCheckResult.Anomaly.CHUNK_BOUNDARY_MISMATCH, 0L, null, null
+			));
+		}
+
+		@Override
+		public final void onUnknownKind(final long fileNumber, final long kind)
+		{
+			if(!this.policy.verify() || this.ignores(Anomaly.UNKNOWN_KIND))
+			{
+				return;
+			}
+			this.sink.add(new StorageIntegrityCheckResult.Finding(
+				this.channelIndex, fileNumber, -1L,
+				StorageIntegrityCheckResult.Anomaly.UNKNOWN_KIND, kind, null, null
+			));
+		}
+
+		@Override
+		public final void onMissingHeader(final long fileNumber)
+		{
+			if(!this.policy.verify() || !this.policy.requireCoverage() || this.ignores(Anomaly.MISSING_HEADER))
+			{
+				return;
+			}
+			this.sink.add(new StorageIntegrityCheckResult.Finding(
+				this.channelIndex, fileNumber, -1L,
+				StorageIntegrityCheckResult.Anomaly.MISSING_HEADER, 0L, null, null
+			));
+		}
+
+		@Override
+		public final void onUncoveredData(final long fileNumber, final long offset)
+		{
+			if(!this.policy.verify() || this.ignores(Anomaly.UNCOVERED_DATA))
+			{
+				return;
+			}
+			this.sink.add(new StorageIntegrityCheckResult.Finding(
+				this.channelIndex, fileNumber, offset,
+				StorageIntegrityCheckResult.Anomaly.UNCOVERED_DATA, 0L, null, null
+			));
+		}
+
+		@Override
+		public final void onFileWalkComplete(final long fileNumber)
+		{
+			// no dedupe state to flush in collecting mode.
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
@@ -694,7 +694,7 @@ public interface StorageChunkChecksumCalculator
 
 		/**
 		 * @return whether this algorithm chains: each chunk's hash folds in the previous chunk's hash, so
-		 *         reorder / insert / delete / substitute of chunks is detectable. Non-chained kinds return
+		 *         reorder / insert / delete / substitute of chunks within a file is detectable. Non-chained kinds return
 		 *         {@code false} and ignore {@link #setChainTip(byte[])} / {@link #chainTip()}.
 		 */
 		public default boolean isChained()
@@ -866,9 +866,12 @@ public interface StorageChunkChecksumCalculator
 		 * Chained SHA-256 algorithm: cryptographic and tamper-evident like {@link Sha256}, but each chunk's
 		 * stored hash folds in the previous chunk's hash &mdash; {@code tip_i = SHA-256(tip_{i-1} || chunk_i)},
 		 * seeded by the file's {@code FileHeaderV1.chainRoot} ({@code tip_0}). Altering any chunk invalidates
-		 * that chunk and every chunk after it, so reordering, insertion, deletion or substitution of chunks is
-		 * detectable &mdash; not just bit-rot of a single chunk. Emits {@code ChunkChecksumChainedV1} records
-		 * (44 B; same envelope+hash layout as {@code ChunkChecksumV1}, distinguished purely by KIND).
+		 * that chunk and every chunk after it in the same file, so reordering, insertion, deletion or
+		 * substitution of chunks <i>within a file</i> is detectable &mdash; not just bit-rot of a single chunk.
+		 * The chain is re-seeded per file from that file's own header, so it does not span files: deleting or
+		 * reordering whole data files (as housekeeping legitimately does) is not detected by the chain. Emits
+		 * {@code ChunkChecksumChainedV1} records (44 B; same envelope+hash layout as {@code ChunkChecksumV1},
+		 * distinguished purely by KIND).
 		 * <p>
 		 * <b>Chaining is SHA-256 only.</b> A chained CRC32C is forgeable (CRC is linear and not
 		 * collision-resistant), so it would provide no tamper-evidence while adding nothing for accidental

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
@@ -16,6 +16,7 @@ package org.eclipse.store.storage.types;
 
 import static org.eclipse.serializer.util.X.checkArrayRange;
 import static org.eclipse.serializer.util.X.notNull;
+import static org.eclipse.serializer.util.X.toBytes;
 
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -180,6 +181,22 @@ public interface StorageChunkChecksumCalculator
 	 */
 	public void verifyDataFile(StorageLiveDataFile.Default file, ByteBuffer buffer, StorageChecksumAnomalyReporter reporter);
 
+	/**
+	 * Streaming variant of {@link #verifyDataFile} for a data file too large to hold resident: reads the file in
+	 * windows of {@code window}'s capacity rather than requiring the whole file in one buffer, bounding the
+	 * integrity check's direct-memory use to one window per channel regardless of the configured data-file size.
+	 * Produces exactly the same anomalies as {@link #verifyDataFile} (and the load walk): each covering record's
+	 * chunk hash is recomputed incrementally over its bytes via {@link Algorithm#beginChunk(byte[])} /
+	 * {@link Algorithm#updateChunk(ByteBuffer)} / {@link Algorithm#finishChunk()}, so a single chunk larger than
+	 * the window still verifies. <b>Side-effect-free</b>: never mutates {@code file}.
+	 *
+	 * @param file         the data file being re-verified (read only; never mutated).
+	 * @param verifyLength the number of bytes to verify from the file start (the caller bounds the head file).
+	 * @param window       a reusable direct buffer used as the sliding read window; its capacity is the window size.
+	 * @param reporter     the sink for detected anomalies; must be non-{@code null}.
+	 */
+	public void verifyDataFileStreaming(StorageLiveDataFile.Default file, long verifyLength, ByteBuffer window, StorageChecksumAnomalyReporter reporter);
+
 
 
 	///////////////////////////////////////////////////////////////////////////
@@ -321,6 +338,23 @@ public interface StorageChunkChecksumCalculator
 
 
 	/**
+	 * Shared framing cross-check (file-relative offsets), used by both the resident {@link #verifyChunk} and the
+	 * streaming {@link Default#verifyDataFileStreaming} so the two cannot diverge: a covering record is consistent
+	 * with the walk when its stored chunk start equals the walker's reconstructed chunk start and the record does
+	 * not precede that start (a corrupted entity LENGTH otherwise leaves the stored start != cursor, or drives the
+	 * chunk start past the record). When inconsistent, {@code [chunkStart, record)} is wrong and must not be hashed.
+	 */
+	private static boolean isChunkFramingConsistent(
+		final int  storedChunkStart,
+		final long walkerChunkStart,
+		final long recordOffset
+	)
+	{
+		return storedChunkStart == walkerChunkStart && recordOffset >= walkerChunkStart;
+	}
+
+
+	/**
 	 * Shared, side-effect-free verification of one covering record's chunk {@code [chunkStart, address)} against
 	 * the stored checksum, used by both the load-time {@link ChunkChecksumHandler} and the on-demand
 	 * {@link Default#verifyDataFile} so the two cannot diverge. Touches no {@link StorageLiveDataFile}:
@@ -347,9 +381,10 @@ public interface StorageChunkChecksumCalculator
 		// than hash it (and never slice a negative length).
 		final int  storedChunkStart = StorageMetaRecord.readChunkChecksumChunkStart(address);
 		final long walkerChunkStart = chunkStart - bufferStartAddress;
-		if(storedChunkStart != walkerChunkStart || address < chunkStart)
+		final long recordOffset     = address - bufferStartAddress;
+		if(!isChunkFramingConsistent(storedChunkStart, walkerChunkStart, recordOffset))
 		{
-			reporter.onChunkBoundaryMismatch(fileNumber, address - bufferStartAddress, storedChunkStart, walkerChunkStart);
+			reporter.onChunkBoundaryMismatch(fileNumber, recordOffset, storedChunkStart, walkerChunkStart);
 			return chained ? verifier.readStoredChecksumBytes(address) : inboundTip;
 		}
 
@@ -375,7 +410,7 @@ public interface StorageChunkChecksumCalculator
 		final byte[] actual = verifier.computeChecksumBytes(chunk);
 		if(!Arrays.equals(actual, expected))
 		{
-			reporter.onChecksumMismatch(fileNumber, address - chunkStart, StorageMetaRecord.kindOf(address), expected, actual);
+			reporter.onChecksumMismatch(fileNumber, walkerChunkStart, StorageMetaRecord.kindOf(address), expected, actual);
 		}
 		// chained: continue from the stored tip (== recomputed on match), the basis the writer chained from.
 		return chained ? expected : inboundTip;
@@ -570,6 +605,14 @@ public interface StorageChunkChecksumCalculator
 
 			for(long address = bufferStartAddress; address < bufferBoundAddress;)
 			{
+				// A trailing remnant shorter than an entity LENGTH prefix cannot be a valid item; reading 8 bytes
+				// would read past the verified region. The startup load walk (StorageEntityInitializer) throws on
+				// this; the on-demand check instead stops and lets the end-of-walk coverage check report the
+				// uncovered tail. A well-formed file ends exactly on an item boundary, so this never trips there.
+				if(bufferBoundAddress - address < Long.BYTES)
+				{
+					break;
+				}
 				final long itemLength = Binary.getEntityLengthRawValue(address);
 				if(itemLength > 0)
 				{
@@ -612,15 +655,27 @@ public interface StorageChunkChecksumCalculator
 					else
 					{
 						final Algorithm verifier = this.algorithmsByKind.get(kind);
-						if(verifier == null || address + verifier.recordLength() > bufferBoundAddress)
-						{
-							// no algorithm for this KIND (drift / corrupt KIND), or truncated record.
-							reporter.onUnknownKind(fileNumber, kind);
-						}
-						else
+						if(verifier != null && address + verifier.recordLength() <= bufferBoundAddress)
 						{
 							chainTip   = verifyChunk(fileNumber, buffer, address, chunkStart, verifier, chainTip, reporter);
 							chunkStart = address + verifier.recordLength();
+						}
+						else
+						{
+							// no algorithm for this KIND (drift / corrupt KIND), or a truncated record.
+							reporter.onUnknownKind(fileNumber, kind);
+							// Mirror StorageMetaRecordRegistry.dispatch: an unknown KIND reached AFTER the
+							// FileHeaderV1 was parsed is a genuine forward-compat record, so advance the chunk
+							// boundary past it (|LENGTH| == -itemLength) — otherwise a later covering record's
+							// stored start would no longer match the walker's cursor, raising a false
+							// CHUNK_BOUNDARY_MISMATCH / UNCOVERED_DATA. A truncated KNOWN record (verifier != null)
+							// leaves chunkStart unadvanced, mirroring ChunkChecksumHandler.onLoad's report-and-skip;
+							// so does an unknown KIND before the header is parsed (a corrupted/lost FileHeaderV1),
+							// so the drift still surfaces instead of loading silently.
+							if(verifier == null && headerKind != 0L)
+							{
+								chunkStart = address - itemLength;
+							}
 						}
 					}
 				}
@@ -642,6 +697,237 @@ public interface StorageChunkChecksumCalculator
 				reporter.onUncoveredData(fileNumber, chunkStart - bufferStartAddress);
 			}
 			reporter.onFileWalkComplete(fileNumber);
+		}
+
+		@Override
+		public final void verifyDataFileStreaming(
+			final StorageLiveDataFile.Default    file        ,
+			final long                           verifyLength,
+			final ByteBuffer                     window      ,
+			final StorageChecksumAnomalyReporter reporter
+		)
+		{
+			final long         fileNumber = file.number();
+			final WindowReader reader     = new WindowReader(file, window, verifyLength);
+
+			// Per-file header state reconstructed from disk into LOCALS (the live file is never mutated) — the same
+			// reconstruction verifyDataFile does, but driven over a sliding read window instead of a resident buffer.
+			long    headerKind  = 0L;   // 0 == no FileHeaderV1 parsed (legacy file)
+			byte[]  chainTip    = null; // running chained tip, seeded from the parsed header's chainRoot
+			boolean hasLiveData = false;
+
+			// Start of the current chunk's bytes (file offset); advances past the FileHeaderV1 and each covering record.
+			long chunkStart = 0L;
+
+			for(long walkCursor = 0L; walkCursor < verifyLength;)
+			{
+				// A trailing remnant shorter than an entity LENGTH prefix cannot be a valid item; reading 8 bytes
+				// would read past the verified region (into stale window slack). Stop and let the end-of-walk
+				// coverage check report the uncovered tail — the same condition the startup load walk rejects.
+				// A well-formed file ends exactly on an item boundary, so this never trips there.
+				if(verifyLength - walkCursor < Long.BYTES)
+				{
+					break;
+				}
+				final long itemLength = Binary.getEntityLengthRawValue(reader.ensureResident(walkCursor, Long.BYTES));
+				if(itemLength > 0)
+				{
+					// data entity: part of the current chunk. Its bytes are hashed lazily as the raw range
+					// [chunkStart, record) at the covering record (feed), so nothing is fed here.
+					hasLiveData = true;
+					walkCursor += itemLength;
+					continue;
+				}
+				if(itemLength == 0)
+				{
+					throw new StorageExceptionConsistency("Zero length data item.");
+				}
+
+				// negative-length entry: legacy opaque gap, or a structured meta record (mirror the envelope guard
+				// in verifyDataFile before reading the marker/KIND).
+				if(walkCursor + StorageMetaRecord.OFFSET_PAYLOAD <= verifyLength
+					&& StorageMetaRecord.isMetaRecord(reader.ensureResident(walkCursor, StorageMetaRecord.OFFSET_PAYLOAD)))
+				{
+					final long kind = StorageMetaRecord.kindOf(reader.ensureResident(walkCursor, StorageMetaRecord.OFFSET_PAYLOAD));
+					if(kind == StorageMetaRecord.KIND_FileHeaderV1)
+					{
+						if(walkCursor + StorageMetaRecord.LENGTH_FILEHEADERV1 > verifyLength)
+						{
+							// truncated header
+							reporter.onUnknownKind(fileNumber, StorageMetaRecord.KIND_FileHeaderV1);
+						}
+						else if(headerKind != 0L)
+						{
+							// second/misplaced header: report, do not re-seed (would rebase every following chunk).
+							reporter.onUnknownKind(fileNumber, StorageMetaRecord.KIND_FileHeaderV1);
+							chunkStart = walkCursor + StorageMetaRecord.LENGTH_FILEHEADERV1;
+						}
+						else
+						{
+							final FileHeaderV1Payload header = StorageMetaRecord.readFileHeaderV1(
+								reader.ensureResident(walkCursor, StorageMetaRecord.LENGTH_FILEHEADERV1)
+							);
+							headerKind = header.chunkChecksumKind();
+							chainTip   = header.chainRoot(); // seed the running tip; chunks advance it
+							chunkStart = walkCursor + StorageMetaRecord.LENGTH_FILEHEADERV1;
+						}
+					}
+					else
+					{
+						final Algorithm verifier = this.algorithmsByKind.get(kind);
+						if(verifier != null && walkCursor + verifier.recordLength() <= verifyLength)
+						{
+							// covering record: re-verify the chunk [chunkStart, walkCursor). Mirrors verifyChunk, but
+							// the chunk bytes are streamed into the digest in windows (begin/feed/finish) rather than
+							// sliced from a resident buffer, so a chunk larger than the window still verifies. Dispatch
+							// the Algorithm by the record's on-disk KIND (the record bytes are read BEFORE feeding,
+							// since feed slides the window away from the record).
+							final int    recordLen        = checkArrayRange(verifier.recordLength());
+							final long   recordAddress     = reader.ensureResident(walkCursor, recordLen);
+							final int    storedChunkStart  = StorageMetaRecord.readChunkChecksumChunkStart(recordAddress);
+							final byte[] expected          = verifier.readStoredChecksumBytes(recordAddress);
+							final boolean chained           = verifier.isChained();
+
+							if(isChunkFramingConsistent(storedChunkStart, chunkStart, walkCursor))
+							{
+								// resolve the chained seed exactly as verifyChunk: a chained covering record with no
+								// parsed FileHeaderV1 means the header was lost/corrupted — report and verify against
+								// the initial seed so a real defect still surfaces as a checksum mismatch.
+								byte[] seed = chained ? chainTip : null;
+								if(chained && seed == null)
+								{
+									reporter.onMissingHeader(fileNumber);
+									seed = verifier.initialSeed();
+								}
+								verifier.beginChunk(seed);
+								reader.feed(verifier, chunkStart, walkCursor); // hash [chunkStart, record) in windows
+								final byte[] actual = verifier.finishChunk();
+								if(!Arrays.equals(actual, expected))
+								{
+									reporter.onChecksumMismatch(fileNumber, chunkStart, kind, expected, actual);
+								}
+								// chained: continue from the stored tip (== recomputed on match), the writer's basis.
+								chainTip = chained ? expected : chainTip;
+							}
+							else
+							{
+								reporter.onChunkBoundaryMismatch(fileNumber, walkCursor, storedChunkStart, chunkStart);
+								if(chained)
+								{
+									chainTip = expected; // re-anchor from the stored tip
+								}
+							}
+							chunkStart = walkCursor + recordLen;
+						}
+						else
+						{
+							// no algorithm for this KIND (drift / corrupt KIND), or a truncated record.
+							reporter.onUnknownKind(fileNumber, kind);
+							// Same forward-compat rule as verifyDataFile: advance past an unknown KIND only once a
+							// FileHeaderV1 has been parsed; otherwise leave chunkStart so the drift still surfaces.
+							if(verifier == null && headerKind != 0L)
+							{
+								chunkStart = walkCursor - itemLength;
+							}
+						}
+					}
+				}
+
+				// advance by the on-disk |LENGTH| regardless (legacy gaps and meta records alike). Gap bytes inside a
+				// chunk are not fed here; the covering record's feed of [chunkStart, record) covers them as raw bytes.
+				walkCursor -= itemLength;
+			}
+
+			// per-file coverage checks (identical to verifyDataFile, in file-relative offsets).
+			if(headerKind == 0L)
+			{
+				if(hasLiveData)
+				{
+					reporter.onMissingHeader(fileNumber);
+				}
+			}
+			else if(chunkStart < verifyLength)
+			{
+				reporter.onUncoveredData(fileNumber, chunkStart);
+			}
+			reporter.onFileWalkComplete(fileNumber);
+		}
+
+		/**
+		 * Sliding read window over a data file for {@link #verifyDataFileStreaming}: keeps at most one window of the
+		 * file resident in the supplied direct buffer and serves both the forward framing walk (small fixed reads via
+		 * {@link #ensureResident(long, int)}) and the incremental chunk hashing (the raw chunk range via
+		 * {@link #feed(Algorithm, long, long)}). Reads never pass {@code fileLength} (the caller's bounded verify
+		 * length), so the head file is read only up to its committed length. Single-threaded (one channel).
+		 */
+		private static final class WindowReader
+		{
+			private final StorageLiveDataFile.Default file         ;
+			private final ByteBuffer                  buffer       ;
+			private final long                        bufferAddress;
+			private final int                         capacity     ;
+			private final long                        fileLength   ;
+			private       long                        windowOffset ; // file offset of buffer[0]; -1 == empty
+			private       long                        windowLength ; // resident byte count
+
+			WindowReader(final StorageLiveDataFile.Default file, final ByteBuffer buffer, final long fileLength)
+			{
+				super();
+				this.file          = file                                  ;
+				this.buffer        = buffer                                ;
+				this.bufferAddress = XMemory.getDirectByteBufferAddress(buffer);
+				this.capacity      = buffer.capacity()                     ;
+				this.fileLength    = fileLength                            ;
+				this.windowOffset  = -1L                                   ;
+				this.windowLength  = 0L                                    ;
+			}
+
+			private void refill(final long offset)
+			{
+				final long toRead = Math.min(this.capacity, this.fileLength - offset);
+				this.buffer.clear();
+				this.buffer.limit(checkArrayRange(toRead));
+				this.file.readBytes(this.buffer, offset, toRead);
+				this.windowOffset = offset;
+				this.windowLength = toRead;
+			}
+
+			/**
+			 * Ensures {@code [offset, offset+need)} is resident ({@code need} fits the window capacity) and returns
+			 * the off-heap address of {@code offset}. The address is valid only until the next refill (any
+			 * {@code ensureResident}/{@code feed} that slides the window).
+			 */
+			long ensureResident(final long offset, final int need)
+			{
+				if(this.windowOffset < 0L
+					|| offset < this.windowOffset
+					|| offset + need > this.windowOffset + this.windowLength)
+				{
+					this.refill(offset);
+				}
+				return this.bufferAddress + (offset - this.windowOffset);
+			}
+
+			/**
+			 * Feeds the raw byte range {@code [from, to)} into {@code verifier}'s open chunk, reading the range in
+			 * windows. This is how a chunk larger than the window is hashed.
+			 */
+			void feed(final Algorithm verifier, long from, final long to)
+			{
+				while(from < to)
+				{
+					if(this.windowOffset < 0L
+						|| from < this.windowOffset
+						|| from >= this.windowOffset + this.windowLength)
+					{
+						this.refill(from);
+					}
+					final long windowEnd = this.windowOffset + this.windowLength;
+					final long n         = Math.min(to, windowEnd) - from;
+					verifier.updateChunk(XMemory.slice(this.buffer, from - this.windowOffset, n));
+					from += n;
+				}
+			}
 		}
 
 	}
@@ -731,12 +1017,42 @@ public interface StorageChunkChecksumCalculator
 			return new byte[StorageMetaRecord.LENGTH_HASH_SHA256];
 		}
 
+		/**
+		 * Begins an incremental chunk hash for the streaming verify path (a chunk too large to hold resident).
+		 * Resets this algorithm's running digest and, for chained kinds, folds in {@code seed} (the running tip)
+		 * exactly as one-shot {@link #computeChecksumBytes(ByteBuffer)} does. Followed by zero or more
+		 * {@link #updateChunk(ByteBuffer)} calls and one {@link #finishChunk()}. Abandoning an open chunk (no
+		 * {@code finishChunk}) is safe: the next {@code beginChunk} resets the digest. Default throws: only
+		 * verifying algorithms support it (the no-op {@code None} is never verified).
+		 */
+		public default void beginChunk(final byte[] seed)
+		{
+			throw new UnsupportedOperationException();
+		}
+
+		/**
+		 * Feeds one window of the current chunk's bytes into the hash opened by {@link #beginChunk(byte[])}.
+		 */
+		public default void updateChunk(final ByteBuffer partial)
+		{
+			throw new UnsupportedOperationException();
+		}
+
+		/**
+		 * Finalizes the chunk hash opened by {@link #beginChunk(byte[])} and returns its bytes; for chained kinds
+		 * this also advances the running tip to the returned hash, mirroring {@link #computeChecksumBytes(ByteBuffer)}.
+		 */
+		public default byte[] finishChunk()
+		{
+			throw new UnsupportedOperationException();
+		}
+
 
 
 		/**
 		 * CRC32C algorithm: non-cryptographic integrity checksum, hardware-accelerated, zero-copy on
 		 * direct buffers. Detects accidental corruption; <b>not</b> collision-resistant or tamper-evident.
-		 * Emits {@code ChunkChecksumCRC32CV1} records (16 B).
+		 * Emits {@code ChunkChecksumCRC32CV1} records (20 B).
 		 */
 		public final class Crc32c implements Algorithm
 		{
@@ -786,13 +1102,6 @@ public interface StorageChunkChecksumCalculator
 			// static methods //
 			///////////////////
 
-			private static byte[] intToBytes(final int value)
-			{
-				return new byte[]{(byte)(value >>> 24), (byte)(value >>> 16), (byte)(value >>> 8), (byte)value};
-			}
-
-
-
 			///////////////////////////////////////////////////////////////////////////
 			// declared methods //
 			/////////////////////
@@ -832,7 +1141,25 @@ public interface StorageChunkChecksumCalculator
 				notNull(chunk);
 				this.crc.reset();
 				this.crc.update(chunk.duplicate());
-				return intToBytes((int)this.crc.getValue());
+				return toBytes((int)this.crc.getValue());
+			}
+
+			@Override
+			public void beginChunk(final byte[] seed)
+			{
+				this.crc.reset(); // non-chained: seed ignored
+			}
+
+			@Override
+			public void updateChunk(final ByteBuffer partial)
+			{
+				this.crc.update(partial.duplicate());
+			}
+
+			@Override
+			public byte[] finishChunk()
+			{
+				return toBytes((int)this.crc.getValue());
 			}
 
 			@Override
@@ -840,10 +1167,10 @@ public interface StorageChunkChecksumCalculator
 			{
 				// Byte-order note: the CRC is persisted as a 4-byte int in NATIVE order (writeRecord uses
 				// target.putInt on a native-order direct buffer) and read back via the matching native
-				// get_int, so the round-trip recovers the same int value. intToBytes (big-endian) is applied
+				// get_int, so the round-trip recovers the same int value. X.toBytes (big-endian) is applied
 				// to that int value on BOTH the read and compute sides purely to obtain comparable byte[]s —
 				// it does not pin the on-disk layout, which is native-endian. Comparison is self-consistent.
-				return intToBytes(XMemory.get_int(recordAddress + OFFSET_CRC));
+				return toBytes(XMemory.get_int(recordAddress + OFFSET_CRC));
 			}
 
 			@Override
@@ -863,14 +1190,14 @@ public interface StorageChunkChecksumCalculator
 
 
 		/**
-		 * Chained SHA-256 algorithm: cryptographic and tamper-evident like {@link Sha256}, but each chunk's
+		 * Chained SHA-256 algorithm: cryptographic and tamper-evident (SHA-256), but each chunk's
 		 * stored hash folds in the previous chunk's hash &mdash; {@code tip_i = SHA-256(tip_{i-1} || chunk_i)},
 		 * seeded by the file's {@code FileHeaderV1.chainRoot} ({@code tip_0}). Altering any chunk invalidates
 		 * that chunk and every chunk after it in the same file, so reordering, insertion, deletion or
 		 * substitution of chunks <i>within a file</i> is detectable &mdash; not just bit-rot of a single chunk.
 		 * The chain is re-seeded per file from that file's own header, so it does not span files: deleting or
 		 * reordering whole data files (as housekeeping legitimately does) is not detected by the chain. Emits
-		 * {@code ChunkChecksumChainedV1} records (44 B; same envelope+hash layout as {@code ChunkChecksumV1},
+		 * {@code ChunkChecksumChainedV1} records (48 B; same envelope+hash layout as {@code ChunkChecksumV1},
 		 * distinguished purely by KIND).
 		 * <p>
 		 * <b>Chaining is SHA-256 only.</b> A chained CRC32C is forgeable (CRC is linear and not
@@ -1020,6 +1347,31 @@ public interface StorageChunkChecksumCalculator
 				this.digest.update(this.tip);          // fold in the previous tip
 				this.digest.update(chunk.duplicate());
 				return this.tip = this.digest.digest();// advance and return the new tip
+			}
+
+			@Override
+			public void beginChunk(final byte[] seed)
+			{
+				// reset (clears any bytes from an abandoned chunk) and fold in the running tip, exactly as the
+				// one-shot computeChecksumBytes does via digest.update(this.tip). `seed` is the resolved running
+				// tip (never null for a chained verify: the caller substitutes initialSeed() on a missing header).
+				this.digest.reset();
+				if(seed != null)
+				{
+					this.digest.update(seed);
+				}
+			}
+
+			@Override
+			public void updateChunk(final ByteBuffer partial)
+			{
+				this.digest.update(partial.duplicate());
+			}
+
+			@Override
+			public byte[] finishChunk()
+			{
+				return this.tip = this.digest.digest(); // advance and return the new tip (mirrors computeChecksumBytes)
 			}
 
 			@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
@@ -1,0 +1,1133 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.eclipse.serializer.util.X.checkArrayRange;
+import static org.eclipse.serializer.util.X.notNull;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.zip.CRC32C;
+
+import org.eclipse.serializer.exceptions.WrapperRuntimeException;
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+import org.eclipse.store.storage.types.StorageMetaRecord.FileHeaderV1Payload;
+
+/**
+ * Per-channel component owning all chunk-checksum work: writing the {@code FileHeaderV1} and chunk-checksum
+ * meta records, and recognizing / verifying them on load. One instance is created per storage channel by
+ * {@link StorageChunkChecksumProvider#createCalculator()}, so the stateful native algorithm objects
+ * ({@link MessageDigest}, {@link CRC32C}) live as plain instance fields without thread-safety concerns &mdash;
+ * each channel calls its own calculator from a single thread.
+ * <p>
+ * The pluggable extension point is {@link Algorithm}: each kind's primitives (record layout, write,
+ * compute, read-stored) live in one {@code Algorithm} subclass. The calculator carries a primary
+ * algorithm (the configured kind, used for writes) and a kind-keyed registry of all known algorithms
+ * (used for verify-time dispatch by the on-disk KIND, so mixed-kind files from a provider change between
+ * runs verify cleanly). Adding a new algorithm in the future is a localized change: a new {@code Algorithm}
+ * subclass plus a new {@link StorageChunkChecksumProvider} subclass that registers it.
+ */
+public interface StorageChunkChecksumCalculator
+{
+	/**
+	 * @return the {@link StorageChunkChecksumPolicy} governing the mode and strictness knobs.
+	 */
+	public StorageChunkChecksumPolicy policy();
+
+	/**
+	 * @return the KIND code of the primary algorithm (the one that will be used for writes).
+	 */
+	public long chunkChecksumKind();
+
+	/**
+	 * @return the byte length of the {@code FileHeaderV1} meta record this calculator emits.
+	 */
+	public long fileHeaderRecordLength();
+
+	/**
+	 * @return the byte length of the chunk-checksum meta record the primary algorithm emits.
+	 */
+	public long chunkChecksumRecordLength();
+
+	/**
+	 * @return whether the policy mode emits meta records on write.
+	 */
+	public boolean isWriting();
+
+	/**
+	 * @return whether the policy mode verifies chunk-checksum records on load.
+	 */
+	public boolean isVerifying();
+
+	/**
+	 * Whether a chunk-checksum record should cover writes appended to the given head file: the policy
+	 * mode must write AND the head file must already carry a {@code FileHeaderV1} of this calculator's
+	 * primary kind. Legacy/pre-feature head files (kind {@code 0}) and head files written by a different
+	 * algorithm are gated out (a file is single-kind).
+	 */
+	public boolean coversChunkWrites(StorageLiveDataFile.Default headFile);
+
+	/**
+	 * Convenience: {@link #chunkChecksumRecordLength()} when {@link #coversChunkWrites(StorageLiveDataFile.Default)}
+	 * is true for the given head file, {@code 0L} otherwise. The bytes the trailing chunk-checksum
+	 * record reserves; every write path uses this to keep raw file size within {@code fileMaximumSize}.
+	 */
+	public default long reservedLengthFor(final StorageLiveDataFile.Default headFile)
+	{
+		return this.coversChunkWrites(headFile) ? this.chunkChecksumRecordLength() : 0L;
+	}
+
+	/**
+	 * Writes a {@code FileHeaderV1} meta record into {@code target} at its current position (advances by
+	 * {@link #fileHeaderRecordLength()}), stamping {@code chainRoot} as the file's chain seed. Target must
+	 * be a direct buffer in native byte order with at least {@link #fileHeaderRecordLength()} bytes
+	 * remaining. {@code chainRoot} is {@link #LENGTH_HASH_SHA256} bytes — all-zero for non-chained kinds,
+	 * the predecessor file's chain tip (or the configured initial seed) for chained kinds; see
+	 * {@link #nextChainRoot(StorageLiveDataFile.Default)}.
+	 */
+	public void writeFileHeaderRecord(ByteBuffer target, byte[] chainRoot);
+
+	/**
+	 * Determines the {@code chainRoot} to stamp into the {@code FileHeaderV1} of a newly created file. For
+	 * chained kinds this is {@code predecessor}'s current chain tip (or the configured initial seed when
+	 * {@code predecessor} is {@code null} or carries no tip — i.e. the first file). For non-chained kinds
+	 * it is an all-zero array (the chain root is unused).
+	 *
+	 * @param predecessor the file that was the head before this new file, or {@code null} for the first file.
+	 * @return the {@link StorageMetaRecord#LENGTH_HASH_SHA256}-byte chain root for the new file's header.
+	 */
+	public byte[] nextChainRoot(StorageLiveDataFile.Default predecessor);
+
+	/**
+	 * Caches on {@code file} the per-file header state that a re-load would parse from the
+	 * {@code FileHeaderV1} just written by {@link #writeFileHeaderRecord(ByteBuffer, byte[])} (kind and the
+	 * given {@code chainRoot}, which also seeds the file's running chain tip).
+	 */
+	public void cacheFileHeaderOn(StorageLiveDataFile.Default file, byte[] chainRoot);
+
+	/**
+	 * Computes the primary algorithm's checksum over {@code dataBuffers} (each from its current position
+	 * to its limit, without advancing them) and writes the covering chunk-checksum meta record into
+	 * {@code target} at its current position (advances by {@link #chunkChecksumRecordLength()}). The record
+	 * stores {@code chunkStartOffset} &mdash; the in-file offset where the covered chunk begins &mdash; so the
+	 * load walk can detect framing desync. For a chained primary kind the previous tip is read from
+	 * {@code file} and the newly computed hash becomes the calculator's pending tip; {@code file} is <b>not</b>
+	 * modified until {@link #commitChunkWrite} is called. For non-chained kinds {@code file} is not modified at all.
+	 *
+	 * @param file             the head file the chunk is being appended to.
+	 * @param chunkStartOffset the in-file offset where the covered chunk's bytes begin.
+	 * @param target           the meta-record buffer to write into.
+	 * @param dataBuffers      the chunk's data buffers (hashed, not advanced).
+	 */
+	public void writeChunkChecksumRecord(StorageLiveDataFile.Default file, long chunkStartOffset, ByteBuffer target, ByteBuffer... dataBuffers);
+
+	/**
+	 * Applies the per-file state advanced by the preceding {@link #writeChunkChecksumRecord} once that write
+	 * has been committed &mdash; currently advancing the chained tip on {@code file} to the newly written hash.
+	 * No-op for non-chained kinds. A chunk write that is never committed (because it failed, or was rolled back
+	 * after a sibling channel failed) therefore never advances the file tip.
+	 *
+	 * @param file the head file whose just-committed chunk write should advance the per-file state.
+	 */
+	public void commitChunkWrite(StorageLiveDataFile.Default file);
+
+	/**
+	 * Registers this calculator's load-time handlers into the channel's {@link StorageMetaRecordRegistry}:
+	 * the shared {@code FileHeaderV1} handler under {@link StorageMetaRecord#KIND_FileHeaderV1} (parses and
+	 * caches the per-file header), and a single chunk-checksum handler under every chunk-checksum algorithm
+	 * KIND this calculator knows (verifies a chunk-checksum record when {@link #isVerifying()}, dispatching
+	 * the {@link Algorithm} by the record's on-disk KIND, so a file written by one algorithm verifies even
+	 * when another is the configured primary). Unknown KINDs are reported via {@code reporter}.
+	 * <p>
+	 * Called once per channel during setup (in the {@code StorageSystem.createChannels()} flow), so each
+	 * channel's registry references that channel's own stateful {@link Algorithm} instances.
+	 *
+	 * @param registry the channel's registry to register into; must be non-{@code null}.
+	 * @param reporter the channel's anomaly reporter, used by the chunk handler to react to a mismatch;
+	 *                 must be non-{@code null}.
+	 */
+	public void registerMetaRecordHandlers(StorageMetaRecordRegistry registry, StorageChecksumAnomalyReporter reporter);
+
+	/**
+	 * Re-verifies an already-resident data file's chunk-checksum records for the on-demand integrity check,
+	 * reporting anomalies through {@code reporter}. <b>Side-effect-free</b>: it reconstructs the per-file header
+	 * kind, chain tip and chunk boundary in local variables and never mutates {@code file} (its cached header
+	 * state and running chain tip belong to the live write path), but otherwise mirrors the load-time
+	 * {@link ChunkChecksumHandler} and per-file coverage checks, so the anomalies match a startup load walk.
+	 * {@code buffer} must already hold the bytes to verify in {@code [0, limit)} (the caller bounds the head
+	 * file to its committed length).
+	 *
+	 * @param file     the data file being re-verified (read only; never mutated).
+	 * @param buffer   the direct buffer holding the file's resident bytes in {@code [0, limit)}.
+	 * @param reporter the sink for detected anomalies; must be non-{@code null}.
+	 */
+	public void verifyDataFile(StorageLiveDataFile.Default file, ByteBuffer buffer, StorageChecksumAnomalyReporter reporter);
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// load-time meta-record handlers //
+	///////////////////////////////////
+
+	/**
+	 * Handles the shared {@code FileHeaderV1} kind: parses the per-file header and caches it on the file.
+	 * Always caches regardless of verify mode — the write side gates on the file's cached
+	 * {@code chunkChecksumKind}, so the cache must reflect what is on disk independent of policy.
+	 */
+	public final class FileHeaderV1Handler implements StorageMetaRecordHandler
+	{
+		private final StorageChecksumAnomalyReporter reporter;
+
+		FileHeaderV1Handler(final StorageChecksumAnomalyReporter reporter)
+		{
+			super();
+			this.reporter = reporter;
+		}
+
+		@Override
+		public final long onLoad(
+			final StorageLiveDataFile.Default file      ,
+			final ByteBuffer                  buffer    ,
+			final long                        address   ,
+			final long                        chunkStart
+		)
+		{
+			// Hostile/corrupt-input guard: the full 46 B header must be resident before we read its
+			// payload (a truncated header would read past the buffer). Report-and-skip on overrun.
+			final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
+			if(address + StorageMetaRecord.LENGTH_FILEHEADERV1 > bufferBoundAddress)
+			{
+				this.reporter.onUnknownKind(file.number(), StorageMetaRecord.KIND_FileHeaderV1);
+				return chunkStart;
+			}
+
+			// By format there is exactly one FileHeaderV1 per file, its first entry. A second/misplaced one
+			// (non-zero cached kind ⇒ a header was already parsed) is anomalous: do NOT let it silently
+			// re-seed the file's chunk-checksum kind / chain tip (which would rebase verification of every
+			// following chunk). Report it and skip past, accounting its bytes as meta.
+			if(file.chunkChecksumKind() != 0L)
+			{
+				this.reporter.onUnknownKind(file.number(), StorageMetaRecord.KIND_FileHeaderV1);
+				file.registerMetaLength(StorageMetaRecord.LENGTH_FILEHEADERV1);
+				return address + StorageMetaRecord.LENGTH_FILEHEADERV1;
+			}
+
+			final FileHeaderV1Payload header = StorageMetaRecord.readFileHeaderV1(address);
+			file.setFileHeaderV1(header.chunkChecksumKind(), header.chainRoot());
+			// Account the header's bytes as meta (not gap) so dataFillRatio treats it as useful overhead.
+			file.registerMetaLength(StorageMetaRecord.LENGTH_FILEHEADERV1);
+			return address + StorageMetaRecord.LENGTH_FILEHEADERV1;
+		}
+	}
+
+
+
+	/**
+	 * Handles every chunk-checksum kind: when verifying, re-checksums the preceding chunk in place and
+	 * compares against the stored checksum, dispatching the {@link Algorithm} by the record's on-disk
+	 * KIND (so a file of one kind verifies even when another is the configured primary). Normally registered
+	 * under exactly the KINDs present in {@code algorithmsByKind}; a lookup miss (registry/map drift, or a
+	 * corrupt on-disk KIND that slipped the marker gate) is reported as an unknown-KIND anomaly rather than
+	 * trusted.
+	 */
+	public final class ChunkChecksumHandler implements StorageMetaRecordHandler
+	{
+		private final StorageChunkChecksumPolicy       policy          ;
+		private final Map<Long, Algorithm>             algorithmsByKind;
+		private final StorageChecksumAnomalyReporter   reporter        ;
+
+		ChunkChecksumHandler(
+			final StorageChunkChecksumPolicy       policy          ,
+			final Map<Long, Algorithm>             algorithmsByKind,
+			final StorageChecksumAnomalyReporter   reporter
+		)
+		{
+			super();
+			this.policy           = policy          ;
+			this.algorithmsByKind = algorithmsByKind;
+			this.reporter         = reporter        ;
+		}
+
+		@Override
+		public final long onLoad(
+			final StorageLiveDataFile.Default file      ,
+			final ByteBuffer                  buffer    ,
+			final long                        address   ,
+			final long                        chunkStart
+		)
+		{
+			final long      kind     = StorageMetaRecord.kindOf(address);
+			final Algorithm verifier = this.algorithmsByKind.get(kind);
+			if(verifier == null)
+			{
+				// This handler is registered for a KIND with no algorithm (registry/map drift) or the
+				// on-disk KIND is corrupt: cannot verify — report and skip (chunk boundary unchanged).
+				this.reporter.onUnknownKind(file.number(), kind);
+				return chunkStart;
+			}
+
+			// Hostile/corrupt-input guard: the full fixed-size record must be resident before we read the
+			// stored checksum (a truncated record would read past the buffer). Report-and-skip on overrun.
+			final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
+			if(address + verifier.recordLength() > bufferBoundAddress)
+			{
+				this.reporter.onUnknownKind(file.number(), kind);
+				return chunkStart;
+			}
+
+			final boolean chained = verifier.isChained();
+			if(this.policy.verify())
+			{
+				// shared verify core; on a chained kind the per-file running tip is the seed in and the tip out.
+				final byte[] tip = verifyChunk(
+					file.number(), buffer, address, chunkStart, verifier,
+					chained ? file.chainTip() : null, this.reporter
+				);
+				if(chained)
+				{
+					file.setChainTip(tip);
+				}
+			}
+			else if(chained)
+			{
+				// Not verifying, but a chained file must still advance its per-file tip during the load
+				// walk so that writes appended to this (head) file after init continue the chain. The tip
+				// after chunk i is simply that chunk's stored hash — read it, no recompute needed.
+				file.setChainTip(verifier.readStoredChecksumBytes(address));
+			}
+			// Account the chunk-checksum record's bytes as meta (not gap).
+			file.registerMetaLength(verifier.recordLength());
+			return address + verifier.recordLength();
+		}
+	}
+
+
+
+	/**
+	 * Shared, side-effect-free verification of one covering record's chunk {@code [chunkStart, address)} against
+	 * the stored checksum, used by both the load-time {@link ChunkChecksumHandler} and the on-demand
+	 * {@link Default#verifyDataFile} so the two cannot diverge. Touches no {@link StorageLiveDataFile}:
+	 * {@code inboundTip} is the chained running tip in, the return value the tip to carry forward (stored tip on
+	 * a chained match or boundary re-anchor; {@code inboundTip} unchanged for non-chained). The caller has
+	 * confirmed the record is fully resident in {@code buffer}.
+	 */
+	private static byte[] verifyChunk(
+		final long                           fileNumber ,
+		final ByteBuffer                     buffer     ,
+		final long                           address    ,
+		final long                           chunkStart ,
+		final Algorithm                      verifier   ,
+		final byte[]                         inboundTip ,
+		final StorageChecksumAnomalyReporter reporter
+	)
+	{
+		final boolean chained            = verifier.isChained();
+		final long    bufferStartAddress = XMemory.getDirectByteBufferAddress(buffer);
+
+		// Framing cross-check: the record's stored chunk start vs the boundary the walk reconstructed from entity
+		// LENGTH prefixes. A corrupted LENGTH leaves the stored start != cursor, or drives chunkStart past the
+		// record (negative chunk length). Either way [chunkStart, address) is wrong: report and re-anchor rather
+		// than hash it (and never slice a negative length).
+		final int  storedChunkStart = StorageMetaRecord.readChunkChecksumChunkStart(address);
+		final long walkerChunkStart = chunkStart - bufferStartAddress;
+		if(storedChunkStart != walkerChunkStart || address < chunkStart)
+		{
+			reporter.onChunkBoundaryMismatch(fileNumber, address - bufferStartAddress, storedChunkStart, walkerChunkStart);
+			return chained ? verifier.readStoredChecksumBytes(address) : inboundTip;
+		}
+
+		// Checksum the chunk in place: it is already resident in `buffer`, so slice that view rather than copying
+		// [chunkStart, address) into a fresh array. Dispatch by on-disk KIND, not the primary.
+		final ByteBuffer chunk    = XMemory.slice(buffer, walkerChunkStart, address - chunkStart);
+		final byte[]     expected = verifier.readStoredChecksumBytes(address);
+		// chained kinds fold the running tip (seeded from the header chainRoot, advanced per verified chunk) into
+		// the recompute, so reorder/insert/delete/substitute breaks here.
+		if(chained)
+		{
+			byte[] seed = inboundTip;
+			if(seed == null)
+			{
+				// Chained covering record but no parsed FileHeaderV1: the engine never writes one to a header-less
+				// file, so the header was lost/corrupted. Report it and verify against the initial seed so a real
+				// defect still surfaces as a checksum mismatch.
+				reporter.onMissingHeader(fileNumber);
+				seed = verifier.initialSeed();
+			}
+			verifier.setChainTip(seed);
+		}
+		final byte[] actual = verifier.computeChecksumBytes(chunk);
+		if(!Arrays.equals(actual, expected))
+		{
+			reporter.onChecksumMismatch(fileNumber, address - chunkStart, StorageMetaRecord.kindOf(address), expected, actual);
+		}
+		// chained: continue from the stored tip (== recomputed on match), the basis the writer chained from.
+		return chained ? expected : inboundTip;
+	}
+
+
+
+	/**
+	 * Algorithm-agnostic implementation: holds the policy, a primary {@link Algorithm} (for writes), and
+	 * a registry of all known algorithms keyed by KIND (for verify-time dispatch).
+	 */
+	public final class Default implements StorageChunkChecksumCalculator
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final StorageChunkChecksumPolicy policy          ;
+		private final Algorithm                  primaryAlgorithm;
+		private final Map<Long, Algorithm>       algorithmsByKind;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(
+			final StorageChunkChecksumPolicy policy          ,
+			final Algorithm                  primaryAlgorithm,
+			final Map<Long, Algorithm>       algorithmsByKind
+		)
+		{
+			super();
+			this.policy           = notNull(policy)          ;
+			this.primaryAlgorithm = notNull(primaryAlgorithm);
+			this.algorithmsByKind = notNull(algorithmsByKind);
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		public final StorageChunkChecksumPolicy policy()
+		{
+			return this.policy;
+		}
+
+		@Override
+		public final long chunkChecksumKind()
+		{
+			return this.primaryAlgorithm.kind();
+		}
+
+		@Override
+		public final long fileHeaderRecordLength()
+		{
+			return StorageMetaRecord.LENGTH_FILEHEADERV1;
+		}
+
+		@Override
+		public final long chunkChecksumRecordLength()
+		{
+			return this.primaryAlgorithm.recordLength();
+		}
+
+		@Override
+		public final boolean isWriting()
+		{
+			return this.policy.emit();
+		}
+
+		@Override
+		public final boolean isVerifying()
+		{
+			return this.policy.verify();
+		}
+
+		@Override
+		public final boolean coversChunkWrites(final StorageLiveDataFile.Default headFile)
+		{
+			return this.isWriting() && headFile.chunkChecksumKind() == this.primaryAlgorithm.kind();
+		}
+
+		@Override
+		public final void writeFileHeaderRecord(final ByteBuffer target, final byte[] chainRoot)
+		{
+			StorageMetaRecord.writeFileHeaderV1(
+				target                      ,
+				this.primaryAlgorithm.kind(),
+				chainRoot
+			);
+		}
+
+		@Override
+		public final byte[] nextChainRoot(final StorageLiveDataFile.Default predecessor)
+		{
+			if(!this.primaryAlgorithm.isChained())
+			{
+				// non-chained kinds use an all-zero chain root (fixed 32-byte field in the format).
+				return new byte[StorageMetaRecord.LENGTH_HASH_SHA256];
+			}
+			// chained: continue from the predecessor's tip, or seed the first file from the primary
+			// algorithm's configured initial seed (tip_0).
+			return predecessor != null && predecessor.chainTip() != null
+				? predecessor.chainTip()
+				: this.primaryAlgorithm.initialSeed()
+			;
+		}
+
+		@Override
+		public final void cacheFileHeaderOn(final StorageLiveDataFile.Default file, final byte[] chainRoot)
+		{
+			file.setFileHeaderV1(this.primaryAlgorithm.kind(), chainRoot);
+		}
+
+		@Override
+		public final void writeChunkChecksumRecord(
+			final StorageLiveDataFile.Default file            ,
+			final long                        chunkStartOffset,
+			final ByteBuffer                  target          ,
+			final ByteBuffer...               dataBuffers
+		)
+		{
+			// chunkStartOffset fits an int (files capped at Integer.MAX_VALUE); fail loud, never truncate.
+			final int chunkStart = checkArrayRange(chunkStartOffset);
+			if(this.primaryAlgorithm.isChained())
+			{
+				// fold the file's running tip into this chunk's hash. The newly computed hash is held as the
+				// algorithm's pending tip; the file tip is advanced only by commitChunkWrite(file), once this
+				// write is committed. A write that is never committed (it failed, or was rolled back after a
+				// sibling channel failed) thus leaves the file tip untouched.
+				this.primaryAlgorithm.setChainTip(file.chainTip());
+				this.primaryAlgorithm.writeRecord(target, chunkStart, dataBuffers);
+			}
+			else
+			{
+				this.primaryAlgorithm.writeRecord(target, chunkStart, dataBuffers);
+			}
+		}
+
+		@Override
+		public final void commitChunkWrite(final StorageLiveDataFile.Default file)
+		{
+			// advance the file's running tip to the hash computed by the preceding writeChunkChecksumRecord,
+			// now that the write is committed. No-op for non-chained kinds (no per-file tip).
+			if(this.primaryAlgorithm.isChained())
+			{
+				file.setChainTip(this.primaryAlgorithm.chainTip());
+			}
+		}
+
+		@Override
+		public final void registerMetaRecordHandlers(
+			final StorageMetaRecordRegistry      registry,
+			final StorageChecksumAnomalyReporter reporter
+		)
+		{
+			final StorageMetaRecordHandler fileHeaderHandler    = new FileHeaderV1Handler(reporter);
+			final StorageMetaRecordHandler chunkChecksumHandler = new ChunkChecksumHandler(this.policy, this.algorithmsByKind, reporter);
+
+			registry.register(StorageMetaRecord.KIND_FileHeaderV1, fileHeaderHandler);
+			for(final Long kind : this.algorithmsByKind.keySet())
+			{
+				// One handler instance serves every chunk-checksum KIND; it dispatches the Algorithm by the
+				// record's on-disk KIND at verify time.
+				registry.register(kind, chunkChecksumHandler);
+			}
+		}
+
+		@Override
+		public final void verifyDataFile(
+			final StorageLiveDataFile.Default    file    ,
+			final ByteBuffer                     buffer  ,
+			final StorageChecksumAnomalyReporter reporter
+		)
+		{
+			final long bufferStartAddress = XMemory.getDirectByteBufferAddress(buffer);
+			final long bufferBoundAddress = bufferStartAddress + buffer.limit();
+			final long fileNumber         = file.number();
+
+			// Per-file header state reconstructed from disk into LOCALS (the live file object is never mutated).
+			long    headerKind  = 0L;   // 0 == no FileHeaderV1 parsed (legacy file)
+			byte[]  chainTip    = null; // running chained tip, seeded from the parsed header's chainRoot
+			boolean hasLiveData = false;
+
+			// Start of the current chunk's bytes; advances past the FileHeaderV1 and each covering record.
+			long chunkStart = bufferStartAddress;
+
+			for(long address = bufferStartAddress; address < bufferBoundAddress;)
+			{
+				final long itemLength = Binary.getEntityLengthRawValue(address);
+				if(itemLength > 0)
+				{
+					hasLiveData = true;
+					address += itemLength;
+					continue;
+				}
+				if(itemLength == 0)
+				{
+					throw new StorageExceptionConsistency("Zero length data item.");
+				}
+
+				// negative-length entry: legacy opaque gap, or a structured meta record (mirror the envelope
+				// guard in StorageMetaRecordRegistry.dispatch before reading the marker/KIND).
+				if(address + StorageMetaRecord.OFFSET_PAYLOAD <= bufferBoundAddress
+					&& StorageMetaRecord.isMetaRecord(address))
+				{
+					final long kind = StorageMetaRecord.kindOf(address);
+					if(kind == StorageMetaRecord.KIND_FileHeaderV1)
+					{
+						if(address + StorageMetaRecord.LENGTH_FILEHEADERV1 > bufferBoundAddress)
+						{
+							// truncated header
+							reporter.onUnknownKind(fileNumber, StorageMetaRecord.KIND_FileHeaderV1);
+						}
+						else if(headerKind != 0L)
+						{
+							// second/misplaced header: report, do not re-seed (would rebase every following chunk).
+							reporter.onUnknownKind(fileNumber, StorageMetaRecord.KIND_FileHeaderV1);
+							chunkStart = address + StorageMetaRecord.LENGTH_FILEHEADERV1;
+						}
+						else
+						{
+							final FileHeaderV1Payload header = StorageMetaRecord.readFileHeaderV1(address);
+							headerKind = header.chunkChecksumKind();
+							chainTip   = header.chainRoot(); // seed the running tip; chunks advance it
+							chunkStart = address + StorageMetaRecord.LENGTH_FILEHEADERV1;
+						}
+					}
+					else
+					{
+						final Algorithm verifier = this.algorithmsByKind.get(kind);
+						if(verifier == null || address + verifier.recordLength() > bufferBoundAddress)
+						{
+							// no algorithm for this KIND (drift / corrupt KIND), or truncated record.
+							reporter.onUnknownKind(fileNumber, kind);
+						}
+						else
+						{
+							chainTip   = verifyChunk(fileNumber, buffer, address, chunkStart, verifier, chainTip, reporter);
+							chunkStart = address + verifier.recordLength();
+						}
+					}
+				}
+
+				// advance by the on-disk |LENGTH| regardless (legacy gaps and meta records alike).
+				address -= itemLength;
+			}
+
+			// per-file coverage checks (mirror StorageMetaRecordRegistry.onFileComplete, using the locals).
+			if(headerKind == 0L)
+			{
+				if(hasLiveData)
+				{
+					reporter.onMissingHeader(fileNumber);
+				}
+			}
+			else if(chunkStart - bufferStartAddress < buffer.limit())
+			{
+				reporter.onUncoveredData(fileNumber, chunkStart - bufferStartAddress);
+			}
+			reporter.onFileWalkComplete(fileNumber);
+		}
+
+	}
+
+
+
+	/**
+	 * Per-kind primitive: owns one algorithm's record layout, write logic, compute primitive, and
+	 * stored-checksum reader. Each instance owns its stateful native object ({@link MessageDigest},
+	 * {@link CRC32C}, ...) and is bound to a single channel by virtue of being held by that channel's
+	 * {@link StorageChunkChecksumCalculator}.
+	 * <p>
+	 * Adding a new algorithm = adding a new sibling subclass here, plus a {@link StorageChunkChecksumProvider}
+	 * subclass that produces it as the primary algorithm and registers it in the kind registry.
+	 */
+	public interface Algorithm
+	{
+		/**
+		 * @return the KIND code identifying this algorithm's chunk-checksum record on disk.
+		 */
+		public long kind();
+
+		/**
+		 * @return the byte length of this algorithm's chunk-checksum record.
+		 */
+		public long recordLength();
+
+		/**
+		 * Computes this algorithm's checksum over {@code dataBuffers} and writes the covering
+		 * chunk-checksum meta record into {@code target} at its current position (advances by
+		 * {@link #recordLength()}). The record stores {@code chunkStartOffset} &mdash; the in-file offset
+		 * where the covered chunk begins &mdash; in its shared envelope (see
+		 * {@link StorageMetaRecord#writeChunkChecksumHeader(ByteBuffer, long, long, int)}).
+		 *
+		 * @param target           the meta-record buffer to write into.
+		 * @param chunkStartOffset the in-file offset where the covered chunk's bytes begin.
+		 * @param dataBuffers      the chunk's data buffers (hashed, not advanced).
+		 */
+		public void writeRecord(ByteBuffer target, int chunkStartOffset, ByteBuffer... dataBuffers);
+
+		/**
+		 * Computes this algorithm's checksum over a single chunk slice (verify path).
+		 */
+		public byte[] computeChecksumBytes(ByteBuffer chunk);
+
+		/**
+		 * Reads the stored checksum bytes from a chunk-checksum record at {@code recordAddress}.
+		 */
+		public byte[] readStoredChecksumBytes(long recordAddress);
+
+		/**
+		 * @return whether this algorithm chains: each chunk's hash folds in the previous chunk's hash, so
+		 *         reorder / insert / delete / substitute of chunks is detectable. Non-chained kinds return
+		 *         {@code false} and ignore {@link #setChainTip(byte[])} / {@link #chainTip()}.
+		 */
+		public default boolean isChained()
+		{
+			return false;
+		}
+
+		/**
+		 * Sets the running chain tip (the previous chunk's hash) that the next {@link #writeRecord} /
+		 * {@link #computeChecksumBytes} call folds in. No-op for non-chained kinds.
+		 */
+		public default void setChainTip(final byte[] tip)
+		{
+			// non-chained: ignored
+		}
+
+		/**
+		 * @return the running chain tip as advanced by the last {@link #writeRecord} /
+		 *         {@link #computeChecksumBytes}; {@code null} for non-chained kinds.
+		 */
+		public default byte[] chainTip()
+		{
+			return null;
+		}
+
+		/**
+		 * @return this algorithm's initial chain seed ({@code tip_0}), stamped into the first data file's
+		 *         {@code FileHeaderV1.chainRoot} and folded into that file's first chunk hash. Chained kinds
+		 *         carry a configurable seed; non-chained kinds return an all-zero
+		 *         {@link StorageMetaRecord#LENGTH_HASH_SHA256}-byte array (unused).
+		 */
+		public default byte[] initialSeed()
+		{
+			return new byte[StorageMetaRecord.LENGTH_HASH_SHA256];
+		}
+
+
+
+		/**
+		 * CRC32C algorithm: non-cryptographic integrity checksum, hardware-accelerated, zero-copy on
+		 * direct buffers. Detects accidental corruption; <b>not</b> collision-resistant or tamper-evident.
+		 * Emits {@code ChunkChecksumCRC32CV1} records (16 B).
+		 */
+		public final class Crc32c implements Algorithm
+		{
+			///////////////////////////////////////////////////////////////////////////
+			// constants //
+			//////////////
+
+			/**
+			 * KIND code for the CRC32C chunk-checksum record ({@code ChunkChecksumCRC32CV1}). Pinned
+			 * by test vector: first 2 bytes of {@code SHA-256("EclipseStoreMetaRecord/Kind/ChunkChecksumCRC32CV1")}.
+			 */
+			public static final long KIND = 0x4667L;
+
+			/**
+			 * Total record length in bytes: envelope (12) + chunk start (4) + crc (4) = 20. The CRC is stored
+			 * as a real 4-byte field — meta records are read via unaligned {@code XMemory} loads, so no padding
+			 * for 8-byte alignment is needed.
+			 */
+			public static final int RECORD_LENGTH = 20;
+
+			private static final int OFFSET_CRC = StorageMetaRecord.OFFSET_CC_CHECKSUM;
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// instance fields //
+			////////////////////
+
+			// CRC32C is stateful and requires reset() before each computation.
+			private final CRC32C crc;
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// constructors //
+			/////////////////
+
+			public Crc32c()
+			{
+				super();
+				this.crc = new CRC32C();
+			}
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// static methods //
+			///////////////////
+
+			private static byte[] intToBytes(final int value)
+			{
+				return new byte[]{(byte)(value >>> 24), (byte)(value >>> 16), (byte)(value >>> 8), (byte)value};
+			}
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// declared methods //
+			/////////////////////
+
+			private int compute(final ByteBuffer... buffers)
+			{
+				this.crc.reset();
+				for(final ByteBuffer buffer : buffers)
+				{
+					notNull(buffer);
+					this.crc.update(buffer.duplicate()); // direct-buffer fast path: zero-copy, in place
+				}
+				return (int)this.crc.getValue();
+			}
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// override methods //
+			/////////////////////
+
+			@Override
+			public long kind()
+			{
+				return KIND;
+			}
+
+			@Override
+			public long recordLength()
+			{
+				return RECORD_LENGTH;
+			}
+
+			@Override
+			public byte[] computeChecksumBytes(final ByteBuffer chunk)
+			{
+				notNull(chunk);
+				this.crc.reset();
+				this.crc.update(chunk.duplicate());
+				return intToBytes((int)this.crc.getValue());
+			}
+
+			@Override
+			public byte[] readStoredChecksumBytes(final long recordAddress)
+			{
+				// Byte-order note: the CRC is persisted as a 4-byte int in NATIVE order (writeRecord uses
+				// target.putInt on a native-order direct buffer) and read back via the matching native
+				// get_int, so the round-trip recovers the same int value. intToBytes (big-endian) is applied
+				// to that int value on BOTH the read and compute sides purely to obtain comparable byte[]s —
+				// it does not pin the on-disk layout, which is native-endian. Comparison is self-consistent.
+				return intToBytes(XMemory.get_int(recordAddress + OFFSET_CRC));
+			}
+
+			@Override
+			public void writeRecord(
+				final ByteBuffer    target          ,
+				final int           chunkStartOffset,
+				final ByteBuffer... dataBuffers
+			)
+			{
+				final int crc = this.compute(dataBuffers);
+				StorageMetaRecord.writeChunkChecksumHeader(target, RECORD_LENGTH, KIND, chunkStartOffset);
+				target.putInt(crc);
+			}
+
+		}
+
+
+
+		/**
+		 * Chained SHA-256 algorithm: cryptographic and tamper-evident like {@link Sha256}, but each chunk's
+		 * stored hash folds in the previous chunk's hash &mdash; {@code tip_i = SHA-256(tip_{i-1} || chunk_i)},
+		 * seeded by the file's {@code FileHeaderV1.chainRoot} ({@code tip_0}). Altering any chunk invalidates
+		 * that chunk and every chunk after it, so reordering, insertion, deletion or substitution of chunks is
+		 * detectable &mdash; not just bit-rot of a single chunk. Emits {@code ChunkChecksumChainedV1} records
+		 * (44 B; same envelope+hash layout as {@code ChunkChecksumV1}, distinguished purely by KIND).
+		 * <p>
+		 * <b>Chaining is SHA-256 only.</b> A chained CRC32C is forgeable (CRC is linear and not
+		 * collision-resistant), so it would provide no tamper-evidence while adding nothing for accidental
+		 * corruption; only this cryptographic variant backs the chained provider.
+		 * <p>
+		 * The running tip is held here as a scratch register: the per-channel
+		 * {@link StorageChunkChecksumCalculator} sets it from the authoritative per-file tip
+		 * ({@link StorageLiveDataFile.Default#chainTip()}) immediately before each call and reads it back
+		 * afterwards, so this instance carries no cross-file state of its own.
+		 */
+		public final class Sha256Chained implements Algorithm
+		{
+			///////////////////////////////////////////////////////////////////////////
+			// constants //
+			//////////////
+
+			/**
+			 * KIND code for the chained SHA-256 chunk-checksum record ({@code ChunkChecksumChainedV1}).
+			 * Pinned by test vector: first 2 bytes of
+			 * {@code SHA-256("EclipseStoreMetaRecord/Kind/ChunkChecksumChainedV1")} = {@code 0x56ba}.
+			 */
+			public static final long KIND = 0x56baL;
+
+			/** Total record length in bytes: envelope (12) + chunk start (4) + hash (32) = 48. */
+			public static final int RECORD_LENGTH = 48;
+
+			private static final int OFFSET_HASH = StorageMetaRecord.OFFSET_CC_CHECKSUM;
+			private static final int HASH_LENGTH = 32;
+
+			private static final String ALGORITHM = "SHA-256";
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// instance fields //
+			////////////////////
+
+			// MessageDigest.digest() auto-resets the instance for the next computation.
+			private final MessageDigest digest;
+
+			// tip_0: the configured initial chain seed, stamped into the first file's FileHeaderV1.chainRoot.
+			private final byte[] initialSeed;
+
+			// Scratch register for the running tip; set/read by the calculator around each use.
+			private byte[] tip;
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// constructors //
+			/////////////////
+
+			public Sha256Chained()
+			{
+				this(null);
+			}
+
+			public Sha256Chained(final byte[] initialSeed)
+			{
+				super();
+				this.initialSeed = validateSeed(initialSeed);
+				this.digest      = newDigest();
+				this.tip         = this.initialSeed.clone(); // running tip starts at the seed; calculator re-sets it per file
+			}
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// static methods //
+			///////////////////
+
+			private static byte[] validateSeed(final byte[] seed)
+			{
+				if(seed == null)
+				{
+					return new byte[HASH_LENGTH];
+				}
+				if(seed.length != HASH_LENGTH)
+				{
+					throw new IllegalArgumentException(
+						"Chain seed must be " + HASH_LENGTH + " bytes, got " + seed.length
+					);
+				}
+				return seed.clone();
+			}
+
+			private static MessageDigest newDigest()
+			{
+				try
+				{
+					return MessageDigest.getInstance(ALGORITHM);
+				}
+				catch(final NoSuchAlgorithmException e)
+				{
+					// SHA-256 is mandated by every conforming JRE; this should never happen.
+					throw new WrapperRuntimeException(e);
+				}
+			}
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// override methods //
+			/////////////////////
+
+			@Override
+			public boolean isChained()
+			{
+				return true;
+			}
+
+			@Override
+			public byte[] initialSeed()
+			{
+				return this.initialSeed.clone();
+			}
+
+			@Override
+			public void setChainTip(final byte[] tip)
+			{
+				this.tip = tip;
+			}
+
+			@Override
+			public byte[] chainTip()
+			{
+				return this.tip;
+			}
+
+			@Override
+			public long kind()
+			{
+				return KIND;
+			}
+
+			@Override
+			public long recordLength()
+			{
+				return RECORD_LENGTH;
+			}
+
+			@Override
+			public byte[] computeChecksumBytes(final ByteBuffer chunk)
+			{
+				notNull(chunk);
+				this.digest.update(this.tip);          // fold in the previous tip
+				this.digest.update(chunk.duplicate());
+				return this.tip = this.digest.digest();// advance and return the new tip
+			}
+
+			@Override
+			public byte[] readStoredChecksumBytes(final long recordAddress)
+			{
+				final byte[] hash = new byte[HASH_LENGTH];
+				XMemory.copyRangeToArray(recordAddress + OFFSET_HASH, hash);
+				return hash;
+			}
+
+			@Override
+			public void writeRecord(
+				final ByteBuffer    target          ,
+				final int           chunkStartOffset,
+				final ByteBuffer... dataBuffers
+			)
+			{
+				this.digest.update(this.tip);          // fold in the previous tip
+				for(final ByteBuffer buffer : dataBuffers)
+				{
+					notNull(buffer);
+					this.digest.update(buffer.duplicate());
+				}
+				final byte[] hash = this.digest.digest();
+				this.tip = hash;                       // advance the tip to this chunk's hash
+				StorageMetaRecord.writeChunkChecksumHeader(target, RECORD_LENGTH, KIND, chunkStartOffset);
+				target.put(hash);
+			}
+
+		}
+
+
+
+		/**
+		 * No-op algorithm representing "no checksum". It emits and verifies nothing; the only sanctioned use
+		 * is as the primary of a {@link StorageChunkChecksumProvider#NewNone() None provider}, which pairs it
+		 * with an off policy ({@link StorageChunkChecksumPolicy#NewOff()}) so neither the write nor the verify
+		 * path ever invokes it. Its compute/write/read methods therefore throw: being asked to produce or check
+		 * a checksum means this algorithm was paired with an emitting/verifying policy by mistake.
+		 * <p>
+		 * Its {@link #kind()} is a reserved <b>non-zero</b> sentinel ({@code 0x0001}), never written to disk.
+		 * It must never be {@code 0}: kind {@code 0} is the on-disk marker for a legacy/pre-feature file, so a
+		 * kind-0 primary would alias every legacy head file as "covered" by
+		 * {@link StorageChunkChecksumCalculator#coversChunkWrites(StorageLiveDataFile.Default)}.
+		 */
+		public final class None implements Algorithm
+		{
+			///////////////////////////////////////////////////////////////////////////
+			// constants //
+			//////////////
+
+			/** Reserved, non-zero KIND for the no-op "no checksum" algorithm; never written to disk. */
+			public static final long KIND = 0x0001L;
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// constructors //
+			/////////////////
+
+			public None()
+			{
+				super();
+			}
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// override methods //
+			/////////////////////
+
+			@Override
+			public long kind()
+			{
+				return KIND;
+			}
+
+			@Override
+			public long recordLength()
+			{
+				return 0L; // emits no record
+			}
+
+			@Override
+			public void writeRecord(final ByteBuffer target, final int chunkStartOffset, final ByteBuffer... dataBuffers)
+			{
+				throw new UnsupportedOperationException(
+					"No-checksum algorithm cannot write a checksum record. Use a writing algorithm, or pair "
+					+ "this one with an off policy (see StorageChunkChecksumProvider.NewNone())."
+				);
+			}
+
+			@Override
+			public byte[] computeChecksumBytes(final ByteBuffer chunk)
+			{
+				throw new UnsupportedOperationException(
+					"No-checksum algorithm cannot compute a checksum. Use a verifying algorithm, or pair "
+					+ "this one with an off policy (see StorageChunkChecksumProvider.NewNone())."
+				);
+			}
+
+			@Override
+			public byte[] readStoredChecksumBytes(final long recordAddress)
+			{
+				throw new UnsupportedOperationException(
+					"No-checksum algorithm has no stored checksum to read."
+				);
+			}
+
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumPolicy.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumPolicy.java
@@ -1,0 +1,372 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.eclipse.serializer.util.X.notNull;
+
+import org.eclipse.serializer.typing.Immutable;
+
+/**
+ * Policy governing the per-chunk checksum meta records. Two orthogonal capability axes &mdash; {@link #emit()}
+ * (write {@code FileHeaderV1} / chunk-checksum records) and {@link #verify()} (recompute and check on load)
+ * &mdash; plus one uniform {@link Reaction} per load-time {@link Anomaly}, and two coverage options
+ * ({@link #requireCoverage()}, {@link #continuousCoverage()}).
+ * <p>
+ * Every load-time anomaly (a checksum mismatch, a chunk-boundary mismatch, an unrecognized record kind, a
+ * missing file header, uncovered data) is an {@link Anomaly} answered by a {@link Reaction}: {@code IGNORE}
+ * (skip silently), {@code LOG} (warn and
+ * continue) or {@code FAIL} (throw and abort the load). Reactions are consulted <b>only when {@link #verify()}
+ * is true</b> &mdash; "not verifying" reacts to nothing, so an off policy cannot surprise.
+ * <p>
+ * Pick a profile rather than assembling the axes by hand:
+ * <ul>
+ *   <li>{@link #New()} &mdash; lenient default: emit + verify, {@code FAIL} on corruption, everything else
+ *       {@code IGNORE} (forward-compatible).</li>
+ *   <li>{@link #NewOff()} &mdash; emit nothing, verify nothing; files indistinguishable from a pre-feature
+ *       engine.</li>
+ *   <li>{@link #NewObserve()} &mdash; emit + verify, all anomalies {@code LOG}; learns about every anomaly via
+ *       logs without ever refusing to start.</li>
+ *   <li>{@link #NewStrict()} &mdash; emit + verify, all anomalies {@code FAIL}, full coverage required;
+ *       zero-tolerance, for a fully-migrated store.</li>
+ *   <li>{@link #NewStrictTolerateLegacy()} &mdash; like {@link #NewStrict()} but pre-existing legacy coverage
+ *       gaps are {@code LOG}ged, not fatal; the migrating-to-strict profile.</li>
+ *   <li>{@link #NewCustom(boolean, boolean, Reaction, Reaction, Reaction, Reaction, boolean, boolean)} &mdash;
+ *       full control, with fail-early validation.</li>
+ * </ul>
+ * The hash algorithm and the emitted chunk-checksum KIND live on {@link StorageChunkChecksumProvider} (which
+ * carries a policy), not on this value object.
+ *
+ * @see #New()
+ * @see Anomaly
+ * @see Reaction
+ */
+public interface StorageChunkChecksumPolicy
+{
+	/**
+	 * @return whether to emit {@code FileHeaderV1} and chunk-checksum records on write.
+	 */
+	public boolean emit();
+
+	/**
+	 * @return whether to recompute and check chunk-checksum records on load.
+	 */
+	public boolean verify();
+
+	/**
+	 * @return whether the load walk treats a whole unprotected file ({@link Anomaly#MISSING_HEADER}, a legacy
+	 *         file with no {@code FileHeaderV1}) as an anomaly. Only meaningful when {@link #verify()} is true.
+	 *         Does <b>not</b> gate {@link Anomaly#UNCOVERED_DATA}: an uncovered tail on a covered file is
+	 *         corruption, raised whenever {@link #verify()} is true.
+	 */
+	public boolean requireCoverage();
+
+	/**
+	 * @return whether enabling emit forces a fresh, covered head file at init so new writes are protected
+	 *         immediately instead of after the next rollover. Only meaningful when {@link #emit()} is true.
+	 */
+	public boolean continuousCoverage();
+
+	/**
+	 * The reaction to a given load-time {@link Anomaly}. Consulted only when {@link #verify()} is true (and,
+	 * for {@link Anomaly#MISSING_HEADER}, only when {@link #requireCoverage()} is also true).
+	 *
+	 * @param anomaly the anomaly category; must be non-{@code null}.
+	 * @return the configured {@link Reaction}.
+	 */
+	public Reaction reactionTo(Anomaly anomaly);
+
+
+
+	/**
+	 * The load-time anomaly categories a chunk-checksum walk can encounter.
+	 */
+	public enum Anomaly
+	{
+		/** A recomputed checksum did not match the stored one &mdash; corruption or tampering. */
+		CHECKSUM_MISMATCH,
+		/** A covering record's stored chunk start disagreed with the boundary the load walk reconstructed: a
+		 *  framing desync (a corrupted entity LENGTH rerouted the walk past a record), not content bit-rot. */
+		CHUNK_BOUNDARY_MISMATCH,
+		/** A meta-record KIND with no registered handler (a removed or future record kind). */
+		UNKNOWN_KIND,
+		/** A file carries live data but no {@code FileHeaderV1} while coverage was expected (legacy file). */
+		MISSING_HEADER,
+		/** A covered file holds live content past its last covering record. A covered file always ends at a
+		 *  covering record after recovery, so this is corruption (typically an overshoot of the final record to
+		 *  EOF). Raised whenever verifying (not gated by requireCoverage). */
+		UNCOVERED_DATA
+	}
+
+	/**
+	 * What to do when an {@link Anomaly} is encountered on load.
+	 */
+	public enum Reaction
+	{
+		/** Skip silently, no trace. */
+		IGNORE,
+		/** Log (warn) and continue; deduped per file + kind by the reporter. */
+		LOG,
+		/** Throw and abort the load on the first occurrence. */
+		FAIL
+	}
+
+
+
+	/**
+	 * @return the framework-default (lenient) policy: emit + verify, {@code FAIL} on the corruption-class
+	 *         anomalies (checksum mismatch, chunk-boundary mismatch, uncovered tail), {@code IGNORE} the
+	 *         forward-compatible ones (unknown kinds and legacy files / missing headers are tolerated).
+	 */
+	public static StorageChunkChecksumPolicy New()
+	{
+		return NewCustom(
+			true, true, Reaction.FAIL, Reaction.FAIL, Reaction.IGNORE, Reaction.IGNORE, Reaction.FAIL, false, false
+		);
+	}
+
+	/**
+	 * @return a "no checksum" policy: emit nothing, verify nothing; data files are indistinguishable from
+	 *         those of a pre-feature engine.
+	 */
+	public static StorageChunkChecksumPolicy NewOff()
+	{
+		return NewCustom(
+			false, false,
+			Reaction.IGNORE, Reaction.IGNORE, Reaction.IGNORE, Reaction.IGNORE, Reaction.IGNORE,
+			false, false
+		);
+	}
+
+	/**
+	 * @return an audit policy: emit + verify, every anomaly {@code LOG} (never {@code FAIL}); learns about
+	 *         corruption / unknown kinds / coverage gaps via logs without risking a store that won't start.
+	 */
+	public static StorageChunkChecksumPolicy NewObserve()
+	{
+		return NewCustom(
+			true, true, Reaction.LOG, Reaction.LOG, Reaction.LOG, Reaction.LOG, Reaction.LOG, true, false
+		);
+	}
+
+	/**
+	 * @return a zero-tolerance policy: emit + verify, every anomaly {@code FAIL}, full coverage required and
+	 *         continuous. Use once a store is fully migrated to assert total coverage.
+	 */
+	public static StorageChunkChecksumPolicy NewStrict()
+	{
+		return NewCustom(
+			true, true, Reaction.FAIL, Reaction.FAIL, Reaction.FAIL, Reaction.FAIL, Reaction.FAIL, true, true
+		);
+	}
+
+	/**
+	 * @return a strict policy that tolerates pre-existing legacy files: {@code FAIL} on corruption
+	 *         ({@link Anomaly#CHECKSUM_MISMATCH}) and unknown kinds ({@link Anomaly#UNKNOWN_KIND}), but
+	 *         {@code LOG} (not fail) on coverage gaps ({@link Anomaly#MISSING_HEADER} /
+	 *         {@link Anomaly#UNCOVERED_DATA}). With {@link #continuousCoverage()} on, new writes are still
+	 *         fully covered &mdash; the migrating-to-strict profile.
+	 */
+	public static StorageChunkChecksumPolicy NewStrictTolerateLegacy()
+	{
+		return NewCustom(
+			true, true, Reaction.FAIL, Reaction.FAIL, Reaction.FAIL, Reaction.LOG, Reaction.LOG, true, true
+		);
+	}
+
+	/**
+	 * Creates a fully specified policy, with fail-early validation: no constructed policy may carry dead or
+	 * contradictory configuration.
+	 * <ul>
+	 *   <li>if {@code verify} is false, every reaction must be {@code IGNORE} (a reaction is gated behind
+	 *       verify, so a non-{@code IGNORE} reaction could never fire);</li>
+	 *   <li>{@code requireCoverage} requires {@code verify};</li>
+	 *   <li>{@code continuousCoverage} requires {@code emit}.</li>
+	 * </ul>
+	 *
+	 * @param emit                     whether to write checksum records.
+	 * @param verify                   whether to recompute and check on load.
+	 * @param onChecksumMismatch       reaction to a checksum mismatch; must be non-{@code null}.
+	 * @param onChunkBoundaryMismatch  reaction to a chunk-boundary mismatch (framing desync); must be non-{@code null}.
+	 * @param onUnknownKind            reaction to an unknown record KIND; must be non-{@code null}.
+	 * @param onMissingHeader          reaction to a missing file header; must be non-{@code null}.
+	 * @param onUncoveredData          reaction to uncovered data; must be non-{@code null}.
+	 * @param requireCoverage          whether missing/uncovered are raised as anomalies.
+	 * @param continuousCoverage       whether enabling emit forces an immediately-covered head file.
+	 * @return a new {@link StorageChunkChecksumPolicy}.
+	 * @throws IllegalArgumentException on a dead or contradictory combination (see above).
+	 */
+	public static StorageChunkChecksumPolicy NewCustom(
+		final boolean  emit                    ,
+		final boolean  verify                  ,
+		final Reaction onChecksumMismatch      ,
+		final Reaction onChunkBoundaryMismatch ,
+		final Reaction onUnknownKind           ,
+		final Reaction onMissingHeader         ,
+		final Reaction onUncoveredData         ,
+		final boolean  requireCoverage         ,
+		final boolean  continuousCoverage
+	)
+	{
+		notNull(onChecksumMismatch)     ;
+		notNull(onChunkBoundaryMismatch);
+		notNull(onUnknownKind)          ;
+		notNull(onMissingHeader)        ;
+		notNull(onUncoveredData)        ;
+
+		// no dead reactions: a reaction that can never fire is a configuration error, not a silent no-op.
+		if(!verify && (onChecksumMismatch      != Reaction.IGNORE
+			||         onChunkBoundaryMismatch != Reaction.IGNORE
+			||         onUnknownKind           != Reaction.IGNORE
+			||         onMissingHeader         != Reaction.IGNORE
+			||         onUncoveredData         != Reaction.IGNORE))
+		{
+			throw new IllegalArgumentException(
+				"verify=false requires every reaction to be IGNORE (reactions are gated behind verify); "
+				+ "use NewOff() or enable verify."
+			);
+		}
+		if(requireCoverage && !verify)
+		{
+			throw new IllegalArgumentException("requireCoverage requires verify.");
+		}
+		if(continuousCoverage && !emit)
+		{
+			throw new IllegalArgumentException("continuousCoverage requires emit.");
+		}
+
+		return new Default(
+			emit                    ,
+			verify                  ,
+			onChecksumMismatch      ,
+			onChunkBoundaryMismatch ,
+			onUnknownKind           ,
+			onMissingHeader         ,
+			onUncoveredData         ,
+			requireCoverage         ,
+			continuousCoverage
+		);
+	}
+
+
+
+	public final class Default implements StorageChunkChecksumPolicy, Immutable
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final boolean  emit                    ;
+		private final boolean  verify                  ;
+		private final Reaction onChecksumMismatch      ;
+		private final Reaction onChunkBoundaryMismatch ;
+		private final Reaction onUnknownKind           ;
+		private final Reaction onMissingHeader         ;
+		private final Reaction onUncoveredData         ;
+		private final boolean  requireCoverage         ;
+		private final boolean  continuousCoverage      ;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(
+			final boolean  emit                    ,
+			final boolean  verify                  ,
+			final Reaction onChecksumMismatch      ,
+			final Reaction onChunkBoundaryMismatch ,
+			final Reaction onUnknownKind           ,
+			final Reaction onMissingHeader         ,
+			final Reaction onUncoveredData         ,
+			final boolean  requireCoverage         ,
+			final boolean  continuousCoverage
+		)
+		{
+			super();
+			this.emit                    = emit                   ;
+			this.verify                  = verify                 ;
+			this.onChecksumMismatch      = onChecksumMismatch     ;
+			this.onChunkBoundaryMismatch = onChunkBoundaryMismatch;
+			this.onUnknownKind           = onUnknownKind          ;
+			this.onMissingHeader         = onMissingHeader        ;
+			this.onUncoveredData         = onUncoveredData        ;
+			this.requireCoverage         = requireCoverage        ;
+			this.continuousCoverage      = continuousCoverage     ;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// methods //
+		////////////
+
+		@Override
+		public boolean emit()
+		{
+			return this.emit;
+		}
+
+		@Override
+		public boolean verify()
+		{
+			return this.verify;
+		}
+
+		@Override
+		public boolean requireCoverage()
+		{
+			return this.requireCoverage;
+		}
+
+		@Override
+		public boolean continuousCoverage()
+		{
+			return this.continuousCoverage;
+		}
+
+		@Override
+		public Reaction reactionTo(final Anomaly anomaly)
+		{
+			switch(notNull(anomaly))
+			{
+				case CHECKSUM_MISMATCH:       return this.onChecksumMismatch     ;
+				case CHUNK_BOUNDARY_MISMATCH: return this.onChunkBoundaryMismatch;
+				case UNKNOWN_KIND:            return this.onUnknownKind          ;
+				case MISSING_HEADER:          return this.onMissingHeader        ;
+				case UNCOVERED_DATA:          return this.onUncoveredData        ;
+				default: throw new IllegalArgumentException("Unhandled anomaly: " + anomaly);
+			}
+		}
+
+		@Override
+		public String toString()
+		{
+			return this.getClass().getName()
+				+ " [emit=" + this.emit
+				+ ", verify=" + this.verify
+				+ ", onChecksumMismatch=" + this.onChecksumMismatch
+				+ ", onChunkBoundaryMismatch=" + this.onChunkBoundaryMismatch
+				+ ", onUnknownKind=" + this.onUnknownKind
+				+ ", onMissingHeader=" + this.onMissingHeader
+				+ ", onUncoveredData=" + this.onUncoveredData
+				+ ", requireCoverage=" + this.requireCoverage
+				+ ", continuousCoverage=" + this.continuousCoverage + "]"
+			;
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumProvider.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumProvider.java
@@ -1,0 +1,398 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.eclipse.serializer.util.X.notNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.eclipse.serializer.typing.Immutable;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+
+/**
+ * Per-storage strategy part choosing the primary chunk-checksum algorithm (the one used for writes) and the
+ * policy, and serving as a factory for per-channel {@link StorageChunkChecksumCalculator} instances.
+ * Configured on the storage via {@link StorageConfiguration} / the storage foundation; defaults to no checksum
+ * ({@link #NewNone()}) when not set.
+ * <p>
+ * The algorithm is the swappable axis, supplied as a factory ({@link Supplier}) to the {@code New(...)}
+ * methods &mdash; it is not hard-coded. The <i>primary</i> is used for writes; alongside it a set of
+ * <i>additional</i> algorithms forms the verify-dispatch universe, so a store written by one algorithm still
+ * verifies after the configured primary changes between runs. The additional set defaults to
+ * {@link #DefaultAlgorithms()} (CRC32C, chained SHA-256). The available built-in algorithms are
+ * {@link StorageChunkChecksumCalculator.Algorithm} implementations:
+ * <ul>
+ *   <li>{@link StorageChunkChecksumCalculator.Algorithm.Crc32c} &mdash; non-cryptographic integrity checksum:
+ *       hardware-accelerated, zero-copy on direct buffers; detects accidental corruption but is <i>not</i>
+ *       tamper-evident.</li>
+ *   <li>{@link StorageChunkChecksumCalculator.Algorithm.Sha256Chained} &mdash; cryptographic, tamper-evident
+ *       chained SHA-256 (each chunk's hash folds in the previous chunk's), carrying a configurable initial
+ *       seed.</li>
+ *   <li>{@link StorageChunkChecksumCalculator.Algorithm.None} &mdash; no-op "no checksum"; only valid as the
+ *       primary of a {@link #NewNone()} provider (which forces an off policy, {@link StorageChunkChecksumPolicy#NewOff()}).</li>
+ * </ul>
+ * A custom algorithm is a further {@link StorageChunkChecksumCalculator.Algorithm} implementation, passed as
+ * the primary (e.g. {@code New(MyAlgorithm::new)}) and/or among the additional algorithms.
+ * <p>
+ * Each channel receives its own calculator via {@link #createCalculator()}; the stateful native algorithm
+ * objects live as plain instance fields on that calculator's algorithms &mdash; no shared state, no
+ * thread-safety hacks. That is why algorithms are supplied as factories: each calculator instantiates its
+ * own fresh set.
+ *
+ * @see #New()
+ * @see #DefaultAlgorithms()
+ * @see StorageChunkChecksumCalculator
+ * @see StorageChunkChecksumPolicy
+ */
+public interface StorageChunkChecksumProvider
+{
+	/**
+	 * @return the {@link StorageChunkChecksumPolicy} governing the mode and strictness knobs.
+	 */
+	public StorageChunkChecksumPolicy policy();
+
+	/**
+	 * The KIND code of the chunk-checksum records this provider's calculators emit on writes (the primary
+	 * algorithm's kind).
+	 *
+	 * @return the chunk-checksum KIND code of the primary algorithm.
+	 */
+	public long chunkChecksumKind();
+
+	/**
+	 * Creates a fresh {@link StorageChunkChecksumCalculator} for one storage channel. Each calculator owns its
+	 * own algorithm instances (and therefore its own {@code MessageDigest} / {@code CRC32C} native objects), so
+	 * multiple channels can call their calculators concurrently without sharing state.
+	 *
+	 * @return a new per-channel calculator.
+	 */
+	public StorageChunkChecksumCalculator createCalculator();
+
+	/**
+	 * Creates a fresh instance of this provider's <i>primary</i> (write)
+	 * {@link StorageChunkChecksumCalculator.Algorithm} &mdash; the one whose
+	 * {@link StorageChunkChecksumCalculator.Algorithm#kind() kind} equals {@link #chunkChecksumKind()}.
+	 * Intended for <b>off-line</b> repair tooling (e.g. {@code StorageObjectRestorer}) that emits a
+	 * {@code FileHeaderV1} + covering record without a running engine, composing the algorithm's file-free
+	 * primitives with {@link StorageMetaRecord#writeFileHeaderV1(java.nio.ByteBuffer, long, byte[])}. The
+	 * returned instance is stateful (native digest / running chain tip) and must not be shared across threads.
+	 *
+	 * @return a fresh primary algorithm instance.
+	 */
+	public StorageChunkChecksumCalculator.Algorithm createPrimaryAlgorithm();
+
+	/**
+	 * Creates the full verify-dispatch universe as a fresh map of KIND code to
+	 * {@link StorageChunkChecksumCalculator.Algorithm} &mdash; the primary plus the additional verify-only
+	 * algorithms, keyed by {@link StorageChunkChecksumCalculator.Algorithm#kind() kind} (the primary winning
+	 * any KIND collision). The read-side counterpart to {@link #createPrimaryAlgorithm()}, for <b>off-line</b>
+	 * tooling (e.g. the storage converter) that verifies existing records without a running engine. Using this
+	 * rather than the static {@link #DefaultAlgorithms()} keeps a provider's <i>custom</i> verify algorithms
+	 * reachable, so an unrecognized on-disk KIND is correctly an unknown-KIND anomaly rather than a silent gap.
+	 * <p>
+	 * The returned instances are stateful (native digest / running chain tip) and must not be shared across
+	 * threads; a fresh map of fresh instances is returned on each call.
+	 *
+	 * @return a fresh KIND &rarr; algorithm map covering every algorithm this provider knows.
+	 */
+	public Map<Long, StorageChunkChecksumCalculator.Algorithm> createAlgorithmsByKind();
+
+
+
+	/**
+	 * @return the framework-default provider: <b>no checksum</b> &mdash; the
+	 *         {@link StorageChunkChecksumCalculator.Algorithm.None None} algorithm paired with an off policy, so
+	 *         nothing is emitted or verified and data files stay indistinguishable from a pre-feature engine.
+	 *         Identical to {@link #NewNone()}; opt in to protection with {@link #NewSha256Chained()},
+	 *         {@link #NewCrc32c()} or a {@link #New(Supplier) custom primary}.
+	 */
+	public static StorageChunkChecksumProvider New()
+	{
+		return NewNone();
+	}
+
+	/**
+	 * Creates a provider with the given primary algorithm, the default {@link StorageChunkChecksumPolicy} and
+	 * the {@link #DefaultAlgorithms() built-in} verify set. The primary is the algorithm used for writes; its
+	 * {@link StorageChunkChecksumCalculator.Algorithm#kind() kind} becomes this provider's
+	 * {@link #chunkChecksumKind()}.
+	 *
+	 * @param primary fresh-instance supplier of the primary (write) algorithm; must be non-{@code null}.
+	 * @return a new {@link StorageChunkChecksumProvider} with the given primary.
+	 */
+	public static StorageChunkChecksumProvider New(
+		final Supplier<StorageChunkChecksumCalculator.Algorithm> primary
+	)
+	{
+		return New(StorageChunkChecksumPolicy.New(), primary, StorageChunkChecksumProvider::DefaultAlgorithms);
+	}
+
+	/**
+	 * Creates a fully specified provider.
+	 * <p>
+	 * The {@code primary} algorithm is used for writes; {@code additionalAlgorithms} supplies the remaining
+	 * verify-dispatch universe (so files written by other kinds still verify). Both are suppliers because the
+	 * algorithms own stateful native objects and must be instantiated fresh per channel. Pass
+	 * {@link #DefaultAlgorithms()} as {@code additionalAlgorithms} to retain the built-ins (recommended, so
+	 * existing SHA-256 / CRC32C / chained stores remain verifiable).
+	 *
+	 * @param policy               the mode/strictness knobs; must be non-{@code null}.
+	 * @param primary              fresh-instance supplier of the primary (write) algorithm; must be non-{@code null}.
+	 * @param additionalAlgorithms fresh-instance supplier of the additional verify-only algorithms; must be
+	 *                             non-{@code null} (use {@link #DefaultAlgorithms()} for the built-ins).
+	 * @return a new {@link StorageChunkChecksumProvider}.
+	 */
+	public static StorageChunkChecksumProvider New(
+		final StorageChunkChecksumPolicy                               policy              ,
+		final Supplier<StorageChunkChecksumCalculator.Algorithm>       primary             ,
+		final Supplier<List<StorageChunkChecksumCalculator.Algorithm>> additionalAlgorithms
+	)
+	{
+		return new Default(notNull(policy), notNull(primary), notNull(additionalAlgorithms));
+	}
+
+	/**
+	 * Creates a {@link StorageChunkChecksumCalculator.Algorithm.Crc32c CRC32C} primary provider with the
+	 * default {@link StorageChunkChecksumPolicy}. CRC32C detects accidental corruption with a zero-copy,
+	 * hardware-accelerated checksum but is <i>not</i> tamper-evident.
+	 *
+	 * @return a new CRC32C {@link StorageChunkChecksumProvider}.
+	 */
+	public static StorageChunkChecksumProvider NewCrc32c()
+	{
+		return New(StorageChunkChecksumCalculator.Algorithm.Crc32c::new);
+	}
+
+	/**
+	 * Creates a {@link StorageChunkChecksumCalculator.Algorithm.Crc32c CRC32C} primary provider governed by the
+	 * given policy.
+	 *
+	 * @param policy the mode/strictness knobs; must be non-{@code null}.
+	 * @return a new CRC32C {@link StorageChunkChecksumProvider}.
+	 */
+	public static StorageChunkChecksumProvider NewCrc32c(final StorageChunkChecksumPolicy policy)
+	{
+		return New(
+			policy                                              ,
+			StorageChunkChecksumCalculator.Algorithm.Crc32c::new,
+			StorageChunkChecksumProvider::DefaultAlgorithms
+		);
+	}
+
+	/**
+	 * Creates a chained-SHA-256 primary provider with the default {@link StorageChunkChecksumPolicy} and an
+	 * all-zero initial chain seed. Each chunk's hash folds in the previous chunk's hash, so chunk reordering,
+	 * insertion, deletion or substitution is detectable &mdash; not just single-chunk bit-rot. See
+	 * {@link StorageChunkChecksumCalculator.Algorithm.Sha256Chained}.
+	 *
+	 * @return a new chained-SHA-256 {@link StorageChunkChecksumProvider}.
+	 */
+	public static StorageChunkChecksumProvider NewSha256Chained()
+	{
+		return NewSha256Chained(StorageChunkChecksumPolicy.New(), null);
+	}
+
+	/**
+	 * Creates a chained-SHA-256 primary provider governed by the given policy, with an all-zero initial chain seed.
+	 *
+	 * @param policy the mode/strictness knobs; must be non-{@code null}.
+	 * @return a new chained-SHA-256 {@link StorageChunkChecksumProvider}.
+	 */
+	public static StorageChunkChecksumProvider NewSha256Chained(final StorageChunkChecksumPolicy policy)
+	{
+		return NewSha256Chained(policy, null);
+	}
+
+	/**
+	 * Creates a chained-SHA-256 primary provider governed by the given policy with a configurable initial chain
+	 * seed. The seed is {@code tip_0}: it is stamped into the very first data file's {@code FileHeaderV1.chainRoot}
+	 * and folded into that file's first chunk hash. (For tamper-evidence the <i>final</i> tip must be anchored
+	 * externally &mdash; an attacker with full disk access can otherwise recompute the whole chain regardless of
+	 * the seed; the seed alone does not provide that.)
+	 * <p>
+	 * Convenience for {@code New(policy, () -> new Sha256Chained(initialSeed), DefaultAlgorithms())}; the seed
+	 * lives on the {@link StorageChunkChecksumCalculator.Algorithm.Sha256Chained} algorithm itself.
+	 *
+	 * @param policy      the mode/strictness knobs; must be non-{@code null}.
+	 * @param initialSeed the chain seed; must be {@link StorageMetaRecord#LENGTH_HASH_SHA256} bytes, or
+	 *                    {@code null} for the default all-zero seed. Defensively copied by the algorithm.
+	 * @return a new chained-SHA-256 {@link StorageChunkChecksumProvider}.
+	 */
+	public static StorageChunkChecksumProvider NewSha256Chained(
+		final StorageChunkChecksumPolicy policy     ,
+		final byte[]                     initialSeed
+	)
+	{
+		return New(
+			policy                                                                       ,
+			() -> new StorageChunkChecksumCalculator.Algorithm.Sha256Chained(initialSeed),
+			StorageChunkChecksumProvider::DefaultAlgorithms
+		);
+	}
+
+	/**
+	 * Creates a "no checksum" provider: the {@link StorageChunkChecksumCalculator.Algorithm.None None}
+	 * algorithm paired with an off policy ({@link StorageChunkChecksumPolicy#NewOff()}). It writes and verifies
+	 * nothing, producing data files indistinguishable from those of a pre-feature engine.
+	 * <p>
+	 * Express "no checksum" this way, <b>not</b> by passing a kind-0 primary algorithm: kind {@code 0} is the
+	 * reserved legacy-file sentinel. The built-in verify set is still supplied, so an <i>existing</i>
+	 * SHA-256 / CRC32C / chained store opened with this provider has its meta records recognized (and skipped
+	 * without verification) rather than treated as unknown KINDs.
+	 *
+	 * @return a new no-checksum {@link StorageChunkChecksumProvider}.
+	 */
+	public static StorageChunkChecksumProvider NewNone()
+	{
+		return New(
+			StorageChunkChecksumPolicy.NewOff()               ,
+			StorageChunkChecksumCalculator.Algorithm.None::new,
+			StorageChunkChecksumProvider::DefaultAlgorithms
+		);
+	}
+
+	/**
+	 * The built-in chunk-checksum algorithms forming the default verify-dispatch universe: CRC32C and chained
+	 * SHA-256 (with the default all-zero seed). Use this when supplying a custom primary while keeping
+	 * the built-ins verifiable, or compose with extra algorithms.
+	 * <p>
+	 * Returns fresh instances on each call &mdash; the algorithms own stateful native objects and must not be
+	 * shared across channels.
+	 *
+	 * @return a new list of the default algorithm instances.
+	 */
+	public static List<StorageChunkChecksumCalculator.Algorithm> DefaultAlgorithms()
+	{
+		return List.of(
+			new StorageChunkChecksumCalculator.Algorithm.Crc32c()       ,
+			new StorageChunkChecksumCalculator.Algorithm.Sha256Chained()
+		);
+	}
+
+
+
+	/**
+	 * The canonical {@link StorageChunkChecksumProvider}: holds the policy, the primary-algorithm factory and
+	 * the additional-algorithms factory. It assembles a per-channel {@link StorageChunkChecksumCalculator} by
+	 * instantiating the primary plus the additional set (the verify-dispatch universe) and keying them by KIND.
+	 */
+	public final class Default implements StorageChunkChecksumProvider, Immutable
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final StorageChunkChecksumPolicy                               policy              ;
+		private final Supplier<StorageChunkChecksumCalculator.Algorithm>       primary             ;
+		private final Supplier<List<StorageChunkChecksumCalculator.Algorithm>> additionalAlgorithms;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(
+			final StorageChunkChecksumPolicy                               policy              ,
+			final Supplier<StorageChunkChecksumCalculator.Algorithm>       primary             ,
+			final Supplier<List<StorageChunkChecksumCalculator.Algorithm>> additionalAlgorithms
+		)
+		{
+			super();
+			this.policy               = policy              ;
+			this.primary              = primary             ;
+			this.additionalAlgorithms = additionalAlgorithms;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		public final StorageChunkChecksumPolicy policy()
+		{
+			return this.policy;
+		}
+
+		@Override
+		public final long chunkChecksumKind()
+		{
+			return this.primary.get().kind();
+		}
+
+		@Override
+		public final StorageChunkChecksumCalculator createCalculator()
+		{
+			final StorageChunkChecksumCalculator.Algorithm primaryAlgorithm = notNull(this.primary.get());
+
+			// fail early: chaining onto an unverified tip provides no tamper-evidence, so a chained primary
+			// that emits must also verify (cannot extend a chain it never validated).
+			if(primaryAlgorithm.isChained() && this.policy.emit() && !this.policy.verify())
+			{
+				throw new StorageExceptionConsistency(
+					"Chained chunk-checksum emit requires verify (cannot extend an unverified chain tip)."
+				);
+			}
+
+			final List<StorageChunkChecksumCalculator.Algorithm> all =
+				new ArrayList<>(notNull(this.additionalAlgorithms.get()));
+			all.add(primaryAlgorithm);
+
+			// Map all algorithms by KIND for verify-time dispatch. The primary is added last so it wins any
+			// KIND collision with a same-kind default: the verify-side instance for the primary's kind is then
+			// the same instance used for writes (harmless — single-threaded channel, digest auto-resets).
+			final Map<Long, StorageChunkChecksumCalculator.Algorithm> algorithmsByKind = new HashMap<>(all.size());
+			for(final StorageChunkChecksumCalculator.Algorithm a : all)
+			{
+				algorithmsByKind.put(notNull(a).kind(), a);
+			}
+
+			return new StorageChunkChecksumCalculator.Default(this.policy, primaryAlgorithm, algorithmsByKind);
+		}
+
+		@Override
+		public final StorageChunkChecksumCalculator.Algorithm createPrimaryAlgorithm()
+		{
+			// fresh, stateful instance (native digest / chain tip); single-threaded off-line use.
+			return notNull(this.primary.get());
+		}
+
+		@Override
+		public final Map<Long, StorageChunkChecksumCalculator.Algorithm> createAlgorithmsByKind()
+		{
+			// Same assembly as createCalculator(): additional verify set plus the primary added last, so the
+			// primary wins any KIND collision with a same-kind default. No emit/verify policy gating here —
+			// this is purely the off-line verify-dispatch universe (a fresh map of fresh, stateful instances).
+			final List<StorageChunkChecksumCalculator.Algorithm> all =
+				new ArrayList<>(notNull(this.additionalAlgorithms.get()));
+			all.add(notNull(this.primary.get()));
+
+			final Map<Long, StorageChunkChecksumCalculator.Algorithm> algorithmsByKind = new HashMap<>(all.size());
+			for(final StorageChunkChecksumCalculator.Algorithm a : all)
+			{
+				algorithmsByKind.put(notNull(a).kind(), a);
+			}
+			return algorithmsByKind;
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConfiguration.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConfiguration.java
@@ -474,7 +474,8 @@ public interface StorageConfiguration
 
 		/**
 		 * Sets the {@link StorageChunkChecksumProvider} to be used by the resulting configuration.
-		 * Passing {@code null} resets the value to the framework default (SHA-256, emit + verify).
+		 * Passing {@code null} resets the value to the framework default
+		 * ({@link StorageChunkChecksumProvider#New()}: no checksum, i.e. the feature off).
 		 *
 		 * @param chunkChecksumProvider the new {@link StorageChunkChecksumProvider}, or {@code null} to reset.
 		 *

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConfiguration.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConfiguration.java
@@ -91,7 +91,23 @@ public interface StorageConfiguration
 	 */
 	public StorageBackupSetup backupSetup();
 
-	
+	/**
+	 * Returns the {@link StorageChunkChecksumProvider} governing per-chunk checksum meta records
+	 * (the hash algorithm plus whether {@code FileHeaderV1} / {@code ChunkChecksumV1} entries are
+	 * written and verified).
+	 * <p>
+	 * Defined as a default method returning {@link StorageChunkChecksumProvider#New()} (the no-checksum
+	 * default, i.e. the feature off) so that pre-existing {@link StorageConfiguration}
+	 * implementations remain source- and binary-compatible.
+	 *
+	 * @return the configured {@link StorageChunkChecksumProvider}; never {@code null}.
+	 */
+	public default StorageChunkChecksumProvider chunkChecksumProvider()
+	{
+		return StorageChunkChecksumProvider.New();
+	}
+
+
 	/**
 	 * Pseudo-constructor method to create a new {@link StorageConfiguration} instance
 	 * using {@code null} as the {@link StorageBackupSetup} part and default instances for everything else.
@@ -159,13 +175,49 @@ public interface StorageConfiguration
 		final StorageBackupSetup            backupSetup
 	)
 	{
+		return New(
+			channelCountProvider  ,
+			housekeepingController,
+			fileProvider          ,
+			dataFileEvaluator     ,
+			entityCacheEvaluator  ,
+			backupSetup           ,
+			StorageChunkChecksumProvider.New()
+		);
+	}
+
+	/**
+	 * Pseudo-constructor method to create a new {@link StorageConfiguration} instance from the
+	 * passed strategy parts, including an explicit {@link StorageChunkChecksumProvider}.
+	 *
+	 * @param channelCountProvider   the {@link StorageChannelCountProvider} to use; must be non-{@code null}.
+	 * @param housekeepingController the {@link StorageHousekeepingController} to use; must be non-{@code null}.
+	 * @param fileProvider           the {@link StorageLiveFileProvider} to use; must be non-{@code null}.
+	 * @param dataFileEvaluator      the {@link StorageDataFileEvaluator} to use; must be non-{@code null}.
+	 * @param entityCacheEvaluator   the {@link StorageEntityCacheEvaluator} to use; must be non-{@code null}.
+	 * @param backupSetup            the {@link StorageBackupSetup} to use, or {@code null} to disable backup.
+	 * @param chunkChecksumProvider  the {@link StorageChunkChecksumProvider} to use; must be non-{@code null}.
+	 *
+	 * @return a new {@link StorageConfiguration} instance with the passed parts.
+	 */
+	public static StorageConfiguration New(
+		final StorageChannelCountProvider   channelCountProvider  ,
+		final StorageHousekeepingController housekeepingController,
+		final StorageLiveFileProvider           fileProvider          ,
+		final StorageDataFileEvaluator      dataFileEvaluator     ,
+		final StorageEntityCacheEvaluator   entityCacheEvaluator  ,
+		final StorageBackupSetup            backupSetup           ,
+		final StorageChunkChecksumProvider  chunkChecksumProvider
+	)
+	{
 		return new StorageConfiguration.Default(
 			notNull(channelCountProvider)  ,
 			notNull(housekeepingController),
 			notNull(fileProvider)          ,
 			notNull(dataFileEvaluator)     ,
 			notNull(entityCacheEvaluator)  ,
-			mayNull(backupSetup)
+			mayNull(backupSetup)           ,
+			notNull(chunkChecksumProvider)
 		);
 	}
 
@@ -185,6 +237,7 @@ public interface StorageConfiguration
 		private final StorageDataFileEvaluator      dataFileEvaluator     ;
 		private final StorageEntityCacheEvaluator   entityCacheEvaluator  ;
 		private final StorageBackupSetup            backupSetup           ;
+		private final StorageChunkChecksumProvider  chunkChecksumProvider ;
 
 
 
@@ -198,7 +251,8 @@ public interface StorageConfiguration
 			final StorageLiveFileProvider           fileProvider          ,
 			final StorageDataFileEvaluator      dataFileEvaluator     ,
 			final StorageEntityCacheEvaluator   entityCacheEvaluator  ,
-			final StorageBackupSetup            backupSetup
+			final StorageBackupSetup            backupSetup           ,
+			final StorageChunkChecksumProvider  chunkChecksumProvider
 		)
 		{
 			super();
@@ -208,6 +262,7 @@ public interface StorageConfiguration
 			this.fileProvider           = fileProvider          ;
 			this.dataFileEvaluator      = dataFileEvaluator     ;
 			this.backupSetup            = backupSetup           ;
+			this.chunkChecksumProvider  = chunkChecksumProvider ;
 		}
 
 
@@ -253,6 +308,12 @@ public interface StorageConfiguration
 		}
 
 		@Override
+		public StorageChunkChecksumProvider chunkChecksumProvider()
+		{
+			return this.chunkChecksumProvider;
+		}
+
+		@Override
 		public String toString()
 		{
 			return VarString.New()
@@ -263,6 +324,7 @@ public interface StorageConfiguration
 				.add(this.entityCacheEvaluator  ).lf()
 				.add(this.dataFileEvaluator     ).lf()
 				.add(this.backupSetup == null ? StorageBackupSetup.class.getName() + ": null": this.backupSetup).lf()
+				.add(this.chunkChecksumProvider ).lf()
 				.toString()
 			;
 		}
@@ -404,6 +466,23 @@ public interface StorageConfiguration
 		public B setEntityCacheEvaluator(StorageEntityCacheEvaluator entityCacheEvaluator);
 
 		/**
+		 * Returns the currently configured {@link StorageChunkChecksumProvider}.
+		 *
+		 * @return the current {@link StorageChunkChecksumProvider}.
+		 */
+		public StorageChunkChecksumProvider chunkChecksumProvider();
+
+		/**
+		 * Sets the {@link StorageChunkChecksumProvider} to be used by the resulting configuration.
+		 * Passing {@code null} resets the value to the framework default (SHA-256, emit + verify).
+		 *
+		 * @param chunkChecksumProvider the new {@link StorageChunkChecksumProvider}, or {@code null} to reset.
+		 *
+		 * @return this builder, for fluent chaining.
+		 */
+		public B setChunkChecksumProvider(StorageChunkChecksumProvider chunkChecksumProvider);
+
+		/**
 		 * Builds a new {@link StorageConfiguration} from the strategy parts currently held by this
 		 * builder.
 		 * <p>
@@ -434,6 +513,7 @@ public interface StorageConfiguration
 			private StorageLiveFileProvider       storageFileProvider    = this.initializeLiveFileProvider();
 			private StorageDataFileEvaluator      dataFileEvaluator      = this.initializeDataFileEvaluator();
 			private StorageEntityCacheEvaluator   entityCacheEvaluator   = this.initializeEntityCacheEvaluator();
+			private StorageChunkChecksumProvider  chunkChecksumProvider  = this.initializeChunkChecksumProvider();
 			private StorageBackupSetup            backupSetup           ; // optional
 			
 			
@@ -476,6 +556,11 @@ public interface StorageConfiguration
 			protected StorageEntityCacheEvaluator initializeEntityCacheEvaluator()
 			{
 				return Storage.EntityCacheEvaluator();
+			}
+
+			protected StorageChunkChecksumProvider initializeChunkChecksumProvider()
+			{
+				return Storage.ChunkChecksumProvider();
 			}
 			
 			@SuppressWarnings("unchecked")
@@ -578,7 +663,23 @@ public interface StorageConfiguration
 				;
 				return this.$();
 			}
-			
+
+			@Override
+			public StorageChunkChecksumProvider chunkChecksumProvider()
+			{
+				return this.chunkChecksumProvider;
+			}
+
+			@Override
+			public B setChunkChecksumProvider(final StorageChunkChecksumProvider chunkChecksumProvider)
+			{
+				this.chunkChecksumProvider = chunkChecksumProvider == null
+					? this.initializeChunkChecksumProvider()
+					: chunkChecksumProvider
+				;
+				return this.$();
+			}
+
 			@Override
 			public StorageConfiguration createConfiguration()
 			{
@@ -588,7 +689,8 @@ public interface StorageConfiguration
 					this.storageFileProvider   ,
 					this.dataFileEvaluator     ,
 					this.entityCacheEvaluator  ,
-					this.backupSetup
+					this.backupSetup           ,
+					this.chunkChecksumProvider
 				);
 			}
 			

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
@@ -133,6 +133,38 @@ public interface StorageConnection extends UsageMarkable, Persister
 	public boolean issueFileCheck(long nanoTimeBudget);
 
 	/**
+	 * Issues a full on-demand storage integrity check: re-verifies every channel's chunk-checksum records
+	 * against freshly recomputed checksums and returns all detected anomalies without throwing. Runs to
+	 * completion in a single call (stores are blocked for its duration) and sees a consistent, complete set of
+	 * files. Honors the configured {@link StorageChunkChecksumPolicy} ({@code IGNORE} anomalies are not
+	 * reported; a non-verifying policy reports nothing); each head file is verified up to its committed length.
+	 *
+	 * @return the complete result; {@link StorageIntegrityCheckResult#isClean()} is {@code true} if no
+	 *         anomalies were found.
+	 *
+	 * @see #issueIntegrityCheck(long)
+	 */
+	public default StorageIntegrityCheckResult issueFullIntegrityCheck()
+	{
+		return this.issueIntegrityCheck(Long.MAX_VALUE);
+	}
+
+	/**
+	 * Issues an on-demand storage integrity check limited to the given time budget in nanoseconds. When the
+	 * budget runs out the scan keeps its progress (resume granularity is one data file) and continues on the
+	 * next call; the scope is snapshotted at the start, so a data file dissolved by housekeeping between calls
+	 * is skipped (coverage is best-effort). Repeat until {@link StorageIntegrityCheckResult#isComplete()},
+	 * unioning the results; for a complete, consistent snapshot in one call use {@link #issueFullIntegrityCheck()}.
+	 *
+	 * @param nanoTimeBudget the time budget in nanoseconds to be used to perform the integrity check.
+	 *
+	 * @return this call's findings and whether the scan has completed.
+	 *
+	 * @see #issueFullIntegrityCheck()
+	 */
+	public StorageIntegrityCheckResult issueIntegrityCheck(long nanoTimeBudget);
+
+	/**
 	 * Issues a full storage cache check to be executed. Depending on the size of the database,
 	 * the available cache, used hardware, etc., this can take any amount of time.
 	 * <p>
@@ -504,6 +536,9 @@ public interface StorageConnection extends UsageMarkable, Persister
 		private final PersistenceManager<Binary> persistenceManager       ;
 		private final StorageRequestAcceptor     connectionRequestAcceptor;
 
+		// whether a budgeted integrity-check scan is mid-flight (so the next call resumes rather than restarts).
+		private boolean integrityCheckInProgress;
+
 
 
 		///////////////////////////////////////////////////////////////////////////
@@ -560,6 +595,32 @@ public interface StorageConnection extends UsageMarkable, Persister
 			{
 				// thread interrupted, task aborted, return
 				return false;
+			}
+		}
+
+		@Override
+		public final StorageIntegrityCheckResult issueIntegrityCheck(final long nanoTimeBudget)
+		{
+			try
+			{
+				// Fresh scan for a full check, or when no scan is in progress; otherwise resume the in-flight one.
+				// Deciding this once (channels can't see each other) lets a budgeted scan across uneven channels
+				// finish without finished channels re-scanning. Not safe to run concurrently on one connection.
+				final boolean freshScan = nanoTimeBudget == Long.MAX_VALUE || !this.integrityCheckInProgress;
+
+				final StorageIntegrityCheckResult result =
+					this.connectionRequestAcceptor.issueIntegrityCheck(nanoTimeBudget, freshScan);
+
+				this.integrityCheckInProgress = !result.isComplete();
+				return result;
+			}
+			catch(final InterruptedException e)
+			{
+				// thread interrupted, task aborted: drop scan state and return an empty, incomplete result.
+				this.integrityCheckInProgress = false;
+				final StorageIntegrityCheckResult.Default result = StorageIntegrityCheckResult.New();
+				result.setComplete(false);
+				return result;
 			}
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
@@ -322,8 +322,43 @@ public interface StorageDataChunkValidator
 
 	}
 	
+	/**
+	 * Default validator: enforces the 2&nbsp;GiB load-buffer ceiling on the <b>resulting on-disk
+	 * file</b> (not just on the chunk payload). The engine appends a {@code FileHeaderV1} and a
+	 * trailing chunk-checksum record when checksums are emitting; a chunk sized just under
+	 * {@code Integer.MAX_VALUE} would otherwise produce a file slightly over 2&nbsp;GiB, which is
+	 * not reloadable into a single direct buffer.
+	 * <p>
+	 * The foundation wires this validator with {@code freshFileMetaReserve = calc.fileHeaderRecordLength()
+	 * + calc.chunkChecksumRecordLength()} for emitting policies (or 0 for non-emitting), so the
+	 * cap automatically tracks the configured checksum algorithm.
+	 */
 	public class MaxFileSize implements StorageDataChunkValidator, Provider, Provider2
 	{
+		private final long freshFileMetaReserve;
+
+		/**
+		 * Backwards-compatible constructor: assumes no meta-record overhead. Direct users who
+		 * keep this constructor must accept that the resulting file may exceed 2&nbsp;GiB by the
+		 * meta-record bytes the engine appends.
+		 */
+		public MaxFileSize()
+		{
+			this(0L);
+		}
+
+		/**
+		 * @param freshFileMetaReserve bytes the engine adds to a fresh file beyond the chunk
+		 *                             payload (typically {@code FileHeaderV1 + ChunkChecksumV1}),
+		 *                             subtracted from the 2&nbsp;GiB load-buffer ceiling so the
+		 *                             resulting file remains reloadable.
+		 */
+		public MaxFileSize(final long freshFileMetaReserve)
+		{
+			super();
+			this.freshFileMetaReserve = freshFileMetaReserve;
+		}
+
 		@Override
 		public Provider provideDataChunkValidatorProvider(
 				final StorageFoundation<?> foundation
@@ -352,12 +387,95 @@ public interface StorageDataChunkValidator
 				{
 					commitSize += bb.limit();
 				}
-								
+
+				// The resulting file (chunk + FileHeaderV1 + trailing chunk-checksum) must fit
+				// in a 2 GiB direct buffer so it remains loadable on the read path.
+				if(commitSize + this.freshFileMetaReserve > Integer.MAX_VALUE)
+				{
+					throw new StorageExceptionCommitSizeExceeded(
+						channelIndex, commitSize + this.freshFileMetaReserve);
+				}
+
+			}
+		}
+	}
+
+	/**
+	 * Strict pre-flight cap: rejects a commit when any channel's chunk plus its fresh-file meta
+	 * overhead ({@code FileHeaderV1} + trailing {@code ChunkChecksumV1}, when applicable) would
+	 * inherently overshoot the configured {@code fileMaximumSize}. Runs on the caller thread
+	 * before the task is enqueued, so the channel thread never sees a chunk that cannot fit into
+	 * a fresh head file under the configured cap.
+	 * <p>
+	 * Opt-in: users who want {@code fileMaximumSize} as a hard upper bound on raw file size
+	 * register this validator via
+	 * {@link StorageFoundation#setDataChunkValidatorProvider2(Provider2)}. The default
+	 * provider remains {@link MaxFileSize} (Java 2&nbsp;GiB load-buffer cap only); existing
+	 * storages and BLOB-style users storing entities larger than {@code fileMaximumSize}
+	 * continue to work unchanged.
+	 * <p>
+	 * Composes with {@link MaxFileSize}: this validator also enforces the 2&nbsp;GiB cap so it
+	 * is a strict superset.
+	 */
+	public final class StrictMaxFileSize implements StorageDataChunkValidator, Provider, Provider2
+	{
+		private final long fileMaximumSize     ;
+		private final long freshFileMetaReserve;
+
+		/**
+		 * @param fileMaximumSize      the configured maximum data file size; commits exceeding this
+		 *                             per channel are rejected.
+		 * @param freshFileMetaReserve the total number of meta bytes that a fresh head file pays for
+		 *                             the upcoming chunk write: the {@code FileHeaderV1} written at
+		 *                             file creation plus the trailing chunk-checksum record. Typically
+		 *                             {@code calc.fileHeaderRecordLength() + calc.chunkChecksumRecordLength()}
+		 *                             for emitting policies, or {@code 0} for non-emitting policies.
+		 *                             The validator runs caller-side without per-file state, so it
+		 *                             must reserve for the worst case: a chunk landing in a fresh
+		 *                             head file that has just paid the header and will append the
+		 *                             chunk plus its trailing checksum.
+		 */
+		public StrictMaxFileSize(final long fileMaximumSize, final long freshFileMetaReserve)
+		{
+			super();
+			this.fileMaximumSize      = fileMaximumSize     ;
+			this.freshFileMetaReserve = freshFileMetaReserve;
+		}
+
+		@Override
+		public Provider provideDataChunkValidatorProvider(final StorageFoundation<?> foundation)
+		{
+			return this;
+		}
+
+		@Override
+		public StorageDataChunkValidator provideDataChunkValidator(final StorageTypeDictionary typeDictionary)
+		{
+			return this;
+		}
+
+		@Override
+		public void validateDataChunk(final Binary data)
+		{
+			for(int channelIndex = 0; channelIndex < data.channelCount(); channelIndex++)
+			{
+				long commitSize = 0;
+				for(final ByteBuffer bb : data.channelChunk(channelIndex).buffers())
+				{
+					commitSize += bb.limit();
+				}
+
 				if(commitSize >= Integer.MAX_VALUE)
 				{
+					// also enforce the 2 GiB load-buffer cap so this validator is a superset of MaxFileSize
 					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize);
 				}
-				
+				if(commitSize + this.freshFileMetaReserve > this.fileMaximumSize)
+				{
+					// chunk + fresh-file meta (FileHeaderV1 + trailing chunk-checksum) cannot fit
+					// in any single file under the configured cap.
+					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize + this.freshFileMetaReserve);
+				}
 			}
 		}
 	}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
@@ -465,10 +465,10 @@ public interface StorageDataChunkValidator
 					commitSize += bb.limit();
 				}
 
-				if(commitSize >= Integer.MAX_VALUE)
+				if(commitSize + this.freshFileMetaReserve > Integer.MAX_VALUE)
 				{
 					// also enforce the 2 GiB load-buffer cap so this validator is a superset of MaxFileSize
-					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize);
+					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize + this.freshFileMetaReserve);
 				}
 				if(commitSize + this.freshFileMetaReserve > this.fileMaximumSize)
 				{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileEvaluator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileEvaluator.java
@@ -41,6 +41,21 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 	public int transactionFileMaximumSize();
 
 	/**
+	 * The soft target size (in bytes) for a single coalesced chunk produced by the coalescing
+	 * dissolution transfer. The transfer stops collecting live sub-runs once their combined length
+	 * reaches this value and emits the compacted chunk plus its covering checksum, which bounds the
+	 * transient transfer buffer (otherwise sized up to {@link #fileMaximumSize()}). A single entity
+	 * larger than the target still forms its own chunk. This does not affect file rollover (governed
+	 * by {@link #fileMaximumSize()}); a head file is still packed with multiple coalesced chunks up to
+	 * its maximum size.
+	 *
+	 * @return the coalesce chunk target size in bytes.
+	 *
+	 * @see StorageDataFileEvaluator.Defaults#defaultCoalesceChunkTargetBytes()
+	 */
+	public long coalesceChunkTargetBytes();
+
+	/**
 	 * Pseudo-constructor method to create a new {@link StorageDataFileEvaluator} instance
 	 * using default values specified by {@link StorageDataFileEvaluator.Defaults}.
 	 * <p>
@@ -284,8 +299,68 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 		final int     transactionFileMaximumSize
 	)
 	{
+		return New(
+			fileMinimumSize                              ,
+			fileMaximumSize                              ,
+			minimumUseRatio                              ,
+			cleanUpHeadFile                              ,
+			transactionFileMaximumSize                   ,
+			Defaults.defaultCoalesceChunkTargetBytes()
+		);
+	}
+
+	/**
+	 * Pseudo-constructor method to create a new {@link StorageDataFileEvaluator} instance
+	 * using the passed values.
+	 * <p>
+	 * For explanations and customizing values, see {@link StorageDataFileEvaluator#New(int, int, double)}.
+	 *
+	 * @param fileMinimumSize the minimum file size in bytes that a single storage file must have. Smaller files
+	 *        will be dissolved.
+	 *
+	 * @param fileMaximumSize the maximum file size in bytes that a single storage file may have. Larger files
+	 *        will be dissolved.<br>
+	 *        Note that a file can exceed this limit if it contains a single entity that already exceeds the limit.
+	 *
+	 * @param minimumUseRatio the ratio (value in ]0.0;1.0]) of non-gap data contained in a storage file to prevent
+	 *        the file from being dissolved.
+	 *
+	 * @param cleanUpHeadFile a flag defining whether the current head file (the only file actively written to)
+	 *        shall be subjected to file cleanups as well.
+	 *
+	 * @param transactionFileMaximumSize the maximum file size for transaction files. Lager files will
+	 *        be deleted and a new one will be created.
+	 *
+	 * @param coalesceChunkTargetBytes the soft target size in bytes for a single coalesced chunk produced by
+	 *        the dissolution transfer. See {@link StorageDataFileEvaluator#coalesceChunkTargetBytes()}.
+	 *
+	 * @return a new {@link StorageDataFileEvaluator} instance.
+	 *
+	 * @see StorageDataFileEvaluator#New()
+	 * @see StorageDataFileEvaluator#New(double)
+	 * @see StorageDataFileEvaluator#New(int, int)
+	 * @see StorageDataFileEvaluator#New(int, int, double)
+	 * @see StorageDataFileEvaluator.Defaults
+	 */
+	public static StorageDataFileEvaluator New(
+		final int     fileMinimumSize          ,
+		final int     fileMaximumSize          ,
+		final double  minimumUseRatio          ,
+		final boolean cleanUpHeadFile          ,
+		final int     transactionFileMaximumSize,
+		final long    coalesceChunkTargetBytes
+	)
+	{
 		Validation.validateParameters(fileMinimumSize, fileMaximumSize, minimumUseRatio, transactionFileMaximumSize);
-		return new Default(fileMinimumSize, fileMaximumSize, minimumUseRatio, cleanUpHeadFile, transactionFileMaximumSize);
+		Validation.validateCoalesceChunkTargetBytes(coalesceChunkTargetBytes);
+		return new Default(
+			fileMinimumSize           ,
+			fileMaximumSize           ,
+			minimumUseRatio           ,
+			cleanUpHeadFile           ,
+			transactionFileMaximumSize,
+			coalesceChunkTargetBytes
+		);
 	}
 
 
@@ -330,6 +405,31 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 		public static double useRatioMaximum()
 		{
 			return 1.0;
+		}
+
+		public static long minimumCoalesceChunkTargetBytes()
+		{
+			return 1L;
+		}
+
+		public static long maximumCoalesceChunkTargetBytes()
+		{
+			// the coalesced chunk is buffered in a single direct ByteBuffer, capped at the array range.
+			return Integer.MAX_VALUE;
+		}
+
+		public static void validateCoalesceChunkTargetBytes(final long coalesceChunkTargetBytes)
+		{
+			if(coalesceChunkTargetBytes < minimumCoalesceChunkTargetBytes()
+			|| coalesceChunkTargetBytes > maximumCoalesceChunkTargetBytes()
+			)
+			{
+				throw new IllegalArgumentException(
+					"Specified coalesce chunk target size of " + coalesceChunkTargetBytes
+					+ " is not in the valid range of ["
+					+ minimumCoalesceChunkTargetBytes() + ", " + maximumCoalesceChunkTargetBytes() + "]."
+				);
+			}
 		}
 
 		public static void validateParameters(
@@ -420,6 +520,15 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 		}
 
 		/**
+		 * @return {@code 1 * 1024 * 1024} (meaning a 1 MB coalesce chunk target size).
+		 */
+		public static long defaultCoalesceChunkTargetBytes()
+		{
+			// 1 MB in common byte magnitude
+			return 1 * 1024 * 1024;
+		}
+
+		/**
 		 * @return {@code 0.75} (meaning 75% minimum use ratio required).
 		 */
 		public static double defaultMinimumUseRatio()
@@ -446,6 +555,7 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 		private final double  minimumUseRatio;
 		private final boolean cleanupHeadFile;
 		private final int     transactionFileMaximumSize;
+		private final long    coalesceChunkTargetBytes;
 
 
 		///////////////////////////////////////////////////////////////////////////
@@ -457,7 +567,8 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 			final int     fileMaximumSize,
 			final double  minimumUseRatio,
 			final boolean cleanupHeadFile,
-			final int     transactionFileMaximumSize
+			final int     transactionFileMaximumSize,
+			final long    coalesceChunkTargetBytes
 		)
 		{
 			super();
@@ -466,6 +577,10 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 			this.minimumUseRatio            = minimumUseRatio;
 			this.cleanupHeadFile            = cleanupHeadFile;
 			this.transactionFileMaximumSize = transactionFileMaximumSize;
+			// a coalesced chunk is written as a single unit into one data file, so the (soft) coalesce
+			// target can never usefully exceed the (hard) file-size cap: clamp it. A target above
+			// fileMaximumSize would otherwise force every coalesced chunk into its own oversized file.
+			this.coalesceChunkTargetBytes   = Math.min(coalesceChunkTargetBytes, fileMaximumSize);
 		}
 
 
@@ -500,6 +615,12 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 		public final int transactionFileMaximumSize()
 		{
 			return this.transactionFileMaximumSize;
+		}
+
+		@Override
+		public final long coalesceChunkTargetBytes()
+		{
+			return this.coalesceChunkTargetBytes;
 		}
 
 		@Override
@@ -544,13 +665,19 @@ public interface StorageDataFileEvaluator extends StorageDataFileDissolvingEvalu
 
 		private boolean isAboveMaximumSize(final StorageLiveDataFile storageFile)
 		{
+			// hard upper bound on raw file size; any file above max gets dissolved. The only files
+			// legitimately exceeding max are single-entity files whose lone entity is itself larger
+			// than (max - meta); those are rescued by isGaplessSingleEntityFile below.
 			return storageFile.totalLength() > this.fileMaximumSize();
 		}
 
 		private boolean isGaplessSingleEntityFile(final StorageLiveDataFile storageFile)
 		{
-			// file has only one entity and contains no further gaps
-			return storageFile.hasSingleEntity() && storageFile.dataLength() == storageFile.totalLength();
+			// File has exactly one entity and no legacy gap (removed-entity) bytes. Meta-record bytes
+			// (FileHeaderV1, ChunkChecksumV1) are NOT gap, so they must be added in: the plain
+			// dataLength == totalLength equality is impossible once any meta record is present.
+			return storageFile.hasSingleEntity()
+				&& storageFile.dataLength() + storageFile.metaLength() == storageFile.totalLength();
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityInitializer.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityInitializer.java
@@ -35,39 +35,44 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 	
 	
 	static StorageEntityInitializer<StorageLiveDataFile.Default> New(
-		final StorageEntityCache.Default                                      entityCache    ,
-		final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> dataFileCreator
+		final StorageEntityCache.Default                                      entityCache       ,
+		final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> dataFileCreator   ,
+		final StorageMetaRecordRegistry                                       metaRecordRegistry
 	)
 	{
 		return new StorageEntityInitializer.Default(
-			notNull(dataFileCreator),
-			notNull(entityCache)
+			notNull(dataFileCreator)   ,
+			notNull(entityCache)       ,
+			notNull(metaRecordRegistry)
 		);
 	}
-	
+
 	final class Default implements StorageEntityInitializer<StorageLiveDataFile.Default>
 	{
 		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
 
-		private final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> dataFileCreator;
-		private final StorageEntityCache.Default                                      entityCache    ;
-		
-		
-		
+		private final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> dataFileCreator        ;
+		private final StorageEntityCache.Default                                      entityCache            ;
+		private final StorageMetaRecordRegistry                                       metaRecordRegistry     ;
+
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
 
 		Default(
-			final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> dataFileCreator,
-			final StorageEntityCache.Default                                      entityCache
+			final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> dataFileCreator        ,
+			final StorageEntityCache.Default                                      entityCache            ,
+			final StorageMetaRecordRegistry                                       metaRecordRegistry
 		)
 		{
 			super();
-			this.dataFileCreator = dataFileCreator;
-			this.entityCache     = entityCache    ;
+			this.dataFileCreator         = dataFileCreator        ;
+			this.entityCache             = entityCache            ;
+			this.metaRecordRegistry      = metaRecordRegistry     ;
 		}
 		
 		
@@ -82,49 +87,51 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 			final long                                             lastFileLength
 		)
 		{
-			return registerEntities(this.dataFileCreator, this.entityCache, files.toReversed(), lastFileLength);
+			return registerEntities(this.dataFileCreator, this.entityCache, files.toReversed(), lastFileLength, this.metaRecordRegistry);
 		}
-		
+
 		private static StorageLiveDataFile.Default registerEntities(
-			final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> fileCreator    ,
-			final StorageEntityCache.Default                                      entityCache    ,
-			final XGettingSequence<? extends StorageDataInventoryFile>            reversedFiles  ,
-			final long                                                            lastFileLength
+			final Function<StorageDataInventoryFile, StorageLiveDataFile.Default> fileCreator            ,
+			final StorageEntityCache.Default                                      entityCache            ,
+			final XGettingSequence<? extends StorageDataInventoryFile>            reversedFiles          ,
+			final long                                                            lastFileLength         ,
+			final StorageMetaRecordRegistry                                       metaRecordRegistry
 		)
 		{
 			final ByteBuffer                               buffer   = allocateInitializationBuffer(reversedFiles);
 			final Iterator<? extends StorageDataInventoryFile> iterator = reversedFiles.iterator();
 			final int[] entityOffsets = createAllFilesOffsetsArray(buffer.capacity());
-			
+
 			final long initTime = System.currentTimeMillis();
-			
+
 			// special case handling for last/head file
 			final StorageLiveDataFile.Default headFile = setupHeadFile(fileCreator.apply(iterator.next()));
-			registerFileEntities(entityCache, initTime, headFile, lastFileLength, buffer, entityOffsets);
-			
+			registerFileEntities(entityCache, initTime, headFile, lastFileLength, buffer, entityOffsets, metaRecordRegistry);
+
 			// simple tail file adding iteration for all remaining (previous!) storage files
 			for(StorageLiveDataFile.Default dataFile = headFile; iterator.hasNext();)
 			{
 				dataFile = linkTailFile(dataFile, fileCreator.apply(iterator.next()));
-				registerFileEntities(entityCache, initTime, dataFile, dataFile.size(), buffer, entityOffsets);
+				registerFileEntities(entityCache, initTime, dataFile, dataFile.size(), buffer, entityOffsets, metaRecordRegistry);
 			}
-			
+
 			XMemory.deallocateDirectByteBuffer(buffer);
-			
+
 			return headFile;
 		}
-		
+
 		final static void registerFileEntities(
-			final StorageEntityCache.Default  entityCache       ,
-			final long                        initializationTime,
-			final StorageLiveDataFile.Default file              ,
-			final long                        fileActualLength  ,
-			final ByteBuffer                  buffer            ,
-			final int[]                       entityOffsets
+			final StorageEntityCache.Default     entityCache            ,
+			final long                           initializationTime     ,
+			final StorageLiveDataFile.Default    file                   ,
+			final long                           fileActualLength       ,
+			final ByteBuffer                     buffer                 ,
+			final int[]                          entityOffsets          ,
+			final StorageMetaRecordRegistry      metaRecordRegistry
 		)
 		{
 			// entities must be indexed first to allow reverse iteration.
-			final int                         entityCount = indexEntities(file, fileActualLength, buffer, entityOffsets);
+			final int                         entityCount = indexEntities(file, fileActualLength, buffer, entityOffsets, metaRecordRegistry);
 			final StorageEntityCacheEvaluator entityCacheEvaluator = entityCache.entityCacheEvaluator;
 			final long                        bufferStartAddress   = XMemory.getDirectByteBufferAddress(buffer);
 			
@@ -160,9 +167,10 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 
 			// the total length of all actually registered entities is the file's content length. The rest is gaps.
 			file.increaseContentLength(totalFileContentLength);
-			
-			// the buffer is currently limited to exactly the file size. So gapLength = limit - contentLength.
-			file.registerGapLength(buffer.limit() - totalFileContentLength);
+
+			// indexEntities already registered meta-record bytes via registerMetaLength as the walker
+			// recognized them. The remainder is the legacy gap from removed entities.
+			file.registerGapLength(buffer.limit() - totalFileContentLength - file.metaLength());
 		}
 				
 		/**
@@ -170,25 +178,30 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 		 * @return the entity count.
 		 */
 		private static int indexEntities(
-			final StorageLiveDataFile.Default file            ,
-			final long                        fileActualLength,
-			final ByteBuffer                  buffer          ,
-			final int[]                       entityOffsets
+			final StorageLiveDataFile.Default    file                   ,
+			final long                           fileActualLength       ,
+			final ByteBuffer                     buffer                 ,
+			final int[]                          entityOffsets          ,
+			final StorageMetaRecordRegistry      metaRecordRegistry
 		)
 		{
 			int lastEntityIndex = -1;
-			
+
 			fillBuffer(buffer, file, fileActualLength);
-			
+
 			final long bufferStartAddress = XMemory.getDirectByteBufferAddress(buffer);
 			final long bufferBoundAddress = bufferStartAddress + buffer.limit();
-			
+
 			long currentItemLength;
-			
+
+			// Start address of the current chunk's hashed bytes. Advances past the FileHeaderV1 (which
+			// is not itself part of any chunk's hash) and past each successfully-verified ChunkChecksumV1.
+			long chunkStart = bufferStartAddress;
+
 			for(long address = bufferStartAddress; address < bufferBoundAddress;)
 			{
 				currentItemLength = Binary.getEntityLengthRawValue(address);
-				
+
 				if(currentItemLength > 0)
 				{
 					// handle actual entity
@@ -197,8 +210,10 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 				}
 				else if(currentItemLength < 0)
 				{
-					// comments (indicated by negative length) just get skipped.
-					// note that gap length gets registered for the file at the end arithmetically
+					// negative-length entry: either a legacy opaque gap (skip) or a structured
+					// meta record (recognize, verify, dispatch). May throw on checksum mismatch.
+					// Returns the updated chunkStart for the next chunk.
+					chunkStart = metaRecordRegistry.dispatch(file, buffer, address, chunkStart);
 					address -= currentItemLength;
 				}
 				else
@@ -207,16 +222,26 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 					throw new StorageExceptionConsistency("Zero length data item.");
 				}
 			}
-			
+
+			// after the walk, let the registry raise MISSING_HEADER / UNCOVERED_DATA via the reporter
+			// (inert unless verifying with coverage required) and flush per-file log dedupe. chunkStart
+			// is the start of the last chunk not followed by a covering checksum record.
+			metaRecordRegistry.onFileComplete(
+				file                            ,
+				chunkStart - bufferStartAddress ,
+				buffer.limit()                  ,
+				lastEntityIndex >= 0
+			);
+
 			return lastEntityIndex + 1;
 		}
-		
-		
-		
+
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// utility methods //
 		////////////////////
-		
+
 		private static StorageLiveDataFile.Default setupHeadFile(
 			final StorageLiveDataFile.Default storageFile
 		)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityInitializer.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityInitializer.java
@@ -200,11 +200,30 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 
 			for(long address = bufferStartAddress; address < bufferBoundAddress;)
 			{
+				// Validate the item length against the buffer bound before using it: a corrupted length is
+				// caught here as a consistency error instead of an out-of-bounds read or a later crash.
+				final long remaining = bufferBoundAddress - address;
+				if(remaining < Long.BYTES)
+				{
+					// too few bytes left to read a length: file does not end on a record boundary.
+					throw new StorageExceptionConsistency(
+						"Truncated data item: " + remaining + " byte(s) remaining at offset "
+						+ (address - bufferStartAddress) + " in " + file + ", cannot read an entity length."
+					);
+				}
+
 				currentItemLength = Binary.getEntityLengthRawValue(address);
 
 				if(currentItemLength > 0)
 				{
-					// handle actual entity
+					// must cover at least the entity header and not overrun the buffered data.
+					if(!Binary.isValidEntityLength(currentItemLength) || currentItemLength > remaining)
+					{
+						throw new StorageExceptionConsistency(
+							"Invalid entity length " + currentItemLength + " at offset "
+							+ (address - bufferStartAddress) + " in " + file + " (remaining " + remaining + ")."
+						);
+					}
 					entityOffsets[++lastEntityIndex] = (int)(address - bufferStartAddress);
 					address += currentItemLength;
 				}
@@ -213,6 +232,14 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 					// negative-length entry: either a legacy opaque gap (skip) or a structured
 					// meta record (recognize, verify, dispatch). May throw on checksum mismatch.
 					// Returns the updated chunkStart for the next chunk.
+					// (< -remaining is the overflow-safe form of |length| > remaining.)
+					if(currentItemLength < -remaining)
+					{
+						throw new StorageExceptionConsistency(
+							"Invalid item length " + currentItemLength + " at offset "
+							+ (address - bufferStartAddress) + " in " + file + " (remaining " + remaining + ")."
+						);
+					}
 					chunkStart = metaRecordRegistry.dispatch(file, buffer, address, chunkStart);
 					address -= currentItemLength;
 				}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -93,6 +93,21 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 	public boolean issuedFileCleanupCheck(long nanoTimeBudgetBound);
 
+	/**
+	 * Re-verifies this channel's data-file chunk checksums for the on-demand integrity check, collecting
+	 * anomalies into the returned per-channel result without throwing. {@code freshScan} starts a new scan
+	 * (snapshotting the scope: every file's number and length, the head file bounded to its committed length);
+	 * otherwise the in-progress snapshot is resumed until the whole scope is covered
+	 * ({@link StorageIntegrityCheckResult#isComplete()}), skipping any file dissolved by housekeeping in between.
+	 * A channel that already finished its scope returns a complete, empty result on a resume call (it does not
+	 * re-scan), so a budgeted scan across uneven channels terminates without duplicating findings.
+	 *
+	 * @param nanoTimeBudgetBound the {@link System#nanoTime()} bound to stop at (resume granularity is one file).
+	 * @param freshScan           whether to start a new scan (vs resume the in-progress one).
+	 * @return this channel's findings and completion state.
+	 */
+	public StorageIntegrityCheckResult verifyChunkChecksums(long nanoTimeBudgetBound, boolean freshScan);
+
 	public void exportData(StorageLiveFileProvider fileProvider);
 
 	public StorageRawFileStatistics.ChannelStatistics createRawFileStatistics();
@@ -148,6 +163,8 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		private final StorageTimestampProvider               timestampProvider            ;
 		private final StorageLiveFileProvider                fileProvider                 ;
 		private final StorageDataFileEvaluator               dataFileEvaluator            ;
+		private final StorageChunkChecksumCalculator         chunkChecksumCalculator      ;
+		private final StorageMetaRecordRegistry              metaRecordRegistry           ;
 		private final StorageEntityCache.Default             entityCache                  ;
 		private final StorageWriteController                 writeController              ;
 		private final StorageFileWriter                      writer                       ;
@@ -200,6 +217,17 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 		// cleared by clearStandardByteBuffer() / reset().
 		private final ByteBuffer standardByteBuffer;
+
+		// Reusable fixed-size chunk-checksum meta buffers (single-threaded channel use, like the entry
+		// buffers above). Sized from the calculator, so allocated in the constructor rather than as field
+		// initializers (chunkChecksumCalculator is not yet assigned at field-init time). Cleared before
+		// each use and freed in deleteBuffers(). Safe to reuse immediately after a write returns: the
+		// bytes are already in the data file, and a backup copy item re-reads them from the file.
+		// chunkChecksumBuffer is shared by storeChunks / dissolution-transfer / import (never concurrent).
+		private final ByteBuffer chunkChecksumBuffer;
+		private final ByteBuffer fileHeaderBuffer   ;
+		private final Iterable<? extends ByteBuffer> chunkChecksumBufferWrap;
+		private final Iterable<? extends ByteBuffer> fileHeaderBufferWrap   ;
 		
 		
 		// state 3.0: mutable fields. Must be cleared on reset.
@@ -210,8 +238,14 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		// cleared and nulled by clearRegisteredFiles() / reset()
 		private StorageLiveDataFile.Default fileCleanupCursor;
 
-		// cleared by clearUncommittedDataLength() / reset()
+		// cleared by clearUncommittedDataLength() / reset().
+		// uncommittedDataLength = bytes of positive-length entity records pending commit
+		//                         (will contribute to BOTH fileTotalLength and fileDataLength).
+		// uncommittedMetaLength = bytes of negative-length meta records pending commit
+		//                         (will contribute to fileTotalLength only — matches load-side
+		//                         gap-length semantics in StorageEntityInitializer).
 		private long uncommittedDataLength;
+		private long uncommittedMetaLength;
 
 		// cleared in reset() directly, but kind of irrelevant.
 		private int pendingFileDeletes;
@@ -221,6 +255,14 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 		// cleared and nulled by clearRegisteredFiles() / reset()
 		private StorageLiveDataFile.Default headFile;
+
+		// On-demand integrity-check scan state spanning the budgeted resume calls of one scan: the scope (file
+		// numbers + lengths, head bounded to its committed length) is snapshotted when a fresh scan starts.
+		// null arrays == no scan in progress; cleared on reset via clearRegisteredFiles().
+		private long[]  integrityScopeNumbers   ;
+		private long[]  integrityScopeLengths   ;
+		private int     integrityScopeCursor    ;
+		private long    integrityScopeHeadNumber; // the file that was head at snapshot (exempt from size-change)
 
 
 		private StorageTransactionsFileCleaner transactionFileCleaner;
@@ -236,6 +278,8 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			final StorageTimestampProvider               timestampProvider            ,
 			final StorageLiveFileProvider                fileProvider                 ,
 			final StorageDataFileEvaluator               dataFileEvaluator            ,
+			final StorageChunkChecksumCalculator         chunkChecksumCalculator      ,
+			final StorageMetaRecordRegistry              metaRecordRegistry           ,
 			final StorageEntityCache.Default             entityCache                  ,
 			final StorageWriteController                 writeController              ,
 			final StorageFileWriter                      writer                       ,
@@ -249,6 +293,8 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			this.initialDataFileNumberProvider =     notNull(initialDataFileNumberProvider);
 			this.timestampProvider             =     notNull(timestampProvider)            ;
 			this.dataFileEvaluator             =     notNull(dataFileEvaluator)            ;
+			this.chunkChecksumCalculator       =     notNull(chunkChecksumCalculator)      ;
+			this.metaRecordRegistry            =     notNull(metaRecordRegistry)           ;
 			this.fileProvider                  =     notNull(fileProvider)                 ;
 			this.entityCache                   =     notNull(entityCache)                  ;
 			this.writeController               =     notNull(writeController)              ;
@@ -259,6 +305,11 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			this.standardByteBuffer = XMemory.allocateDirectNative(
 				standardBufferSizeProvider.provideBufferSize()
 			);
+
+			this.chunkChecksumBuffer     = XMemory.allocateDirectNative(X.checkArrayRange(chunkChecksumCalculator.chunkChecksumRecordLength()));
+			this.fileHeaderBuffer        = XMemory.allocateDirectNative(X.checkArrayRange(chunkChecksumCalculator.fileHeaderRecordLength())   );
+			this.chunkChecksumBufferWrap = X.ArrayView(this.chunkChecksumBuffer);
+			this.fileHeaderBufferWrap    = X.ArrayView(this.fileHeaderBuffer)   ;
 		}
 
 
@@ -330,6 +381,9 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			 */
 			this.clearTransactionsFile();
 
+			// drop any in-flight integrity-check scan state; it refers to the file generation being cleared.
+			this.clearIntegrityScope();
+
 			if(this.headFile == null)
 			{
 				return; // already cleared or no files in the first place
@@ -375,103 +429,224 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			      StorageEntity.Default   last     = null                    ;
 			      StorageEntity.Default   current  = first                   ;
 
-			final long copyStart                = first.storagePosition                     ;
-			final long targetFileOldTotalLength = headFile.totalLength()                    ;
-			final long maximumFileSize          = this.dataFileEvaluator.fileMaximumSize()  ;
-			final long freeSpace                = maximumFileSize - targetFileOldTotalLength;
-			      long copyLength               = 0                                         ;
+			// Reserve room for the trailing ChunkChecksumV1 that appendBytesToHeadFile will emit when the
+			// destination head file carries a FileHeaderV1. Without it the dissolution write overshoots
+			// fileMaximumSize by the checksum-record length and dissolution loops forever producing
+			// identically oversized successors.
+			final long checksumReserve         = this.chunkChecksumCalculator.reservedLengthFor(headFile);
+			final long firstSourceOffset        = first.storagePosition                                  ;
+			final long targetFileOldTotalLength = headFile.totalLength()                                 ;
+			final long maximumFileSize          = this.dataFileEvaluator.fileMaximumSize()               ;
+			// Clamp to 0: if the target file is already at/above max (legacy/imported head, or future
+			// bug) freeSpace would otherwise go negative; the loop is correct with 0 too (any positive
+			// entity triggers the "won't fit" branch) but the explicit clamp documents intent.
+			final long freeSpace = Math.max(0L, maximumFileSize - targetFileOldTotalLength - checksumReserve);
+
+			// A covering ChunkChecksumV1 hashes one contiguous block, so when a checksum is emitted the
+			// transfer may COALESCE several live sub-runs into one compacted chunk, skipping the gaps
+			// between them. When no checksum is emitted the relocation uses the zero-copy file-to-file
+			// transfer, which can only move one contiguous range, so the chain breaks at the first gap.
+			final boolean coalesce = checksumReserve != 0L;
+
+			// Soft cap on a coalesced chunk's size: once the collected live bytes reach this target the
+			// run is closed and the chunk emitted, keeping the transient transfer buffer (sized to
+			// totalLive) bounded. Only the coalescing path buffers and is capped.
+			final long coalesceChunkTargetBytes = this.dataFileEvaluator.coalesceChunkTargetBytes();
+
+			// Live sub-runs to relocate, as physical {sourceStart, length} ranges in the source file.
+			// One entry unless coalescing across gaps; their lengths sum to totalLive.
+			final BulkList<long[]> subRanges = BulkList.New();
+			      long runStart  = firstSourceOffset;
+			      long runLen    = 0L               ;
+			      long totalLive = 0L               ;
 
 			/*
 			 * Collecting the transfer chain has 2 abort conditions:
-			 * 1.) a gap between entities is detected (next entity's position is not the expected position)
-			 * 2.) the current entity's length would not fit in the target file's remaining space
-			 * Note:
-			 * As the method is guaranteed to be called on a non-empty file,
-			 * point 1) automatically recognizes the tail entry or file end.
+			 * 1.) the current entity's length would not fit in the target file's remaining space
+			 * 2.) the source file's tail is reached (the whole live chain has been collected)
+			 * A gap between entities (next entity's position is not the expected position) no longer
+			 * aborts the collection when coalescing; it merely closes the current sub-run and opens a
+			 * new one after the gap. As the method is guaranteed to be called on a non-empty file, the
+			 * first entity is never the tail.
 			 */
-			do
+			while(current != sourceFile.tail)
 			{
 				// check for enough free space
-				if(copyLength + current.length > freeSpace)
+				if(totalLive + current.length > freeSpace)
 				{
 					// if there is already something to transfer, break and copy it
-					if(copyLength != 0)
+					if(totalLive != 0L)
 					{
 						break;
 					}
 
-					// nothing to transfer yet, so create next storage file and try again in next round.
-					if(targetFileOldTotalLength != 0)
+					// Nothing to transfer yet. Roll over to the next head file ONLY if the current head
+					// already holds reclaimable entity bytes; rolling over a head that has only protocol
+					// overhead (FileHeaderV1 / ChunkChecksumV1) produces an identically-shaped successor
+					// and loops forever. dataLength(), not totalLength(), because the latter is non-zero
+					// once a FileHeaderV1 is emitted.
+					if(headFile.dataLength() != 0L)
 					{
 						this.createNextStorageFile();
 						return;
 					}
 
-					// nothing to transfer yet and empty target file, transfer singleton oversized entity anyway
+					// nothing to transfer yet and head has no entity content — singleton oversized
+					// entity falls through and is written into this head file as the only option.
+				}
+
+				// gap (intervening checksum record or dead-entity gap): the next live entity is not
+				// physically adjacent to the current sub-run.
+				if(current.storagePosition != runStart + runLen)
+				{
+					if(!coalesce)
+					{
+						// no coalescing: stop at the first gap so the relocation stays one contiguous range.
+						break;
+					}
+					// close the current sub-run and start a new one after the gap.
+					subRanges.add(new long[]{runStart, runLen});
+					runStart = current.storagePosition;
+					runLen   = 0L                     ;
 				}
 
 				// set new file. Enqueuing in the file's item chain is done for the whole sub chain
 				current.typeInFile      = headFile.typeInFile(current.typeInFile.type);
-								
-				// update position to the one in the target file (old length plus current copy length)
-				current.storagePosition = XTypes.to_int(targetFileOldTotalLength + copyLength);
 
-				// advance to next entity and add current entity's length to the total copy length
-				copyLength += current.length;
+				// update position to the COMPACTED layout in the target file (old length plus live bytes so far)
+				current.storagePosition = XTypes.to_int(targetFileOldTotalLength + totalLive);
+
+				// advance to next entity and add current entity's length to the running totals
+				runLen    += current.length;
+				totalLive += current.length;
 				current = (last = current).fileNext;
+
+				// soft size cap: emit the coalesced chunk once it reaches the target. The current entity
+				// was already added, so a single entity larger than the target still forms its own chunk.
+				if(coalesce && totalLive >= coalesceChunkTargetBytes)
+				{
+					break;
+				}
 			}
-			while(current.storagePosition == copyStart + copyLength);
+			// close the trailing sub-run.
+			if(runLen != 0L)
+			{
+				subRanges.add(new long[]{runStart, runLen});
+			}
 
 			// can only reach here if there is at least one entity to transfer
 
 			// update source file to keep consistency as it might not be cleared completely
-			sourceFile.removeHeadBoundChain(current, copyLength);
+			sourceFile.removeHeadBoundChain(current, totalLive);
 
 			// update target file's content length. Must be done here as next transfer depends on updated length
 			headFile.addChainToTail(first, last);
 
-			this.appendBytesToHeadFile(sourceFile, copyStart, copyLength);
+			this.appendBytesToHeadFile(sourceFile, subRanges, firstSourceOffset, totalLive, checksumReserve);
 
 			// derive fullness state of target file. Can happen on exact fit or oversized single entity.
-			if(copyLength >= freeSpace)
+			if(totalLive >= freeSpace)
 			{
 				this.createNextStorageFile();
 			}
 		}
 
 		private void appendBytesToHeadFile(
-			final StorageLiveDataFile.Default sourceFile,
-			final long                           copyStart ,
-			final long                           copyLength
+			final StorageLiveDataFile.Default sourceFile     ,
+			final BulkList<long[]>            subRanges      ,
+			final long                        firstSourceOffset,
+			final long                        totalLive      ,
+			final long                        checksumReserve
 		)
 		{
 
 			final StorageLiveDataFile.Default headFile = this.headFile;
 
-			long headFileLength = headFile.totalLength();
-			
-			// do the actual file-level copying in one go at the end and validate the byte count to be sure
-			long bytes = this.writer.writeTransfer(sourceFile, copyStart, copyLength, headFile);
-			if(copyLength != bytes) {
-				
-				logger.error("Data transfer error! Expected {} bytes transferred to head file but only {} bytes had been transferred! Trying again.", copyLength, bytes);
-				headFile.truncate(headFileLength);
-				
-				bytes = this.writer.writeTransfer(sourceFile, copyStart, copyLength, headFile);
-				if(copyLength != bytes) {
-					logger.error("Data transfer retry error! Expected {} bytes transferred to head file but only {} bytes had been transferred! Aborting!", copyLength, bytes);
-					throw new StorageExceptionIoWriting("Transfer to head file failed, only " + bytes + " of " + copyLength + " bytes transferred.");
+			final long    headFileLength = headFile.totalLength()                       ;
+			final long    timestamp      = this.timestampProvider.currentNanoTimestamp();
+			final boolean emitChecksum   = checksumReserve != 0L                        ;
+
+			if(emitChecksum)
+			{
+				/*
+				 * The relocated chain must carry its own covering ChunkChecksumV1, otherwise the next
+				 * normal commit's ChunkChecksumV1 would implicitly cover these un-hashed bytes and fail
+				 * verification at the next load. The bytes are not otherwise in memory, so read the live
+				 * sub-runs out of the source file (skipping the gaps) into one compacted block, hash it,
+				 * and write the block plus a single covering record as one gathering write. writeStore
+				 * (not the bare write) so the backup mirrors the relocated bytes and their checksum.
+				 */
+				final int        totalLiveInt = X.checkArrayRange(totalLive)              ;
+				final ByteBuffer dataBuffer    = XMemory.allocateDirectNative(totalLiveInt);
+				final ByteBuffer metaBuffer    = this.chunkChecksumBuffer; // reused; cleared before each use
+				metaBuffer.clear();
+				try
+				{
+					// concatenate every live sub-run into the compacted block (gaps are skipped).
+					// readBytes fills at the buffer's current position and advances it, so successive
+					// sub-runs append; the lengths sum to totalLive, exactly filling the buffer. Each
+					// readBytes pins the buffer's limit to position+length, so the full limit must be
+					// restored before the next read or its remaining-space guard would see zero.
+					for(final long[] subRange : subRanges)
+					{
+						dataBuffer.limit(totalLiveInt);
+						sourceFile.readBytes(dataBuffer, subRange[0], subRange[1]);
+					}
+					dataBuffer.flip();
+					// the compacted block is appended at headFileLength, so that is the chunk start the record stores.
+					this.chunkChecksumCalculator.writeChunkChecksumRecord(headFile, headFileLength, metaBuffer, dataBuffer);
+					metaBuffer.flip();
+
+					final ByteBuffer[] gather   = {dataBuffer, metaBuffer}                                            ;
+					final long         expected = totalLive + this.chunkChecksumCalculator.chunkChecksumRecordLength();
+
+					this.writeStoreExactOrTruncate(headFile, X.ArrayView(gather), expected, headFileLength, "Data transfer");
 				}
+				finally
+				{
+					// metaBuffer is the reused chunkChecksumBuffer field — not freed here.
+					XMemory.deallocateDirectByteBuffer(dataBuffer);
+				}
+
+				// the gather write succeeded (otherwise an exception propagated above): commit the chained-tip
+				// advance for this coalesced chunk so the next coalesced chunk chains from it.
+				this.chunkChecksumCalculator.commitChunkWrite(headFile);
+
+				// chain entity bytes contribute to both fileTotalLength and fileDataLength;
+				// the covering ChunkChecksumV1 entry is a negative-length record and contributes only
+				// to fileTotalLength (gap-length semantics — matches load-side accounting).
+				headFile.increaseContentLength(totalLive);
+				headFile.registerMetaLength(this.chunkChecksumCalculator.chunkChecksumRecordLength());
+			}
+			else
+			{
+				// No checksum to emit: the chain was collected as a single contiguous run starting at
+				// firstSourceOffset, so relocate it with the zero-copy, backup-aware file-to-file
+				// transfer (no in-memory buffering, relocated bytes stay mirrored to the backup).
+				long bytes = this.writer.writeTransfer(sourceFile, firstSourceOffset, totalLive, headFile);
+				if(totalLive != bytes)
+				{
+					logger.error("Data transfer error! Expected {} bytes transferred to head file but only {} bytes had been transferred! Trying again.", totalLive, bytes);
+					headFile.truncate(headFileLength);
+
+					bytes = this.writer.writeTransfer(sourceFile, firstSourceOffset, totalLive, headFile);
+					if(totalLive != bytes)
+					{
+						logger.error("Data transfer retry error! Expected {} bytes transferred to head file but only {} bytes had been transferred! Aborting!", totalLive, bytes);
+						throw new StorageExceptionIoWriting("Transfer to head file failed, only " + bytes + " of " + totalLive + " bytes transferred.");
+					}
+				}
+
+				// (15.02.2019 TM)NOTE: changed from arithmetic inside #addChainToTail to directly using copyLength in here.
+				headFile.increaseContentLength(totalLive);
 			}
 
-			// increase content length by length of chain
-			// (15.02.2019 TM)NOTE: changed from arithmetic inside #addChainToTail to directly using copyLength in here.
-			headFile.increaseContentLength(copyLength);
-
 			final long newHeadFileLength = headFile.totalLength();
-			final long timestamp         = this.timestampProvider.currentNanoTimestamp();
-			this.writeTransactionsEntryTransfer(sourceFile, copyStart, copyLength, timestamp, newHeadFileLength);
-			
+			// One transfer entry suffices for a coalesced (or single-run) write: init validates only
+			// the monotonic head-file length; the source number/offset are informational. The offset
+			// records the first sub-run's start.
+			this.writeTransactionsEntryTransfer(sourceFile, firstSourceOffset, totalLive, timestamp, newHeadFileLength);
+
 			/*
 			 * Note:
 			 * It can happen that a transfer is written completely but the process terminates right before the
@@ -518,10 +693,71 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				throw new StorageExceptionIoWriting("New storage file is not empty: " + file);
 			}
 
+			// capture the current head as the chain predecessor BEFORE registerStorageHeadFile reassigns
+			// this.headFile; null for the first file (chain seeds from the configured initial seed).
+			final StorageLiveDataFile.Default predecessor = this.headFile;
+
 			// create and register StorageFile instance with an attached channel
 			final StorageLiveDataFile.Default dataFile = this.createLiveDataFile(file, this.channelIndex(), fileNumber);
 			this.registerStorageHeadFile(dataFile);
-			this.writeTransactionsEntryFileCreation(0, this.timestampProvider.currentNanoTimestamp(), fileNumber);
+
+			// Emit FileHeaderV1 as the new file's first content (only when the policy emits). The
+			// transaction-log entry below records the initial length so load-time consistency checks
+			// see physical-size == expected-size. When the policy does not emit, no FileHeaderV1 is
+			// written, the file's chunkChecksumKind stays 0 (indistinguishable from a legacy file), the
+			// chunk-checksum gates in storeChunks/dissolution/import emit nothing, and the initial
+			// length is 0.
+			final long initialFileLength = this.chunkChecksumCalculator.isWriting()
+				? this.chunkChecksumCalculator.fileHeaderRecordLength()
+				: 0L
+			;
+			if(initialFileLength != 0L)
+			{
+				this.writeFileHeaderRecord(dataFile, predecessor);
+			}
+
+			this.writeTransactionsEntryFileCreation(
+				initialFileLength                                    ,
+				this.timestampProvider.currentNanoTimestamp()        ,
+				fileNumber
+			);
+		}
+
+		/**
+		 * Writes the file-header meta record (as produced by the {@link StorageChunkChecksumCalculator})
+		 * as the new file's first negative-length entry, registers it as gap length and caches the
+		 * header state in memory. Only called when the calculator is writing (see
+		 * {@link #createNewStorageFile(long)}).
+		 */
+		private void writeFileHeaderRecord(
+			final StorageLiveDataFile.Default file       ,
+			final StorageLiveDataFile.Default predecessor
+		)
+		{
+			// chain root stamped into the header: predecessor's tip (chained) / all-zero (non-chained).
+			final byte[]     chainRoot    = this.chunkChecksumCalculator.nextChainRoot(predecessor);
+			final long       headerLength = this.chunkChecksumCalculator.fileHeaderRecordLength();
+			final ByteBuffer headerBuffer = this.fileHeaderBuffer; // reused; cleared before each use
+			headerBuffer.clear();
+			this.chunkChecksumCalculator.writeFileHeaderRecord(headerBuffer, chainRoot);
+			headerBuffer.flip();
+
+			// writeStore (not the bare write) so the backup mirrors the FileHeaderV1 record.
+			final long bytesWritten = this.writer.writeStore(file, this.fileHeaderBufferWrap);
+			if(bytesWritten != headerLength)
+			{
+				throw new StorageExceptionIoWriting(
+					"Expected " + headerLength
+					+ " bytes for file-header meta record but wrote " + bytesWritten
+				);
+			}
+
+			// Update file accounting and cache the header state in memory so the rest of the session
+			// sees the same state a re-load would produce. The file-header meta record is a negative-
+			// length entry: it counts toward fileTotalLength but NOT fileDataLength (matches load-side
+			// semantics in StorageEntityInitializer).
+			file.registerMetaLength(headerLength);
+			this.chunkChecksumCalculator.cacheFileHeaderOn(file, chainRoot);
 		}
 		
 		private void registerStorageHeadFile(final StorageLiveDataFile.Default storageFile)
@@ -599,29 +835,54 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			return physicalLength;
 		}
 		
-		private void ensureHeadFileLoadableSize(final ByteBuffer[] dataBuffers)
+		/**
+		 * Two-stage pre-write rollover for the upcoming gather chunk:
+		 * <ol>
+		 *   <li>The total commit size must fit in an int (single-buffer load constraint, 2 GiB cap);
+		 *       if the cumulative would push the head past 2^31, rotate the head before writing.</li>
+		 *   <li>The chunk plus the trailing {@code ChunkChecksumV1} (when applicable) must not push
+		 *       the head past {@code fileMaximumSize}. {@link #checkForNewFile()} only retires a head
+		 *       that is ALREADY at/above max; without this second guard the last store before
+		 *       retirement overshoots by exactly {@code entityBytes + checksumReserve}.
+		 *       If the head has no entity bytes yet (only protocol envelope, e.g. just a
+		 *       {@code FileHeaderV1}), rolling over cannot help — keep the overshoot rather than
+		 *       create an empty successor file (mirrors the singleton fall-through in
+		 *       {@link #transferOneChainToHeadFile}).</li>
+		 * </ol>
+		 */
+		private void ensureHeadFitsUpcomingChunk(final ByteBuffer[] dataBuffers)
 		{
-			//Must ensure that a file size never exceeds 2^31 bytes size.
-			//If that size is exceeded the storage is corrupted and can't be loaded any more because
-			//the current implementation use only one byte buffer to load a file.
-			//This buffer size is limited to an Integer.MAX_VALUE value.
-			
-			long commitSize = 0;
+			long chunkSize = 0;
 			for(int i = 0; i < dataBuffers.length; i++)
 			{
-				commitSize += dataBuffers[i].limit();
-				if(commitSize > Integer.MAX_VALUE)
-				{
-					//Should never be reached, this case should be already handled by
-					//org.eclipse.store.storage.types.StorageDataChunkValidator.MaxFileSize.
-					//But keep exception to have second guard as the validator might be replaced.
-					throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), commitSize);
-				}
-				if(commitSize + this.headFile.totalLength() > Integer.MAX_VALUE)
-				{
-					logger.debug("creating new storage file because appending would exceed the file size limit of 2^31 bytes");
-					this.createNextStorageFile();
-				}
+				chunkSize += dataBuffers[i].limit();
+			}
+			if(chunkSize > Integer.MAX_VALUE)
+			{
+				// Should never be reached — handled by StorageDataChunkValidator.MaxFileSize.
+				// Kept as a second guard in case the validator is replaced.
+				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), chunkSize);
+			}
+			if(chunkSize + this.headFile.totalLength() > Integer.MAX_VALUE)
+			{
+				logger.debug("creating new storage file because appending would exceed the file size limit of 2^31 bytes");
+				this.createNextStorageFile();
+			}
+
+			final long checksumReserve = this.chunkChecksumCalculator.reservedLengthFor(this.headFile);
+			final long maximumFileSize = this.dataFileEvaluator.fileMaximumSize();
+			final long projectedTotal  = this.headFile.totalLength() + chunkSize + checksumReserve;
+			// Defence in depth: even on a fresh head (dataLength == 0) we refuse to produce a file
+			// that the load path can no longer read back into a single 2 GiB direct buffer. This
+			// guards against a user wiring a no-op validator that bypasses MaxFileSize.
+			if(projectedTotal > Integer.MAX_VALUE)
+			{
+				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), projectedTotal);
+			}
+			if(projectedTotal > maximumFileSize
+				&& this.headFile.dataLength() != 0L)
+			{
+				this.createNextStorageFile();
 			}
 		}
 
@@ -631,24 +892,70 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		{
 			if(dataBuffers.length == 0)
 			{
-				return new long[0]; // nothing to write (empty chunk, only header for consistency)
+				// nothing to write (empty chunk, only header for consistency). Clear any pending lengths so a
+				// prior rolled-back store's stale values cannot be applied by this store's commitWrite.
+				this.uncommittedDataLength = 0L;
+				this.uncommittedMetaLength = 0L;
+				return new long[0];
 			}
-			
+
 			this.checkForNewFile();
-			this.ensureHeadFileLoadableSize(dataBuffers);
-				
+			this.ensureHeadFitsUpcomingChunk(dataBuffers); // 2 GiB / fileMaximumSize check + possible head rollover
+
 			final long   oldTotalLength   = this.ensureHeadFileTotalLength();
 			final long[] storagePositions = allChunksStoragePositions(dataBuffers, oldTotalLength);
-			final long   writeCount       = this.writer.writeStore(this.headFile, X.ArrayView(dataBuffers));
-			final long   newTotalLength   = oldTotalLength + writeCount;
-			
+
+			// Single-write contract: compute the checksum over dataBuffers, build the ChunkChecksumV1
+			// meta-record buffer, and submit the entity buffers plus the meta buffer as one gathering
+			// write (no separate write, no intermediate fsync).
+			//
+			// Emit the ChunkChecksumV1 only when the policy emits AND the head file carries a
+			// FileHeaderV1 (chunkChecksumKind() != 0; no automatic upgrade of legacy files). A legacy
+			// head file has none, so emitting a checksum there would make the load walker hash from
+			// file offset 0 across un-covered bytes and throw; such files accumulate unprotected writes
+			// until they roll over to a fresh FileHeaderV1 file. ensureHeadFitsUpcomingChunk above may
+			// have rolled the head over, so the gate re-checks coversChunkWrites against the new head.
+			final long writeCount;
+			if(this.chunkChecksumCalculator.coversChunkWrites(this.headFile))
+			{
+				final long       metaLength = this.chunkChecksumCalculator.chunkChecksumRecordLength();
+				final ByteBuffer metaBuffer = this.chunkChecksumBuffer; // reused; cleared before each use
+				metaBuffer.clear();
+				// the checksum write computes the chained tip but does NOT advance the file tip; that happens
+				// in commitWrite() via commitChunkWrite(). A rolled-back/failed store thus never advances it.
+				// the chunk's data is appended at oldTotalLength (the head file's length before this write), so
+				// that is the in-file chunk start the covering record records for the load-walk cross-check.
+				this.chunkChecksumCalculator.writeChunkChecksumRecord(this.headFile, oldTotalLength, metaBuffer, dataBuffers);
+				metaBuffer.flip();
+
+				final ByteBuffer[] gather = new ByteBuffer[dataBuffers.length + 1];
+				System.arraycopy(dataBuffers, 0, gather, 0, dataBuffers.length);
+				gather[dataBuffers.length] = metaBuffer;
+
+				writeCount = this.writer.writeStore(this.headFile, X.ArrayView(gather));
+
+				// Split the writeCount: entity bytes go to fileDataLength via increaseContentLength
+				// at commit time; meta-record bytes go to fileTotalLength via registerGapLength
+				// (matches load-side semantics). The two fields are accumulated here and consumed
+				// by commitWrite()/rollbackWrite().
+				this.uncommittedDataLength = writeCount - metaLength;
+				this.uncommittedMetaLength = metaLength;
+			}
+			else
+			{
+				// Legacy head file: write entity buffers only, exactly as the pre-feature engine did.
+				writeCount = this.writer.writeStore(this.headFile, X.ArrayView(dataBuffers));
+				this.uncommittedDataLength = writeCount;
+				this.uncommittedMetaLength = 0L;
+			}
+
+			final long newTotalLength = oldTotalLength + writeCount;
+
 			if(newTotalLength != this.headFile.size())
 			{
 				throwImpossibleStoreLengthException(timestamp, oldTotalLength, writeCount, dataBuffers);
 			}
-			
-			this.uncommittedDataLength = writeCount;
-			
+
 			this.writeTransactionsEntryStore(this.headFile, oldTotalLength, writeCount, timestamp, newTotalLength);
 
 			this.restartFileCleanupCursor();
@@ -659,33 +966,52 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		@Override
 		public final void rollbackWrite()
 		{
-			// only roll back if an uncommitted write actually happened (size grew past the committed length).
-			// channels that wrote nothing (e.g. empty chunk) must not accrue a spurious truncation entry.
-			if(this.headFile.totalLength() != this.headFile.size())
-			{
-				final long timestamp = this.timestampProvider.currentNanoTimestamp();
+				// The chained tip is advanced only by commitWrite, so the file tip is already correct here
+				// and left as-is. Only roll back the on-disk bytes if an uncommitted write actually happened
+				// (size grew past the committed length). Channels that wrote nothing (e.g. empty chunk) must
+				// not accrue a spurious truncation entry.
+				if(this.headFile.totalLength() != this.headFile.size())
+				{
+						final long timestamp = this.timestampProvider.currentNanoTimestamp();
 
-				// write truncation entry (BEFORE the actual truncate), mirroring handleLastFile, so the
-				// transaction log and the data file stay consistent after a rolled-back partial store.
-				this.writeTransactionsEntryFileTruncation(this.headFile, timestamp, this.headFile.totalLength());
+						// write truncation entry (BEFORE the actual truncate), mirroring handleLastFile, so the
+						// transaction log and the data file stay consistent after a rolled-back partial store.
+						this.writeTransactionsEntryFileTruncation(this.headFile, timestamp, this.headFile.totalLength());
 
-				this.writer.truncate(this.headFile, this.headFile.totalLength(), this.fileProvider);
-			}
+						this.writer.truncate(this.headFile, this.headFile.totalLength(), this.fileProvider);
+				}
+
+				// The store is abandoned: discard its pending length contributions so a later commitWrite
+				// (e.g. a subsequent empty-chunk store that returns early without re-setting these) cannot
+				// apply the stale values and spuriously advance the chained tip for a chunk never written.
+				this.clearUncommittedDataLength();
 		}
+
 
 		@Override
 		public final void commitWrite()
 		{
-			// commit data length
+			// commit length: entity bytes contribute to both fileTotalLength and fileDataLength,
+			// meta-record bytes contribute to fileTotalLength and fileMetaLength (so dataFillRatio
+			// treats them as useful overhead rather than reclaimable gap — matches load-side
+			// accounting in StorageEntityInitializer).
 			this.headFile.increaseContentLength(this.uncommittedDataLength);
+			if(this.uncommittedMetaLength != 0L)
+			{
+				this.headFile.registerMetaLength(this.uncommittedMetaLength);
+				// a covering chunk checksum was written this store: now that it is committed, advance the
+				// chained tip on the head file (no-op for non-chained kinds).
+				this.chunkChecksumCalculator.commitChunkWrite(this.headFile);
+			}
 
-			// reset the length change helper field
+			// reset the length change helper fields
 			this.clearUncommittedDataLength();
 		}
-		
+
 		final void clearUncommittedDataLength()
 		{
-			this.uncommittedDataLength = 0;
+			this.uncommittedDataLength     = 0;
+			this.uncommittedMetaLength     = 0;
 		}
 		
 		final void loadData(
@@ -1039,7 +1365,8 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// register items (gaps and entities, with latest version of each entity replacing all previous)
 			final StorageEntityInitializer<StorageLiveDataFile.Default> initializer =
 				StorageEntityInitializer.New(this.entityCache, f ->
-					StorageLiveDataFile.New(this, f)
+					StorageLiveDataFile.New(this, f),
+					this.metaRecordRegistry
 				)
 			;
 			this.headFile = initializer.registerEntities(files, lastFileLength);
@@ -1055,6 +1382,15 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 			// check if last file is over-sized and should be retired right away.
 			this.checkForNewFile();
+
+			// continuousCoverage: if emit is on but the head file is not covered by the primary kind (a
+			// legacy file, or one written by a different algorithm), roll over now so new writes land in a
+			// covered file instead of extending an unprotected tail. A no-op once the head is already covered.
+			if(this.chunkChecksumCalculator.policy().continuousCoverage()
+				&& !this.chunkChecksumCalculator.coversChunkWrites(this.headFile))
+			{
+				this.createNextStorageFile();
+			}
 
 			return idAnalysis;
 		}
@@ -1327,6 +1663,8 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			XMemory.deallocateDirectByteBuffer(this.entryBufferFileDeletion);
 			XMemory.deallocateDirectByteBuffer(this.entryBufferFileTruncation);
 			XMemory.deallocateDirectByteBuffer(this.standardByteBuffer);
+			XMemory.deallocateDirectByteBuffer(this.chunkChecksumBuffer);
+			XMemory.deallocateDirectByteBuffer(this.fileHeaderBuffer);
 		}
 
 		final void handleLastFile(
@@ -1421,6 +1759,172 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		public final boolean issuedFileCleanupCheck(final long nanoTimeBudgetBound)
 		{
 			return this.internalCheckForCleanup(nanoTimeBudgetBound, this.dataFileEvaluator);
+		}
+
+		@Override
+		public final StorageIntegrityCheckResult verifyChunkChecksums(final long nanoTimeBudgetBound, final boolean freshScan)
+		{
+			final StorageIntegrityCheckResult.Default result = StorageIntegrityCheckResult.New();
+
+			// Honor the configured policy: a non-verifying policy (None / verify-off) checks nothing.
+			if(!this.chunkChecksumCalculator.isVerifying() || this.headFile == null)
+			{
+				return result; // complete + clean
+			}
+
+			if(freshScan)
+			{
+				this.snapshotIntegrityScope();
+			}
+			else if(this.integrityScopeNumbers == null)
+			{
+				// already finished this scan: return complete+empty rather than re-snapshotting, so a budgeted
+				// scan across uneven channels terminates without re-hashing or duplicating findings.
+				return result;
+			}
+
+			// O(files) number->file lookup for this pass; a snapshotted file no longer present was dissolved.
+			final EqHashTable<Long, StorageLiveDataFile.Default> filesByNumber = this.currentFilesByNumber();
+
+			final StorageChecksumAnomalyReporter reporter = StorageChecksumAnomalyReporter.NewCollecting(
+				this.chunkChecksumCalculator.policy(),
+				this.channelIndex()                  ,
+				result
+			);
+
+			ByteBuffer buffer = null;
+			try
+			{
+				while(this.integrityScopeCursor < this.integrityScopeNumbers.length)
+				{
+					final long                        number = this.integrityScopeNumbers[this.integrityScopeCursor];
+					final long                        length = this.integrityScopeLengths[this.integrityScopeCursor];
+					final StorageLiveDataFile.Default file   = filesByNumber.get(number);
+
+					// file == null => dissolved by housekeeping between resume calls => skip (no false positive).
+					if(file != null && length > 0L)
+					{
+						// A sealed (non-head) file is immutable: a size change since the snapshot is corruption /
+						// tampering — always an error. The snapshot head is exempt (it legitimately grows) and is
+						// verified only up to its snapshot committed length.
+						final long currentSize = file.size();
+						final long verifyLength;
+						if(number == this.integrityScopeHeadNumber)
+						{
+							verifyLength = length;
+						}
+						else
+						{
+							if(currentSize != length)
+							{
+								result.add(new StorageIntegrityCheckResult.Finding(
+									this.channelIndex(), number, currentSize,
+									StorageIntegrityCheckResult.Anomaly.FILE_SIZE_CHANGED, 0L, null, null
+								));
+							}
+							// verify the surviving region; clamp so a shrunk file is not read past its end.
+							verifyLength = Math.min(length, currentSize);
+						}
+
+						if(verifyLength > 0L)
+						{
+							final int len = X.checkArrayRange(verifyLength);
+							if(buffer == null || buffer.capacity() < len)
+							{
+								if(buffer != null)
+								{
+									XMemory.deallocateDirectByteBuffer(buffer);
+								}
+								buffer = XMemory.allocateDirectNative(Math.max(len, XMemory.defaultBufferSize()));
+							}
+							buffer.clear();
+							buffer.limit(len);
+							file.readBytes(buffer, 0, verifyLength);
+
+							this.chunkChecksumCalculator.verifyDataFile(file, buffer, reporter);
+						}
+					}
+
+					this.integrityScopeCursor++;
+
+					// resume granularity is one whole file (chained files must be walked from their header), and
+					// the budget is checked AFTER a file so each call makes progress even with a tiny budget.
+					if(this.integrityScopeCursor < this.integrityScopeNumbers.length
+						&& System.nanoTime() >= nanoTimeBudgetBound)
+					{
+						result.setComplete(false);
+						return result;
+					}
+				}
+
+				// whole scope covered: this channel is done. Clear the scope so resume calls (freshScan == false)
+				// from siblings still working return complete+empty instead of re-scanning.
+				result.setComplete(true);
+				this.clearIntegrityScope();
+				return result;
+			}
+			finally
+			{
+				if(buffer != null)
+				{
+					XMemory.deallocateDirectByteBuffer(buffer);
+				}
+			}
+		}
+
+		private void snapshotIntegrityScope()
+		{
+			// snapshot every file's (number, length); the head file is bounded to its current committed length.
+			final StorageLiveDataFile.Default headFile = this.headFile;
+
+			int count = 0;
+			StorageLiveDataFile.Default file = headFile;
+			do
+			{
+				file = file.next;
+				count++;
+			}
+			while(file != headFile);
+
+			final long[] numbers = new long[count];
+			final long[] lengths = new long[count];
+			int i = 0;
+			file = headFile;
+			do
+			{
+				file = file.next;
+				numbers[i] = file.number()     ;
+				lengths[i] = file.totalLength(); // head file: current committed length L (immutable in [0, L)).
+				i++;
+			}
+			while(file != headFile);
+
+			this.integrityScopeNumbers    = numbers          ;
+			this.integrityScopeLengths    = lengths          ;
+			this.integrityScopeCursor     = 0                ;
+			this.integrityScopeHeadNumber = headFile.number();
+		}
+
+		private void clearIntegrityScope()
+		{
+			this.integrityScopeNumbers = null;
+			this.integrityScopeLengths = null;
+			this.integrityScopeCursor  = 0   ;
+		}
+
+		private EqHashTable<Long, StorageLiveDataFile.Default> currentFilesByNumber()
+		{
+			final EqHashTable<Long, StorageLiveDataFile.Default> table = EqHashTable.New();
+			final StorageLiveDataFile.Default headFile = this.headFile;
+			StorageLiveDataFile.Default file = headFile;
+			do
+			{
+				file = file.next;
+				table.put(file.number(), file);
+			}
+			while(file != headFile);
+
+			return table;
 		}
 
 		public boolean issuedTransactionFileCheck(final boolean checkSize)
@@ -1647,6 +2151,10 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				this.importHelper = null;
 				throw new StorageException(e);
 			}
+			// base of the 2 GiB guard: the fresh import file's FileHeaderV1 (0 when the policy does
+			// not emit). totalLength() stays frozen at this value during import (it is only raised in
+			// commitImport), so importBatch tracks the projected run length itself.
+			this.importHelper.importHeadFileLength = this.headFile.totalLength();
 		}
 
 		public void copyData(final StorageImportSource importSource)
@@ -1679,9 +2187,128 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 			final long copyLength = loopFileLength - oldTotalLength;
 			headFile.increaseContentLength(copyLength);
+
+			// The imported entity bytes were appended contiguously (zero-copy transfer) with no covering
+			// ChunkChecksumV1. Emit one now over the whole imported run [oldTotalLength, loopFileLength)
+			// so the load-time walker has an authoritative hash and a later store's ChunkChecksumV1 does
+			// not fold this un-hashed run into its own chunk hash. Mirrors appendBytesToHeadFile.
+			final long metaLength = this.appendImportChunkChecksum(headFile, oldTotalLength, copyLength);
+
 			this.cleanupImportHelper();
 
-			this.writeTransactionsEntryStore(this.headFile, oldTotalLength, copyLength, taskTimestamp, loopFileLength);
+			this.writeTransactionsEntryStore(
+				this.headFile          ,
+				oldTotalLength         ,
+				copyLength + metaLength,
+				taskTimestamp          ,
+				loopFileLength + metaLength
+			);
+		}
+
+		/**
+		 * Gathering-writes {@code buffers} to {@code headFile}, asserting exactly {@code expected} bytes land. On a
+		 * short write it logs, truncates back to {@code truncateBackTo}, rewinds the buffers and retries once; a
+		 * second short write throws {@link StorageExceptionIoWriting}. Shared by the dissolution-transfer and
+		 * import covering-record writes.
+		 *
+		 * @param headFile       the head file being appended to.
+		 * @param buffers        the buffers to write (and rewind before the retry).
+		 * @param expected       the exact byte count the write must produce.
+		 * @param truncateBackTo the file length to truncate back to before retrying.
+		 * @param what           a short label for the operation, used in the log/exception messages.
+		 */
+		private void writeStoreExactOrTruncate(
+			final StorageLiveDataFile.Default    headFile      ,
+			final Iterable<? extends ByteBuffer> buffers       ,
+			final long                           expected      ,
+			final long                           truncateBackTo,
+			final String                         what
+		)
+		{
+			long bytes = this.writer.writeStore(headFile, buffers);
+			if(bytes == expected)
+			{
+				return;
+			}
+
+			logger.error("{} error! Expected {} bytes written to head file but only {} bytes had been written! Trying again.", what, expected, bytes);
+			headFile.truncate(truncateBackTo);
+			for(final ByteBuffer buffer : buffers)
+			{
+				buffer.rewind();
+			}
+
+			bytes = this.writer.writeStore(headFile, buffers);
+			if(bytes != expected)
+			{
+				logger.error("{} retry error! Expected {} bytes written to head file but only {} bytes had been written! Aborting!", what, expected, bytes);
+				throw new StorageExceptionIoWriting(what + " to head file failed, only " + bytes + " of " + expected + " bytes written.");
+			}
+		}
+
+		/**
+		 * Writes a single covering {@code ChunkChecksumV1} meta record over the contiguous
+		 * imported entity run {@code [chunkStart, chunkStart + chunkLength)} that {@link #importBatch}
+		 * appended to the head file. The bytes were transferred zero-copy and are not otherwise in
+		 * memory, so they are read back from the head file to compute the checksum. The meta
+		 * record is then appended and registered as gap length (negative-length record &mdash; counts
+		 * toward {@code fileTotalLength} only, matching load-side accounting). Returns the number of
+		 * meta bytes written, or {@code 0} for an empty import (no checksum emitted).
+		 *
+		 * @param headFile    the import head file the entity run was written to
+		 * @param chunkStart  file offset of the first imported entity byte (== old head total length)
+		 * @param chunkLength total length of the contiguous imported entity run
+		 * @return the meta-record byte count appended, or {@code 0} if {@code chunkLength == 0}
+		 */
+		private long appendImportChunkChecksum(
+			final StorageLiveDataFile.Default headFile   ,
+			final long                        chunkStart ,
+			final long                        chunkLength
+		)
+		{
+			// chunkLength == 0: empty import, nothing to cover. Otherwise emit only when the policy emits
+			// AND the head file carries a FileHeaderV1, as in storeChunks. In practice the import
+			// destination is always a fresh FileHeaderV1 file, so the second guard is defensive and keeps
+			// the three emission sites (storeChunks, dissolution, import) consistent.
+			if(chunkLength == 0L || !this.chunkChecksumCalculator.coversChunkWrites(headFile))
+			{
+				return 0L;
+			}
+
+			final long       headFileLength = headFile.totalLength()                                       ;
+			final int        chunkLengthInt = X.checkArrayRange(chunkLength)                                ;
+			final long       metaLength     = this.chunkChecksumCalculator.chunkChecksumRecordLength()        ;
+			final ByteBuffer dataBuffer     = XMemory.allocateDirectNative(chunkLengthInt)                  ;
+			final ByteBuffer metaBuffer     = this.chunkChecksumBuffer; // reused; cleared before each use
+			metaBuffer.clear();
+			try
+			{
+				headFile.readBytes(dataBuffer, chunkStart, chunkLength);
+				dataBuffer.flip();
+
+				// chunkStart is the imported run's in-file offset — the chunk start the record stores.
+				this.chunkChecksumCalculator.writeChunkChecksumRecord(headFile, chunkStart, metaBuffer, dataBuffer);
+				metaBuffer.flip();
+
+				// writeStore (not the bare write) so the backup mirrors the import-covering checksum.
+				this.writeStoreExactOrTruncate(
+					headFile, this.chunkChecksumBufferWrap, metaLength, headFileLength, "Import checksum write");
+			}
+			finally
+			{
+				// metaBuffer is the reused chunkChecksumBuffer field — not freed here.
+				XMemory.deallocateDirectByteBuffer(dataBuffer);
+			}
+
+			// the import-covering write succeeded (otherwise an exception propagated above): commit the
+			// chained-tip advance for this imported chunk.
+			this.chunkChecksumCalculator.commitChunkWrite(headFile);
+
+			// negative-length meta record: contributes to fileTotalLength and fileMetaLength (so
+			// dataFillRatio treats it as useful overhead rather than reclaimable gap).
+			headFile.registerMetaLength(metaLength);
+
+			return metaLength;
 		}
 
 		final void cleanupImportHelper()
@@ -1697,8 +2324,22 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				return;
 			}
 
+			// 2 GiB loadability guard: the whole per-channel import run is written contiguously into a
+			// single head file (no mid-run rollover), and commitImport appends one covering
+			// ChunkChecksumV1 at the end. The resulting file must stay loadable into a single direct
+			// ByteBuffer, i.e. within Integer.MAX_VALUE bytes. The trailing-checksum reserve is the
+			// configured chunk-checksum record length (0 when the policy does not emit). Failing fast
+			// here turns a silently-unloadable oversized file into a clean, rolled-back import error.
+			final long checksumReserve = this.chunkChecksumCalculator.reservedLengthFor(this.headFile);
+			final long projectedLength = this.importHelper.importHeadFileLength + length + checksumReserve;
+			if(projectedLength > Integer.MAX_VALUE)
+			{
+				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), projectedLength);
+			}
+
 			this.checkForNewFile();
 			this.writer.writeImport(source, position, length, this.headFile);
+			this.importHelper.importHeadFileLength += length;
 		}
 
 		final void rollbackImport()
@@ -1747,6 +2388,11 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			final StorageLiveDataFile.Default         preImportHeadFile;
 			final BulkList<StorageChannelImportBatch> importBatches     = BulkList.New(1000);
 			StorageImportSource                       source           ;
+
+			// Running projected length of the single import head file. Initialized to the fresh import
+			// file's totalLength (its FileHeaderV1) and grown per batch so importBatch can guard the
+			// 2 GiB load limit.
+			long importHeadFileLength;
 
 
 			ImportHelper(final StorageLiveDataFile.Default preImportHeadFile)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -128,6 +128,13 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		// the only reason for this limit is to have an int instead of a long for the item's file position.
 		static final int MAX_FILE_LENGTH = Integer.MAX_VALUE;
 
+		// Upper bound for the on-demand integrity check's per-channel verify buffer. A data file at or below this
+		// size is read whole (the proven resident verifyDataFile walk); a larger one is streamed in windows of this
+		// size (verifyDataFileStreaming), so peak direct memory of a full integrity check is channelCount × this
+		// value regardless of the configured data-file maximum size (which can be raised toward the ~2 GiB cap).
+		// 8 MiB matches StorageDataFileEvaluator.defaultFileMaximumSize(), so default-sized stores never stream.
+		static final int INTEGRITY_VERIFY_BUFFER_LIMIT = 8 * 1024 * 1024;
+
 		// (22.05.2015 TM)TODO: Debug Flag to disable file cleanup for testing
 		private static final boolean DEBUG_ENABLE_FILE_CLEANUP = true;
 
@@ -481,11 +488,13 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 					}
 
 					// Nothing to transfer yet. Roll over to the next head file ONLY if the current head
-					// already holds reclaimable entity bytes; rolling over a head that has only protocol
-					// overhead (FileHeaderV1 / ChunkChecksumV1) produces an identically-shaped successor
-					// and loops forever. dataLength(), not totalLength(), because the latter is non-zero
-					// once a FileHeaderV1 is emitted.
-					if(headFile.dataLength() != 0L)
+					// already holds relocatable content (live entity bytes OR reclaimable gap bytes); rolling
+					// over a head that has only protocol overhead (FileHeaderV1 / ChunkChecksumV1) produces an
+					// identically-shaped successor and loops forever. Subtract metaLength() rather than testing
+					// dataLength(): totalLength() is non-zero once a FileHeaderV1 is emitted, but an all-gap head
+					// (every entity GC'd) still has reclaimable gap bytes and must roll over, as it did before
+					// the checksum feature (old guard: totalLength() != 0).
+					if(headFile.totalLength() - headFile.metaLength() != 0L)
 					{
 						this.createNextStorageFile();
 						return;
@@ -874,7 +883,9 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			final long projectedTotal  = this.headFile.totalLength() + chunkSize + checksumReserve;
 			// Defence in depth: even on a fresh head (dataLength == 0) we refuse to produce a file
 			// that the load path can no longer read back into a single 2 GiB direct buffer. This
-			// guards against a user wiring a no-op validator that bypasses MaxFileSize.
+			// guards against a user wiring a no-op validator that bypasses MaxFileSize. Strict '>' to
+			// match the load limit (StorageEntityInitializer rejects only > Integer.MAX_VALUE, and
+			// X.checkArrayRange accepts exactly Integer.MAX_VALUE) and the chunkSize guards above.
 			if(projectedTotal > Integer.MAX_VALUE)
 			{
 				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), projectedTotal);
@@ -1386,7 +1397,11 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// continuousCoverage: if emit is on but the head file is not covered by the primary kind (a
 			// legacy file, or one written by a different algorithm), roll over now so new writes land in a
 			// covered file instead of extending an unprotected tail. A no-op once the head is already covered.
-			if(this.chunkChecksumCalculator.policy().continuousCoverage()
+			// Skipped in read-only mode: createNextStorageFile() writes a FileHeaderV1 + transaction-log
+			// entry that a disabled WriteController would reject, and no chunks are ever appended in
+			// read-only mode anyway, so ensuring future writes land covered is moot.
+			if(this.writeController.isWritable()
+				&& this.chunkChecksumCalculator.policy().continuousCoverage()
 				&& !this.chunkChecksumCalculator.coversChunkWrites(this.headFile))
 			{
 				this.createNextStorageFile();
@@ -1792,6 +1807,19 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				result
 			);
 
+			// One bounded buffer per channel serves the whole scan: files within the cap are read whole (the proven
+			// resident walk), larger files are streamed in windows of this same buffer. Sized to the largest in-scope
+			// file but never above INTEGRITY_VERIFY_BUFFER_LIMIT, so peak direct memory stays channelCount × cap.
+			long maxScopeLength = 0L;
+			for(final long scopeLength : this.integrityScopeLengths)
+			{
+				if(scopeLength > maxScopeLength)
+				{
+					maxScopeLength = scopeLength;
+				}
+			}
+			final int bufferSize = X.checkArrayRange(Math.min((long)INTEGRITY_VERIFY_BUFFER_LIMIT, maxScopeLength));
+
 			ByteBuffer buffer = null;
 			try
 			{
@@ -1828,20 +1856,23 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 						if(verifyLength > 0L)
 						{
-							final int len = X.checkArrayRange(verifyLength);
-							if(buffer == null || buffer.capacity() < len)
+							if(buffer == null)
 							{
-								if(buffer != null)
-								{
-									XMemory.deallocateDirectByteBuffer(buffer);
-								}
-								buffer = XMemory.allocateDirectNative(Math.max(len, XMemory.defaultBufferSize()));
+								buffer = XMemory.allocateDirectNative(bufferSize);
 							}
-							buffer.clear();
-							buffer.limit(len);
-							file.readBytes(buffer, 0, verifyLength);
-
-							this.chunkChecksumCalculator.verifyDataFile(file, buffer, reporter);
+							if(verifyLength <= INTEGRITY_VERIFY_BUFFER_LIMIT)
+							{
+								// fits the buffer: read the whole file and use the proven resident walk.
+								buffer.clear();
+								buffer.limit(X.checkArrayRange(verifyLength));
+								file.readBytes(buffer, 0, verifyLength);
+								this.chunkChecksumCalculator.verifyDataFile(file, buffer, reporter);
+							}
+							else
+							{
+								// larger than the cap: stream the verify in windows of this buffer (bounded memory).
+								this.chunkChecksumCalculator.verifyDataFileStreaming(file, verifyLength, buffer, reporter);
+							}
 						}
 					}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
@@ -1019,7 +1019,12 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 
 		protected StorageDataChunkValidator.Provider2 ensureDataChunkValidatorProvider2()
 		{
-			return new StorageDataChunkValidator.MaxFileSize();
+			final StorageChunkChecksumCalculator calc =
+				this.getConfiguration().chunkChecksumProvider().createCalculator();
+			final long freshFileMetaReserve = calc.isWriting()
+				? calc.fileHeaderRecordLength() + calc.chunkChecksumRecordLength()
+				: 0L;
+			return new StorageDataChunkValidator.MaxFileSize(freshFileMetaReserve);
 		}
 
 		protected StorageChannelsCreator ensureChannelCreator()

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingBroker.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingBroker.java
@@ -31,8 +31,14 @@ public interface StorageHousekeepingBroker
 		long                        nanoTimeBudget ,
 		StorageEntityCacheEvaluator entityEvaluator
 	);
-	
-	
+
+	public StorageIntegrityCheckResult performIssuedIntegrityCheck(
+		StorageHousekeepingExecutor executor      ,
+		long                        nanoTimeBudget,
+		boolean                     freshScan
+	);
+
+
 	public boolean performFileCleanupCheck(
 		StorageHousekeepingExecutor executor      ,
 		long                        nanoTimeBudget
@@ -102,7 +108,17 @@ public interface StorageHousekeepingBroker
 		{
 			return executor.performIssuedEntityCacheCheck(nanoTimeBudget, evaluator);
 		}
-		
+
+		@Override
+		public StorageIntegrityCheckResult performIssuedIntegrityCheck(
+			final StorageHousekeepingExecutor executor      ,
+			final long                        nanoTimeBudget,
+			final boolean                     freshScan
+		)
+		{
+			return executor.performIssuedIntegrityCheck(nanoTimeBudget, freshScan);
+		}
+
 
 		@Override
 		public boolean performFileCleanupCheck(

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingExecutor.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingExecutor.java
@@ -22,8 +22,10 @@ public interface StorageHousekeepingExecutor
 	public boolean performIssuedGarbageCollection(long nanoTimeBudget);
 	
 	public boolean performIssuedEntityCacheCheck(long nanoTimeBudget, StorageEntityCacheEvaluator evaluator);
-	
-	
+
+	public StorageIntegrityCheckResult performIssuedIntegrityCheck(long nanoTimeBudget, boolean freshScan);
+
+
 	public boolean performFileCleanupCheck(long nanoTimeBudget);
 	
 	public boolean performGarbageCollection(long nanoTimeBudget);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageIntegrityCheckResult.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageIntegrityCheckResult.java
@@ -1,0 +1,303 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.chars.VarString;
+import org.eclipse.serializer.collections.BulkList;
+import org.eclipse.serializer.collections.types.XGettingSequence;
+
+/**
+ * Aggregated result of an on-demand storage integrity check (see
+ * {@link StorageConnection#issueFullIntegrityCheck()} / {@link StorageConnection#issueIntegrityCheck(long)}).
+ * <p>
+ * Collects every detected {@link Anomaly} rather than throwing, so one call surfaces all corruption across
+ * all channels. The chunk-checksum anomalies are routed through the configured
+ * {@link StorageChunkChecksumPolicy} ({@code IGNORE} ones are not collected; {@code LOG} / {@code FAIL} ones
+ * are); {@link Anomaly#FILE_SIZE_CHANGED} is detected by the check itself and is always reported.
+ * {@link #isComplete()} is {@code false} when a budgeted call ran out of time and carries only that call's
+ * findings; repeat until complete (the full check always completes in one call).
+ */
+public interface StorageIntegrityCheckResult
+{
+	/**
+	 * The categories of anomaly an integrity check can report. The first five mirror the load-time
+	 * {@link StorageChunkChecksumPolicy.Anomaly} categories (raised via the configured policy); the last is
+	 * specific to the on-demand check.
+	 */
+	public enum Anomaly
+	{
+		/** A recomputed checksum did not match the stored one. */
+		CHECKSUM_MISMATCH,
+		/** A covering record's stored chunk start disagreed with the boundary the walk reconstructed. */
+		CHUNK_BOUNDARY_MISMATCH,
+		/** A meta-record KIND with no registered handler. */
+		UNKNOWN_KIND,
+		/** A file carries live data but no {@code FileHeaderV1} while coverage was expected. */
+		MISSING_HEADER,
+		/** A covered file holds live content past its last covering record. */
+		UNCOVERED_DATA,
+		/** A sealed (non-head) data file's size changed since the scan began — a sealed file is immutable, so any
+		 *  change (truncation, growth, rewrite) is corruption/tampering. The head file is exempt (it grows).
+		 *  Detected by the check itself and always reported, regardless of the configured policy. */
+		FILE_SIZE_CHANGED
+	}
+
+	/**
+	 * @return {@code true} if no anomalies were collected.
+	 */
+	public boolean isClean();
+
+	/**
+	 * @return {@code true} if the scan covered all in-scope files (it was not cut short by a time budget).
+	 */
+	public boolean isComplete();
+
+	/**
+	 * @return the number of collected anomalies.
+	 */
+	public long anomalyCount();
+
+	/**
+	 * @return an immutable view of the collected anomalies.
+	 */
+	public XGettingSequence<Finding> anomalies();
+
+
+
+	/**
+	 * One detected anomaly: which channel and data file it occurred in, where, its kind, and &mdash; for a
+	 * checksum mismatch &mdash; the stored vs recomputed checksum bytes. Pure data carrier.
+	 */
+	public final class Finding
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final int     channelIndex;
+		private final long    fileNumber  ;
+		private final long    position    ;
+		private final Anomaly anomaly     ;
+		private final long    kind        ;
+		private final byte[]  expected    ;
+		private final byte[]  actual      ;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Finding(
+			final int     channelIndex,
+			final long    fileNumber  ,
+			final long    position    ,
+			final Anomaly anomaly     ,
+			final long    kind        ,
+			final byte[]  expected    ,
+			final byte[]  actual
+		)
+		{
+			super();
+			this.channelIndex = channelIndex;
+			this.fileNumber   = fileNumber  ;
+			this.position     = position    ;
+			this.anomaly      = anomaly     ;
+			this.kind         = kind        ;
+			this.expected     = expected    ;
+			this.actual       = actual      ;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// getters //
+		////////////
+
+		public int channelIndex()
+		{
+			return this.channelIndex;
+		}
+
+		public long fileNumber()
+		{
+			return this.fileNumber;
+		}
+
+		public long position()
+		{
+			return this.position;
+		}
+
+		public Anomaly anomaly()
+		{
+			return this.anomaly;
+		}
+
+		public long kind()
+		{
+			return this.kind;
+		}
+
+		/**
+		 * @return the stored checksum bytes for a {@link Anomaly#CHECKSUM_MISMATCH}; {@code null} otherwise.
+		 */
+		public byte[] expected()
+		{
+			return this.expected;
+		}
+
+		/**
+		 * @return the recomputed checksum bytes for a {@link Anomaly#CHECKSUM_MISMATCH}; {@code null} otherwise.
+		 */
+		public byte[] actual()
+		{
+			return this.actual;
+		}
+
+		@Override
+		public String toString()
+		{
+			final VarString vs = VarString.New()
+				.add(this.anomaly).add(" in channel #").add(this.channelIndex)
+				.add(" data file #").add(this.fileNumber).add(" at offset ").add(this.position)
+			;
+			if(this.kind != 0L)
+			{
+				vs.add(" (kind 0x").add(Long.toHexString(this.kind)).add(')');
+			}
+			if(this.expected != null && this.actual != null)
+			{
+				vs.add(": expected ").add(toHex(this.expected)).add(", got ").add(toHex(this.actual));
+			}
+			return vs.toString();
+		}
+
+		private static String toHex(final byte[] bytes)
+		{
+			final VarString vs = VarString.New();
+			for(final byte b : bytes)
+			{
+				vs.add(Character.forDigit((b >> 4) & 0xF, 16)).add(Character.forDigit(b & 0xF, 16));
+			}
+			return vs.toString();
+		}
+	}
+
+
+
+	public static StorageIntegrityCheckResult.Default New()
+	{
+		return new StorageIntegrityCheckResult.Default();
+	}
+
+
+
+	public final class Default implements StorageIntegrityCheckResult
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final BulkList<Finding> findings = BulkList.New();
+		private       boolean           complete = true          ;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default()
+		{
+			super();
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// declared methods //
+		/////////////////////
+
+		final void add(final Finding finding)
+		{
+			this.findings.add(finding);
+		}
+
+		final void setComplete(final boolean complete)
+		{
+			this.complete = complete;
+		}
+
+		/**
+		 * Folds a per-channel result into this aggregate: appends its findings, {@code AND}s its completion flag.
+		 * Synchronized because each channel merges from its own thread; reads {@code other.findings} directly to
+		 * avoid the defensive copy {@link #anomalies()} would make.
+		 */
+		final synchronized void merge(final StorageIntegrityCheckResult.Default other)
+		{
+			this.findings.addAll(other.findings);
+			this.complete &= other.complete;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		public final boolean isClean()
+		{
+			return this.findings.isEmpty();
+		}
+
+		@Override
+		public final boolean isComplete()
+		{
+			return this.complete;
+		}
+
+		@Override
+		public final long anomalyCount()
+		{
+			return this.findings.size();
+		}
+
+		@Override
+		public final XGettingSequence<Finding> anomalies()
+		{
+			return this.findings.immure();
+		}
+
+		@Override
+		public final String toString()
+		{
+			final VarString vs = VarString.New()
+				.add("StorageIntegrityCheckResult [")
+				.add(this.isClean() ? "clean" : this.findings.size() + " anomalies")
+				.add(this.complete ? "" : ", incomplete")
+				.add(']')
+			;
+			for(final Finding finding : this.findings)
+			{
+				vs.lf().tab().add(finding);
+			}
+			return vs.toString();
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageIntegrityCheckResult.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageIntegrityCheckResult.java
@@ -180,17 +180,7 @@ public interface StorageIntegrityCheckResult
 			}
 			if(this.expected != null && this.actual != null)
 			{
-				vs.add(": expected ").add(toHex(this.expected)).add(", got ").add(toHex(this.actual));
-			}
-			return vs.toString();
-		}
-
-		private static String toHex(final byte[] bytes)
-		{
-			final VarString vs = VarString.New();
-			for(final byte b : bytes)
-			{
-				vs.add(Character.forDigit((b >> 4) & 0xF, 16)).add(Character.forDigit(b & 0xF, 16));
+				vs.add(": expected ").addHexDec(this.expected).add(", got ").addHexDec(this.actual);
 			}
 			return vs.toString();
 		}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLiveDataFile.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLiveDataFile.java
@@ -32,6 +32,13 @@ extends StorageDataFile, StorageLiveChannelFile<StorageLiveDataFile>, StorageCre
 
 	public long dataLength();
 
+	/**
+	 * @return bytes contributed by protocol meta records ({@code FileHeaderV1},
+	 *         {@code ChunkChecksumV1}, ...). Counted into {@link #totalLength()} but kept separate
+	 *         from legacy gap bytes so sizing decisions can treat them as unreclaimable overhead.
+	 */
+	public long metaLength();
+
 	public double dataFillRatio();
 
 	public boolean isHeadFile();
@@ -92,6 +99,19 @@ extends StorageDataFile, StorageLiveChannelFile<StorageLiveDataFile>, StorageCre
 		
 		private long fileTotalLength;
 		private long fileDataLength ;
+		// Bytes contributed by meta records (FileHeaderV1, ChunkChecksumV1...). Counted into
+		// fileTotalLength but kept separate from legacy gap so dataFillRatio() treats protocol
+		// overhead as unreclaimable rather than dissolvable space.
+		private long fileMetaLength ;
+
+		// Cached from the FileHeaderV1 meta record. 0L kind / null chainRoot mean "no FileHeaderV1
+		// seen" (legacy file). The KIND constants in StorageMetaRecord cannot collide with 0L.
+		private long   chunkChecksumKind;
+		private byte[] chainRoot        ;
+		// Running chain tip for chained chunk-checksum kinds: the stored hash of this file's last
+		// chunk, or chainRoot when the file has no chunks yet. Seeded in setFileHeaderV1, advanced
+		// per chunk on write and re-derived on load. null for legacy files; unused by non-chained kinds.
+		private byte[] chainTip         ;
 
 		StorageLiveDataFile.Default next, prev;
 
@@ -163,6 +183,35 @@ extends StorageDataFile, StorageLiveChannelFile<StorageLiveDataFile>, StorageCre
 			super.truncate(newLength);
 		}
 
+		// FileHeaderV1 cached state. 0L / null means no FileHeaderV1 was parsed for this file.
+
+		final long chunkChecksumKind()
+		{
+			return this.chunkChecksumKind;
+		}
+
+		final byte[] chainRoot()
+		{
+			return this.chainRoot;
+		}
+
+		final void setFileHeaderV1(final long chunkChecksumKind, final byte[] chainRoot)
+		{
+			this.chunkChecksumKind = chunkChecksumKind;
+			this.chainRoot         = chainRoot        ;
+			this.chainTip          = chainRoot        ; // seed the running tip; chunks advance it
+		}
+
+		final byte[] chainTip()
+		{
+			return this.chainTip;
+		}
+
+		final void setChainTip(final byte[] chainTip)
+		{
+			this.chainTip = chainTip;
+		}
+
 		final TypeInFile typeInFile(final StorageEntityType.Default type)
 		{
 			// identity equality is enough as every type has a unique instance per channel
@@ -216,6 +265,18 @@ extends StorageDataFile, StorageLiveChannelFile<StorageLiveDataFile>, StorageCre
 		final void registerGapLength(final long length)
 		{
 			this.fileTotalLength += length;
+		}
+
+		final void registerMetaLength(final long length)
+		{
+			this.fileTotalLength += length;
+			this.fileMetaLength  += length;
+		}
+
+		@Override
+		public final long metaLength()
+		{
+			return this.fileMetaLength;
 		}
 
 		final boolean needsRetirement(final StorageDataFileEvaluator configuration)
@@ -300,7 +361,10 @@ extends StorageDataFile, StorageLiveChannelFile<StorageLiveDataFile>, StorageCre
 		@Override
 		public final double dataFillRatio()
 		{
-			return (double)this.fileDataLength / this.fileTotalLength;
+			// Treat meta-record bytes as useful overhead, not gap: they are protocol envelope
+			// (FileHeaderV1, ChunkChecksumV1...) that re-appears on every new file and cannot
+			// be reclaimed by dissolution. Only legacy gap from removed entities is reclaimable.
+			return (double)(this.fileDataLength + this.fileMetaLength) / this.fileTotalLength;
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecord.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecord.java
@@ -1,0 +1,306 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.eclipse.serializer.util.X.notNull;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.binary.types.Binary;
+
+/**
+ * Format-only spec for in-gap meta records inside {@code .dat} data files.
+ * <p>
+ * A meta record is a negative-length entry whose interior carries a structured payload
+ * identified by a high-entropy {@code META_MARKER} at offset 8 and a {@code KIND} code
+ * at offset 10. Old readers (without meta-record awareness) skip the whole entry by
+ * {@code |LENGTH|} without inspecting its content; new readers recognize the marker and
+ * dispatch on the kind code to parse the kind-specific payload.
+ * <p>
+ * The cross-kind envelope and one shared kind &mdash; {@code FileHeaderV1} &mdash; live here:
+ * <ul>
+ *   <li>{@link #KIND_FileHeaderV1} &mdash; one per data file, emitted as the file's first
+ *       entry at creation. Carries the chosen chunk-checksum kind and the chain root
+ *       (used by chained-hash variants). Total size: 46 bytes (LENGTH = -46).</li>
+ * </ul>
+ * The framing for each chunk-checksum kind (its KIND code, record layout, writer and reader) lives
+ * with its algorithm &mdash; see {@code StorageChunkChecksumCalculator.Algorithm}; each implementation
+ * owns its KIND, layout, write and read, and is supplied to {@code StorageChunkChecksumProvider}.
+ * <p>
+ * Envelope layout (any kind):
+ * <pre>
+ *   offset  0   LENGTH        8 B   negative; magnitude = total entry size
+ *   offset  8   META_MARKER   2 B   reserved; same value for every kind
+ *   offset 10   KIND          2 B   identifies the record type
+ *   offset 12   payload ...         kind-specific; total length implied by LENGTH
+ * </pre>
+ * <p>
+ * The {@code META_MARKER} and {@code KIND} codes are the first 2 bytes of a SHA-256 hash of
+ * fixed strings (see the constants below). The marker and kind together form a 32-bit gate: a
+ * non-meta negative-length entry is misread as a meta record only if its offset-8 2-byte value
+ * matches {@code META_MARKER} <i>and</i> its offset-10 2-byte value matches a registered KIND &mdash;
+ * otherwise it falls through to the unknown-KIND strictness (skip by default).
+ *
+ * @see Binary
+ */
+public final class StorageMetaRecord
+{
+	///////////////////////////////////////////////////////////////////////////
+	// constants //
+	//////////////
+
+	/**
+	 * Reserved marker at offset 8 of every meta record. Distinguishes a structured meta
+	 * record from any other negative-length entry (e.g., legacy gap tombstones).
+	 * <p>
+	 * Derivation: the first 2 bytes (big-endian) of
+	 * {@code SHA-256("EclipseStoreMetaRecord/V1")}, interpreted as a Java {@code short}.
+	 * <p>
+	 * Test vector: {@code SHA-256("EclipseStoreMetaRecord/V1")} =
+	 * {@code 215eeffbf92a641c860ad7aa243f9563f16c118a653c0b0e119042a2621b8b4f}; first 2
+	 * bytes = {@code 0x215e}.
+	 */
+	public static final short META_MARKER = (short)0x215e;
+
+	/**
+	 * KIND code for {@code FileHeaderV1} &mdash; emitted as the first entry in every new
+	 * data file. Carries the file's chunk-checksum kind selection and chain root.
+	 * <p>
+	 * Derivation: the first 2 bytes (big-endian) of
+	 * {@code SHA-256("EclipseStoreMetaRecord/Kind/FileHeaderV1")}, as an unsigned 16-bit
+	 * value held in a {@code long}.
+	 * <p>
+	 * Test vector: first 2 bytes = {@code 0xe5a3}.
+	 */
+	public static final long KIND_FileHeaderV1 = 0xe5a3L;
+
+	// Envelope offsets (every kind): LENGTH 8 B, META_MARKER 2 B, KIND 2 B
+	public static final int OFFSET_LENGTH      =  0;
+	public static final int OFFSET_META_MARKER =  8;
+	public static final int OFFSET_KIND        = 10;
+	public static final int OFFSET_PAYLOAD     = 12;
+
+	// FileHeaderV1 payload layout: kind_selection 2 B, chain_root 32 B
+	public static final int OFFSET_FH_KIND_SELECTION = 12;
+	public static final int OFFSET_FH_CHAIN_ROOT     = 14;
+	public static final int LENGTH_FILEHEADERV1      = 46;
+
+	// Chunk-checksum record payload: chunk_start (4 B, in-file offset of the covered chunk) then the algorithm's
+	// checksum bytes. The stored chunk start lets the load walk detect framing desync (a corrupted LENGTH that
+	// reroutes it past a record). Fits an int: data files are capped at Integer.MAX_VALUE.
+	public static final int OFFSET_CC_CHUNK_START = 12;
+	public static final int OFFSET_CC_CHECKSUM    = 16;
+
+	// SHA-256 output length in bytes — also the FileHeaderV1.chain_root field size (fixed by format,
+	// shared across chunk-checksum kinds, used by every chained-variant provider as seed length).
+	public static final int LENGTH_HASH_SHA256 = 32;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// recognizer //
+	////////////////
+
+	/**
+	 * Returns {@code true} if the negative-length entry at {@code address} is a structured
+	 * meta record (META_MARKER present at offset 8). Caller must have already established
+	 * that the entry's LENGTH (at offset 0) is negative; this method does not re-check.
+	 *
+	 * @param address absolute memory address of the entry's start (offset 0 = LENGTH).
+	 * @return {@code true} if offset 8 contains the META_MARKER.
+	 */
+	public static boolean isMetaRecord(final long address)
+	{
+		return XMemory.get_short(address + OFFSET_META_MARKER) == META_MARKER;
+	}
+
+	/**
+	 * Reads the KIND code at offset 10. Caller must have already called
+	 * {@link #isMetaRecord(long)} and confirmed it returned {@code true}.
+	 *
+	 * @param address absolute memory address of the meta record's start.
+	 * @return the KIND code as written.
+	 */
+	public static long kindOf(final long address)
+	{
+		return XMemory.get_short(address + OFFSET_KIND) & 0xFFFFL;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// payload writers //
+	/////////////////////
+
+	/**
+	 * Writes a {@code FileHeaderV1} entry into {@code target} at its current position
+	 * (advances position by {@value #LENGTH_FILEHEADERV1}). The {@code target} buffer must
+	 * be in native byte order &mdash; the encoded values are read back via
+	 * {@link XMemory#get_long(long)} which performs no byte-order transformation.
+	 *
+	 * @param target              direct ByteBuffer in native byte order; must have at
+	 *                            least {@value #LENGTH_FILEHEADERV1} bytes remaining.
+	 * @param chunkChecksumKind   KIND code of the chunk-checksum variant used in this file
+	 *                            (the value of the corresponding provider's {@code KIND}).
+	 * @param chainRoot32         32-byte chain seed for chained variants; all-zeros for
+	 *                            non-chained kinds.
+	 */
+	public static void writeFileHeaderV1(
+		final ByteBuffer target            ,
+		final long       chunkChecksumKind ,
+		final byte[]     chainRoot32
+	)
+	{
+		notNull(target)     ;
+		notNull(chainRoot32);
+		if(chainRoot32.length != LENGTH_HASH_SHA256)
+		{
+			throw new IllegalArgumentException(
+				"chainRoot32 must be " + LENGTH_HASH_SHA256 + " bytes, got " + chainRoot32.length
+			);
+		}
+
+		target.putLong (-(long)LENGTH_FILEHEADERV1);
+		target.putShort(META_MARKER               );
+		target.putShort((short)KIND_FileHeaderV1   );
+		target.putShort((short)chunkChecksumKind   );
+		target.put     (chainRoot32                );
+	}
+
+	/**
+	 * Writes the shared chunk-checksum record envelope (negative LENGTH, {@link #META_MARKER}, {@code kind},
+	 * {@code chunkStart}) into {@code target}, advancing by {@value #OFFSET_CC_CHECKSUM} bytes; the calling
+	 * algorithm appends its checksum bytes after. {@code target} must be a native-order direct buffer.
+	 *
+	 * @param target       direct ByteBuffer in native byte order.
+	 * @param recordLength total record length (envelope + chunk start + checksum); written negated as LENGTH.
+	 * @param kind         the chunk-checksum algorithm KIND code.
+	 * @param chunkStart   in-file offset where the covered chunk begins.
+	 */
+	public static void writeChunkChecksumHeader(
+		final ByteBuffer target      ,
+		final long       recordLength,
+		final long       kind        ,
+		final int        chunkStart
+	)
+	{
+		notNull(target);
+		target.putLong (-recordLength);
+		target.putShort(META_MARKER  );
+		target.putShort((short)kind  );
+		target.putInt  (chunkStart   );
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// payload readers //
+	/////////////////////
+
+	/**
+	 * Parses a {@code FileHeaderV1} entry at {@code address}. Caller is responsible for
+	 * having confirmed (via {@link #isMetaRecord(long)} + {@link #kindOf(long)}) that the
+	 * entry at this address is a FileHeaderV1.
+	 *
+	 * @param address absolute memory address of the entry's start.
+	 * @return the parsed payload.
+	 */
+	public static FileHeaderV1Payload readFileHeaderV1(final long address)
+	{
+		final long   kindSelection = XMemory.get_short(address + OFFSET_FH_KIND_SELECTION) & 0xFFFFL;
+		final byte[] chainRoot     = new byte[LENGTH_HASH_SHA256]                       ;
+		XMemory.copyRangeToArray(address + OFFSET_FH_CHAIN_ROOT, chainRoot);
+		return new FileHeaderV1Payload(kindSelection, chainRoot);
+	}
+
+	/**
+	 * Reads the covered chunk's in-file start offset from a chunk-checksum record at {@code address}. Caller must
+	 * have confirmed (via {@link #isMetaRecord(long)} + {@link #kindOf(long)}) that the entry at this address is a
+	 * chunk-checksum record.
+	 *
+	 * @param address absolute memory address of the record's start.
+	 * @return the stored chunk-start in-file offset.
+	 */
+	public static int readChunkChecksumChunkStart(final long address)
+	{
+		return XMemory.get_int(address + OFFSET_CC_CHUNK_START);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// nested payload types //
+	//////////////////////////
+
+	/**
+	 * Parsed {@code FileHeaderV1} payload. Pure data carrier &mdash; no behavior.
+	 */
+	public static final class FileHeaderV1Payload
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final long   chunkChecksumKind;
+		private final byte[] chainRoot        ;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		FileHeaderV1Payload(final long chunkChecksumKind, final byte[] chainRoot)
+		{
+			super();
+			this.chunkChecksumKind = chunkChecksumKind;
+			this.chainRoot         = chainRoot        ;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// getters //
+		////////////
+
+		public long chunkChecksumKind()
+		{
+			return this.chunkChecksumKind;
+		}
+
+		public byte[] chainRoot()
+		{
+			return this.chainRoot;
+		}
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	/**
+	 * Dummy constructor to prevent instantiation of this static-only utility class.
+	 *
+	 * @throws UnsupportedOperationException when called.
+	 */
+	private StorageMetaRecord()
+	{
+		// static only
+		throw new UnsupportedOperationException();
+	}
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordHandler.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordHandler.java
@@ -1,0 +1,50 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.nio.ByteBuffer;
+
+/**
+ * Load-time handler for one or more meta-record KIND codes. The kind-agnostic walker
+ * ({@link StorageEntityInitializer}) hands every negative-length entry to a
+ * {@link StorageMetaRecordRegistry}, which dispatches recognized entries to the handler registered for
+ * their {@link StorageMetaRecord#kindOf(long) KIND}.
+ * <p>
+ * A handler may be registered under several KINDs (e.g. the chunk-checksum handler serves every
+ * registered chunk-checksum algorithm); it re-reads {@code kindOf(address)} when it needs to know which
+ * one it was invoked for. The {@code chunkStart} value is a running cursor the walker threads from one
+ * meta record to the next: a handler that consumes a record advances it past that record's bytes; a
+ * handler that does not move the boundary returns it unchanged.
+ *
+ * @see StorageMetaRecordRegistry
+ */
+public interface StorageMetaRecordHandler
+{
+	/**
+	 * Handles a recognized meta record at {@code address} during the load walk.
+	 *
+	 * @param file       the data file currently being walked.
+	 * @param buffer     the direct buffer holding the file's resident bytes (for in-place verification).
+	 * @param address    absolute memory address of the meta record's start (offset 0 = LENGTH).
+	 * @param chunkStart the running chunk-boundary cursor threaded by the walker.
+	 * @return the updated {@code chunkStart} for the next meta record.
+	 */
+	public long onLoad(
+		StorageLiveDataFile.Default file      ,
+		ByteBuffer                  buffer    ,
+		long                        address   ,
+		long                        chunkStart
+	);
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordRegistry.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordRegistry.java
@@ -200,9 +200,33 @@ public interface StorageMetaRecordRegistry
 				return handler.onLoad(file, buffer, address, chunkStart);
 			}
 
-			// unknown KIND — forward-compat, reaction applied (and gated) by the reporter.
+			// unknown KIND — the reaction is applied (and gated) by the reporter; how the record is accounted
+			// then depends on whether the file's FileHeaderV1 has already been parsed (chunkChecksumKind != 0).
+			// FileHeaderV1 is by format the file's first entry, so once it is parsed every later meta record is
+			// reached with a non-zero kind, and a parsed header always carries a non-zero algorithm kind (the
+			// same invariant FileHeaderHandler and onFileComplete rely on).
 			this.reporter.onUnknownKind(file.number(), kind);
-			return chunkStart;
+			if(file.chunkChecksumKind() == 0L)
+			{
+				// No header parsed yet: an unknown record at the header position is a corrupted / lost
+				// FileHeaderV1 (its KIND garbled while the META_MARKER survived), NOT a forward-compat record.
+				// Leave the chunk boundary unadvanced so the following covering record's stored-chunk-start
+				// cross-check surfaces the drift (CHUNK_BOUNDARY_MISMATCH) instead of the corrupted file loading
+				// silently. (Header-less legacy / off files reach here too, but carry no covering records, so
+				// nothing is mis-flagged.)
+				return chunkStart;
+			}
+
+			// Header already parsed: this is a genuine forward-compat record in a checksummed file. Account it
+			// like every other meta record so the chunk bookkeeping stays consistent — advance the chunk boundary
+			// past the record (so a later covering record's stored start still matches the walker's cursor instead
+			// of raising a false CHUNK_BOUNDARY_MISMATCH / UNCOVERED_DATA) and register its bytes as meta overhead
+			// (so they are not mis-classified as reclaimable legacy gap by metaLength() / dataFillRatio()). The
+			// magnitude of the envelope LENGTH is the whole record size; the caller already validated it is fully
+			// resident (|LENGTH| <= remaining).
+			final long recordLength = -XMemory.get_long(address + StorageMetaRecord.OFFSET_LENGTH);
+			file.registerMetaLength(recordLength);
+			return address + recordLength;
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordRegistry.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordRegistry.java
@@ -1,0 +1,238 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.eclipse.serializer.util.X.notNull;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+
+/**
+ * Per-channel, kind-agnostic registry and dispatch point for in-gap meta records during the load walk.
+ * Owns a {@code KIND -> handler} map and delegates the forward-compat behavior for unrecognized KINDs to the
+ * channel's {@link StorageChecksumAnomalyReporter}; it knows nothing about any particular kind's payload. One
+ * instance exists per storage channel; each feature that owns a meta-record kind registers its handler via
+ * {@link #register(long, StorageMetaRecordHandler)} during channel setup. The walker
+ * ({@link StorageEntityInitializer}) then hands every negative-length entry
+ * to {@link #dispatch(StorageLiveDataFile.Default, ByteBuffer, long, long)}, which:
+ * <ul>
+ *   <li>returns {@code chunkStart} unchanged for a non-meta negative-length entry (a legacy opaque gap);</li>
+ *   <li>delegates to the {@link StorageMetaRecordHandler} registered for the record's KIND, if any;</li>
+ *   <li>otherwise reports an {@link StorageChunkChecksumPolicy.Anomaly#UNKNOWN_KIND} via the reporter
+ *       (IGNORE / LOG / FAIL per policy).</li>
+ * </ul>
+ * After each file the walker calls {@link #onFileComplete(StorageLiveDataFile.Default, long, long, boolean)},
+ * which raises the coverage anomalies ({@link StorageChunkChecksumPolicy.Anomaly#MISSING_HEADER} /
+ * {@link StorageChunkChecksumPolicy.Anomaly#UNCOVERED_DATA}) through the reporter and flushes its per-file
+ * log-dedupe state.
+ *
+ * @see StorageMetaRecordHandler
+ * @see StorageChecksumAnomalyReporter
+ * @see #New(StorageChecksumAnomalyReporter)
+ */
+public interface StorageMetaRecordRegistry
+{
+	/**
+	 * Dispatches the negative-length entry at {@code address} to its registered handler, or reports an
+	 * unknown-KIND anomaly, or leaves a legacy gap untouched.
+	 *
+	 * @param file       the data file currently being walked.
+	 * @param buffer     the direct buffer holding the file's resident bytes.
+	 * @param address    absolute memory address of the entry's start (offset 0 = LENGTH); its LENGTH is
+	 *                   already established to be negative by the caller.
+	 * @param chunkStart the running chunk-boundary cursor threaded by the walker.
+	 * @return the updated {@code chunkStart} for the next entry.
+	 */
+	public long dispatch(
+		StorageLiveDataFile.Default file      ,
+		ByteBuffer                  buffer    ,
+		long                        address   ,
+		long                        chunkStart
+	);
+
+	/**
+	 * Called by the walker once per file, after its entries have been walked, to raise coverage anomalies and
+	 * flush the reporter's per-file log-dedupe. A file with no parsed {@code FileHeaderV1} (cached
+	 * {@code chunkChecksumKind == 0}) that carries live data is a {@link StorageChunkChecksumPolicy.Anomaly#MISSING_HEADER};
+	 * a covered file whose last covering record is followed by further content
+	 * ({@code lastChunkOffset < fileContentLength}) has {@link StorageChunkChecksumPolicy.Anomaly#UNCOVERED_DATA}.
+	 * Both are gated by the reporter: {@code MISSING_HEADER} is inert unless verifying <i>and</i> coverage is
+	 * required (legacy tolerance), while {@code UNCOVERED_DATA} (corruption on a covered file) fires whenever
+	 * verifying.
+	 *
+	 * @param file              the data file just walked.
+	 * @param lastChunkOffset   in-file offset where the last (uncovered) chunk begins (end of the last meta record).
+	 * @param fileContentLength the file's resident content length walked.
+	 * @param hasLiveData       whether the file held any positive-length (live) entity.
+	 */
+	public void onFileComplete(
+		StorageLiveDataFile.Default file             ,
+		long                        lastChunkOffset  ,
+		long                        fileContentLength,
+		boolean                     hasLiveData
+	);
+
+	/**
+	 * Registers {@code handler} as the load-time handler for meta records of the given {@code kind}. Called
+	 * during per-channel setup by each feature that owns a meta-record kind; a kind may be registered only
+	 * once. Not thread-safe — all registration happens before the load walk begins.
+	 *
+	 * @param kind    the meta-record KIND code this handler recognizes.
+	 * @param handler the handler; must be non-{@code null}.
+	 * @return this registry, for chaining.
+	 */
+	public StorageMetaRecordRegistry register(long kind, StorageMetaRecordHandler handler);
+
+
+
+	/**
+	 * Creates an empty registry that reports unknown / coverage anomalies through {@code reporter}. Handlers
+	 * are added afterwards via {@link #register(long, StorageMetaRecordHandler)}.
+	 *
+	 * @param reporter the channel's anomaly reporter; must be non-{@code null}.
+	 * @return a new, empty {@link StorageMetaRecordRegistry}.
+	 */
+	public static StorageMetaRecordRegistry New(
+		final StorageChecksumAnomalyReporter reporter
+	)
+	{
+		return new Default(notNull(reporter));
+	}
+
+
+
+	public final class Default implements StorageMetaRecordRegistry
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final StorageChecksumAnomalyReporter      reporter      ;
+		private final Map<Long, StorageMetaRecordHandler> handlersByKind;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(
+			final StorageChecksumAnomalyReporter reporter
+		)
+		{
+			super();
+			this.reporter       = reporter      ;
+			this.handlersByKind = new HashMap<>();
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		public final StorageMetaRecordRegistry register(final long kind, final StorageMetaRecordHandler handler)
+		{
+			// StorageMetaRecord.kindOf masks the on-disk KIND to 0xFFFF; a KIND with bits above 16 would be
+			// registered under a value the walker can never produce, so its handler would silently never
+			// dispatch — reject it here.
+			if(kind != (kind & 0xFFFFL))
+			{
+				throw new StorageExceptionConsistency(
+					"Meta-record KIND 0x" + Long.toHexString(kind) + " does not fit the 2-byte on-disk KIND field."
+				);
+			}
+
+			final StorageMetaRecordHandler previous = this.handlersByKind.putIfAbsent(kind, notNull(handler));
+			if(previous != null)
+			{
+				throw new StorageExceptionConsistency(
+					"Meta-record KIND 0x" + Long.toHexString(kind) + " already has a registered handler."
+				);
+			}
+			return this;
+		}
+
+		@Override
+		public final long dispatch(
+			final StorageLiveDataFile.Default file      ,
+			final ByteBuffer                  buffer    ,
+			final long                        address   ,
+			final long                        chunkStart
+		)
+		{
+			// Corrupt-input guard: the envelope (LENGTH 8B + META_MARKER 2B + KIND 2B = 12B) must be fully
+			// resident before we read the marker/KIND. An entry starting within fewer than 12 bytes of the
+			// buffer end cannot be a meta record (reading its marker would run past the buffer), so treat it
+			// as a legacy opaque gap. Only fires on a truncated/corrupted file.
+			final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
+			if(address + StorageMetaRecord.OFFSET_PAYLOAD > bufferBoundAddress)
+			{
+				return chunkStart;
+			}
+
+			if(!StorageMetaRecord.isMetaRecord(address))
+			{
+				return chunkStart; // legacy gap — chunk boundary unchanged
+			}
+
+			final long                     kind    = StorageMetaRecord.kindOf(address);
+			final StorageMetaRecordHandler handler = this.handlersByKind.get(kind);
+			if(handler != null)
+			{
+				return handler.onLoad(file, buffer, address, chunkStart);
+			}
+
+			// unknown KIND — forward-compat, reaction applied (and gated) by the reporter.
+			this.reporter.onUnknownKind(file.number(), kind);
+			return chunkStart;
+		}
+
+		@Override
+		public final void onFileComplete(
+			final StorageLiveDataFile.Default file             ,
+			final long                        lastChunkOffset  ,
+			final long                        fileContentLength,
+			final boolean                     hasLiveData
+		)
+		{
+			final long kind = file.chunkChecksumKind();
+			if(kind == 0L)
+			{
+				// no FileHeaderV1 was parsed: a legacy/pre-feature file.
+				if(hasLiveData)
+				{
+					this.reporter.onMissingHeader(file.number());
+				}
+			}
+			else if(lastChunkOffset < fileContentLength)
+			{
+				// covered file, but content trails the last covering record: an uncovered tail.
+				// NOTE: lastChunkOffset is the walker's chunkStart cursor, advanced past each header /
+				// covering record by the handlers' return values, so this comparison is coupled to them —
+				// a header-only file is "covered" only because the header handler advanced the cursor.
+				this.reporter.onUncoveredData(file.number(), lastChunkOffset);
+			}
+			this.reporter.onFileWalkComplete(file.number());
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestAcceptor.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestAcceptor.java
@@ -75,6 +75,8 @@ public interface StorageRequestAcceptor
 	public boolean issueCacheCheck(long nanoTimeBudget, StorageEntityCacheEvaluator entityEvaluator)
 		throws InterruptedException;
 
+	public StorageIntegrityCheckResult issueIntegrityCheck(long nanoTimeBudget, boolean freshScan) throws InterruptedException;
+
 	public void issueTransactionsLogCleanup()
 		throws InterruptedException;
 	 
@@ -227,6 +229,13 @@ public interface StorageRequestAcceptor
 			throws InterruptedException
 		{
 			return waitOnTask(this.taskBroker.issueFileCheck(nanoTimeBudget)).result();
+		}
+
+		@Override
+		public StorageIntegrityCheckResult issueIntegrityCheck(final long nanoTimeBudget, final boolean freshScan)
+			throws InterruptedException
+		{
+			return waitOnTask(this.taskBroker.issueIntegrityCheck(nanoTimeBudget, freshScan)).result();
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
@@ -93,6 +93,13 @@ public interface StorageRequestTaskCreator
 		StorageOperationController  operationController
 	);
 
+	public StorageRequestTaskIntegrityCheck createIntegrityCheckTask(
+		int                        channelCount       ,
+		long                       nanoTimeBudget     ,
+		boolean                    freshScan          ,
+		StorageOperationController operationController
+	);
+
 	public StorageRequestTaskTransactionsLogCleanup CreateTransactionsLogCleanupTask(
 		int                        channelCount       ,
 		StorageOperationController operationController
@@ -307,6 +314,23 @@ public interface StorageRequestTaskCreator
 				channelCount,
 				nanoTimeBudget,
 				entityEvaluator,
+				operationController
+			);
+		}
+
+		@Override
+		public StorageRequestTaskIntegrityCheck createIntegrityCheckTask(
+			final int                        channelCount       ,
+			final long                       nanoTimeBudget     ,
+			final boolean                    freshScan          ,
+			final StorageOperationController operationController
+		)
+		{
+			return new StorageRequestTaskIntegrityCheck.Default(
+				this.timestampProvider.currentNanoTimestamp(),
+				channelCount,
+				nanoTimeBudget,
+				freshScan,
 				operationController
 			);
 		}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskIntegrityCheck.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskIntegrityCheck.java
@@ -1,0 +1,84 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+
+public interface StorageRequestTaskIntegrityCheck extends StorageRequestTask
+{
+	public StorageIntegrityCheckResult result();
+
+
+
+	public final class Default
+	extends StorageChannelSynchronizingTask.AbstractCompletingTask<StorageIntegrityCheckResult>
+	implements StorageRequestTaskIntegrityCheck, StorageChannelTaskStoreEntities
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final long                               nanoTimeBudget;
+		private final boolean                            freshScan     ;
+		private final StorageIntegrityCheckResult.Default result        ;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(
+			final long                       timestamp     ,
+			final int                        channelCount  ,
+			final long                       nanoTimeBudget,
+			final boolean                    freshScan     ,
+			final StorageOperationController controller
+		)
+		{
+			super(timestamp, channelCount, controller);
+			this.nanoTimeBudget = nanoTimeBudget;
+			this.freshScan      = freshScan     ;
+			this.result         = StorageIntegrityCheckResult.New();
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// methods //
+		////////////
+
+		@Override
+		protected final StorageIntegrityCheckResult internalProcessBy(final StorageChannel channel)
+		{
+			return channel.issuedIntegrityCheck(this.nanoTimeBudget, this.freshScan);
+		}
+
+		@Override
+		protected final void succeed(final StorageChannel channel, final StorageIntegrityCheckResult result)
+		{
+			// each channel folds its findings into the shared aggregate (merge is synchronized). Every per-channel
+			// result is a Default (produced by StorageFileManager.verifyChunkChecksums).
+			this.result.merge((StorageIntegrityCheckResult.Default)result);
+		}
+
+		@Override
+		public final StorageIntegrityCheckResult result()
+		{
+			return this.result;
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
@@ -156,6 +156,7 @@ public interface StorageSystem extends StorageController
 		private final StorageConfiguration                       configuration                 ;
 		private final StorageInitialDataFileNumberProvider       initialDataFileNumberProvider ;
 		private final StorageDataFileEvaluator                   fileDissolver                 ;
+		private final StorageChunkChecksumProvider               chunkChecksumProvider         ;
 		private final StorageLiveFileProvider                    fileProvider                  ;
 		private final StorageWriteController                     writeController               ;
 		private final StorageFileWriter.Provider                 writerProvider                ;
@@ -264,6 +265,7 @@ public interface StorageSystem extends StorageController
 			this.operationController            = notNull(ocCreator.createOperationController(ccp, this));
 			this.initialDataFileNumberProvider  = notNull(initialDataFileNumberProvider)       ;
 			this.fileDissolver                  = storageConfiguration.dataFileEvaluator()     ;
+			this.chunkChecksumProvider          = storageConfiguration.chunkChecksumProvider();
 			this.fileProvider                   = storageConfiguration.fileProvider()          ;
 			this.entityCacheEvaluator           = storageConfiguration.entityCacheEvaluator()  ;
 			this.housekeepingController         = storageConfiguration.housekeepingController();
@@ -544,6 +546,7 @@ public interface StorageSystem extends StorageController
 				this.initialDataFileNumberProvider         ,
 				this.exceptionHandler                      ,
 				this.fileDissolver                         ,
+				this.chunkChecksumProvider                 ,
 				this.fileProvider                          ,
 				this.entityCacheEvaluator                  ,
 				this.typeDictionary                        ,

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
@@ -95,6 +95,9 @@ public interface StorageTaskBroker
 	)
 		throws InterruptedException;
 
+	public StorageRequestTaskIntegrityCheck issueIntegrityCheck(long nanoTimeBudget, boolean freshScan)
+		throws InterruptedException;
+
 	public StorageRequestTaskTransactionsLogCleanup issueTransactionsLogCleanup()
 		throws InterruptedException;
 	
@@ -273,6 +276,23 @@ public interface StorageTaskBroker
 			final StorageRequestTaskFileCheck task = this.taskCreator.createFullFileCheckTask(
 				this.channelCount,
 				nanoTimeBudget,
+				this.operationController
+			);
+			this.enqueueTaskAndNotifyAll(task);
+			return task;
+		}
+
+		@Override
+		public final synchronized StorageRequestTaskIntegrityCheck issueIntegrityCheck(
+			final long    nanoTimeBudget,
+			final boolean freshScan
+		)
+			throws InterruptedException
+		{
+			final StorageRequestTaskIntegrityCheck task = this.taskCreator.createIntegrityCheckTask(
+				this.channelCount,
+				nanoTimeBudget,
+				freshScan,
 				this.operationController
 			);
 			this.enqueueTaskAndNotifyAll(task);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/util/StorageObjectRestorer.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/util/StorageObjectRestorer.java
@@ -262,11 +262,29 @@ public interface StorageObjectRestorer
                     ? writeRawBlob(storageFile, blob)
                     : writeCheckedBlob(storageFile, blob, algorithm);
 
+                // The Store log length is an int. If the file is too large to log, roll it back and abort
+                // before writing any log entry, so no Create entry or unlogged file is left behind.
+                final int storeLength;
+                try
+                {
+                    storeLength = Math.toIntExact(contentLength);
+                }
+                catch(final ArithmeticException e)
+                {
+                    logger.warn(
+                        "Recovery file content length {} for channel {} exceeds the int transaction-log length "
+                        + "field; rolling back the recovery file and aborting the append.",
+                        contentLength, channelIndex, e
+                    );
+                    rollbackRecoveryFile(storageFile);
+                    return false;
+                }
+
                 try
                 {
                     final long fileTimeStamp = getLastTimeStamp(storageFileProvider) + 1;
                     writeTransactionLogCreate(channelIndex, lastFileNumber, fileTimeStamp);
-                    writeTransactionLogStore(channelIndex, fileTimeStamp, Math.toIntExact(contentLength));
+                    writeTransactionLogStore(channelIndex, fileTimeStamp, storeLength);
 
                     //write other channels transaction log zero store
                     for(int channel = 0; channel < channelCount; channel++)
@@ -496,6 +514,28 @@ public interface StorageObjectRestorer
             catch(final Throwable suppressed)
             {
                 logger.warn("Failed to delete the partially-written recovery file {} during rollback", path, suppressed);
+            }
+        }
+
+        /**
+         * Deletes a written-but-unlogged recovery file to restore the pre-write state. Best-effort: a deletion
+         * failure is logged, not rethrown.
+         */
+        private static void rollbackRecoveryFile(final AFile storageFile)
+        {
+            final AWritableFile wFile = storageFile.useWriting();
+            try
+            {
+                final boolean deleted = wFile.delete();
+                logger.warn("Rolled back recovery file {} (deleted={}).", wFile.toPathString(), deleted);
+            }
+            catch(final Throwable suppressed)
+            {
+                logger.warn("Failed to delete the recovery file {} during rollback", wFile.toPathString(), suppressed);
+            }
+            finally
+            {
+                wFile.release();
             }
         }
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/util/StorageObjectRestorer.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/util/StorageObjectRestorer.java
@@ -64,6 +64,12 @@ public interface StorageObjectRestorer
         private final HashMap<Integer, TreeMap<Long, StorageDataInventoryFile>> dataFiles      = new HashMap<>();
         private final int[]                                                      dataFilesSizes;
 
+        // The chunk-checksum provider from the StorageConfiguration, or null when constructed from a bare
+        // StorageLiveFileProvider. Supplies the primary write algorithm so a restored file carries a
+        // FileHeaderV1 + covering record matching the store's on-disk kind. null + a checksummed store:
+        // resolvePrimaryAlgorithm throws rather than silently writing an unprotected, header-less file.
+        private final StorageChunkChecksumProvider                               chunkChecksumProvider;
+
 
         /**
          * Immutable descriptor of a stored entity occurrence inside a data file.
@@ -90,9 +96,10 @@ public interface StorageObjectRestorer
         public Default(final StorageLiveFileProvider storageFileProvider, final int channelCount)
         {
             super();
-            this.storageFileProvider = storageFileProvider;
-            this.channelCount = channelCount;
-            this.dataFilesSizes = new int[channelCount];
+            this.storageFileProvider   = storageFileProvider;
+            this.channelCount          = channelCount;
+            this.dataFilesSizes        = new int[channelCount];
+            this.chunkChecksumProvider = null; // no configuration: checksummed targets are refused.
         }
 
         /**
@@ -106,9 +113,13 @@ public interface StorageObjectRestorer
         public Default(final StorageConfiguration configuration)
         {
             super();
-            this.storageFileProvider = configuration.fileProvider();
-            this.channelCount = configuration.channelCountProvider().getChannelCount();
-            this.dataFilesSizes = new int[channelCount];
+            this.storageFileProvider   = configuration.fileProvider();
+            this.channelCount          = configuration.channelCountProvider().getChannelCount();
+            this.dataFilesSizes        = new int[channelCount];
+            // chunkChecksumProvider() is a default method that never returns null (falls back to the
+            // framework default provider); the on-disk kind probe, not this provider, decides whether
+            // coverage is actually required.
+            this.chunkChecksumProvider = configuration.chunkChecksumProvider();
         }
 
 
@@ -236,26 +247,26 @@ public interface StorageObjectRestorer
                     ? 1L
                     : channelFiles.firstKey() + 1;
 
+                // Decide how to cover the recovery file from the store's ON-DISK checksum kind (the disk is
+                // truth; the config is only intent). resolvePrimaryAlgorithm throws when the store is
+                // checksummed but no matching algorithm is available — that must stay loud (below).
+                final long                                     onDiskKind = probeOnDiskChecksumKind(channelFiles);
+                final StorageChunkChecksumCalculator.Algorithm algorithm  = resolvePrimaryAlgorithm(onDiskKind);
+
                 final AFile storageFile = storageFileProvider.provideDataFile(channelIndex, lastFileNumber);
                 storageFile.ensureExists();
 
-                final ByteBuffer writeBuf = XMemory.toDirectByteBuffer(blob);
-                final AWritableFile wFile = storageFile.useWriting();
-                try
-                {
-                    wFile.writeBytes(writeBuf);
-                }
-                finally
-                {
-                    wFile.release();
-                    XMemory.deallocateDirectByteBuffer(writeBuf);
-                }
+                // Total content length of the recovery file — logged in the Store entry so the transaction
+                // log length matches the bytes on disk, whether or not a checksum was emitted.
+                final long contentLength = algorithm == null
+                    ? writeRawBlob(storageFile, blob)
+                    : writeCheckedBlob(storageFile, blob, algorithm);
 
                 try
                 {
                     final long fileTimeStamp = getLastTimeStamp(storageFileProvider) + 1;
                     writeTransactionLogCreate(channelIndex, lastFileNumber, fileTimeStamp);
-                    writeTransactionLogStore(channelIndex, fileTimeStamp, blob.length);
+                    writeTransactionLogStore(channelIndex, fileTimeStamp, Math.toIntExact(contentLength));
 
                     //write other channels transaction log zero store
                     for(int channel = 0; channel < channelCount; channel++)
@@ -274,10 +285,217 @@ public interface StorageObjectRestorer
 
                 return true;
             }
+            catch (final StorageExceptionChunkChecksumUnavailable e)
+            {
+                // Guard: checksum-protected store but no compliant algorithm. Surface loudly and
+                // actionably rather than swallowing into a silent, unprotected header-less append.
+                throw e;
+            }
             catch (final Throwable t)
             {
                 logger.warn("Failed to append blob to storage for channel {}", channelIndex, t);
                 return false;
+            }
+        }
+
+        /**
+         * Determines the target store's on-disk chunk-checksum kind by reading the {@code FileHeaderV1} of
+         * its existing data files (highest-numbered first, returning the first header found). Returns
+         * {@code 0} when no data file carries a {@code FileHeaderV1} — i.e. the store is not checksum-protected.
+         *
+         * @param channelFiles the channel's current data files (reverse-ordered: highest number first)
+         * @return the on-disk chunk-checksum kind, or {@code 0} if the store is not checksummed
+         */
+        private static long probeOnDiskChecksumKind(final TreeMap<Long, StorageDataInventoryFile> channelFiles)
+        {
+            for (final StorageDataInventoryFile inventoryFile : channelFiles.values())
+            {
+                final long kind = readFileHeaderKind(inventoryFile.file());
+                if (kind != 0L)
+                {
+                    return kind;
+                }
+            }
+            return 0L;
+        }
+
+        /**
+         * Reads the chunk-checksum kind from the {@code FileHeaderV1} at offset 0 of {@code file}, or
+         * {@code 0} if the file has no {@code FileHeaderV1} (too short, positive-length first entry, or a
+         * non-header meta record) — i.e. a legacy / unchecksummed file.
+         */
+        private static long readFileHeaderKind(final AFile file)
+        {
+            if (file.size() < StorageMetaRecord.LENGTH_FILEHEADERV1)
+            {
+                return 0L;
+            }
+            final ByteBuffer buffer = XMemory.allocateDirectNative(StorageMetaRecord.LENGTH_FILEHEADERV1);
+            final AReadableFile rFile = file.useReading();
+            try
+            {
+                rFile.open();
+                rFile.readBytes(buffer, 0, StorageMetaRecord.LENGTH_FILEHEADERV1);
+                final long address = XMemory.getDirectByteBufferAddress(buffer);
+
+                // a FileHeaderV1 is the file's first entry: a negative-length meta record of that kind.
+                if (Binary.getEntityLengthRawValue(address) >= 0L
+                    || !StorageMetaRecord.isMetaRecord(address)
+                    || StorageMetaRecord.kindOf(address) != StorageMetaRecord.KIND_FileHeaderV1)
+                {
+                    return 0L;
+                }
+                return StorageMetaRecord.readFileHeaderV1(address).chunkChecksumKind();
+            }
+            finally
+            {
+                rFile.release();
+                XMemory.deallocateDirectByteBuffer(buffer);
+            }
+        }
+
+        /**
+         * Resolves the primary write algorithm for the probed on-disk kind, applying the guard:
+         * <ul>
+         *   <li>{@code onDiskKind == 0} (store not checksummed) → {@code null}: append the raw blob as before;</li>
+         *   <li>checksummed store but no provider (bare constructor) → throw;</li>
+         *   <li>checksummed store but the configured provider writes a different kind → throw;</li>
+         *   <li>checksummed store and the configured provider's kind matches → a fresh primary algorithm.</li>
+         * </ul>
+         */
+        private StorageChunkChecksumCalculator.Algorithm resolvePrimaryAlgorithm(final long onDiskKind)
+        {
+            if (onDiskKind == 0L)
+            {
+                return null; // store not checksum-protected → no regression, append raw blob
+            }
+            if (this.chunkChecksumProvider == null)
+            {
+                throw new StorageExceptionChunkChecksumUnavailable(onDiskKind, -1L);
+            }
+            final long configuredKind = this.chunkChecksumProvider.chunkChecksumKind();
+            if (configuredKind != onDiskKind)
+            {
+                // the provider can verify any kind but only WRITES its primary; a mismatched write would
+                // manufacture a mixed store. Refuse rather than guess.
+                throw new StorageExceptionChunkChecksumUnavailable(onDiskKind, configuredKind);
+            }
+            return this.chunkChecksumProvider.createPrimaryAlgorithm();
+        }
+
+        /**
+         * Appends the raw blob to a fresh recovery file (pre-feature behavior, for unchecksummed stores).
+         *
+         * @return the recovery file's content length (== blob length)
+         */
+        private static long writeRawBlob(final AFile storageFile, final byte[] blob)
+        {
+            final ByteBuffer writeBuf = XMemory.toDirectByteBuffer(blob);
+            final AWritableFile wFile = storageFile.useWriting();
+            boolean complete = false;
+            try
+            {
+                wFile.writeBytes(writeBuf);
+                complete = true;
+            }
+            finally
+            {
+                rollbackOnFailure(wFile, complete);
+                wFile.release();
+                XMemory.deallocateDirectByteBuffer(writeBuf);
+            }
+            return blob.length;
+        }
+
+        /**
+         * Writes a covered recovery file: {@code [FileHeaderV1][blob][covering record]} for the store's
+         * on-disk kind, using the algorithm's file-free primitives ({@code writeRecord} + the chain-tip
+         * accessors) and {@link StorageMetaRecord#writeFileHeaderV1}, so the restored object is
+         * checksum-protected and the file (now the head) does not pause coverage for later writes. For
+         * chained kinds the new file starts a fresh sub-chain seeded by the algorithm's initial seed; it
+         * still verifies self-contained from its own header.
+         *
+         * @return the recovery file's content length (header + blob + covering record)
+         */
+        private static long writeCheckedBlob(
+            final AFile                                    storageFile,
+            final byte[]                                   blob       ,
+            final StorageChunkChecksumCalculator.Algorithm algorithm
+        )
+        {
+            final byte[] chainRoot = algorithm.isChained()
+                ? algorithm.initialSeed()
+                : new byte[StorageMetaRecord.LENGTH_HASH_SHA256];
+            if (algorithm.isChained())
+            {
+                algorithm.setChainTip(chainRoot);
+            }
+
+            final int        headerLength = StorageMetaRecord.LENGTH_FILEHEADERV1;
+            final int        recordLength = (int)algorithm.recordLength();
+            final ByteBuffer headerBuffer = XMemory.allocateDirectNative(headerLength);
+            final ByteBuffer blobBuffer   = XMemory.toDirectByteBuffer(blob); // position 0, limit == blob.length
+            final ByteBuffer recordBuffer = XMemory.allocateDirectNative(recordLength);
+
+            final AWritableFile wFile = storageFile.useWriting();
+            boolean complete = false;
+            try
+            {
+                StorageMetaRecord.writeFileHeaderV1(headerBuffer, algorithm.kind(), chainRoot);
+                headerBuffer.flip();
+
+                // the covering record hashes exactly the blob bytes (read non-destructively); for chained kinds
+                // this folds + advances the tip seeded above. The blob follows the FileHeaderV1, so headerLength
+                // is the chunk start the record stores.
+                algorithm.writeRecord(recordBuffer, headerLength, blobBuffer);
+                recordBuffer.flip();
+
+                // header first, then the entity blob, then its covering record — the layout the load walk
+                // expects ([chunkStart, recordAddress) == the blob bytes).
+                wFile.writeBytes(headerBuffer);
+                wFile.writeBytes(blobBuffer);
+                wFile.writeBytes(recordBuffer);
+                complete = true;
+            }
+            finally
+            {
+                rollbackOnFailure(wFile, complete);
+                wFile.release();
+                XMemory.deallocateDirectByteBuffer(headerBuffer);
+                XMemory.deallocateDirectByteBuffer(blobBuffer);
+                XMemory.deallocateDirectByteBuffer(recordBuffer);
+            }
+            return (long)headerLength + blob.length + recordLength;
+        }
+
+        /**
+         * Rolls a partially-written recovery file back by deleting it when a write sequence did not complete.
+         * The three {@code writeBytes} calls of {@link #writeCheckedBlob} (and the single one of
+         * {@link #writeRawBlob}) are not atomic: an I/O failure mid-sequence would otherwise leave a torn file
+         * on disk &mdash; for a checksummed store a {@code [FileHeaderV1][blob]} body with no covering record,
+         * which the load walk reports as {@code UNCOVERED_DATA} and a strict policy refuses to open. The file
+         * was freshly created by the caller ({@code storageFile.ensureExists()}) and has no transaction-log
+         * entry yet, so deleting it restores the pre-write state. Best-effort: a rollback failure is logged but
+         * never masks the original write failure propagating out of the {@code finally}.
+         */
+        private static void rollbackOnFailure(final AWritableFile wFile, final boolean complete)
+        {
+            if(complete)
+            {
+                return;
+            }
+            final String path = wFile.toPathString();
+            try
+            {
+                final boolean deleted = wFile.delete();
+                logger.warn(
+                    "Recovery-file write did not complete; rolled back by deleting the partial recovery file {} (deleted={}).",
+                    path, deleted
+                );
+            }
+            catch(final Throwable suppressed)
+            {
+                logger.warn("Failed to delete the partially-written recovery file {} during rollback", path, suppressed);
             }
         }
 


### PR DESCRIPTION
Adds optional integrity checksums to the storage data files. Every committed chunk of data is followed by a checksum record covering its bytes; on startup the engine recomputes and verifies them, so silent on-disk corruption (bit-rot, a bad block, a damaged backup) is detected before the data is used. Disabled by default.