### PR TITLE
update dependencies: upgrade jackson-databind to 2.22.0 and javalin t…

### DIFF
--- a/examples/gigamap/pom.xml
+++ b/examples/gigamap/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.20.2</version>
+            <version>2.22.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/storage/rest/service-javalin/pom.xml
+++ b/storage/rest/service-javalin/pom.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
-            <version>7.0.1</version>
+            <version>7.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This pull request updates dependencies in the Maven configuration files for both the `examples/gigamap` and `storage/rest/service-javalin` modules. The main focus is on upgrading the versions of `jackson-databind` and `javalin` to improve compatibility and security.

Dependency version upgrades:

* Upgraded `jackson-databind` to version `2.22.0` in both `examples/gigamap/pom.xml` and `storage/rest/service-javalin/pom.xml` for improved security and bug fixes. [[1]](diffhunk://#diff-82e2a1869b9a9e72790898a89ef722e136387ac5b6d716dc3b77c59a5d1d83d6L46-R46) [[2]](diffhunk://#diff-b7c9a51488c757275d62ea613a77ddf1afb089461e23e3c6408b8799ba7933afL31-R36)
* Upgraded `javalin` to version `7.2.2` in `storage/rest/service-javalin/pom.xml` for the latest features and fixes.