### PR TITLE
Add documentation on mutex lock behavior and fix cloud storage config…

### DIFF
--- a/docs/modules/misc/pages/integrations/spring-boot.adoc
+++ b/docs/modules/misc/pages/integrations/spring-boot.adoc
@@ -230,6 +230,14 @@ public class JokesStorageImpl implements JokesStorage
 }
 ----
 
+[CAUTION]
+====
+* *No lock upgrade:* a `@Read` method calling a `@Write` method guarded by the same lock deadlocks itself (`ReentrantReadWriteLock` cannot upgrade read to write).
+* Without `@Mutex`, *all* `@Read`/`@Write` methods in the application share one global lock — assign distinct `@Mutex` names for independent storages or subsystems.
+* With JDK interface proxies (`spring.aop.proxy-target-class=false`), a `@Mutex` present only on the implementation is not found and the global lock is used silently — annotate the interface, or keep the default class-based proxies.
+* Self-invocation (`this.someWriteMethod()`) bypasses the proxy and acquires no lock.
+====
+
 == Logging
 
 {product-name} Spring module supports standard Spring logging, so you can add this into your config:

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/azure/Credentials.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/azure/Credentials.java
@@ -42,7 +42,7 @@ public class Credentials
     /**
      * The account name, used when "credentials.type" is "shared-key".
      */
-    private String accountMame;
+    private String accountName;
 
     /**
      * The account key, used when "credentials.type" is "shared-key".
@@ -79,14 +79,37 @@ public class Credentials
         this.password = password;
     }
 
-    public String getAccountMame()
+    public String getAccountName()
     {
-        return this.accountMame;
+        return this.accountName;
     }
 
+    public void setAccountName(final String accountName)
+    {
+        this.accountName = accountName;
+    }
+
+    /**
+     * @return the account name
+     * @deprecated typo alias, use {@link #getAccountName()} instead.
+     */
+    @Deprecated
+    public String getAccountMame()
+    {
+        return this.accountName;
+    }
+
+    /**
+     * Binds the historical, misspelled {@code account-mame} property for
+     * backwards compatibility.
+     *
+     * @param accountMame the account name
+     * @deprecated typo alias, use {@link #setAccountName(String)} instead.
+     */
+    @Deprecated
     public void setAccountMame(final String accountMame)
     {
-        this.accountMame = accountMame;
+        this.accountName = accountMame;
     }
 
     public String getAccountKey()

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -206,7 +206,7 @@ public class EclipseStoreConfigConverter
         }
         if (properties.getRedis() != null)
         {
-            values.put(ConfigKeys.REDIS_URI.value(), properties.getRedis().getUri());
+            values.put(this.composeKey(key, ConfigKeys.REDIS_URI.value()), properties.getRedis().getUri());
         }
         if (properties.getGooglecloud() != null)
         {
@@ -220,6 +220,10 @@ public class EclipseStoreConfigConverter
     private Map<String, String> prepareGoogleCloud(final Googlecloud googlecloud, final String key)
     {
         final Map<String, String> values = new HashMap<>();
+        if (googlecloud.getFirestore() == null)
+        {
+            return values;
+        }
         values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_DATABASE_ID.value()), googlecloud.getFirestore().getDatabaseId());
         values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_EMULATOR_HOST.value()), googlecloud.getFirestore().getEmulatorHost());
         values.put(this.composeKey(key, ConfigKeys.GOOGLECLOUD_FIRESTORE_HOST.value()), googlecloud.getFirestore().getHost());
@@ -235,14 +239,25 @@ public class EclipseStoreConfigConverter
     private Map<String, String> prepareOracleCloud(final Oraclecloud oraclecloud, final String key)
     {
         final Map<String, String> values = new HashMap<>();
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CONFIG_FILE_PATH.value()), oraclecloud.getObjectStorage().getConfigFile().getPath());
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CONFIG_FILE_PROFILE.value()), oraclecloud.getObjectStorage().getConfigFile().getProfile());
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CONFIG_FILE_CHARSET.value()), oraclecloud.getObjectStorage().getConfigFile().getCharset());
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CLIENT_CONNECTION_TIMEOUT_MILLIS.value()), oraclecloud.getObjectStorage().getClient().getConnectionTimeoutMillis());
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CLIENT_READ_TIMEOUT_MILLIS.value()), oraclecloud.getObjectStorage().getClient().getReadTimeoutMillis());
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CLIENT_MAX_ASYNC_THREADS.value()), oraclecloud.getObjectStorage().getClient().getMaxAsyncThreads());
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_REGION.value()), oraclecloud.getObjectStorage().getRegion());
-        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_ENDPOINT.value()), oraclecloud.getObjectStorage().getEndpoint());
+        final var objectStorage = oraclecloud.getObjectStorage();
+        if (objectStorage == null)
+        {
+            return values;
+        }
+        if (objectStorage.getConfigFile() != null)
+        {
+            values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CONFIG_FILE_PATH.value()), objectStorage.getConfigFile().getPath());
+            values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CONFIG_FILE_PROFILE.value()), objectStorage.getConfigFile().getProfile());
+            values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CONFIG_FILE_CHARSET.value()), objectStorage.getConfigFile().getCharset());
+        }
+        if (objectStorage.getClient() != null)
+        {
+            values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CLIENT_CONNECTION_TIMEOUT_MILLIS.value()), objectStorage.getClient().getConnectionTimeoutMillis());
+            values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CLIENT_READ_TIMEOUT_MILLIS.value()), objectStorage.getClient().getReadTimeoutMillis());
+            values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_CLIENT_MAX_ASYNC_THREADS.value()), objectStorage.getClient().getMaxAsyncThreads());
+        }
+        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_REGION.value()), objectStorage.getRegion());
+        values.put(this.composeKey(key, ConfigKeys.ORACLECLOUD_ENDPOINT.value()), objectStorage.getEndpoint());
         return values;
     }
 
@@ -250,13 +265,20 @@ public class EclipseStoreConfigConverter
     private Map<String, String> prepareAzure(final Azure azure, final String key)
     {
         final Map<String, String> values = new HashMap<>();
+        if (azure.getStorage() == null)
+        {
+            return values;
+        }
         values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CONNECTION_STRING.value()), azure.getStorage().getConnectionString());
         values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_ENCRYPTION_SCOPE.value()), azure.getStorage().getEncryptionScope());
-        values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_TYPE.value()), azure.getStorage().getCredentials().getType());
-        values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_USERNAME.value()), azure.getStorage().getCredentials().getUsername());
-        values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_PASSWORD.value()), azure.getStorage().getCredentials().getPassword());
-        values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_ACCOUNT_NAME.value()), azure.getStorage().getCredentials().getAccountMame());
-        values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_ACCOUNT_KEY.value()), azure.getStorage().getCredentials().getAccountKey());
+        if (azure.getStorage().getCredentials() != null)
+        {
+            values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_TYPE.value()), azure.getStorage().getCredentials().getType());
+            values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_USERNAME.value()), azure.getStorage().getCredentials().getUsername());
+            values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_PASSWORD.value()), azure.getStorage().getCredentials().getPassword());
+            values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_ACCOUNT_NAME.value()), azure.getStorage().getCredentials().getAccountName());
+            values.put(this.composeKey(key, ConfigKeys.AZURE_STORAGE_CREDENTIALS_ACCOUNT_KEY.value()), azure.getStorage().getCredentials().getAccountKey());
+        }
         return values;
     }
 
@@ -284,9 +306,12 @@ public class EclipseStoreConfigConverter
         values.put(this.composeKey(key, ConfigKeys.CACHE.value()), Boolean.toString(awsProperties.isCache()));
         values.put(this.composeKey(key, ConfigKeys.AWS_ENDPOINT_OVERRIDE.value()), awsProperties.getEndpointOverride());
         values.put(this.composeKey(key, ConfigKeys.AWS_REGION.value()), awsProperties.getRegion());
-        values.put(this.composeKey(key, ConfigKeys.AWS_CREDENTIALS_TYPE.value()), awsProperties.getCredentials().getType());
-        values.put(this.composeKey(key, ConfigKeys.AWS_CREDENTIALS_ACCESS_KEY_ID.value()), awsProperties.getCredentials().getAccessKeyId());
-        values.put(this.composeKey(key, ConfigKeys.AWS_CREDENTIALS_SECRET_ACCESS_KEY.value()), awsProperties.getCredentials().getSecretAccessKey());
+        if (awsProperties.getCredentials() != null)
+        {
+            values.put(this.composeKey(key, ConfigKeys.AWS_CREDENTIALS_TYPE.value()), awsProperties.getCredentials().getType());
+            values.put(this.composeKey(key, ConfigKeys.AWS_CREDENTIALS_ACCESS_KEY_ID.value()), awsProperties.getCredentials().getAccessKeyId());
+            values.put(this.composeKey(key, ConfigKeys.AWS_CREDENTIALS_SECRET_ACCESS_KEY.value()), awsProperties.getCredentials().getSecretAccessKey());
+        }
         return values;
     }
 

--- a/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/AzureCredentialsAccountNameTest.java
+++ b/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/AzureCredentialsAccountNameTest.java
@@ -1,0 +1,96 @@
+package org.eclipse.store.integrations.spring.boot.types.converter;
+
+/*-
+ * #%L
+ * EclipseStore Integrations SpringBoot
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+/**
+ * The Azure shared-key credentials property historically had a typo in the
+ * binding name: the field was called {@code accountMame}, so only
+ * {@code ...credentials.account-mame} bound and the documented
+ * {@code ...credentials.account-name} was silently ignored (the converter then
+ * dropped the null value and the account name never reached the storage
+ * configuration).
+ *
+ * <p>These tests verify both states: the documented {@code account-name}
+ * property binds and reaches the converted configuration, and the misspelled
+ * {@code account-mame} keeps working as a deprecated alias for anyone who
+ * worked around the typo.
+ */
+class AzureCredentialsAccountNameTest
+{
+    private static final String PROPERTY_BASE =
+            "org.eclipse.store.storage-filesystem.azure.storage.credentials";
+
+    private static final String CONVERTED_KEY =
+            "storage-filesystem.azure.storage.credentials.account-name";
+
+    private final EclipseStoreConfigConverter converter = new EclipseStoreConfigConverter();
+
+    @Test
+    void documentedAccountNamePropertyBindsAndReachesConfiguration()
+    {
+        final EclipseStoreProperties properties = this.bind(Map.of(
+                PROPERTY_BASE + ".type", "shared-key",
+                PROPERTY_BASE + ".account-name", "my-account"
+        ));
+
+        assertEquals("my-account",
+                properties.getStorageFilesystem().getAzure().getStorage().getCredentials().getAccountName(),
+                "the documented account-name property must bind");
+
+        final Map<String, String> map = this.converter.convertConfigurationToMap(properties);
+        assertEquals("my-account", map.get(CONVERTED_KEY),
+                "the bound account name must reach the converted storage configuration");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecatedAccountMameAliasStillBinds()
+    {
+        final EclipseStoreProperties properties = this.bind(Map.of(
+                PROPERTY_BASE + ".type", "shared-key",
+                PROPERTY_BASE + ".account-mame", "legacy-account"
+        ));
+
+        assertEquals("legacy-account",
+                properties.getStorageFilesystem().getAzure().getStorage().getCredentials().getAccountName(),
+                "the historical misspelled property must keep binding as a deprecated alias");
+        assertEquals("legacy-account",
+                properties.getStorageFilesystem().getAzure().getStorage().getCredentials().getAccountMame(),
+                "the deprecated getter must expose the same value");
+
+        final Map<String, String> map = this.converter.convertConfigurationToMap(properties);
+        assertEquals("legacy-account", map.get(CONVERTED_KEY),
+                "the alias-bound account name must reach the converted storage configuration");
+    }
+
+    private EclipseStoreProperties bind(final Map<String, String> propertyValues)
+    {
+        final Map<String, String> source = new HashMap<>(propertyValues);
+        final Binder binder = new Binder(new MapConfigurationPropertySource(source));
+        return binder.bind("org.eclipse.store", Bindable.of(EclipseStoreProperties.class))
+                .orElseThrow(() -> new IllegalStateException("binding produced no result"));
+    }
+}

--- a/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/ConverterPartialConfigurationTest.java
+++ b/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/ConverterPartialConfigurationTest.java
@@ -1,0 +1,115 @@
+package org.eclipse.store.integrations.spring.boot.types.converter;
+
+/*-
+ * #%L
+ * EclipseStore Integrations SpringBoot
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
+import org.eclipse.store.integrations.spring.boot.types.configuration.StorageFilesystem;
+import org.eclipse.store.integrations.spring.boot.types.configuration.aws.Aws;
+import org.eclipse.store.integrations.spring.boot.types.configuration.aws.S3;
+import org.eclipse.store.integrations.spring.boot.types.configuration.azure.Azure;
+import org.eclipse.store.integrations.spring.boot.types.configuration.googlecloud.Googlecloud;
+import org.eclipse.store.integrations.spring.boot.types.configuration.oraclecloud.ObjectStorage;
+import org.eclipse.store.integrations.spring.boot.types.configuration.oraclecloud.Oraclecloud;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Partially populated backend configurations must convert without a
+ * {@code NullPointerException} — optional nested nodes (credentials, client,
+ * config-file, ...) are simply absent from the resulting map. Before the null
+ * guards, e.g. an S3 configuration relying on environment-provided credentials
+ * (a plain endpoint-override + region setup) crashed the startup with an NPE
+ * inside the converter.
+ */
+class ConverterPartialConfigurationTest
+{
+    private final EclipseStoreConfigConverter converter = new EclipseStoreConfigConverter();
+
+    @Test
+    void s3WithoutCredentialsConverts()
+    {
+        final S3 s3 = new S3();
+        s3.setEndpointOverride("http://minio:9000");
+        s3.setRegion("eu-central-1");
+        final Aws aws = new Aws();
+        aws.setS3(s3);
+
+        final Map<String, String> map = this.convertWith(fs -> fs.setAws(aws));
+
+        assertEquals("http://minio:9000", map.get("storage-filesystem.aws.s3.endpoint-override"));
+        assertEquals("eu-central-1", map.get("storage-filesystem.aws.s3.region"));
+        assertFalse(map.containsKey("storage-filesystem.aws.s3.credentials.type"));
+    }
+
+    @Test
+    void azureWithoutCredentialsConverts()
+    {
+        final Azure azure = new Azure();
+        final org.eclipse.store.integrations.spring.boot.types.configuration.azure.Storage storage =
+                new org.eclipse.store.integrations.spring.boot.types.configuration.azure.Storage();
+        storage.setConnectionString("UseDevelopmentStorage=true");
+        azure.setStorage(storage);
+
+        final Map<String, String> map = this.convertWith(fs -> fs.setAzure(azure));
+
+        assertEquals("UseDevelopmentStorage=true", map.get("storage-filesystem.azure.storage.connection-string"));
+        assertFalse(map.containsKey("storage-filesystem.azure.storage.credentials.type"));
+    }
+
+    @Test
+    void azureWithoutStorageNodeConverts()
+    {
+        assertDoesNotThrow(() -> this.convertWith(fs -> fs.setAzure(new Azure())));
+    }
+
+    @Test
+    void oracleCloudWithoutConfigFileAndClientConverts()
+    {
+        final ObjectStorage objectStorage = new ObjectStorage();
+        objectStorage.setRegion("eu-frankfurt-1");
+        objectStorage.setEndpoint("https://objectstorage.example");
+        final Oraclecloud oraclecloud = new Oraclecloud();
+        oraclecloud.setObjectStorage(objectStorage);
+
+        final Map<String, String> map = this.convertWith(fs -> fs.setOraclecloud(oraclecloud));
+
+        assertEquals("eu-frankfurt-1", map.get("storage-filesystem.oraclecloud.object-storage.region"));
+        assertFalse(map.containsKey("storage-filesystem.oraclecloud.object-storage.config-file.path"));
+    }
+
+    @Test
+    void oracleCloudWithoutObjectStorageNodeConverts()
+    {
+        assertDoesNotThrow(() -> this.convertWith(fs -> fs.setOraclecloud(new Oraclecloud())));
+    }
+
+    @Test
+    void googleCloudWithoutFirestoreNodeConverts()
+    {
+        assertDoesNotThrow(() -> this.convertWith(fs -> fs.setGooglecloud(new Googlecloud())));
+    }
+
+    private Map<String, String> convertWith(final java.util.function.Consumer<StorageFilesystem> filesystemSetup)
+    {
+        final EclipseStoreProperties properties = new EclipseStoreProperties();
+        final StorageFilesystem filesystem = new StorageFilesystem();
+        filesystemSetup.accept(filesystem);
+        properties.setStorageFilesystem(filesystem);
+        return this.converter.convertConfigurationToMap(properties);
+    }
+}

--- a/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/RedisFilesystemKeyTest.java
+++ b/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/RedisFilesystemKeyTest.java
@@ -1,0 +1,78 @@
+package org.eclipse.store.integrations.spring.boot.types.converter;
+
+/*-
+ * #%L
+ * EclipseStore Integrations SpringBoot
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
+import org.eclipse.store.integrations.spring.boot.types.configuration.StorageFilesystem;
+import org.eclipse.store.integrations.spring.boot.types.configuration.redis.Redis;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test: the Redis URI must be emitted under the composed filesystem
+ * key ({@code storage-filesystem.redis.uri} / {@code backup-filesystem.redis.uri})
+ * like every other backend. It used to be emitted under the bare {@code redis.uri}
+ * key, which the storage configuration silently ignores — the storage then
+ * started on the default NIO backend instead of Redis, and a storage- and a
+ * backup-filesystem Redis configuration collided on the single bare key.
+ */
+class RedisFilesystemKeyTest
+{
+    private final EclipseStoreConfigConverter converter = new EclipseStoreConfigConverter();
+
+    @Test
+    void storageFilesystemRedisUriIsPrefixed()
+    {
+        final EclipseStoreProperties properties = new EclipseStoreProperties();
+        final StorageFilesystem filesystem = new StorageFilesystem();
+        final Redis redis = new Redis();
+        redis.setUri("redis://storage-host:6379");
+        filesystem.setRedis(redis);
+        properties.setStorageFilesystem(filesystem);
+
+        final Map<String, String> map = this.converter.convertConfigurationToMap(properties);
+
+        assertNull(map.get("redis.uri"),
+                "Redis URI must not be emitted under the bare, prefix-less key");
+        assertEquals("redis://storage-host:6379", map.get("storage-filesystem.redis.uri"));
+    }
+
+    @Test
+    void backupFilesystemRedisUriIsPrefixedAndDoesNotCollide()
+    {
+        final EclipseStoreProperties properties = new EclipseStoreProperties();
+
+        final StorageFilesystem storageFs = new StorageFilesystem();
+        final Redis storageRedis = new Redis();
+        storageRedis.setUri("redis://storage-host:6379");
+        storageFs.setRedis(storageRedis);
+        properties.setStorageFilesystem(storageFs);
+
+        final StorageFilesystem backupFs = new StorageFilesystem();
+        final Redis backupRedis = new Redis();
+        backupRedis.setUri("redis://backup-host:6379");
+        backupFs.setRedis(backupRedis);
+        properties.setBackupFilesystem(backupFs);
+
+        final Map<String, String> map = this.converter.convertConfigurationToMap(properties);
+
+        assertEquals("redis://storage-host:6379", map.get("storage-filesystem.redis.uri"));
+        assertEquals("redis://backup-host:6379", map.get("backup-filesystem.redis.uri"),
+                "storage and backup Redis configurations must not collide on one key");
+    }
+}


### PR DESCRIPTION
…uration converter

- Add caution block documenting mutex lock limitations: no read-to-write upgrade, global lock behavior without explicit mutex names, interface proxy pitfalls, and self-invocation bypass
- Fix Redis filesystem URI to use proper prefix key instead of bare `redis.uri`
- Add null guards in converter for optional cloud storage credential and client nodes
- Fix Azure credentials property typo: rename `accountMame` to `accountName` while preserving deprecated alias for backwards compatibility
- Add regression tests for partial cloud configurations, Redis filesystem keys, and Azure credentials binding