### PR TITLE
Storage checksums: review fixes + bounded integrity-check memory

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/checksum/ChunkChecksumRegressionTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/checksum/ChunkChecksumRegressionTest.java
@@ -1,0 +1,241 @@
+package test.eclipse.store.checksum;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.eclipse.store.storage.embedded.configuration.types.EmbeddedStorageConfigurationBuilder;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult.Anomaly;
+import org.eclipse.store.storage.types.StorageIntegrityCheckResult.Finding;
+import org.eclipse.store.storage.types.StorageWriteControllerReadOnlyMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression tests for fixes made to the storage chunk-checksum feature (PR #717 review).
+ * Each test pins a specific behavioral fix so a future change that reintroduces the bug fails here.
+ */
+class ChunkChecksumRegressionTest
+{
+	///////////////////////////////////////////////////////////////////////////
+	// #1 -- checksum-mismatch offset is the chunk's FILE OFFSET, not its byte length
+	/////////////////////////////////////////////////////////////////////////////
+
+	/**
+	 * A checksum mismatch must report the corrupted chunk's <em>file offset</em>, not its byte length.
+	 * <p>
+	 * The fixed bug passed {@code address - chunkStart} (the chunk's byte length) where every consumer
+	 * treats the value as a file offset. We store a single large object (one covered chunk that starts a
+	 * few dozen bytes into the file, right after the {@code FileHeaderV1}), corrupt a byte deep inside it,
+	 * then assert the reported position is that small chunk-start offset &mdash; it must be at or before the
+	 * corrupted byte, whereas the bug reported the chunk length (which exceeds the file midpoint).
+	 */
+	@Test
+	void checksumMismatchReportsChunkFileOffsetNotByteLength(@TempDir final Path workDir) throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final int    payloadSize = 200_000;
+		final byte[] payload     = new byte[payloadSize];
+		for(int i = 0; i < payloadSize; i++)
+		{
+			payload[i] = (byte)(i * 31 + 7);
+		}
+
+		// session 1: write with checksums emitting + verifying (observe = emit+verify, all anomalies LOG)
+		try(final EmbeddedStorageManager mgr = checksumConfig(storageDir, "observe", "crc32c")
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(payload)
+			.start())
+		{
+			mgr.storeRoot();
+		}
+
+		// corrupt one byte deep inside the chunk (file midpoint is well past the header, inside the data)
+		final Path dataFile  = largestDataFile(storageDir);
+		final long fileSize  = Files.size(dataFile);
+		final long corruptAt = fileSize / 2;
+		flipByte(dataFile, corruptAt);
+
+		// session 2: reopen and scan; observe logs the mismatch on load (no throw), the on-demand check collects it
+		final StorageIntegrityCheckResult result;
+		try(final EmbeddedStorageManager mgr = checksumConfig(storageDir, "observe", "crc32c")
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			result = mgr.issueFullIntegrityCheck();
+		}
+
+		assertFalse(result.isClean(), "on-disk corruption of a covered chunk must be detected");
+
+		final Finding mismatch = firstOf(result, Anomaly.CHECKSUM_MISMATCH);
+		assertNotNull(mismatch, "expected a CHECKSUM_MISMATCH finding, got: " + result);
+
+		assertTrue(mismatch.position() >= 0L, "offset must be non-negative, got " + mismatch.position());
+		assertTrue(
+			mismatch.position() <= corruptAt,
+			"checksum-mismatch position must be the chunk's FILE OFFSET (<= the corrupted byte at "
+				+ corruptAt + "), not its byte length; got " + mismatch.position()
+				+ " (a value > " + corruptAt + " indicates the reverted bug that reported chunk length)"
+		);
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// #5 -- read-only open with continuousCoverage must not write at startup
+	/////////////////////////////////////////////////////////////////////////
+
+	/**
+	 * Opening an existing legacy (un-checksummed) store <em>read-only</em> with a {@code continuousCoverage}
+	 * profile must not write at startup. The fixed bug unconditionally rolled the head file over (writing a
+	 * {@code FileHeaderV1} + transaction-log entry) when the head was not covered, which throws under a
+	 * disabled {@link StorageWriteControllerReadOnlyMode}. We assert the read-only open succeeds, the data is
+	 * readable, and no new data file was written.
+	 */
+	@Test
+	void readOnlyOpenWithContinuousCoverageOverLegacyStoreDoesNotWrite(@TempDir final Path workDir) throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final ArrayList<String> root = new ArrayList<>(List.of("alpha", "beta", "gamma"));
+
+		// session 1: legacy store -- no chunk-checksum property set, so the engine default (off) is used
+		try(final EmbeddedStorageManager mgr = EmbeddedStorageConfigurationBuilder.New()
+			.setStorageDirectory(storageDir.toString())
+			.setChannelCount(1)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(root)
+			.start())
+		{
+			mgr.storeRoot();
+		}
+
+		final Map<String, Long> dataFilesBefore = dataFileSizes(storageDir);
+
+		// session 2: reopen READ-ONLY with strict-tolerate-legacy (continuousCoverage = true, legacy tolerated)
+		final EmbeddedStorageFoundation<?> foundation =
+			checksumConfig(storageDir, "strict-tolerate-legacy", "sha256-chained")
+				.createEmbeddedStorageFoundation();
+		final StorageWriteControllerReadOnlyMode readOnly =
+			new StorageWriteControllerReadOnlyMode(foundation.getWriteController());
+		readOnly.setReadOnly(true);
+		foundation.setWriteController(readOnly);
+
+		final Object loadedRoot;
+		try(final EmbeddedStorageManager mgr = foundation.createEmbeddedStorageManager().start())
+		{
+			// reaching here at all is the core assertion: before the fix start() threw AfsExceptionReadOnly
+			loadedRoot = mgr.root();
+		}
+
+		assertNotNull(loadedRoot, "root must be loadable after a read-only reopen");
+		assertEquals(root, loadedRoot, "legacy data must be intact after a read-only reopen");
+		assertEquals(
+			dataFilesBefore, dataFileSizes(storageDir),
+			"read-only open with continuousCoverage must not have written or rolled over a data file"
+		);
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// helpers //
+	////////////
+
+	private static EmbeddedStorageConfigurationBuilder checksumConfig(
+		final Path   storageDir,
+		final String profile   ,
+		final String algorithm
+	)
+	{
+		return EmbeddedStorageConfigurationBuilder.New()
+			.setStorageDirectory(storageDir.toString())
+			.setChannelCount(1)
+			.setChunkChecksumProfile(profile)
+			.setChunkChecksumAlgorithm(algorithm);
+	}
+
+	private static Path largestDataFile(final Path storageDir) throws IOException
+	{
+		try(final Stream<Path> stream = Files.walk(storageDir))
+		{
+			return stream
+				.filter(Files::isRegularFile)
+				.filter(p -> p.getFileName().toString().endsWith(".dat"))
+				.max(Comparator.comparingLong(ChunkChecksumRegressionTest::sizeOf))
+				.orElseThrow(() -> new IllegalStateException("no .dat data file under " + storageDir));
+		}
+	}
+
+	private static long sizeOf(final Path p)
+	{
+		try
+		{
+			return Files.size(p);
+		}
+		catch(final IOException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static void flipByte(final Path file, final long index) throws IOException
+	{
+		final byte[] bytes = Files.readAllBytes(file);
+		final int    i     = Math.toIntExact(index);
+		bytes[i] = (byte)(bytes[i] ^ 0xFF);
+		Files.write(file, bytes);
+	}
+
+	private static Map<String, Long> dataFileSizes(final Path storageDir) throws IOException
+	{
+		final Map<String, Long> result = new LinkedHashMap<>();
+		try(final Stream<Path> stream = Files.walk(storageDir))
+		{
+			stream
+				.filter(Files::isRegularFile)
+				.filter(p -> p.getFileName().toString().endsWith(".dat"))
+				.sorted(Comparator.comparing(Path::toString))
+				.forEach(p -> result.put(storageDir.relativize(p).toString(), sizeOf(p)));
+		}
+		return result;
+	}
+
+	private static Finding firstOf(final StorageIntegrityCheckResult result, final Anomaly anomaly)
+	{
+		for(final Finding f : result.anomalies())
+		{
+			if(f.anomaly() == anomaly)
+			{
+				return f;
+			}
+		}
+		return null;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/checksum/ChunkChecksumRegressionTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/checksum/ChunkChecksumRegressionTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.eclipse.serializer.configuration.types.ByteSize;
+import org.eclipse.serializer.configuration.types.ByteUnit;
 import org.eclipse.store.storage.embedded.configuration.types.EmbeddedStorageConfigurationBuilder;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -38,6 +40,8 @@ import org.eclipse.store.storage.types.StorageIntegrityCheckResult.Finding;
 import org.eclipse.store.storage.types.StorageWriteControllerReadOnlyMode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Regression tests for fixes made to the storage chunk-checksum feature (PR #717 review).
@@ -165,8 +169,170 @@ class ChunkChecksumRegressionTest
 	}
 
 	///////////////////////////////////////////////////////////////////////////
+	// #4 -- bounded streaming verify for files larger than the integrity-check buffer cap
+	///////////////////////////////////////////////////////////////////////////////////////
+
+	// Mirrors StorageFileManager.INTEGRITY_VERIFY_BUFFER_LIMIT (package-private): files above this are verified
+	// via the windowed streaming walk instead of being read whole.
+	private static final int STREAMING_CAP = 8 * 1024 * 1024;
+
+	/**
+	 * A data file larger than the 8 MiB integrity-check buffer must be verified by the windowed streaming walk
+	 * (StorageChunkChecksumCalculator.verifyDataFileStreaming) without reading the whole file resident. This
+	 * stores a single ~20 MiB object, so its one covered chunk is larger than the window and is hashed
+	 * incrementally across windows. Asserts the intact file verifies clean and that corrupting a byte deep past
+	 * the first window is detected with the chunk's file offset (not its byte length). Run for both algorithms;
+	 * sha256-chained additionally exercises the running tip across windows.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {"crc32c", "sha256-chained"})
+	void largeSingleChunkIsStreamedVerifiedAndCorruptionDetected(final String algorithm, @TempDir final Path workDir)
+		throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final int    payloadSize = 20 * 1024 * 1024; // > 8 MiB window: one chunk spanning multiple windows
+		final byte[] payload     = new byte[payloadSize];
+		for(int i = 0; i < payloadSize; i++)
+		{
+			payload[i] = (byte)(i * 31 + 7);
+		}
+
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(payload)
+			.start())
+		{
+			mgr.storeRoot();
+		}
+
+		final Path dataFile = largestDataFile(storageDir);
+		final long fileSize = Files.size(dataFile);
+		assertTrue(
+			fileSize > STREAMING_CAP,
+			"test must produce a data file larger than the streaming cap to exercise streaming; got " + fileSize
+		);
+
+		// intact: the streaming walk must report clean (no false anomalies across window boundaries)
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			final StorageIntegrityCheckResult clean = mgr.issueFullIntegrityCheck();
+			assertTrue(clean.isClean(), "intact large file must verify clean via streaming; got: " + clean);
+		}
+
+		// corrupt a byte at the file midpoint (well past the 8 MiB window -> a later window is exercised)
+		final long corruptAt = fileSize / 2;
+		flipByte(dataFile, corruptAt);
+
+		final StorageIntegrityCheckResult result;
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			result = mgr.issueFullIntegrityCheck();
+		}
+
+		assertFalse(result.isClean(), "corruption in a streamed large file must be detected");
+		final Finding mismatch = firstOf(result, Anomaly.CHECKSUM_MISMATCH);
+		assertNotNull(mismatch, "expected a CHECKSUM_MISMATCH finding, got: " + result);
+		assertTrue(
+			mismatch.position() >= 0L && mismatch.position() <= corruptAt,
+			"mismatch position must be the chunk's file offset (<= corrupted byte " + corruptAt + "), got "
+				+ mismatch.position()
+		);
+	}
+
+	/**
+	 * A large file made of several chunks (separate commits) exercises the streaming walk crossing window
+	 * boundaries at real chunk boundaries and, for sha256-chained, carrying the running tip from one chunk to the
+	 * next across windows. Asserts the intact file verifies clean, then that corruption in a later chunk is
+	 * detected.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {"crc32c", "sha256-chained"})
+	void largeMultiChunkFileIsStreamedVerified(final String algorithm, @TempDir final Path workDir)
+		throws IOException
+	{
+		final Path storageDir = workDir.resolve("storage");
+
+		final int chunkPayload = 6 * 1024 * 1024; // 6 MiB per commit
+		final int commits      = 4;               // ~24 MiB across 4 chunks -> file > 8 MiB window
+
+		final ArrayList<byte[]> root = new ArrayList<>();
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager(root)
+			.start())
+		{
+			mgr.storeRoot();
+			for(int c = 0; c < commits; c++)
+			{
+				final byte[] arr = new byte[chunkPayload];
+				for(int i = 0; i < chunkPayload; i++)
+				{
+					arr[i] = (byte)(i + c);
+				}
+				// keep each array reachable from the root so housekeeping GC cannot dissolve its data file
+				// between sessions; storing the updated root in its own commit yields one chunk + covering record
+				// per array (so the file ends up with several chunks spread across the streaming windows).
+				root.add(arr);
+				mgr.store(root);
+			}
+		}
+
+		final Path dataFile = largestDataFile(storageDir);
+		assertTrue(
+			Files.size(dataFile) > STREAMING_CAP,
+			"expected a data file larger than the streaming cap, got " + Files.size(dataFile)
+		);
+
+		// many covering records spread across windows must verify clean (tip carried across windows for chained)
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			final StorageIntegrityCheckResult clean = mgr.issueFullIntegrityCheck();
+			assertTrue(clean.isClean(), "intact multi-chunk large file must verify clean via streaming; got: " + clean);
+		}
+
+		// corrupt a byte inside the last chunk (a later window) and assert detection
+		final long corruptAt = Files.size(dataFile) - chunkPayload / 2;
+		flipByte(dataFile, corruptAt);
+
+		try(final EmbeddedStorageManager mgr = largeFileConfig(storageDir, "observe", algorithm)
+			.createEmbeddedStorageFoundation()
+			.createEmbeddedStorageManager()
+			.start())
+		{
+			final StorageIntegrityCheckResult result = mgr.issueFullIntegrityCheck();
+			assertFalse(result.isClean(), "corruption in a later chunk of a streamed file must be detected");
+			assertNotNull(firstOf(result, Anomaly.CHECKSUM_MISMATCH), "expected a CHECKSUM_MISMATCH finding, got: " + result);
+		}
+	}
+
+	///////////////////////////////////////////////////////////////////////////
 	// helpers //
 	////////////
+
+	// Config with a large data-file maximum so a single growing head file exceeds the 8 MiB streaming cap.
+	private static EmbeddedStorageConfigurationBuilder largeFileConfig(
+		final Path   storageDir,
+		final String profile   ,
+		final String algorithm
+	)
+	{
+		return EmbeddedStorageConfigurationBuilder.New()
+			.setStorageDirectory(storageDir.toString())
+			.setChannelCount(1)
+			.setChunkChecksumProfile(profile)
+			.setChunkChecksumAlgorithm(algorithm)
+			.setDataFileMaximumSize(ByteSize.New(64, ByteUnit.MB));
+	}
 
 	private static EmbeddedStorageConfigurationBuilder checksumConfig(
 		final Path   storageDir,

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumMismatch.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionChunkChecksumMismatch.java
@@ -14,6 +14,8 @@ package org.eclipse.store.storage.exceptions;
  * #L%
  */
 
+import org.eclipse.serializer.chars.VarString;
+
 /**
  * Raised when a chunk-checksum meta record's stored hash does not match the checksum recomputed over the
  * chunk's preceding bytes during load-time verification. Indicates either bit-rot on the underlying
@@ -97,16 +99,8 @@ public class StorageExceptionChunkChecksumMismatch extends StorageExceptionConsi
 
 	private static String toHex(final byte[] bytes)
 	{
-		if(bytes == null)
-		{
-			return "(null)";
-		}
-		final StringBuilder sb = new StringBuilder(bytes.length * 2);
-		for(final byte b : bytes)
-		{
-			sb.append(Character.forDigit((b >> 4) & 0xF, 16))
-			  .append(Character.forDigit( b       & 0xF, 16));
-		}
-		return sb.toString();
+		return bytes == null
+			? "(null)"
+			: VarString.New().addHexDec(bytes).toString();
 	}
 }

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
@@ -181,6 +181,22 @@ public interface StorageChunkChecksumCalculator
 	 */
 	public void verifyDataFile(StorageLiveDataFile.Default file, ByteBuffer buffer, StorageChecksumAnomalyReporter reporter);
 
+	/**
+	 * Streaming variant of {@link #verifyDataFile} for a data file too large to hold resident: reads the file in
+	 * windows of {@code window}'s capacity rather than requiring the whole file in one buffer, bounding the
+	 * integrity check's direct-memory use to one window per channel regardless of the configured data-file size.
+	 * Produces exactly the same anomalies as {@link #verifyDataFile} (and the load walk): each covering record's
+	 * chunk hash is recomputed incrementally over its bytes via {@link Algorithm#beginChunk(byte[])} /
+	 * {@link Algorithm#updateChunk(ByteBuffer)} / {@link Algorithm#finishChunk()}, so a single chunk larger than
+	 * the window still verifies. <b>Side-effect-free</b>: never mutates {@code file}.
+	 *
+	 * @param file         the data file being re-verified (read only; never mutated).
+	 * @param verifyLength the number of bytes to verify from the file start (the caller bounds the head file).
+	 * @param window       a reusable direct buffer used as the sliding read window; its capacity is the window size.
+	 * @param reporter     the sink for detected anomalies; must be non-{@code null}.
+	 */
+	public void verifyDataFileStreaming(StorageLiveDataFile.Default file, long verifyLength, ByteBuffer window, StorageChecksumAnomalyReporter reporter);
+
 
 
 	///////////////////////////////////////////////////////////////////////////
@@ -322,6 +338,23 @@ public interface StorageChunkChecksumCalculator
 
 
 	/**
+	 * Shared framing cross-check (file-relative offsets), used by both the resident {@link #verifyChunk} and the
+	 * streaming {@link Default#verifyDataFileStreaming} so the two cannot diverge: a covering record is consistent
+	 * with the walk when its stored chunk start equals the walker's reconstructed chunk start and the record does
+	 * not precede that start (a corrupted entity LENGTH otherwise leaves the stored start != cursor, or drives the
+	 * chunk start past the record). When inconsistent, {@code [chunkStart, record)} is wrong and must not be hashed.
+	 */
+	private static boolean isChunkFramingConsistent(
+		final int  storedChunkStart,
+		final long walkerChunkStart,
+		final long recordOffset
+	)
+	{
+		return storedChunkStart == walkerChunkStart && recordOffset >= walkerChunkStart;
+	}
+
+
+	/**
 	 * Shared, side-effect-free verification of one covering record's chunk {@code [chunkStart, address)} against
 	 * the stored checksum, used by both the load-time {@link ChunkChecksumHandler} and the on-demand
 	 * {@link Default#verifyDataFile} so the two cannot diverge. Touches no {@link StorageLiveDataFile}:
@@ -348,9 +381,10 @@ public interface StorageChunkChecksumCalculator
 		// than hash it (and never slice a negative length).
 		final int  storedChunkStart = StorageMetaRecord.readChunkChecksumChunkStart(address);
 		final long walkerChunkStart = chunkStart - bufferStartAddress;
-		if(storedChunkStart != walkerChunkStart || address < chunkStart)
+		final long recordOffset     = address - bufferStartAddress;
+		if(!isChunkFramingConsistent(storedChunkStart, walkerChunkStart, recordOffset))
 		{
-			reporter.onChunkBoundaryMismatch(fileNumber, address - bufferStartAddress, storedChunkStart, walkerChunkStart);
+			reporter.onChunkBoundaryMismatch(fileNumber, recordOffset, storedChunkStart, walkerChunkStart);
 			return chained ? verifier.readStoredChecksumBytes(address) : inboundTip;
 		}
 
@@ -657,6 +691,229 @@ public interface StorageChunkChecksumCalculator
 			reporter.onFileWalkComplete(fileNumber);
 		}
 
+		@Override
+		public final void verifyDataFileStreaming(
+			final StorageLiveDataFile.Default    file        ,
+			final long                           verifyLength,
+			final ByteBuffer                     window      ,
+			final StorageChecksumAnomalyReporter reporter
+		)
+		{
+			final long         fileNumber = file.number();
+			final WindowReader reader     = new WindowReader(file, window, verifyLength);
+
+			// Per-file header state reconstructed from disk into LOCALS (the live file is never mutated) — the same
+			// reconstruction verifyDataFile does, but driven over a sliding read window instead of a resident buffer.
+			long    headerKind  = 0L;   // 0 == no FileHeaderV1 parsed (legacy file)
+			byte[]  chainTip    = null; // running chained tip, seeded from the parsed header's chainRoot
+			boolean hasLiveData = false;
+
+			// Start of the current chunk's bytes (file offset); advances past the FileHeaderV1 and each covering record.
+			long chunkStart = 0L;
+
+			for(long walkCursor = 0L; walkCursor < verifyLength;)
+			{
+				final long itemLength = Binary.getEntityLengthRawValue(reader.ensureResident(walkCursor, Long.BYTES));
+				if(itemLength > 0)
+				{
+					// data entity: part of the current chunk. Its bytes are hashed lazily as the raw range
+					// [chunkStart, record) at the covering record (feed), so nothing is fed here.
+					hasLiveData = true;
+					walkCursor += itemLength;
+					continue;
+				}
+				if(itemLength == 0)
+				{
+					throw new StorageExceptionConsistency("Zero length data item.");
+				}
+
+				// negative-length entry: legacy opaque gap, or a structured meta record (mirror the envelope guard
+				// in verifyDataFile before reading the marker/KIND).
+				if(walkCursor + StorageMetaRecord.OFFSET_PAYLOAD <= verifyLength
+					&& StorageMetaRecord.isMetaRecord(reader.ensureResident(walkCursor, StorageMetaRecord.OFFSET_PAYLOAD)))
+				{
+					final long kind = StorageMetaRecord.kindOf(reader.ensureResident(walkCursor, StorageMetaRecord.OFFSET_PAYLOAD));
+					if(kind == StorageMetaRecord.KIND_FileHeaderV1)
+					{
+						if(walkCursor + StorageMetaRecord.LENGTH_FILEHEADERV1 > verifyLength)
+						{
+							// truncated header
+							reporter.onUnknownKind(fileNumber, StorageMetaRecord.KIND_FileHeaderV1);
+						}
+						else if(headerKind != 0L)
+						{
+							// second/misplaced header: report, do not re-seed (would rebase every following chunk).
+							reporter.onUnknownKind(fileNumber, StorageMetaRecord.KIND_FileHeaderV1);
+							chunkStart = walkCursor + StorageMetaRecord.LENGTH_FILEHEADERV1;
+						}
+						else
+						{
+							final FileHeaderV1Payload header = StorageMetaRecord.readFileHeaderV1(
+								reader.ensureResident(walkCursor, StorageMetaRecord.LENGTH_FILEHEADERV1)
+							);
+							headerKind = header.chunkChecksumKind();
+							chainTip   = header.chainRoot(); // seed the running tip; chunks advance it
+							chunkStart = walkCursor + StorageMetaRecord.LENGTH_FILEHEADERV1;
+						}
+					}
+					else
+					{
+						final Algorithm verifier = this.algorithmsByKind.get(kind);
+						if(verifier != null && walkCursor + verifier.recordLength() <= verifyLength)
+						{
+							// covering record: re-verify the chunk [chunkStart, walkCursor). Mirrors verifyChunk, but
+							// the chunk bytes are streamed into the digest in windows (begin/feed/finish) rather than
+							// sliced from a resident buffer, so a chunk larger than the window still verifies. Dispatch
+							// the Algorithm by the record's on-disk KIND (the record bytes are read BEFORE feeding,
+							// since feed slides the window away from the record).
+							final int    recordLen        = checkArrayRange(verifier.recordLength());
+							final long   recordAddress     = reader.ensureResident(walkCursor, recordLen);
+							final int    storedChunkStart  = StorageMetaRecord.readChunkChecksumChunkStart(recordAddress);
+							final byte[] expected          = verifier.readStoredChecksumBytes(recordAddress);
+							final boolean chained           = verifier.isChained();
+
+							if(isChunkFramingConsistent(storedChunkStart, chunkStart, walkCursor))
+							{
+								// resolve the chained seed exactly as verifyChunk: a chained covering record with no
+								// parsed FileHeaderV1 means the header was lost/corrupted — report and verify against
+								// the initial seed so a real defect still surfaces as a checksum mismatch.
+								byte[] seed = chained ? chainTip : null;
+								if(chained && seed == null)
+								{
+									reporter.onMissingHeader(fileNumber);
+									seed = verifier.initialSeed();
+								}
+								verifier.beginChunk(seed);
+								reader.feed(verifier, chunkStart, walkCursor); // hash [chunkStart, record) in windows
+								final byte[] actual = verifier.finishChunk();
+								if(!Arrays.equals(actual, expected))
+								{
+									reporter.onChecksumMismatch(fileNumber, chunkStart, kind, expected, actual);
+								}
+								// chained: continue from the stored tip (== recomputed on match), the writer's basis.
+								chainTip = chained ? expected : chainTip;
+							}
+							else
+							{
+								reporter.onChunkBoundaryMismatch(fileNumber, walkCursor, storedChunkStart, chunkStart);
+								if(chained)
+								{
+									chainTip = expected; // re-anchor from the stored tip
+								}
+							}
+							chunkStart = walkCursor + recordLen;
+						}
+						else
+						{
+							// no algorithm for this KIND (drift / corrupt KIND), or a truncated record.
+							reporter.onUnknownKind(fileNumber, kind);
+							// Same forward-compat rule as verifyDataFile: advance past an unknown KIND only once a
+							// FileHeaderV1 has been parsed; otherwise leave chunkStart so the drift still surfaces.
+							if(verifier == null && headerKind != 0L)
+							{
+								chunkStart = walkCursor - itemLength;
+							}
+						}
+					}
+				}
+
+				// advance by the on-disk |LENGTH| regardless (legacy gaps and meta records alike). Gap bytes inside a
+				// chunk are not fed here; the covering record's feed of [chunkStart, record) covers them as raw bytes.
+				walkCursor -= itemLength;
+			}
+
+			// per-file coverage checks (identical to verifyDataFile, in file-relative offsets).
+			if(headerKind == 0L)
+			{
+				if(hasLiveData)
+				{
+					reporter.onMissingHeader(fileNumber);
+				}
+			}
+			else if(chunkStart < verifyLength)
+			{
+				reporter.onUncoveredData(fileNumber, chunkStart);
+			}
+			reporter.onFileWalkComplete(fileNumber);
+		}
+
+		/**
+		 * Sliding read window over a data file for {@link #verifyDataFileStreaming}: keeps at most one window of the
+		 * file resident in the supplied direct buffer and serves both the forward framing walk (small fixed reads via
+		 * {@link #ensureResident(long, int)}) and the incremental chunk hashing (the raw chunk range via
+		 * {@link #feed(Algorithm, long, long)}). Reads never pass {@code fileLength} (the caller's bounded verify
+		 * length), so the head file is read only up to its committed length. Single-threaded (one channel).
+		 */
+		private static final class WindowReader
+		{
+			private final StorageLiveDataFile.Default file         ;
+			private final ByteBuffer                  buffer       ;
+			private final long                        bufferAddress;
+			private final int                         capacity     ;
+			private final long                        fileLength   ;
+			private       long                        windowOffset ; // file offset of buffer[0]; -1 == empty
+			private       long                        windowLength ; // resident byte count
+
+			WindowReader(final StorageLiveDataFile.Default file, final ByteBuffer buffer, final long fileLength)
+			{
+				super();
+				this.file          = file                                  ;
+				this.buffer        = buffer                                ;
+				this.bufferAddress = XMemory.getDirectByteBufferAddress(buffer);
+				this.capacity      = buffer.capacity()                     ;
+				this.fileLength    = fileLength                            ;
+				this.windowOffset  = -1L                                   ;
+				this.windowLength  = 0L                                    ;
+			}
+
+			private void refill(final long offset)
+			{
+				final long toRead = Math.min(this.capacity, this.fileLength - offset);
+				this.buffer.clear();
+				this.buffer.limit(checkArrayRange(toRead));
+				this.file.readBytes(this.buffer, offset, toRead);
+				this.windowOffset = offset;
+				this.windowLength = toRead;
+			}
+
+			/**
+			 * Ensures {@code [offset, offset+need)} is resident ({@code need} fits the window capacity) and returns
+			 * the off-heap address of {@code offset}. The address is valid only until the next refill (any
+			 * {@code ensureResident}/{@code feed} that slides the window).
+			 */
+			long ensureResident(final long offset, final int need)
+			{
+				if(this.windowOffset < 0L
+					|| offset < this.windowOffset
+					|| offset + need > this.windowOffset + this.windowLength)
+				{
+					this.refill(offset);
+				}
+				return this.bufferAddress + (offset - this.windowOffset);
+			}
+
+			/**
+			 * Feeds the raw byte range {@code [from, to)} into {@code verifier}'s open chunk, reading the range in
+			 * windows. This is how a chunk larger than the window is hashed.
+			 */
+			void feed(final Algorithm verifier, long from, final long to)
+			{
+				while(from < to)
+				{
+					if(this.windowOffset < 0L
+						|| from < this.windowOffset
+						|| from >= this.windowOffset + this.windowLength)
+					{
+						this.refill(from);
+					}
+					final long windowEnd = this.windowOffset + this.windowLength;
+					final long n         = Math.min(to, windowEnd) - from;
+					verifier.updateChunk(XMemory.slice(this.buffer, from - this.windowOffset, n));
+					from += n;
+				}
+			}
+		}
+
 	}
 
 
@@ -742,6 +999,36 @@ public interface StorageChunkChecksumCalculator
 		public default byte[] initialSeed()
 		{
 			return new byte[StorageMetaRecord.LENGTH_HASH_SHA256];
+		}
+
+		/**
+		 * Begins an incremental chunk hash for the streaming verify path (a chunk too large to hold resident).
+		 * Resets this algorithm's running digest and, for chained kinds, folds in {@code seed} (the running tip)
+		 * exactly as one-shot {@link #computeChecksumBytes(ByteBuffer)} does. Followed by zero or more
+		 * {@link #updateChunk(ByteBuffer)} calls and one {@link #finishChunk()}. Abandoning an open chunk (no
+		 * {@code finishChunk}) is safe: the next {@code beginChunk} resets the digest. Default throws: only
+		 * verifying algorithms support it (the no-op {@code None} is never verified).
+		 */
+		public default void beginChunk(final byte[] seed)
+		{
+			throw new UnsupportedOperationException();
+		}
+
+		/**
+		 * Feeds one window of the current chunk's bytes into the hash opened by {@link #beginChunk(byte[])}.
+		 */
+		public default void updateChunk(final ByteBuffer partial)
+		{
+			throw new UnsupportedOperationException();
+		}
+
+		/**
+		 * Finalizes the chunk hash opened by {@link #beginChunk(byte[])} and returns its bytes; for chained kinds
+		 * this also advances the running tip to the returned hash, mirroring {@link #computeChecksumBytes(ByteBuffer)}.
+		 */
+		public default byte[] finishChunk()
+		{
+			throw new UnsupportedOperationException();
 		}
 
 
@@ -838,6 +1125,24 @@ public interface StorageChunkChecksumCalculator
 				notNull(chunk);
 				this.crc.reset();
 				this.crc.update(chunk.duplicate());
+				return toBytes((int)this.crc.getValue());
+			}
+
+			@Override
+			public void beginChunk(final byte[] seed)
+			{
+				this.crc.reset(); // non-chained: seed ignored
+			}
+
+			@Override
+			public void updateChunk(final ByteBuffer partial)
+			{
+				this.crc.update(partial.duplicate());
+			}
+
+			@Override
+			public byte[] finishChunk()
+			{
 				return toBytes((int)this.crc.getValue());
 			}
 
@@ -1026,6 +1331,31 @@ public interface StorageChunkChecksumCalculator
 				this.digest.update(this.tip);          // fold in the previous tip
 				this.digest.update(chunk.duplicate());
 				return this.tip = this.digest.digest();// advance and return the new tip
+			}
+
+			@Override
+			public void beginChunk(final byte[] seed)
+			{
+				// reset (clears any bytes from an abandoned chunk) and fold in the running tip, exactly as the
+				// one-shot computeChecksumBytes does via digest.update(this.tip). `seed` is the resolved running
+				// tip (never null for a chained verify: the caller substitutes initialSeed() on a missing header).
+				this.digest.reset();
+				if(seed != null)
+				{
+					this.digest.update(seed);
+				}
+			}
+
+			@Override
+			public void updateChunk(final ByteBuffer partial)
+			{
+				this.digest.update(partial.duplicate());
+			}
+
+			@Override
+			public byte[] finishChunk()
+			{
+				return this.tip = this.digest.digest(); // advance and return the new tip (mirrors computeChecksumBytes)
 			}
 
 			@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
@@ -605,6 +605,14 @@ public interface StorageChunkChecksumCalculator
 
 			for(long address = bufferStartAddress; address < bufferBoundAddress;)
 			{
+				// A trailing remnant shorter than an entity LENGTH prefix cannot be a valid item; reading 8 bytes
+				// would read past the verified region. The startup load walk (StorageEntityInitializer) throws on
+				// this; the on-demand check instead stops and lets the end-of-walk coverage check report the
+				// uncovered tail. A well-formed file ends exactly on an item boundary, so this never trips there.
+				if(bufferBoundAddress - address < Long.BYTES)
+				{
+					break;
+				}
 				final long itemLength = Binary.getEntityLengthRawValue(address);
 				if(itemLength > 0)
 				{
@@ -713,6 +721,14 @@ public interface StorageChunkChecksumCalculator
 
 			for(long walkCursor = 0L; walkCursor < verifyLength;)
 			{
+				// A trailing remnant shorter than an entity LENGTH prefix cannot be a valid item; reading 8 bytes
+				// would read past the verified region (into stale window slack). Stop and let the end-of-walk
+				// coverage check report the uncovered tail — the same condition the startup load walk rejects.
+				// A well-formed file ends exactly on an item boundary, so this never trips there.
+				if(verifyLength - walkCursor < Long.BYTES)
+				{
+					break;
+				}
 				final long itemLength = Binary.getEntityLengthRawValue(reader.ensureResident(walkCursor, Long.BYTES));
 				if(itemLength > 0)
 				{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
@@ -16,6 +16,7 @@ package org.eclipse.store.storage.types;
 
 import static org.eclipse.serializer.util.X.checkArrayRange;
 import static org.eclipse.serializer.util.X.notNull;
+import static org.eclipse.serializer.util.X.toBytes;
 
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -375,7 +376,7 @@ public interface StorageChunkChecksumCalculator
 		final byte[] actual = verifier.computeChecksumBytes(chunk);
 		if(!Arrays.equals(actual, expected))
 		{
-			reporter.onChecksumMismatch(fileNumber, address - chunkStart, StorageMetaRecord.kindOf(address), expected, actual);
+			reporter.onChecksumMismatch(fileNumber, walkerChunkStart, StorageMetaRecord.kindOf(address), expected, actual);
 		}
 		// chained: continue from the stored tip (== recomputed on match), the basis the writer chained from.
 		return chained ? expected : inboundTip;
@@ -612,15 +613,27 @@ public interface StorageChunkChecksumCalculator
 					else
 					{
 						final Algorithm verifier = this.algorithmsByKind.get(kind);
-						if(verifier == null || address + verifier.recordLength() > bufferBoundAddress)
-						{
-							// no algorithm for this KIND (drift / corrupt KIND), or truncated record.
-							reporter.onUnknownKind(fileNumber, kind);
-						}
-						else
+						if(verifier != null && address + verifier.recordLength() <= bufferBoundAddress)
 						{
 							chainTip   = verifyChunk(fileNumber, buffer, address, chunkStart, verifier, chainTip, reporter);
 							chunkStart = address + verifier.recordLength();
+						}
+						else
+						{
+							// no algorithm for this KIND (drift / corrupt KIND), or a truncated record.
+							reporter.onUnknownKind(fileNumber, kind);
+							// Mirror StorageMetaRecordRegistry.dispatch: an unknown KIND reached AFTER the
+							// FileHeaderV1 was parsed is a genuine forward-compat record, so advance the chunk
+							// boundary past it (|LENGTH| == -itemLength) — otherwise a later covering record's
+							// stored start would no longer match the walker's cursor, raising a false
+							// CHUNK_BOUNDARY_MISMATCH / UNCOVERED_DATA. A truncated KNOWN record (verifier != null)
+							// leaves chunkStart unadvanced, mirroring ChunkChecksumHandler.onLoad's report-and-skip;
+							// so does an unknown KIND before the header is parsed (a corrupted/lost FileHeaderV1),
+							// so the drift still surfaces instead of loading silently.
+							if(verifier == null && headerKind != 0L)
+							{
+								chunkStart = address - itemLength;
+							}
 						}
 					}
 				}
@@ -736,7 +749,7 @@ public interface StorageChunkChecksumCalculator
 		/**
 		 * CRC32C algorithm: non-cryptographic integrity checksum, hardware-accelerated, zero-copy on
 		 * direct buffers. Detects accidental corruption; <b>not</b> collision-resistant or tamper-evident.
-		 * Emits {@code ChunkChecksumCRC32CV1} records (16 B).
+		 * Emits {@code ChunkChecksumCRC32CV1} records (20 B).
 		 */
 		public final class Crc32c implements Algorithm
 		{
@@ -786,13 +799,6 @@ public interface StorageChunkChecksumCalculator
 			// static methods //
 			///////////////////
 
-			private static byte[] intToBytes(final int value)
-			{
-				return new byte[]{(byte)(value >>> 24), (byte)(value >>> 16), (byte)(value >>> 8), (byte)value};
-			}
-
-
-
 			///////////////////////////////////////////////////////////////////////////
 			// declared methods //
 			/////////////////////
@@ -832,7 +838,7 @@ public interface StorageChunkChecksumCalculator
 				notNull(chunk);
 				this.crc.reset();
 				this.crc.update(chunk.duplicate());
-				return intToBytes((int)this.crc.getValue());
+				return toBytes((int)this.crc.getValue());
 			}
 
 			@Override
@@ -840,10 +846,10 @@ public interface StorageChunkChecksumCalculator
 			{
 				// Byte-order note: the CRC is persisted as a 4-byte int in NATIVE order (writeRecord uses
 				// target.putInt on a native-order direct buffer) and read back via the matching native
-				// get_int, so the round-trip recovers the same int value. intToBytes (big-endian) is applied
+				// get_int, so the round-trip recovers the same int value. X.toBytes (big-endian) is applied
 				// to that int value on BOTH the read and compute sides purely to obtain comparable byte[]s —
 				// it does not pin the on-disk layout, which is native-endian. Comparison is self-consistent.
-				return intToBytes(XMemory.get_int(recordAddress + OFFSET_CRC));
+				return toBytes(XMemory.get_int(recordAddress + OFFSET_CRC));
 			}
 
 			@Override
@@ -863,14 +869,14 @@ public interface StorageChunkChecksumCalculator
 
 
 		/**
-		 * Chained SHA-256 algorithm: cryptographic and tamper-evident like {@link Sha256}, but each chunk's
+		 * Chained SHA-256 algorithm: cryptographic and tamper-evident (SHA-256), but each chunk's
 		 * stored hash folds in the previous chunk's hash &mdash; {@code tip_i = SHA-256(tip_{i-1} || chunk_i)},
 		 * seeded by the file's {@code FileHeaderV1.chainRoot} ({@code tip_0}). Altering any chunk invalidates
 		 * that chunk and every chunk after it in the same file, so reordering, insertion, deletion or
 		 * substitution of chunks <i>within a file</i> is detectable &mdash; not just bit-rot of a single chunk.
 		 * The chain is re-seeded per file from that file's own header, so it does not span files: deleting or
 		 * reordering whole data files (as housekeeping legitimately does) is not detected by the chain. Emits
-		 * {@code ChunkChecksumChainedV1} records (44 B; same envelope+hash layout as {@code ChunkChecksumV1},
+		 * {@code ChunkChecksumChainedV1} records (48 B; same envelope+hash layout as {@code ChunkChecksumV1},
 		 * distinguished purely by KIND).
 		 * <p>
 		 * <b>Chaining is SHA-256 only.</b> A chained CRC32C is forgeable (CRC is linear and not

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
@@ -390,7 +390,7 @@ public interface StorageDataChunkValidator
 
 				// The resulting file (chunk + FileHeaderV1 + trailing chunk-checksum) must fit
 				// in a 2 GiB direct buffer so it remains loadable on the read path.
-				if(commitSize + this.freshFileMetaReserve > Integer.MAX_VALUE)
+				if(commitSize + this.freshFileMetaReserve >= Integer.MAX_VALUE)
 				{
 					throw new StorageExceptionCommitSizeExceeded(
 						channelIndex, commitSize + this.freshFileMetaReserve);
@@ -465,10 +465,10 @@ public interface StorageDataChunkValidator
 					commitSize += bb.limit();
 				}
 
-				if(commitSize >= Integer.MAX_VALUE)
+				if(commitSize + this.freshFileMetaReserve >= Integer.MAX_VALUE)
 				{
 					// also enforce the 2 GiB load-buffer cap so this validator is a superset of MaxFileSize
-					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize);
+					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize + this.freshFileMetaReserve);
 				}
 				if(commitSize + this.freshFileMetaReserve > this.fileMaximumSize)
 				{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataChunkValidator.java
@@ -390,7 +390,7 @@ public interface StorageDataChunkValidator
 
 				// The resulting file (chunk + FileHeaderV1 + trailing chunk-checksum) must fit
 				// in a 2 GiB direct buffer so it remains loadable on the read path.
-				if(commitSize + this.freshFileMetaReserve >= Integer.MAX_VALUE)
+				if(commitSize + this.freshFileMetaReserve > Integer.MAX_VALUE)
 				{
 					throw new StorageExceptionCommitSizeExceeded(
 						channelIndex, commitSize + this.freshFileMetaReserve);
@@ -465,7 +465,7 @@ public interface StorageDataChunkValidator
 					commitSize += bb.limit();
 				}
 
-				if(commitSize + this.freshFileMetaReserve >= Integer.MAX_VALUE)
+				if(commitSize + this.freshFileMetaReserve > Integer.MAX_VALUE)
 				{
 					// also enforce the 2 GiB load-buffer cap so this validator is a superset of MaxFileSize
 					throw new StorageExceptionCommitSizeExceeded(channelIndex, commitSize + this.freshFileMetaReserve);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -481,11 +481,13 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 					}
 
 					// Nothing to transfer yet. Roll over to the next head file ONLY if the current head
-					// already holds reclaimable entity bytes; rolling over a head that has only protocol
-					// overhead (FileHeaderV1 / ChunkChecksumV1) produces an identically-shaped successor
-					// and loops forever. dataLength(), not totalLength(), because the latter is non-zero
-					// once a FileHeaderV1 is emitted.
-					if(headFile.dataLength() != 0L)
+					// already holds relocatable content (live entity bytes OR reclaimable gap bytes); rolling
+					// over a head that has only protocol overhead (FileHeaderV1 / ChunkChecksumV1) produces an
+					// identically-shaped successor and loops forever. Subtract metaLength() rather than testing
+					// dataLength(): totalLength() is non-zero once a FileHeaderV1 is emitted, but an all-gap head
+					// (every entity GC'd) still has reclaimable gap bytes and must roll over, as it did before
+					// the checksum feature (old guard: totalLength() != 0).
+					if(headFile.totalLength() - headFile.metaLength() != 0L)
 					{
 						this.createNextStorageFile();
 						return;
@@ -875,7 +877,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// Defence in depth: even on a fresh head (dataLength == 0) we refuse to produce a file
 			// that the load path can no longer read back into a single 2 GiB direct buffer. This
 			// guards against a user wiring a no-op validator that bypasses MaxFileSize.
-			if(projectedTotal > Integer.MAX_VALUE)
+			if(projectedTotal >= Integer.MAX_VALUE)
 			{
 				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), projectedTotal);
 			}
@@ -1386,7 +1388,11 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// continuousCoverage: if emit is on but the head file is not covered by the primary kind (a
 			// legacy file, or one written by a different algorithm), roll over now so new writes land in a
 			// covered file instead of extending an unprotected tail. A no-op once the head is already covered.
-			if(this.chunkChecksumCalculator.policy().continuousCoverage()
+			// Skipped in read-only mode: createNextStorageFile() writes a FileHeaderV1 + transaction-log
+			// entry that a disabled WriteController would reject, and no chunks are ever appended in
+			// read-only mode anyway, so ensuring future writes land covered is moot.
+			if(this.writeController.isWritable()
+				&& this.chunkChecksumCalculator.policy().continuousCoverage()
 				&& !this.chunkChecksumCalculator.coversChunkWrites(this.headFile))
 			{
 				this.createNextStorageFile();
@@ -2332,7 +2338,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// here turns a silently-unloadable oversized file into a clean, rolled-back import error.
 			final long checksumReserve = this.chunkChecksumCalculator.reservedLengthFor(this.headFile);
 			final long projectedLength = this.importHelper.importHeadFileLength + length + checksumReserve;
-			if(projectedLength > Integer.MAX_VALUE)
+			if(projectedLength >= Integer.MAX_VALUE)
 			{
 				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), projectedLength);
 			}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -128,6 +128,13 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		// the only reason for this limit is to have an int instead of a long for the item's file position.
 		static final int MAX_FILE_LENGTH = Integer.MAX_VALUE;
 
+		// Upper bound for the on-demand integrity check's per-channel verify buffer. A data file at or below this
+		// size is read whole (the proven resident verifyDataFile walk); a larger one is streamed in windows of this
+		// size (verifyDataFileStreaming), so peak direct memory of a full integrity check is channelCount × this
+		// value regardless of the configured data-file maximum size (which can be raised toward the ~2 GiB cap).
+		// 8 MiB matches StorageDataFileEvaluator.defaultFileMaximumSize(), so default-sized stores never stream.
+		static final int INTEGRITY_VERIFY_BUFFER_LIMIT = 8 * 1024 * 1024;
+
 		// (22.05.2015 TM)TODO: Debug Flag to disable file cleanup for testing
 		private static final boolean DEBUG_ENABLE_FILE_CLEANUP = true;
 
@@ -1798,6 +1805,19 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				result
 			);
 
+			// One bounded buffer per channel serves the whole scan: files within the cap are read whole (the proven
+			// resident walk), larger files are streamed in windows of this same buffer. Sized to the largest in-scope
+			// file but never above INTEGRITY_VERIFY_BUFFER_LIMIT, so peak direct memory stays channelCount × cap.
+			long maxScopeLength = 0L;
+			for(final long scopeLength : this.integrityScopeLengths)
+			{
+				if(scopeLength > maxScopeLength)
+				{
+					maxScopeLength = scopeLength;
+				}
+			}
+			final int bufferSize = X.checkArrayRange(Math.min((long)INTEGRITY_VERIFY_BUFFER_LIMIT, maxScopeLength));
+
 			ByteBuffer buffer = null;
 			try
 			{
@@ -1834,20 +1854,23 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 						if(verifyLength > 0L)
 						{
-							final int len = X.checkArrayRange(verifyLength);
-							if(buffer == null || buffer.capacity() < len)
+							if(buffer == null)
 							{
-								if(buffer != null)
-								{
-									XMemory.deallocateDirectByteBuffer(buffer);
-								}
-								buffer = XMemory.allocateDirectNative(Math.max(len, XMemory.defaultBufferSize()));
+								buffer = XMemory.allocateDirectNative(bufferSize);
 							}
-							buffer.clear();
-							buffer.limit(len);
-							file.readBytes(buffer, 0, verifyLength);
-
-							this.chunkChecksumCalculator.verifyDataFile(file, buffer, reporter);
+							if(verifyLength <= INTEGRITY_VERIFY_BUFFER_LIMIT)
+							{
+								// fits the buffer: read the whole file and use the proven resident walk.
+								buffer.clear();
+								buffer.limit(X.checkArrayRange(verifyLength));
+								file.readBytes(buffer, 0, verifyLength);
+								this.chunkChecksumCalculator.verifyDataFile(file, buffer, reporter);
+							}
+							else
+							{
+								// larger than the cap: stream the verify in windows of this buffer (bounded memory).
+								this.chunkChecksumCalculator.verifyDataFileStreaming(file, verifyLength, buffer, reporter);
+							}
 						}
 					}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -883,8 +883,10 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			final long projectedTotal  = this.headFile.totalLength() + chunkSize + checksumReserve;
 			// Defence in depth: even on a fresh head (dataLength == 0) we refuse to produce a file
 			// that the load path can no longer read back into a single 2 GiB direct buffer. This
-			// guards against a user wiring a no-op validator that bypasses MaxFileSize.
-			if(projectedTotal >= Integer.MAX_VALUE)
+			// guards against a user wiring a no-op validator that bypasses MaxFileSize. Strict '>' to
+			// match the load limit (StorageEntityInitializer rejects only > Integer.MAX_VALUE, and
+			// X.checkArrayRange accepts exactly Integer.MAX_VALUE) and the chunkSize guards above.
+			if(projectedTotal > Integer.MAX_VALUE)
 			{
 				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), projectedTotal);
 			}
@@ -2361,7 +2363,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// here turns a silently-unloadable oversized file into a clean, rolled-back import error.
 			final long checksumReserve = this.chunkChecksumCalculator.reservedLengthFor(this.headFile);
 			final long projectedLength = this.importHelper.importHeadFileLength + length + checksumReserve;
-			if(projectedLength >= Integer.MAX_VALUE)
+			if(projectedLength > Integer.MAX_VALUE)
 			{
 				throw new StorageExceptionCommitSizeExceeded(this.channelIndex(), projectedLength);
 			}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageIntegrityCheckResult.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageIntegrityCheckResult.java
@@ -180,17 +180,7 @@ public interface StorageIntegrityCheckResult
 			}
 			if(this.expected != null && this.actual != null)
 			{
-				vs.add(": expected ").add(toHex(this.expected)).add(", got ").add(toHex(this.actual));
-			}
-			return vs.toString();
-		}
-
-		private static String toHex(final byte[] bytes)
-		{
-			final VarString vs = VarString.New();
-			for(final byte b : bytes)
-			{
-				vs.add(Character.forDigit((b >> 4) & 0xF, 16)).add(Character.forDigit(b & 0xF, 16));
+				vs.add(": expected ").addHexDec(this.expected).add(", got ").addHexDec(this.actual);
 			}
 			return vs.toString();
 		}


### PR DESCRIPTION
## Summary

Follow-up to the storage checksum feature (PR #717), addressing findings from a detailed review of that branch. Fixes correctness/consistency bugs in the verify path, bounds the on-demand integrity check's memory use, and adds regression tests. Targets `feature/storageCheckSums`.

## Correctness fixes

- **Mismatch offset** (`StorageChunkChecksumCalculator`): a checksum-mismatch anomaly now reports the corrupted chunk's **file offset**, not its byte length — every consumer (exception, log, `Finding.position`) treats the value as a file offset.
- **On-demand vs. startup parity**: `verifyDataFile` now mirrors the load walk for **forward-compatible unknown meta-record KINDs** (advances past them once a header is parsed), eliminating false `CHUNK_BOUNDARY_MISMATCH` / `UNCOVERED_DATA` findings on files that load cleanly.
- **Relocation rollover** (`StorageFileManager`): the head-file rollover guard keys on reclaimable content (`totalLength − metaLength`) instead of `dataLength`, restoring the pre-feature behavior of rolling over an all-gap head file while still avoiding the all-meta infinite-loop the checksum feature introduced.
- **Read-only startup**: skip the `continuousCoverage` rollover when the store is read-only
  — it would otherwise write a `FileHeaderV1` and fail under a disabled write controller.
- **Max-file-size bound** (`StorageDataChunkValidator` + `StorageFileManager` guards): restored the strict `≥ Integer.MAX_VALUE` rejection so an exactly-2 GiB file (unloadable into a single direct buffer) cannot be produced.

## Memory: bounded integrity-check buffer

The on-demand integrity check previously read each data file **whole** into a direct buffer, with one task per channel running concurrently — peak `channelCount × largestFile`, which could OOM when `data-file-maximum-size` is raised. Now:

- Files within an **8 MiB cap** use the existing whole-file verify (unchanged for default-sized stores).
- Larger files are verified by a new **windowed streaming walk** that recomputes each chunk's hash incrementally (new `Algorithm.beginChunk/updateChunk/finishChunk`), so a single chunk larger than the window still verifies.
- Peak direct memory is now `channelCount × 8 MiB` regardless of configured file size.

The streaming and resident walks share the framing cross-check so they cannot diverge; parity was confirmed by forcing all files through the streaming path.

## Cleanup

Replaced three hand-rolled hex/byte helpers with `VarString.addHexDec` / `X.toBytes`; fixed a dangling `{@link Sha256}` reference and stale record-length comments.

## Tests

New `ChunkChecksumRegressionTest` (integration-tests): corruption-offset reporting, the read-only `continuousCoverage` skip, and the streaming verify (both algorithms, multi-window files, and a chunk larger than the window). Each was verified to **fail on the pre-fix code** and pass after.

## Follow-up (tracked, not in this PR)

Unify the four chunk-checksum verify walks (load, on-demand resident, on-demand streaming, converter) behind one mechanism — quality/maintainability only.