### PR TITLE
Back-fill the Lucene index when registered on a populated GigaMap

### DIFF
--- a/docs/modules/gigamap/pages/indexing/lucene/defining.adoc
+++ b/docs/modules/gigamap/pages/indexing/lucene/defining.adoc
@@ -50,4 +50,6 @@ List<Article> hits = index.query("title:eclipse");
 
 By default the Lucene data is stored inside the GigaMap object graph. To store it in a directory instead, create the handler with a directory: `LuceneAnnotationHandler.New(path)` or `LuceneAnnotationHandler.New(directoryCreator)`.
 
+Like a manually registered Lucene index, an annotation-generated one is back-filled: if `generateIndices` runs on a GigaMap that already contains entities, those existing entities are indexed immediately, so generation can happen before or after the data is loaded.
+
 The handler is a no-op when the entity type carries no `@FullText` member, so it composes safely with bitmap (`@Index`) and other annotations on the same entity. See xref:indexing/annotations.adoc[Annotation-based Indexing] for the overall model.

--- a/docs/modules/gigamap/pages/indexing/lucene/index.adoc
+++ b/docs/modules/gigamap/pages/indexing/lucene/index.adoc
@@ -1,6 +1,6 @@
 = Lucene Index
 
-The Lucene index adds full-text search capabilities to entities stored in a GigaMap. Like the xref:indexing/bitmap/index.adoc[Bitmap] and xref:indexing/jvector/index.adoc[JVector] indices, it is registered with the GigaMap and automatically kept in sync as entities are added, updated, or removed.
+The Lucene index adds full-text search capabilities to entities stored in a GigaMap. Like the xref:indexing/bitmap/index.adoc[Bitmap] and xref:indexing/jvector/index.adoc[JVector] indices, it is registered with the GigaMap and automatically kept in sync as entities are added, updated, or removed. When it is registered on a GigaMap that already contains entities, those existing entities are indexed immediately (back-filled), so the index can be added at any time — whether before or after the data is loaded.
 
 Under the hood, the index uses https://lucene.apache.org[Apache Lucene], the de facto industry standard for full-text indexing in the Java ecosystem. This enables powerful text search features including tokenization, stemming, relevance scoring, and the full Lucene query syntax.
 
@@ -97,6 +97,8 @@ LuceneIndex<Article> luceneIndex = articles.index().register(LuceneIndex.Categor
 articles.add(new Article("Python Guide", "Learn Python programming...", "Jane"));
 articles.add(new Article("Java Tips", "Best practices for Java...", "John"));
 ----
+
+NOTE: Registration order does not matter. If the GigaMap already holds entities when the index is registered, they are back-filled into the new index, so a subsequent `query` finds them just like entities added afterwards. On a very large GigaMap this back-fill iterates all entities once, which can take a while; registering the index before bulk-loading avoids that initial scan.
 
 Query using the Lucene query syntax.
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -417,12 +417,35 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 				}
 				
 				this.indexGroups.add(indexGroup);
-				this.markStateChangeInstance();
 
 				// let the freshly added group back-fill itself from entities that already exist in the
 				// map (no-op for most groups; only reached for a newly-added group, see the early return
 				// above). Not invoked on deserialization, which reconstructs groups via their handlers.
-				indexGroup.internalOnRegistered();
+				try
+				{
+					indexGroup.internalOnRegistered();
+				}
+				catch(final Throwable e)
+				{
+					// keep registration atomic: a failed back-fill must not leave a half-initialized group
+					// registered. Roll back the addition and release native resources the group may hold.
+					this.indexGroups.removeOne(indexGroup);
+					if(indexGroup instanceof Closeable)
+					{
+						try
+						{
+							((Closeable)indexGroup).close();
+						}
+						catch(final IOException suppressed)
+						{
+							e.addSuppressed(suppressed);
+						}
+					}
+					throw e;
+				}
+
+				// mark the change only after the group is fully and successfully registered.
+				this.markStateChangeInstance();
 
 				return category.indexType().cast(indexGroup);
 			}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -419,6 +419,11 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 				this.indexGroups.add(indexGroup);
 				this.markStateChangeInstance();
 
+				// let the freshly added group back-fill itself from entities that already exist in the
+				// map (no-op for most groups; only reached for a newly-added group, see the early return
+				// above). Not invoked on deserialization, which reconstructs groups via their handlers.
+				indexGroup.internalOnRegistered();
+
 				return category.indexType().cast(indexGroup);
 			}
 		}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
@@ -78,7 +78,23 @@ public interface IndexGroup<E> extends GigaMap.Component<E>
 		 * Removes all entities from this index.
 		 */
 		public void internalRemoveAll();
-		
+
+		/**
+		 * Lifecycle hook invoked by {@link GigaIndices.Default#register(IndexCategory)} immediately
+		 * after this group has been added, while holding the parent-map lock, to let the group
+		 * synchronize itself with entities that already exist in the map at registration time
+		 * (back-fill). It is <b>not</b> called on deserialization, so a group that back-fills here
+		 * will not re-index everything on restart.
+		 * <p>
+		 * The default is a no-op. Groups that are registered while the map is still empty (e.g. the
+		 * bitmap group at build time) or that back-fill their individual indices when those are added
+		 * (e.g. the vector group) do not override it.
+		 */
+		public default void internalOnRegistered()
+		{
+			// no-op
+		}
+
 		public void clearStateChangeMarkers();
 	}
 	

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -427,8 +427,10 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			// the GigaMap may already hold entities at the moment this index is registered; index them
 			// now so a full-text search sees pre-existing entities, not only those added afterwards.
 			// Documents are added incrementally (no per-entity commit, no buffering of the whole corpus)
-			// and committed once at the end via optCommit, which also honors the manual-commit contract
-			// (context.autoCommit() == false defers visibility to the user's explicit commit()).
+			// and committed once at the end via optCommit, which honors the manual-commit contract: with
+			// context.autoCommit() == false the back-fill performs no commit, leaving durability to the
+			// user's explicit commit() (the near-real-time reader still makes the documents queryable in
+			// the meantime, just like internalAdd).
 			try
 			{
 				synchronized(this.gigaMap)

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -339,12 +339,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 				synchronized(this.gigaMap)
 				{
 					this.lazyInit();
-				
-					final Document document = new Document();
-					document.add(new LongField(ENTITY_ID_FIELD, entityId, Store.YES));
-					this.context.documentPopulator().populate(document, entity);
-					
-					this.writer.addDocument(document);
+
+					this.writer.addDocument(this.toDocument(entityId, entity));
                     this.optCommit();
 				}
 			}
@@ -368,10 +364,7 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 					
 					for(final E entity : entities)
 					{
-						final Document document = new Document();
-						document.add(new LongField(ENTITY_ID_FIELD, currentEntityId++, Store.YES));
-						this.context.documentPopulator().populate(document, entity);
-						documents.add(document);
+						documents.add(this.toDocument(currentEntityId++, entity));
 					}
 					
 					this.writer.addDocuments(documents);
@@ -427,7 +420,57 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 				throw new IORuntimeException(e);
 			}
 		}
-		
+
+		@Override
+		public void internalOnRegistered()
+		{
+			// the GigaMap may already hold entities at the moment this index is registered; index them
+			// now so a full-text search sees pre-existing entities, not only those added afterwards.
+			// Documents are added incrementally (no per-entity commit, no buffering of the whole corpus)
+			// and committed once at the end via optCommit, which also honors the manual-commit contract
+			// (context.autoCommit() == false defers visibility to the user's explicit commit()).
+			try
+			{
+				synchronized(this.gigaMap)
+				{
+					this.lazyInit();
+
+					this.gigaMap.iterateIndexed(this::backfillDocument);
+
+					if(!this.gigaMap.isEmpty())
+					{
+						this.optCommit();
+					}
+				}
+			}
+			catch(final IOException e)
+			{
+				throw new IORuntimeException(e);
+			}
+		}
+
+		private void backfillDocument(final long entityId, final E entity)
+		{
+			// uses the GigaMap-assigned entityId (not a contiguous counter) so ENTITY_ID_FIELD stays the
+			// authoritative id that queryFor(entityId) relies on for later update/remove.
+			try
+			{
+				this.writer.addDocument(this.toDocument(entityId, entity));
+			}
+			catch(final IOException e)
+			{
+				throw new IORuntimeException(e);
+			}
+		}
+
+		private Document toDocument(final long entityId, final E entity)
+		{
+			final Document document = new Document();
+			document.add(new LongField(ENTITY_ID_FIELD, entityId, Store.YES));
+			this.context.documentPopulator().populate(document, entity);
+			return document;
+		}
+
 		@Override
 		public void internalPrepareIndicesUpdate(final E replacedEntity)
 		{
@@ -453,11 +496,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 				synchronized(this.gigaMap)
 				{
 					this.lazyInit();
-					
-					final Document document = new Document();
-					document.add(new LongField(ENTITY_ID_FIELD, entityId, Store.YES));
-					this.context.documentPopulator().populate(document, entity);
-					this.writer.updateDocuments(queryFor(entityId), List.of(document));
+
+					this.writer.updateDocuments(queryFor(entityId), List.of(this.toDocument(entityId, entity)));
                     this.optCommit();
 				}
 			}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneBackfillTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneBackfillTest.java
@@ -1,0 +1,225 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.apache.lucene.document.Document;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that registering a {@link LuceneIndex} on a {@link GigaMap} that already contains
+ * entities back-fills those pre-existing entities into the index (matching the bitmap and vector
+ * index behavior), rather than only indexing entities added after registration.
+ */
+public class LuceneBackfillTest
+{
+	@TempDir
+	Path storagePath;
+
+	// ── back-fill basic ─────────────────────────────────────────────────────────
+
+	@Test
+	void existingEntitiesAreIndexedOnRegistration()
+	{
+		final GigaMap<Article> gigaMap = GigaMap.New();
+
+		// entities added BEFORE the Lucene index exists
+		gigaMap.add(new Article("Title_1", "eclipse store"));
+		gigaMap.add(new Article("Title_2", "eclipse foundation"));
+		gigaMap.add(new Article("Title_3", "java runtime"));
+
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(standardContext())))
+		{
+			assertEquals(2, luceneIndex.query("content:eclipse").size(),
+				"Pre-existing entities must be back-filled into a freshly registered Lucene index");
+			assertEquals(1, luceneIndex.query("title:Title_3").size());
+			assertEquals(3, gigaMap.size());
+		}
+	}
+
+	// ── empty map (no regression, no empty commit) ──────────────────────────────
+
+	@Test
+	void registerOnEmptyMapThenAddStillIndexes()
+	{
+		final GigaMap<Article> gigaMap = GigaMap.New();
+
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(standardContext())))
+		{
+			assertEquals(0, luceneIndex.query("content:eclipse").size());
+
+			gigaMap.add(new Article("Title_1", "eclipse store"));
+
+			assertEquals(1, luceneIndex.query("content:eclipse").size(),
+				"Entities added after registration on an initially empty map must still be indexed");
+		}
+	}
+
+	// ── id correctness: update / remove of a back-filled entity ─────────────────
+
+	@Test
+	void backfilledEntitiesCarryCorrectIdsForUpdateAndRemove()
+	{
+		final GigaMap<Article> gigaMap = GigaMap.New();
+
+		final long id1 = gigaMap.add(new Article("original", "content one"));
+		gigaMap.add(new Article("keep", "content two"));
+
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(standardContext())))
+		{
+			assertEquals(1, luceneIndex.query("title:original").size());
+
+			// update a back-filled entity: relies on ENTITY_ID_FIELD holding the real GigaMap id
+			gigaMap.set(id1, new Article("replaced", "content one"));
+			assertEquals(0, luceneIndex.query("title:original").size(),
+				"Old document of a back-filled entity must be removed on update");
+			assertEquals(1, luceneIndex.query("title:replaced").size(),
+				"New document of a back-filled entity must be present after update");
+
+			// remove a back-filled entity
+			gigaMap.removeById(id1);
+			assertEquals(0, luceneIndex.query("title:replaced").size(),
+				"Document of a back-filled entity must be removed on removeById");
+			assertEquals(1, luceneIndex.query("title:keep").size());
+		}
+	}
+
+	// ── persistence round-trip: back-fill persists and is not re-indexed on reload ─
+
+	@Test
+	void backfillPersistsAndIsNotDoubleIndexedOnReload()
+	{
+		final GigaMap<Article> gigaMap = GigaMap.New();
+
+		gigaMap.add(new Article("Title_1", "eclipse store"));
+		gigaMap.add(new Article("Title_2", "eclipse foundation"));
+
+		// in-graph index (null DirectoryCreator) so the back-filled data is stored with the GigaMap
+		final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(
+			LuceneContext.New(null, AnalyzerCreator.Standard(), new ArticlePopulator())));
+
+		assertEquals(2, luceneIndex.query("content:eclipse").size());
+
+		try(final EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, this.storagePath))
+		{
+			// store the back-filled index along with the map
+		}
+		luceneIndex.close();
+
+		LuceneIndex<Article> reloaded = null;
+		try(final EmbeddedStorageManager storageManager = EmbeddedStorage.start(GigaMap.<Article>New(), this.storagePath))
+		{
+			final GigaMap<Article> gigaMap2 = storageManager.root();
+			reloaded = gigaMap2.index().get(LuceneIndex.class);
+
+			assertEquals(2, reloaded.query("content:eclipse").size(),
+				"Back-filled documents must survive a store/reload and must not be re-indexed (duplicated)");
+			assertEquals(2, gigaMap2.size());
+		}
+		finally
+		{
+			if(reloaded != null)
+			{
+				reloaded.close();
+			}
+		}
+	}
+
+	// ── manual-commit context: back-fill must not force a commit ────────────────
+
+	@Test
+	void backfillWithManualCommitContext()
+	{
+		final GigaMap<Article> gigaMap = GigaMap.New();
+
+		gigaMap.add(new Article("Title_1", "eclipse store"));
+		gigaMap.add(new Article("Title_2", "eclipse foundation"));
+
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(
+			LuceneIndex.Category(new ManualCommitContext())))
+		{
+			// the near-real-time reader sees the back-filled (uncommitted) documents immediately,
+			// just like internalAdd under a manual-commit context
+			assertEquals(2, luceneIndex.query("content:eclipse").size(),
+				"Back-filled documents must be queryable under a manual-commit context");
+
+			// an explicit commit must work and keep the data visible
+			assertDoesNotThrow(luceneIndex::commit);
+			assertEquals(2, luceneIndex.query("content:eclipse").size());
+		}
+	}
+
+	// ── fixtures ────────────────────────────────────────────────────────────────
+
+	private static LuceneContext<Article> standardContext()
+	{
+		return LuceneContext.New(DirectoryCreator.ByteBuffers(), new ArticlePopulator());
+	}
+
+	private static class ManualCommitContext extends LuceneContext.Default<Article>
+	{
+		ManualCommitContext()
+		{
+			super(DirectoryCreator.ByteBuffers(), AnalyzerCreator.Standard(), new ArticlePopulator());
+		}
+
+		@Override
+		public boolean autoCommit()
+		{
+			return false;
+		}
+	}
+
+	private static class ArticlePopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			document.add(createTextField("title",   entity.getTitle()));
+			document.add(createTextField("content", entity.getContent()));
+		}
+	}
+
+	private static class Article
+	{
+		private final String title;
+		private final String content;
+
+		Article(final String title, final String content)
+		{
+			this.title   = title;
+			this.content = content;
+		}
+
+		String getTitle()
+		{
+			return this.title;
+		}
+
+		String getContent()
+		{
+			return this.content;
+		}
+	}
+}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneBackfillTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneBackfillTest.java
@@ -22,10 +22,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Verifies that registering a {@link LuceneIndex} on a {@link GigaMap} that already contains
@@ -167,6 +168,39 @@ public class LuceneBackfillTest
 			// an explicit commit must work and keep the data visible
 			assertDoesNotThrow(luceneIndex::commit);
 			assertEquals(2, luceneIndex.query("content:eclipse").size());
+		}
+	}
+
+	// ── failed back-fill rolls back the registration ────────────────────────────
+
+	@Test
+	void failedBackfillRollsBackRegistration()
+	{
+		final GigaMap<Article> gigaMap = GigaMap.New();
+		gigaMap.add(new Article("Title_1", "eclipse store"));
+
+		// a populator that fails during back-fill of the pre-existing entity
+		final LuceneContext<Article> failing = LuceneContext.New(
+			DirectoryCreator.ByteBuffers(),
+			new DocumentPopulator<Article>()
+			{
+				@Override
+				public void populate(final Document document, final Article entity)
+				{
+					throw new IllegalStateException("boom");
+				}
+			});
+
+		assertThrows(IllegalStateException.class,
+			() -> gigaMap.index().register(LuceneIndex.Category(failing)));
+
+		assertNull(gigaMap.index().get(LuceneIndex.class),
+			"A back-fill failure must roll back the index-group registration");
+
+		// the map remains usable: a subsequent successful registration back-fills normally
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(standardContext())))
+		{
+			assertEquals(1, luceneIndex.query("content:eclipse").size());
 		}
 	}
 


### PR DESCRIPTION
## Problem

A Lucene full-text index registered on a `GigaMap` that **already contained entities** only indexed entities added *after* registration — pre-existing entities were silently invisible to full-text search. The bitmap and JVector indices already back-fill from existing entities on registration; Lucene did not, which is both an inconsistency and a silent correctness gap (queries miss data).

This also affected the annotation-driven path (`@FullText` / `LuceneAnnotationHandler` / `IndexerGenerator.generateIndices`), which is user-callable on a populated map.

## Change

- Add a default no-op lifecycle hook `internalOnRegistered()` to `IndexGroup.Internal`, invoked by `GigaIndices.register(...)` immediately after a group is added. It is **not** called on deserialization (groups are reconstructed via their binary handlers), so there is no re-indexing / double-indexing on restart.
- `LuceneIndex` overrides the hook to index all existing entities via `iterateIndexed`, using the real GigaMap-assigned entity ids (so later `update`/`remove`, which look up by id, keep working). Documents are added incrementally and committed **once** at the end, honoring the `autoCommit` contract and skipping an empty commit on an empty map.
- Bitmap and JVector groups inherit the no-op, so registering the (empty) `VectorIndices` container does **not** trigger a wasteful full-map scan; its existing per-index back-fill is unchanged.
- Extracted a shared `toDocument(entityId, entity)` helper, now the single document-construction point used by `internalAdd`, `internalAddAll`, `internalUpdateIndices`, and the back-fill.

Registration order no longer matters: an index can be added before or after data is loaded.

## Why a hook (not a generic back-fill in `register`)

A generic `iterateIndexed` in `register` would force a full-map scan (loading every `Lazy` segment) just to register the empty `VectorIndices` container. Doing it in `createIndexGroup` would scan the map even for a discarded duplicate group (the already-registered check runs after creation). The hook lets each group opt in; only Lucene needs it.

## Tests

New `LuceneBackfillTest`:
- existing entities are indexed on registration
- register on empty map, then add still indexes (no regression / no empty commit)
- back-filled entities carry correct ids for `update`/`remove`
- persistence round-trip: back-fill persists and is **not** double-indexed on reload
- manual-commit (`autoCommit=false`) context

All module suites pass: `gigamap` (1034), `lucene` (58), `jvector` (189).

## Docs

Updated the Lucene index and annotation pages to state that registering on a populated GigaMap back-fills existing entities, with a note about the one-time full-entity scan on very large maps.