### PR TITLE
Allow GigaMap reindexing without a bitmap index via entityId-based update()/apply() (#713)

### DIFF
--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -97,7 +97,10 @@ long entityId = searchResultEntry.entityId();
 
 // update / apply by id — no bitmap index required
 gigaMap.update(entityId, p -> p.setLastName("Smith"));
-gigaMap.apply(entityId, p -> p.recompute());
+gigaMap.apply(entityId, p -> {
+    p.recompute();
+    return null;
+});
 
 // the index-free equivalents of replace / remove already exist:
 gigaMap.set(entityId, replacement);

--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -83,3 +83,23 @@ gigaMap.update(person, p -> {
 Entities modified through `update` (or `apply`) are automatically persisted when calling `store()`. See xref:persistence.adoc[] for details.
 
 WARNING: Because `update` / `apply` mutate the entity in place, a constraint violation triggered by the new state cannot be rolled back. The GigaMap therefore **removes** the offending entity from the map and rethrows the `ConstraintViolationException`. See xref:constraints.adoc#_constraint_violations[Constraints — Constraint Violations] for the full rollback semantics across CRUD operations.
+
+=== Updating by Entity Id
+
+Resolving an entity instance to its id (as done by `update(entity, …)`, `apply(entity, …)`, `replace(current, replacement)` and `remove(entity)`) relies on a *bitmap* index. A GigaMap that only has non-bitmap indices — for example a Lucene-only or vector-only map — therefore cannot use these entity-instance methods and would throw an `IllegalStateException`.
+
+For these maps, use the entityId-based overloads instead, which take the id directly and need no bitmap index. The required id is available from query and search results, e.g. via `GigaQuery.iterateIndexed(…)` / `executeWithId(…)` or the `entityId()` of a scored Lucene / vector search result.
+
+[source, java]
+----
+// id obtained from a Lucene/vector search result or a query
+long entityId = searchResultEntry.entityId();
+
+// update / apply by id — no bitmap index required
+gigaMap.update(entityId, p -> p.setLastName("Smith"));
+gigaMap.apply(entityId, p -> p.recompute());
+
+// the index-free equivalents of replace / remove already exist:
+gigaMap.set(entityId, replacement);
+gigaMap.removeById(entityId);
+----

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -156,13 +156,15 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	/**
 	 * Removes the specified entity if present in this collection and returns its previously mapped id.
 	 * <p>
-	 * In order for this method to work, at least one bitmap index is needed. If no index is present an
-	 * {@link IllegalStateException} will be thrown.
+	 * Because the entity instance has to be resolved to its id first, at least one bitmap index is
+	 * needed for this method to work; if none is present an {@link IllegalStateException} is thrown.
+	 * Maps without a bitmap index (e.g. Lucene-only or vector-only maps) can use the entityId-based
+	 * {@link #removeById(long)} instead, passing an id obtained from a query or search result.
 	 * <p>
 	 * To get the best performance for this operation is the use of an identity index.
 	 * See {@link BitmapIndices#setIdentityIndices(IndexIdentifier...)}.
-	 * 
-	 * 
+	 *
+	 *
 	 * @param entity the entity to be removed
 	 * @return the previously mapped id of the entity, or -1 if none was removed
 	 * @throws IllegalStateException if no bitmap index is present
@@ -267,8 +269,10 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Replaces the specified entity if present with a different one, updates the indices accordingly,
 	 * and returns its mapped id.
 	 * <p>
-	 * In order for this method to work, at least one bitmap index is needed. If no index is present an
-	 * {@link IllegalStateException} will be thrown.
+	 * Because the current entity instance has to be resolved to its id first, at least one bitmap index
+	 * is needed for this method to work; if none is present an {@link IllegalStateException} is thrown.
+	 * Maps without a bitmap index (e.g. Lucene-only or vector-only maps) can use the entityId-based
+	 * {@link #set(long, Object)} instead, passing an id obtained from a query or search result.
 	 * <p>
 	 * To get the best performance for this operation is the use of an identity index.
 	 * See {@link BitmapIndices#setIdentityIndices(IndexIdentifier...)}.
@@ -288,8 +292,10 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
 	 * are automatically persisted when {@link #store()} is called.
 	 * <p>
-	 * In order for this method to work, at least one bitmap index is needed. If no index is present an
-	 * {@link IllegalStateException} will be thrown.
+	 * Because the entity instance has to be resolved to its id first, at least one bitmap index is
+	 * needed for this method to work; if none is present an {@link IllegalStateException} is thrown.
+	 * Maps without a bitmap index (e.g. Lucene-only or vector-only maps) can use the entityId-based
+	 * {@link #update(long, Consumer)} instead, passing an id obtained from a query or search result.
 	 * <p>
 	 * To get the best performance for this operation is the use of an identity index.
 	 * See {@link BitmapIndices#setIdentityIndices(IndexIdentifier...)}.
@@ -324,15 +330,53 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 		return current;
 	}
-	
+
+	/**
+	 * Updates the entity mapped to the given id and the indices accordingly.
+	 * <p>
+	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
+	 * are automatically persisted when {@link #store()} is called.
+	 * <p>
+	 * Unlike {@link #update(Object, Consumer)}, this variant takes the entity id directly and therefore
+	 * needs <b>no</b> bitmap index. It is the recommended way to trigger reindexing on maps that only
+	 * have non-bitmap indices (e.g. Lucene-only or vector-only maps). Suitable ids are available from
+	 * query and search results, e.g. via {@link GigaQuery#iterateIndexed(EntryConsumer)} /
+	 * {@link GigaQuery#executeWithId(EntryConsumer)} or the {@code entityId()} of a scored search result.
+	 * <p>
+	 * <b>Behavior on constraint violation (potential data loss):</b> identical to
+	 * {@link #apply(long, Function)}: if the post-update state violates a registered constraint, a
+	 * {@link ConstraintViolationException ConstraintViolationException} is thrown <em>and the entity is
+	 * removed from this GigaMap</em>, because the in-place mutation cannot be rolled back.
+	 *
+	 * @param entityId the id of the entity to be updated
+	 * @param logic the update logic to be executed
+	 * @return the updated entity
+	 * @throws IllegalArgumentException if no entity is mapped to the given id
+	 * @throws ConstraintViolationException if the post-update state
+	 *         violates a registered constraint; the entity is removed from the map before this is thrown
+	 */
+	public default E update(final long entityId, final Consumer<? super E> logic)
+	{
+		notNull(logic);
+		this.apply(entityId, e ->
+		{
+			logic.accept(e);
+			return null;
+		});
+
+		return this.get(entityId);
+	}
+
 	/**
 	 * Applies the specified logic for the given entity and updates the indices accordingly.
 	 * <p>
 	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
 	 * are automatically persisted when {@link #store()} is called.
 	 * <p>
-	 * In order for this method to work, at least one bitmap index is needed. If no index is present an
-	 * {@link IllegalStateException} will be thrown.
+	 * Because the entity instance has to be resolved to its id first, at least one bitmap index is
+	 * needed for this method to work; if none is present an {@link IllegalStateException} is thrown.
+	 * Maps without a bitmap index (e.g. Lucene-only or vector-only maps) can use the entityId-based
+	 * {@link #apply(long, Function)} instead, passing an id obtained from a query or search result.
 	 * <p>
 	 * To get the best performance for this operation is the use of an identity index.
 	 * See {@link BitmapIndices#setIdentityIndices(IndexIdentifier...)}.
@@ -358,6 +402,38 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 *         thrown
 	 */
 	public <R> R apply(E current, Function<? super E, R> logic);
+
+	/**
+	 * Applies the specified logic to the entity mapped to the given id and updates the indices accordingly.
+	 * <p>
+	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
+	 * are automatically persisted when {@link #store()} is called.
+	 * <p>
+	 * Unlike {@link #apply(Object, Function)}, this variant takes the entity id directly and therefore
+	 * needs <b>no</b> bitmap index. It is the recommended way to trigger reindexing on maps that only
+	 * have non-bitmap indices (e.g. Lucene-only or vector-only maps). Suitable ids are available from
+	 * query and search results, e.g. via {@link GigaQuery#iterateIndexed(EntryConsumer)} /
+	 * {@link GigaQuery#executeWithId(EntryConsumer)} or the {@code entityId()} of a scored search result.
+	 * <p>
+	 * <b>Behavior on constraint violation (potential data loss):</b> if the post-application state of the
+	 * entity violates a registered constraint, a
+	 * {@link ConstraintViolationException ConstraintViolationException}
+	 * is thrown <em>and the entity is removed from this GigaMap</em>. Because {@code logic} mutates the
+	 * entity in place, the previous state is no longer available and cannot be restored — removing the
+	 * entry is the only way to keep the map consistent. The thrown exception carries the offending entity
+	 * and its id (via {@code violatingEntity} and {@code entityId}); callers that need to recover can
+	 * re-add the entity after correcting the violation, or use {@link #set(long, Object) set} when
+	 * non-destructive semantics are required.
+	 *
+	 * @param entityId the id of the entity the logic is applied to
+	 * @param logic the logic to be executed
+	 * @return the result of the given logic
+	 * @throws IllegalArgumentException if no entity is mapped to the given id
+	 * @throws ConstraintViolationException if the post-application
+	 *         state violates a registered constraint; the entity is removed from the map before this is
+	 *         thrown
+	 */
+	public <R> R apply(long entityId, Function<? super E, R> logic);
 	
 	/**
 	 * Releases all strong references to on-demand loaded data.
@@ -1696,7 +1772,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			
 			if(indicesCollector.isEmpty())
 			{
-				throw new IllegalStateException("Cannot perform entity-related searching without at least one index.");
+				throw new IllegalStateException(
+					"This GigaMap has no bitmap index, so an entity instance cannot be resolved to its id. "
+					+ "Register a bitmap index, or use the entityId-based methods "
+					+ "(apply(long, ...), update(long, ...), set(long, ...), removeById(long)) instead - "
+					+ "entityIds are available from query and search results."
+				);
 			}
 			
 			return indicesCollector;
@@ -1865,13 +1946,36 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			this.validateForCRUD(current);
 			notNull(logic);
 			this.ensureMutability();
-			
+
 			final long entityId = this.lookupEntityIdPeeking(current, this.determineIdentityLookupIndices());
 			if(entityId < 0)
 			{
 				throw new IllegalArgumentException("Entity not found");
 			}
-			
+
+			return this.internalApply(entityId, current, logic);
+		}
+
+		@Override
+		public final synchronized <R> R apply(final long entityId, final Function<? super E, R> logic)
+		{
+			notNull(logic);
+			this.ensureMutability();
+			this.validateEntityId(entityId);
+
+			// Resolves the entity directly via its id, so no (bitmap) index is required. This is the
+			// only update path available to maps that have solely non-bitmap indices (e.g. Lucene, vector).
+			final E current = this.get(entityId);
+			if(current == null)
+			{
+				throw new IllegalArgumentException("Entity not found for id: " + entityId);
+			}
+
+			return this.internalApply(entityId, current, logic);
+		}
+
+		private <R> R internalApply(final long entityId, final E current, final Function<? super E, R> logic)
+		{
 			try
 			{
 				final R result = this.indices.internalUpdateIndices(entityId, current, logic, this.constraints.custom());
@@ -1900,7 +2004,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				throw e;
 			}
 		}
-		
+
 		private void ensureMutability()
 		{
 			while(this.checkingIsReadOnly())

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -358,13 +358,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public default E update(final long entityId, final Consumer<? super E> logic)
 	{
 		notNull(logic);
-		this.apply(entityId, e ->
+		// Return the entity from inside apply() so the lookup+update stay atomic under apply()'s lock.
+		return this.apply(entityId, e ->
 		{
 			logic.accept(e);
-			return null;
+			return e;
 		});
-
-		return this.get(entityId);
 	}
 
 	/**

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/ApplyByIdTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/crud/ApplyByIdTest.java
@@ -1,0 +1,176 @@
+
+package org.eclipse.store.gigamap.crud;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for the entityId-based {@link GigaMap#apply(long, java.util.function.Function)} and
+ * {@link GigaMap#update(long, java.util.function.Consumer)} overloads, which trigger reindexing
+ * without requiring a bitmap index (issue #713).
+ */
+public class ApplyByIdTest
+{
+	@TempDir
+	Path tempDir;
+
+	/**
+	 * A map with no bitmap index at all can still be updated in place via the entityId-based
+	 * methods. The entity-instance based update()/apply() would throw IllegalStateException here.
+	 */
+	@Test
+	void applyById_worksWithoutBitmapIndex()
+	{
+		final GigaMap<Item> gigaMap = GigaMap.New(); // no index registered
+
+		final long id1 = gigaMap.add(new Item("item1", 1));
+		gigaMap.add(new Item("item2", 2));
+
+		final Integer result = gigaMap.apply(id1, item ->
+		{
+			item.setName("renamed");
+			return item.getOrder();
+		});
+
+		assertEquals(1, result);
+		assertEquals("renamed", gigaMap.get(id1).getName());
+	}
+
+	@Test
+	void updateById_worksWithoutBitmapIndex()
+	{
+		final GigaMap<Item> gigaMap = GigaMap.New(); // no index registered
+
+		final long id1 = gigaMap.add(new Item("item1", 1));
+
+		final Item updated = gigaMap.update(id1, item -> item.setOrder(42));
+
+		assertSame(gigaMap.get(id1), updated);
+		assertEquals(42, gigaMap.get(id1).getOrder());
+	}
+
+	/**
+	 * The in-place mutation must be re-persisted by store() (covered by the pendingEntityStores
+	 * tracking) and survive a reload.
+	 */
+	@Test
+	void applyById_persistsAcrossReload()
+	{
+		final GigaMap<Item> gigaMap = GigaMap.New();
+		final long id = gigaMap.add(new Item("original", 1));
+
+		try(final EmbeddedStorageManager storageManager = EmbeddedStorage.start(gigaMap, this.tempDir))
+		{
+			gigaMap.update(id, item -> item.setName("changed"));
+			gigaMap.store();
+		}
+
+		try(final EmbeddedStorageManager storageManager = EmbeddedStorage.start(this.tempDir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Item> loaded = (GigaMap<Item>)storageManager.root();
+			assertEquals("changed", loaded.get(id).getName());
+		}
+	}
+
+	@Test
+	void applyById_invalidIdThrows()
+	{
+		final GigaMap<Item> gigaMap = GigaMap.New();
+		gigaMap.add(new Item("item1", 1));
+
+		assertThrows(IllegalArgumentException.class, () -> gigaMap.apply(-1L, item -> null));
+		assertThrows(IllegalArgumentException.class, () -> gigaMap.apply(999L, item -> null));
+	}
+
+	/**
+	 * Constraint-violation semantics must match the entity-instance based apply(): the offending
+	 * entity is ejected from the map and the exception carries its id.
+	 */
+	@Test
+	void applyById_constraintViolationEjectsEntity()
+	{
+		final BinaryIndexerString<Item> nameIndex = new BinaryIndexerString.Abstract<>()
+		{
+			@Override
+			protected String getString(final Item item)
+			{
+				return item.getName();
+			}
+		};
+
+		final GigaMap<Item> gigaMap = GigaMap.<Item>Builder()
+			.withBitmapUniqueIndex(nameIndex)
+			.build();
+
+		final long aliceId = gigaMap.add(new Item("alice", 1));
+		gigaMap.add(new Item("bob", 2));
+
+		final UniqueConstraintViolationException ex = assertThrows(
+			UniqueConstraintViolationException.class,
+			() -> gigaMap.apply(aliceId, item -> { item.setName("bob"); return null; })
+		);
+
+		assertEquals(aliceId, ex.getEntityId());
+		assertNull(gigaMap.peek(aliceId), "the offending entity must be ejected");
+		assertEquals(1, gigaMap.size());
+	}
+
+	static class Item
+	{
+		private String  name;
+		private Integer order;
+
+		Item(final String name, final Integer order)
+		{
+			this.name  = name;
+			this.order = order;
+		}
+
+		String getName()
+		{
+			return this.name;
+		}
+
+		void setName(final String name)
+		{
+			this.name = name;
+		}
+
+		Integer getOrder()
+		{
+			return this.order;
+		}
+
+		void setOrder(final Integer order)
+		{
+			this.order = order;
+		}
+	}
+}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneReindexByIdTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneReindexByIdTest.java
@@ -1,0 +1,99 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.apache.lucene.document.Document;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that a GigaMap with only a (non-bitmap) Lucene index can trigger reindexing of a mutated
+ * entity through the entityId-based {@link GigaMap#apply(long, java.util.function.Function)} /
+ * {@link GigaMap#update(long, java.util.function.Consumer)}, without a dummy bitmap index (issue #713).
+ * The entity-instance based update()/apply() would throw IllegalStateException on such a map.
+ */
+public class LuceneReindexByIdTest
+{
+	@Test
+	void updateById_reindexesLuceneOnlyMap()
+	{
+		final LuceneContext<Article> luceneContext = LuceneContext.New(
+			DirectoryCreator.ByteBuffers(),
+			new ArticleDocumentPopulator()
+		);
+
+		final GigaMap<Article> gigaMap = GigaMap.New(); // no bitmap index
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(luceneContext)))
+		{
+			final long id = gigaMap.add(new Article("Title_1", "SomeContent"));
+
+			// in-place mutation + reindex via the entityId-based overload
+			gigaMap.update(id, article -> article.setTitle("Title_2"));
+
+			// the old title is no longer found ...
+			final List<Article> oldHits = new ArrayList<>();
+			luceneIndex.query("title:Title_1", (i, entity, score) -> oldHits.add(entity));
+			assertEquals(0, oldHits.size(), "stale title must not be indexed any more");
+
+			// ... and the new title is found.
+			final List<Article> newHits = new ArrayList<>();
+			luceneIndex.query("title:Title_2", (i, entity, score) -> newHits.add(entity));
+			assertEquals(1, newHits.size(), "updated title must be reindexed");
+			assertEquals("Title_2", newHits.get(0).getTitle());
+		}
+	}
+
+	private static class ArticleDocumentPopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			document.add(createTextField("title", entity.getTitle()));
+			document.add(createTextField("content", entity.getContent()));
+		}
+	}
+
+	private static class Article
+	{
+		private String title;
+		private String content;
+
+		Article(final String title, final String content)
+		{
+			this.title   = title;
+			this.content = content;
+		}
+
+		String getTitle()
+		{
+			return this.title;
+		}
+
+		void setTitle(final String title)
+		{
+			this.title = title;
+		}
+
+		String getContent()
+		{
+			return this.content;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #713.

`GigaMap`'s entity-instance update methods — `update(E, …)`, `apply(E, …)`, `replace(E, E)` and `remove(E)` — must first resolve the entity instance to its `long` id. They do this through `determineIdentityLookupIndices()`, which consults **only bitmap indices**. As a result, a map that has solely non-bitmap indices (Lucene-only, vector-only, or any mixed non-bitmap setup) had no sanctioned way to trigger index-group reindexing after mutating an entity, and was forced to register a dummy bitmap index purely to satisfy the precondition (see #708).

This PR adds entityId-based overloads that take the id directly and require **no** bitmap index, mirroring the already index-free `set(long, E)` and `removeById(long)`.
The id is readily available from query/search results (`GigaQuery.iterateIndexed` / `executeWithId`, or `entityId()` on a scored Lucene/vector search result).

## Changes

- **New API on `GigaMap`:**
    - `<R> R apply(long entityId, Function<? super E, R> logic)` (abstract)
    - `E update(long entityId, Consumer<? super E> logic)` (default, delegates to `apply`)
- **`GigaMap.Default`:** extracted the shared post-lookup body into `internalApply(...)`; both the existing `apply(E, …)` and the new `apply(long, …)` reuse it, so persistence (`pendingEntityStores`) and constraint-violation/ejection semantics are identical.
- **Clearer error message:** `determineIdentityLookupIndices()` now states that a *bitmap* index is required and points to the entityId-based methods.
- **Docs/Javadoc:** updated `update(E)`/`apply(E)`/`replace`/`remove(E)` Javadoc to say "bitmap index" and cross-reference the index-free counterparts; added an "Updating by Entity Id" section to `docs/.../gigamap/pages/crud.adoc`.

Note: `set()` (mentioned in the issue title) already works without a bitmap index — no change was needed there.

## Tests

- `crud/ApplyByIdTest` — bitmap-free apply/update, persistence round-trip, invalid-id, and constraint-violation ejection parity.
- `lucene/LuceneReindexByIdTest` — a Lucene-only map reindexes a mutated field through `update(long, …)`.
- Full `gigamap` module suite green: **1039 tests, 0 failures** (1 pre-existing skip).

## Compatibility note

Adding an abstract method (`apply(long, Function)`) to the public `GigaMap` interface is source-incompatible for any **external** code that implements `GigaMap` directly. Within the repo, `GigaMap.Default` is the only implementor, so nothing internal breaks.