### PR TITLE
chore: Align serializer version with branch snapshot

### DIFF
--- a/.github/workflows/maven_javadoc.yml
+++ b/.github/workflows/maven_javadoc.yml
@@ -22,5 +22,9 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: 'maven'
+    - name: Align serializer version to matching branch snapshot
+      uses: ./.github/actions/align-serializer-version
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build with Maven
       run: mvn -P examples -P javadoc-check -B clean package --file pom.xml -U


### PR DESCRIPTION
This pull request updates the Maven Javadoc workflow to ensure that the serializer version is aligned with the corresponding branch snapshot before building. This helps prevent version mismatches during the CI process.

CI process improvements:

* Added a step to the `.github/workflows/maven_javadoc.yml` workflow that uses the `align-serializer-version` GitHub Action to synchronize the serializer version with the current branch snapshot prior to building.