### PR TITLE
Add GigaMap.reindex() and clarify index persistence timing (#714, #716)

### DIFF
--- a/docs/modules/gigamap/pages/indexing/lucene/advanced.adoc
+++ b/docs/modules/gigamap/pages/indexing/lucene/advanced.adoc
@@ -345,6 +345,24 @@ Map<String, Long> categoryCounts = products.query(Query.all())
 
 == Index Lifecycle
 
+=== Reindexing
+
+GigaMap has no automatic change tracking. The Lucene index is only updated when an entity is added, removed, or mutated through `update` / `apply`. If an indexed field is changed *directly* and the entity is then stored, the document is never re-populated, so searches silently return stale results.
+
+To recover, mutate the entity through the entityId-based `update` / `apply` (single entity), or rebuild the whole index from the current entity state with `reindex()`:
+
+[source, java]
+----
+// stale: title was changed directly, not via update()
+article.setTitle("New Title");
+gigaMap.store();           // entity persisted, Lucene index NOT updated
+
+gigaMap.reindex();         // rebuild all indices from current entity state
+gigaMap.store();           // persist (embedded index); external index already committed
+----
+
+`reindex()` drops the existing documents and re-populates them via the configured `DocumentPopulator`, committing once at the end (honoring `autoCommit`). It is also useful after a bulk import that added entities without indexing them. On a very large map this iterates all entities, so prefer `update` / `apply` for routine single-entity changes.
+
 === Closing and Re-opening
 
 [source, java]

--- a/docs/modules/gigamap/pages/indexing/lucene/advanced.adoc
+++ b/docs/modules/gigamap/pages/indexing/lucene/advanced.adoc
@@ -347,21 +347,21 @@ Map<String, Long> categoryCounts = products.query(Query.all())
 
 === Reindexing
 
-GigaMap has no automatic change tracking. The Lucene index is only updated when an entity is added, removed, or mutated through `update` / `apply`. If an indexed field is changed *directly* and the entity is then stored, the document is never re-populated, so searches silently return stale results.
+GigaMap has no automatic change tracking. The Lucene index is only updated when an entity is added, removed, or mutated through `update` / `apply`. If an indexed field is changed *directly*, the document is never re-populated, so searches silently return stale results — and a subsequent `gigaMap.store()` neither fixes the index nor persists the direct change.
 
-To recover, mutate the entity through the entityId-based `update` / `apply` (single entity), or rebuild the whole index from the current entity state with `reindex()`:
+The preferred fix is to mutate the entity through the entityId-based `update` / `apply` (single entity), which re-indexes it and schedules it for storing. To repair an index that has already drifted, store the affected entities explicitly and rebuild the whole index from the current entity state with `reindex()`:
 
 [source, java]
 ----
 // stale: title was changed directly, not via update()
 article.setTitle("New Title");
-gigaMap.store();           // entity persisted, Lucene index NOT updated
+storageManager.store(article);  // persist the changed entity explicitly (not tracked by GigaMap)
 
-gigaMap.reindex();         // rebuild all indices from current entity state
-gigaMap.store();           // persist (embedded index); external index already committed
+gigaMap.reindex();              // rebuild all indices from current entity state
+gigaMap.store();                // persist the rebuilt indices
 ----
 
-`reindex()` drops the existing documents and re-populates them via the configured `DocumentPopulator`, committing once at the end (honoring `autoCommit`). It is also useful after a bulk import that added entities without indexing them. On a very large map this iterates all entities, so prefer `update` / `apply` for routine single-entity changes.
+`reindex()` drops the existing documents and re-populates them via the configured `DocumentPopulator`, committing once at the end (honoring `autoCommit`: with an external directory and `autoCommit=false` the commit is deferred to the next `gigaMap.store()` boundary). It rebuilds only the index structures — it does not store the entities — so ensure the entities themselves are persisted as shown above. On a very large map this iterates all entities, so prefer `update` / `apply` for routine single-entity changes.
 
 === Closing and Re-opening
 

--- a/docs/modules/gigamap/pages/indexing/lucene/use-cases.adoc
+++ b/docs/modules/gigamap/pages/indexing/lucene/use-cases.adoc
@@ -2,6 +2,8 @@
 
 This section provides recommended configurations and examples for common use cases.
 
+NOTE: Whenever an indexed entity changes, mutate it through `update` / `apply` so the Lucene index is kept in sync — a direct field change is not tracked and leaves searches stale. See xref:indexing/lucene/advanced.adoc#_reindexing[Reindexing] for recovery.
+
 == Product Catalog Search
 
 Enable customers to search products by name, description, or other attributes.

--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -36,14 +36,16 @@ gigaMap.store();
 ====
 GigaMap has no automatic change tracking. Changes made to entities *directly* (outside of `update`, `apply`, `set`, `replace`, `add` or `remove`) are not tracked, so they are neither stored automatically *nor reflected in the indices*.
 
-Mutating an indexed field directly and then calling `store()` persists the entity but leaves the indices stale: bitmap queries return wrong results, and Lucene searches fail *silently* (no error).
+Mutating an indexed field directly leaves the indices stale: bitmap queries return wrong results, and Lucene searches fail *silently* (no error). A subsequent `gigaMap.store()` does not fix this — it neither re-runs the indexers nor implicitly persists the direct mutation.
 
-Always mutate indexed entities through `update` / `apply`. To recover an index that has drifted out of sync — or after a bulk import that bypassed per-entity indexing — call `reindex()` to rebuild all indices from the current entity state, then `store()`:
+Always mutate indexed entities through `update` / `apply`, which update the indices and schedule the entity for storing. If a mutation already bypassed them, store the affected entities explicitly and call `reindex()` to rebuild all indices from the current entity state, then `store()` (note that `reindex()` rebuilds only the index structures — it does not store the entities):
 
 [source, java]
 ----
-gigaMap.reindex(); // rebuild every index from current entity state
-gigaMap.store();
+person.setLastName("Smith");        // direct mutation (not tracked)
+storageManager.store(person);       // persist the changed entity explicitly
+gigaMap.reindex();                  // rebuild every index from current entity state
+gigaMap.store();                    // persist the rebuilt indices
 ----
 ====
 

--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -32,7 +32,20 @@ gigaMap.update(person, p -> {
 gigaMap.store();
 ----
 
-NOTE: Changes made to entities directly (outside of `update` or `apply`) are not tracked by the GigaMap and must be stored manually.
+[WARNING]
+====
+GigaMap has no automatic change tracking. Changes made to entities *directly* (outside of `update`, `apply`, `set`, `replace`, `add` or `remove`) are not tracked, so they are neither stored automatically *nor reflected in the indices*.
+
+Mutating an indexed field directly and then calling `store()` persists the entity but leaves the indices stale: bitmap queries return wrong results, and Lucene searches fail *silently* (no error).
+
+Always mutate indexed entities through `update` / `apply`. To recover an index that has drifted out of sync — or after a bulk import that bypassed per-entity indexing — call `reindex()` to rebuild all indices from the current entity state, then `store()`:
+
+[source, java]
+----
+gigaMap.reindex(); // rebuild every index from current entity state
+gigaMap.store();
+----
+====
 
 === Why not `storageManager.store(gigaMap)`?
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -254,7 +254,20 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 			}
 			this.markStateChangeChildren();
 		}
-		
+
+		void internalReindex()
+		{
+			// Rebuild every index group from the current entity state. Each group clears its data and
+			// re-indexes all entities of the parent map (see IndexGroup.Internal#internalReindex), so an
+			// index that drifted out of sync - e.g. because an indexed entity was mutated directly instead
+			// of via update()/apply() - is brought back in line.
+			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			{
+				indexGroup.internalReindex(this.parent);
+			}
+			this.markStateChangeChildren();
+		}
+
 		void internalUpdateIndices(
 			final long                         entityId          ,
 			final E                            replacedEntity    ,

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -69,10 +69,13 @@ import static org.eclipse.serializer.util.X.notNull;
  * indexed field must go through this collection's mutating methods ({@link #add(Object) add},
  * {@link #remove(Object) remove}, {@link #set(long, Object) set}, {@link #replace(Object, Object) replace},
  * {@link #update(long, Consumer) update}, {@link #apply(long, Function) apply}); only these re-run the
- * indexers. Mutating an entity's indexed field <em>directly</em> and then calling {@link #store()} persists
- * the entity but leaves the indices stale - for bitmap indices this yields wrong query results, for Lucene
- * indices it fails silently. To bring a single entity back in sync use {@link #update(long, Consumer)} /
- * {@link #apply(long, Function)}; to rebuild every index from the current entity state use {@link #reindex()}.
+ * indexers. Mutating an entity's indexed field <em>directly</em> leaves the indices stale - for bitmap indices
+ * this yields wrong query results, for Lucene indices it fails silently. A subsequent {@link #store()} does
+ * not fix this: it neither updates the indices nor implicitly persists the direct mutation (only entities
+ * mutated through {@code update} / {@code apply} are scheduled for storing; a directly mutated entity must be
+ * stored explicitly, as usual). To bring a single entity back in sync use {@link #update(long, Consumer)} /
+ * {@link #apply(long, Function)} (which also schedule the entity for storing); to rebuild every index from the
+ * current entity state use {@link #reindex()}.
  *
  * @param <E> the type of entities in this collection
  */
@@ -461,22 +464,24 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Rebuilds all registered indices (bitmap, Lucene, vector, ...) from the current state of the
 	 * entities contained in this map.
 	 * <p>
-	 * GigaMap has no automatic change tracking. An entity whose indexed fields are mutated <em>directly</em>
+	 * GigaMap has no automatic change tracking. When an entity's indexed fields are mutated <em>directly</em>
 	 * (i.e. not through {@link #update(long, Consumer) update} / {@link #apply(long, Function) apply} /
-	 * {@link #set(long, Object) set} / {@link #replace(Object, Object) replace}) is persisted by
-	 * {@link #store()}, but its index entries are <b>not</b> updated and therefore become stale. For bitmap
-	 * indices this typically surfaces as wrong query results; for Lucene indices it fails silently. This
-	 * method is the recovery path for such situations, and is also useful after a bulk import that bypassed
-	 * per-entity indexing.
+	 * {@link #set(long, Object) set} / {@link #replace(Object, Object) replace}), its index entries are
+	 * <b>not</b> updated and therefore become stale. For bitmap indices this typically surfaces as wrong query
+	 * results; for Lucene indices it fails silently. This method is the recovery path for such situations, and
+	 * is also useful after a bulk operation that bypassed per-entity indexing.
 	 * <p>
 	 * The rebuild drops each index' data and re-indexes every entity from its current state; a per-entity
 	 * update replay would be insufficient because the previous index key of a directly mutated entity is no
 	 * longer available.
 	 * <p>
-	 * Persistence follows the usual rules: call {@link #store()} afterwards to persist the rebuilt bitmap and
-	 * embedded (graph) Lucene/vector indices. An external-directory Lucene index is committed during the
-	 * rebuild according to its Lucene configuration (the {@code LuceneContext.autoCommit} setting). On a very
-	 * large map this can be an expensive operation, as it iterates all entities once per index group.
+	 * This rebuilds only the index structures; it does <b>not</b> store the entities themselves. A directly
+	 * mutated entity must still be persisted explicitly (mutating via {@code update} / {@code apply} does this
+	 * for you), otherwise a reload would restore the old entity state behind the rebuilt index. Call
+	 * {@link #store()} afterwards to persist the rebuilt bitmap and embedded (graph) Lucene/vector indices. An
+	 * external-directory Lucene index is committed during the rebuild when its {@code LuceneContext.autoCommit}
+	 * is {@code true} (the default), otherwise at the next {@link #store()} boundary. On a very large map this
+	 * can be an expensive operation, as it iterates all entities once per index group.
 	 *
 	 * @see #update(long, Consumer)
 	 * @see #apply(long, Function)
@@ -773,10 +778,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Entities mutated through the {@link #update} or {@link #apply} methods are automatically included in the
 	 * store operation. However, changes made to entities directly (outside of these methods) are NOT stored
 	 * implicitly since it is not possible to automatically track changes made to objects outside the framework.
-	 * Such a direct mutation also leaves the indices stale: storing the entity does not re-run the indexers, so
-	 * bitmap queries return wrong results and Lucene searches fail silently. Mutate indexed entities via
-	 * {@link #update(long, Consumer)} / {@link #apply(long, Function)}, or call {@link #reindex()} to rebuild
-	 * the indices from the current entity state before storing.
+	 * Such a direct mutation also leaves the indices stale, and this store does not re-run the indexers: bitmap
+	 * queries then return wrong results and Lucene searches fail silently. Mutate indexed entities via
+	 * {@link #update(long, Consumer)} / {@link #apply(long, Function)} (which update the indices and schedule
+	 * the entity for storing), or - if a mutation already bypassed them - store the affected entities yourself
+	 * and call {@link #reindex()} to rebuild the indices from the current entity state before storing.
 	 * <p>
 	 * <b>Note on concurrency:</b><br>
 	 * Using this method guarantees concurrency safety since it locks the {@link GigaMap} instance internally.<br>

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -64,6 +64,15 @@ import static org.eclipse.serializer.util.X.notNull;
  * Equality depends on the given {@link #equalator()}. By default, identity equality is used.
  * If you want value equality instead, you can use {@link XHashing#hashEqualityValue()} in the constructor methods,
  * or {@link Builder#withValueEquality()}.
+ * <p>
+ * <b>Keeping indices in sync:</b> GigaMap has no automatic change tracking. Any mutation that affects an
+ * indexed field must go through this collection's mutating methods ({@link #add(Object) add},
+ * {@link #remove(Object) remove}, {@link #set(long, Object) set}, {@link #replace(Object, Object) replace},
+ * {@link #update(long, Consumer) update}, {@link #apply(long, Function) apply}); only these re-run the
+ * indexers. Mutating an entity's indexed field <em>directly</em> and then calling {@link #store()} persists
+ * the entity but leaves the indices stale - for bitmap indices this yields wrong query results, for Lucene
+ * indices it fails silently. To bring a single entity back in sync use {@link #update(long, Consumer)} /
+ * {@link #apply(long, Function)}; to rebuild every index from the current entity state use {@link #reindex()}.
  *
  * @param <E> the type of entities in this collection
  */
@@ -289,8 +298,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	/**
 	 * Updates the specified entity and the indices accordingly.
 	 * <p>
-	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
-	 * are automatically persisted when {@link #store()} is called.
+	 * The entity is mutated in-place by the given logic. The entity itself, the changes to bitmap indices,
+	 * and the changes to embedded (graph) Lucene/vector indices are persisted when {@link #store()} is
+	 * called. An external-directory Lucene index instead commits on a schedule controlled by its
+	 * {@code LuceneContext.autoCommit} setting: by default ({@code autoCommit == true}) it commits
+	 * immediately at this method's call time, independently of {@link #store()}.
 	 * <p>
 	 * Because the entity instance has to be resolved to its id first, at least one bitmap index is
 	 * needed for this method to work; if none is present an {@link IllegalStateException} is thrown.
@@ -334,8 +346,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	/**
 	 * Updates the entity mapped to the given id and the indices accordingly.
 	 * <p>
-	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
-	 * are automatically persisted when {@link #store()} is called.
+	 * The entity is mutated in-place by the given logic. The entity itself, the changes to bitmap indices,
+	 * and the changes to embedded (graph) Lucene/vector indices are persisted when {@link #store()} is
+	 * called. An external-directory Lucene index instead commits on a schedule controlled by its
+	 * {@code LuceneContext.autoCommit} setting: by default ({@code autoCommit == true}) it commits
+	 * immediately at this method's call time, independently of {@link #store()}.
 	 * <p>
 	 * Unlike {@link #update(Object, Consumer)}, this variant takes the entity id directly and therefore
 	 * needs <b>no</b> bitmap index. It is the recommended way to trigger reindexing on maps that only
@@ -354,6 +369,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * @throws IllegalArgumentException if no entity is mapped to the given id
 	 * @throws ConstraintViolationException if the post-update state
 	 *         violates a registered constraint; the entity is removed from the map before this is thrown
+	 * @see #reindex()
 	 */
 	public default E update(final long entityId, final Consumer<? super E> logic)
 	{
@@ -369,8 +385,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	/**
 	 * Applies the specified logic for the given entity and updates the indices accordingly.
 	 * <p>
-	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
-	 * are automatically persisted when {@link #store()} is called.
+	 * The entity is mutated in-place by the given logic. The entity itself, the changes to bitmap indices,
+	 * and the changes to embedded (graph) Lucene/vector indices are persisted when {@link #store()} is
+	 * called. An external-directory Lucene index instead commits on a schedule controlled by its
+	 * {@code LuceneContext.autoCommit} setting: by default ({@code autoCommit == true}) it commits
+	 * immediately at this method's call time, independently of {@link #store()}.
 	 * <p>
 	 * Because the entity instance has to be resolved to its id first, at least one bitmap index is
 	 * needed for this method to work; if none is present an {@link IllegalStateException} is thrown.
@@ -405,8 +424,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	/**
 	 * Applies the specified logic to the entity mapped to the given id and updates the indices accordingly.
 	 * <p>
-	 * The entity is mutated in-place by the given logic. Both the index changes and the entity itself
-	 * are automatically persisted when {@link #store()} is called.
+	 * The entity is mutated in-place by the given logic. The entity itself, the changes to bitmap indices,
+	 * and the changes to embedded (graph) Lucene/vector indices are persisted when {@link #store()} is
+	 * called. An external-directory Lucene index instead commits on a schedule controlled by its
+	 * {@code LuceneContext.autoCommit} setting: by default ({@code autoCommit == true}) it commits
+	 * immediately at this method's call time, independently of {@link #store()}.
 	 * <p>
 	 * Unlike {@link #apply(Object, Function)}, this variant takes the entity id directly and therefore
 	 * needs <b>no</b> bitmap index. It is the recommended way to trigger reindexing on maps that only
@@ -431,9 +453,36 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * @throws ConstraintViolationException if the post-application
 	 *         state violates a registered constraint; the entity is removed from the map before this is
 	 *         thrown
+	 * @see #reindex()
 	 */
 	public <R> R apply(long entityId, Function<? super E, R> logic);
-	
+
+	/**
+	 * Rebuilds all registered indices (bitmap, Lucene, vector, ...) from the current state of the
+	 * entities contained in this map.
+	 * <p>
+	 * GigaMap has no automatic change tracking. An entity whose indexed fields are mutated <em>directly</em>
+	 * (i.e. not through {@link #update(long, Consumer) update} / {@link #apply(long, Function) apply} /
+	 * {@link #set(long, Object) set} / {@link #replace(Object, Object) replace}) is persisted by
+	 * {@link #store()}, but its index entries are <b>not</b> updated and therefore become stale. For bitmap
+	 * indices this typically surfaces as wrong query results; for Lucene indices it fails silently. This
+	 * method is the recovery path for such situations, and is also useful after a bulk import that bypassed
+	 * per-entity indexing.
+	 * <p>
+	 * The rebuild drops each index' data and re-indexes every entity from its current state; a per-entity
+	 * update replay would be insufficient because the previous index key of a directly mutated entity is no
+	 * longer available.
+	 * <p>
+	 * Persistence follows the usual rules: call {@link #store()} afterwards to persist the rebuilt bitmap and
+	 * embedded (graph) Lucene/vector indices. An external-directory Lucene index is committed during the
+	 * rebuild according to its Lucene configuration (the {@code LuceneContext.autoCommit} setting). On a very
+	 * large map this can be an expensive operation, as it iterates all entities once per index group.
+	 *
+	 * @see #update(long, Consumer)
+	 * @see #apply(long, Function)
+	 */
+	public void reindex();
+
 	/**
 	 * Releases all strong references to on-demand loaded data.
 	 */
@@ -724,6 +773,10 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Entities mutated through the {@link #update} or {@link #apply} methods are automatically included in the
 	 * store operation. However, changes made to entities directly (outside of these methods) are NOT stored
 	 * implicitly since it is not possible to automatically track changes made to objects outside the framework.
+	 * Such a direct mutation also leaves the indices stale: storing the entity does not re-run the indexers, so
+	 * bitmap queries return wrong results and Lucene searches fail silently. Mutate indexed entities via
+	 * {@link #update(long, Consumer)} / {@link #apply(long, Function)}, or call {@link #reindex()} to rebuild
+	 * the indices from the current entity state before storing.
 	 * <p>
 	 * <b>Note on concurrency:</b><br>
 	 * Using this method guarantees concurrency safety since it locks the {@link GigaMap} instance internally.<br>
@@ -1971,6 +2024,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			}
 
 			return this.internalApply(entityId, current, logic);
+		}
+
+		@Override
+		public final synchronized void reindex()
+		{
+			this.ensureMutability();
+			this.indices.internalReindex();
 		}
 
 		private <R> R internalApply(final long entityId, final E current, final Function<? super E, R> logic)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
@@ -95,6 +95,30 @@ public interface IndexGroup<E> extends GigaMap.Component<E>
 			// no-op
 		}
 
+		/**
+		 * Rebuilds this group's index data from scratch, using the current state of all entities in the
+		 * given parent map. Invoked by {@link GigaMap#reindex()} to recover from an index that drifted out
+		 * of sync - typically because an indexed entity was mutated directly instead of through
+		 * {@link GigaMap#update(long, java.util.function.Consumer)} /
+		 * {@link GigaMap#apply(long, java.util.function.Function)}.
+		 * <p>
+		 * A full rebuild (clear + re-add) rather than a per-entity update replay is required because after a
+		 * direct mutation the previous index key is no longer available, so only re-indexing from the
+		 * current state is correct.
+		 * <p>
+		 * The default implementation drops all data via {@link #internalRemoveAll()} and re-adds every
+		 * entity via {@link #internalAdd(long, Object)}, which is correct for in-memory groups (e.g. bitmap,
+		 * vector). Groups with an external commit cost (e.g. Lucene) should override this to batch the
+		 * re-add and commit once.
+		 *
+		 * @param parentMap the map whose entities this group indexes
+		 */
+		public default void internalReindex(final GigaMap<E> parentMap)
+		{
+			this.internalRemoveAll();
+			parentMap.iterateIndexed((entityId, entity) -> this.internalAdd(entityId, entity));
+		}
+
 		public void clearStateChangeMarkers();
 	}
 	

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap714Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap714Test.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -92,19 +93,25 @@ public class GigaMap714Test
 
 		try(final EmbeddedStorageManager manager = EmbeddedStorage.start(map, dir))
 		{
-			// initial graph is persisted by start(); now mutate an indexed field directly (index goes stale),
-			// rebuild from current state and store the rebuilt index.
+			// initial graph is persisted by start(); now mutate an indexed field directly (index goes stale).
+			// A direct mutation is not tracked by GigaMap, so the entity must be stored explicitly; reindex()
+			// then rebuilds the index structures, which gigaMap.store() persists.
 			alice.setName("Carol");
+			manager.store(alice);
 			map.reindex();
 			map.store();
 		}
 
-		// reopen and confirm the rebuilt index was persisted
+		// reopen and confirm the rebuilt index AND the entity state were persisted consistently
 		try(final EmbeddedStorageManager manager = EmbeddedStorage.start(dir))
 		{
 			final GigaMap<Customer> root = manager.root();
 			assertEquals(0, root.query(nameIndexer.is("Alice")).count(), "stale key must not survive a reload");
-			assertEquals(1, root.query(nameIndexer.is("Carol")).count(), "rebuilt key must be persisted");
+
+			final List<Customer> carol = root.query(nameIndexer.is("Carol")).toList();
+			assertEquals(1, carol.size(), "rebuilt key must be persisted");
+			assertEquals("Carol", carol.get(0).getName(), "entity state and index must be consistent after reload");
+
 			assertEquals(1, root.query(nameIndexer.is("Bob")).count());
 		}
 	}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap714Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap714Test.java
@@ -1,0 +1,140 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.data.Entity;
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@link GigaMap#reindex()} rebuilds a bitmap index from the current entity state, recovering
+ * from the stale-index situation that arises when an indexed field is mutated directly (i.e. not via
+ * {@code update()} / {@code apply()}) - issue #714.
+ */
+public class GigaMap714Test
+{
+	@Test
+	void reindex_recoversStaleBitmapIndex()
+	{
+		final GigaMap<Entity> map = GigaMap.New();
+		map.index().bitmap().add(Entity.wordIndex);
+
+		final Entity entity = Entity.Random().setWord("alpha");
+		map.add(entity);
+		map.add(Entity.Random().setWord("gamma"));
+
+		// direct mutation - bypasses the indexers, so the bitmap index stays stale
+		entity.setWord("beta");
+
+		assertEquals(1, map.query(Entity.wordIndex.is("alpha")).toList().size(), "index is expected to be stale before reindex");
+		assertEquals(0, map.query(Entity.wordIndex.is("beta")).toList().size(), "new key must not be indexed before reindex");
+
+		map.reindex();
+
+		assertEquals(0, map.query(Entity.wordIndex.is("alpha")).toList().size(), "stale key must be gone after reindex");
+		assertEquals(1, map.query(Entity.wordIndex.is("beta")).toList().size(), "updated key must be reindexed");
+	}
+
+	@Test
+	void reindex_preservesUniqueConstraint()
+	{
+		final GigaMap<Entity> map = GigaMap.New();
+		map.index().bitmap().addUniqueConstraint(Entity.uniqueWordIndex);
+
+		map.add(Entity.Random().setWord("a"));
+		map.add(Entity.Random().setWord("b"));
+
+		// rebuilding valid (still unique) data must not fail
+		map.reindex();
+
+		assertEquals(1, map.query(Entity.uniqueWordIndex.is("a")).toList().size());
+		assertEquals(1, map.query(Entity.uniqueWordIndex.is("b")).toList().size());
+
+		// the unique constraint must still be enforced after the rebuild
+		assertThrows(
+			ConstraintViolationException.class,
+			() -> map.add(Entity.Random().setWord("a"))
+		);
+	}
+
+	@Test
+	void reindex_persistsRebuiltIndex(@TempDir final Path dir)
+	{
+		final NameIndexer nameIndexer = new NameIndexer();
+		final Customer    alice       = new Customer("Alice");
+
+		final GigaMap<Customer> map = GigaMap.New();
+		map.index().bitmap().add(nameIndexer);
+		map.add(alice);
+		map.add(new Customer("Bob"));
+
+		try(final EmbeddedStorageManager manager = EmbeddedStorage.start(map, dir))
+		{
+			// initial graph is persisted by start(); now mutate an indexed field directly (index goes stale),
+			// rebuild from current state and store the rebuilt index.
+			alice.setName("Carol");
+			map.reindex();
+			map.store();
+		}
+
+		// reopen and confirm the rebuilt index was persisted
+		try(final EmbeddedStorageManager manager = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Customer> root = manager.root();
+			assertEquals(0, root.query(nameIndexer.is("Alice")).count(), "stale key must not survive a reload");
+			assertEquals(1, root.query(nameIndexer.is("Carol")).count(), "rebuilt key must be persisted");
+			assertEquals(1, root.query(nameIndexer.is("Bob")).count());
+		}
+	}
+
+	static class NameIndexer extends IndexerString.Abstract<Customer>
+	{
+		@Override
+		protected String getString(final Customer entity)
+		{
+			return entity.getName();
+		}
+	}
+
+	static class Customer
+	{
+		private String name;
+
+		Customer(final String name)
+		{
+			this.name = name;
+		}
+
+		String getName()
+		{
+			return this.name;
+		}
+
+		void setName(final String name)
+		{
+			this.name = name;
+		}
+	}
+}

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorReindexTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorReindexTest.java
@@ -1,0 +1,146 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Probes the PR #724 claim that {@code GigaMap.reindex()} is "correct for bitmap/vector groups",
+ * which the PR does NOT cover with any jvector test. A vector field is mutated DIRECTLY (not via
+ * set()/update()/apply()), so the HNSW graph goes stale; reindex() must rebuild it from current state.
+ */
+class VectorReindexTest
+{
+    static class Entity
+    {
+        float[] vector;
+
+        Entity(final float[] vector)
+        {
+            this.vector = vector;
+        }
+    }
+
+    static class EntityVectorizer extends Vectorizer<Entity>
+    {
+        @Override
+        public float[] vectorize(final Entity entity)
+        {
+            return entity.vector;
+        }
+    }
+
+    private static VectorIndices<Entity> registerIndex(final GigaMap<Entity> map, final Path indexDir)
+    {
+        final VectorIndices<Entity> vectorIndices = map.index().register(VectorIndices.Category());
+        vectorIndices.add(
+            "vec",
+            VectorIndexConfiguration.builder()
+                .dimension(4)
+                .similarityFunction(VectorSimilarityFunction.COSINE)
+                .onDisk(true)
+                .indexDirectory(indexDir)
+                .eventualIndexing(false)
+                .build(),
+            new EntityVectorizer()
+        );
+        return vectorIndices;
+    }
+
+    @Test
+    void reindex_recoversStaleVectorIndex(@TempDir final Path tempDir)
+    {
+        final GigaMap<Entity> map = GigaMap.New();
+        final VectorIndices<Entity> vectorIndices = registerIndex(map, tempDir.resolve("index"));
+
+        final Entity entityA = new Entity(new float[]{1, 0, 0, 0});
+        final long idA = map.add(entityA);
+        map.add(new Entity(new float[]{0, 1, 0, 0}));
+
+        final VectorIndex<Entity> index = vectorIndices.get("vec");
+
+        // sanity: index reflects the original vector
+        assertArrayEquals(new float[]{1, 0, 0, 0}, index.getVector(idA), "index should hold original vector");
+
+        // DIRECT mutation - bypasses the indexers, so the HNSW graph stays stale
+        entityA.vector = new float[]{0, 0, 0, 1};
+
+        // stale state: index still has the old vector, not the directly mutated one
+        assertArrayEquals(new float[]{1, 0, 0, 0}, index.getVector(idA),
+            "index is expected to be stale before reindex");
+
+        // rebuild from current entity state
+        map.reindex();
+
+        final float[] afterReindex = index.getVector(idA);
+        assertNotNull(afterReindex, "entity must still be indexed after reindex");
+        assertArrayEquals(new float[]{0, 0, 0, 1}, afterReindex,
+            "reindex must rebuild the vector from current entity state. Actual: " + Arrays.toString(afterReindex));
+
+        // and search must now rank idA top for its new vector
+        final var hits = index.search(new float[]{0, 0, 0, 1}, 2);
+        assertFalse(hits.isEmpty(), "search should return results after reindex");
+        assertEquals(idA, hits.stream().findFirst().orElseThrow().entityId(),
+            "entity A should be the top result for its updated vector after reindex");
+    }
+
+    @Test
+    void reindex_recoversStaleVectorIndex_eventualIndexing()
+    {
+        final GigaMap<Entity> map = GigaMap.New();
+        final VectorIndices<Entity> vectorIndices = map.index().register(VectorIndices.Category());
+        vectorIndices.add(
+            "vec",
+            VectorIndexConfiguration.builder()
+                .dimension(4)
+                .similarityFunction(VectorSimilarityFunction.COSINE)
+                .eventualIndexing(true)
+                .build(),
+            new EntityVectorizer()
+        );
+
+        final Entity entityA = new Entity(new float[]{1, 0, 0, 0});
+        final long idA = map.add(entityA);
+        map.add(new Entity(new float[]{0, 1, 0, 0}));
+
+        final VectorIndex.Default<Entity> index = (VectorIndex.Default<Entity>) vectorIndices.get("vec");
+        index.backgroundTaskManager.drainQueue();
+        assertArrayEquals(new float[]{1, 0, 0, 0}, index.getVector(idA), "index should hold original vector");
+
+        // DIRECT mutation, then rebuild
+        entityA.vector = new float[]{0, 0, 0, 1};
+        map.reindex();
+
+        // honor eventual semantics: drain the background queue, then the rebuild must be visible
+        index.backgroundTaskManager.drainQueue();
+
+        final float[] afterReindex = index.getVector(idA);
+        assertNotNull(afterReindex, "entity must still be indexed after reindex + drain");
+        assertArrayEquals(new float[]{0, 0, 0, 1}, afterReindex,
+            "reindex must rebuild the vector under eventualIndexing. Actual: " + Arrays.toString(afterReindex));
+
+        final var hits = index.search(new float[]{0, 0, 0, 1}, 2);
+        assertFalse(hits.isEmpty(), "search should return results after reindex + drain");
+        assertEquals(idA, hits.stream().findFirst().orElseThrow().entityId(),
+            "entity A should be the top result for its updated vector after reindex");
+    }
+}

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -429,6 +429,20 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 		{
 			// the GigaMap may already hold entities at the moment this index is registered; index them
 			// now so a full-text search sees pre-existing entities, not only those added afterwards.
+			this.internalRebuild(false);
+		}
+
+		@Override
+		public void internalReindex(final GigaMap<E> parentMap)
+		{
+			// Rebuild the whole index from the current entity state to recover from a stale index (e.g. an
+			// entity mutated directly instead of via update()/apply()). The existing documents are dropped
+			// first; otherwise this is the same batched back-fill as registration.
+			this.internalRebuild(true);
+		}
+
+		private void internalRebuild(final boolean clearFirst)
+		{
 			// Documents are added incrementally (no per-entity commit, no buffering of the whole corpus)
 			// and committed once at the end via optCommit, which honors the manual-commit contract: with
 			// context.autoCommit() == false the back-fill performs no commit, leaving durability to the
@@ -440,9 +454,15 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 				{
 					this.lazyInit();
 
+					if(clearFirst)
+					{
+						this.writer.deleteAll();
+					}
+
 					this.gigaMap.iterateIndexed(this::backfillDocument);
 
-					if(!this.gigaMap.isEmpty())
+					// On a rebuild also commit when the map is empty, so the deleteAll itself is flushed.
+					if(clearFirst || !this.gigaMap.isEmpty())
 					{
 						this.optCommit();
 					}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneReindexTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneReindexTest.java
@@ -1,0 +1,137 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.apache.lucene.document.Document;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that {@link GigaMap#reindex()} rebuilds a Lucene index from the current entity state, recovering
+ * from the stale-index situation that arises when an indexed entity is mutated directly (i.e. not via
+ * {@code update()} / {@code apply()}) and then stored (issue #714).
+ */
+public class LuceneReindexTest
+{
+	@Test
+	void reindex_recoversStaleEmbeddedIndex()
+	{
+		final LuceneContext<Article> context = LuceneContext.New(
+			DirectoryCreator.ByteBuffers(),
+			new ArticleDocumentPopulator()
+		);
+
+		final GigaMap<Article> gigaMap = GigaMap.New();
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(context)))
+		{
+			final Article article = new Article("Title_1", "SomeContent");
+			gigaMap.add(article);
+
+			// direct mutation - bypasses the indexers, so the Lucene document stays stale
+			article.setTitle("Title_2");
+
+			// stale state: the old title is still indexed, the new one is not
+			assertEquals(1, query(luceneIndex, "title:Title_1").size(), "index is expected to be stale before reindex");
+			assertEquals(0, query(luceneIndex, "title:Title_2").size(), "new title must not be indexed before reindex");
+
+			// rebuild from current entity state
+			gigaMap.reindex();
+
+			assertEquals(0, query(luceneIndex, "title:Title_1").size(), "stale title must be gone after reindex");
+			final List<Article> newHits = query(luceneIndex, "title:Title_2");
+			assertEquals(1, newHits.size(), "updated title must be reindexed");
+			assertEquals("Title_2", newHits.get(0).getTitle());
+		}
+	}
+
+	@Test
+	void reindex_recoversStaleExternalIndex(@TempDir final Path indexDir)
+	{
+		final LuceneContext<Article> context = LuceneContext.New(
+			DirectoryCreator.MMap(indexDir),
+			new ArticleDocumentPopulator()
+		);
+
+		final GigaMap<Article> gigaMap = GigaMap.New();
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(context)))
+		{
+			final Article article = new Article("Alpha", "SomeContent");
+			gigaMap.add(article);
+
+			article.setTitle("Beta");
+
+			assertEquals(1, query(luceneIndex, "title:Alpha").size(), "index is expected to be stale before reindex");
+			assertEquals(0, query(luceneIndex, "title:Beta").size(), "new title must not be indexed before reindex");
+
+			gigaMap.reindex();
+
+			assertEquals(0, query(luceneIndex, "title:Alpha").size(), "stale title must be gone after reindex");
+			final List<Article> newHits = query(luceneIndex, "title:Beta");
+			assertEquals(1, newHits.size(), "updated title must be reindexed");
+			assertEquals("Beta", newHits.get(0).getTitle());
+		}
+	}
+
+	private static List<Article> query(final LuceneIndex<Article> luceneIndex, final String queryText)
+	{
+		final List<Article> hits = new ArrayList<>();
+		luceneIndex.query(queryText, (id, entity, score) -> hits.add(entity));
+		return hits;
+	}
+
+	private static class ArticleDocumentPopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			document.add(createTextField("title", entity.getTitle()));
+			document.add(createTextField("content", entity.getContent()));
+		}
+	}
+
+	private static class Article
+	{
+		private String title;
+		private String content;
+
+		Article(final String title, final String content)
+		{
+			this.title   = title;
+			this.content = content;
+		}
+
+		String getTitle()
+		{
+			return this.title;
+		}
+
+		void setTitle(final String title)
+		{
+			this.title = title;
+		}
+
+		String getContent()
+		{
+			return this.content;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #714
Fixes #716

## Background

GigaMap has no automatic change tracking. The indexers only run when an entity goes through `add` / `remove` / `set` / `replace` / `update` / `apply`. Mutating an indexed field **directly** and then calling `store()` persists the entity but leaves the indices stale — wrong results for bitmap indices, and **silent** staleness for Lucene. Two issues called this out:

- **#716** — the `update()` / `apply()` Javadoc claimed index changes are persisted *"when `store()` is called"*. That only holds for bitmap and embedded (graph) Lucene/vector indices; an external-directory Lucene index commits per its `LuceneContext.autoCommit` setting (immediately at call time by default).
- **#714** — asked for prominent documentation of the rule and, ideally, a re-indexing utility.

## Changes

### #716 — accurate persistence-timing Javadoc
Reworded the misleading sentence in all four `update`/`apply` overloads to distinguish bitmap/embedded persistence (at `store()`) from external-directory Lucene commit timing (`autoCommit`).

### #714 — documentation
- New "Keeping indices in sync" paragraph in the `GigaMap` class Javadoc.
- Extended the `store()` Javadoc to call out stale *indices* (silent for Lucene).
- `persistence.adoc`: soft NOTE promoted to a WARNING covering index staleness.
- `indexing/lucene/advanced.adoc`: new "Reindexing" section; pointer note in `use-cases.adoc`.

### #714 — new `GigaMap.reindex()` API
Rebuilds **all** registered indices from the current entity state. A full clear + re-add is required (rather than a per-entity update replay) because a directly mutated entity's previous index key is no longer available.

- `GigaMap.reindex()` → `GigaIndices.Default#internalReindex()`.
- Default `IndexGroup.Internal#internalReindex(parentMap)` clears and re-adds via `iterateIndexed` — correct for bitmap/vector groups.
- `LuceneIndex` overrides it to reuse the existing batched back-fill (`deleteAll` + iterate + single commit), shared with `internalOnRegistered`.

`reindex()` follows the usual persistence rules: call `store()` afterwards to persist bitmap/embedded indices; an external-directory Lucene index commits during the rebuild.

Directly mutated entity's previous index key is no longer available.

- `GigaMap.reindex()` → `GigaIndices.Default#internalReindex()`.
- Default `IndexGroup.Internal#internalReindex(parentMap)` clears and re-adds via `iterateIndexed` — correct for bitmap/vector groups.
- `LuceneIndex` overrides it to reuse the existing batched back-fill (`deleteAll` + iterate + single commit), shared with `internalOnRegistered`.

`reindex()` follows the usual persistence rules: call `store()` afterwards to persist bitmap/embedded indices; an external-directory Lucene index commits during the rebuild.

## Tests
- `LuceneReindexTest` — embedded (`ByteBuffers`) and external (`MMap`) directories.
- `GigaMap714Test` — bitmap staleness recovery, unique-constraint preservation through a rebuild, and store → reload persistence of the rebuilt index.