### PR TITLE
remove alignment step for serializer version in Windows Maven build

### DIFF
--- a/.github/workflows/maven_build_win.yml
+++ b/.github/workflows/maven_build_win.yml
@@ -22,9 +22,5 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: 'maven'
-    - name: Align serializer version to matching branch snapshot
-      uses: ./.github/actions/align-serializer-version
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build with Maven
       run: mvn  -T 1C -P examples -B clean package --file pom.xml -U


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow for building with Maven on Windows. The step that aligned the serializer version to the matching branch snapshot has been removed, script is not working in WIN.