### PR TITLE
Small fixes for examples

### DIFF
--- a/examples/custom-legacy-type-handler/src/main/java/org/eclipse/store/examples/customlegacytypehandler/Main.java
+++ b/examples/custom-legacy-type-handler/src/main/java/org/eclipse/store/examples/customlegacytypehandler/Main.java
@@ -38,15 +38,14 @@ import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 public class Main
 {
 	static final File workingdir = GetTempWorkDirectory("e008-LegacyTypeMappingExample");
-	static final String storageChannelFileName = "channel_0\\channel_0_1.dat";
-	
+
 	@SuppressWarnings("resource")
 	public static void main(final String[] args)
 	{
 		final EmbeddedStorageManager storage;
-				
+
 		//if no channel storage files are found a new storage is created
-		if(!Files.exists(Paths.get(workingdir.getPath(), storageChannelFileName)))
+		if(!Files.exists(Paths.get(workingdir.getPath(), "channel_0", "channel_0_1.dat")))
 		{
 			storage = EmbeddedStorage.Foundation(workingdir.toPath()).start();
 			final NicePlace myPlace = new NicePlace("Campground", "not far away");

--- a/examples/spring-boot3-advanced/pom.xml
+++ b/examples/spring-boot3-advanced/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.2.0</version>

--- a/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/JokesStorageImpl.java
+++ b/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/JokesStorageImpl.java
@@ -15,6 +15,7 @@ package org.microstream.spring.boot.example.advanced.storage;
  */
 
 import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.store.integrations.spring.boot.types.concurrent.Mutex;
 import org.eclipse.store.integrations.spring.boot.types.concurrent.Read;
 import org.eclipse.store.integrations.spring.boot.types.concurrent.Write;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -27,6 +28,7 @@ import java.util.List;
 
 
 @Component
+@Mutex("jokes")
 public class JokesStorageImpl implements JokesStorage
 {
     private final EmbeddedStorageManager storageManager;
@@ -46,7 +48,7 @@ public class JokesStorageImpl implements JokesStorage
     {
         String joke;
         JokesRoot root = storageManager.root();
-        if (id > root.getJokes().size())
+        if (id < 0 || id >= root.getJokes().size())
         {
             throw new IllegalArgumentException("No jokes with this id");
         }

--- a/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/MuppetsStorageImpl.java
+++ b/examples/spring-boot3-advanced/src/main/java/org/microstream/spring/boot/example/advanced/storage/MuppetsStorageImpl.java
@@ -15,6 +15,7 @@ package org.microstream.spring.boot.example.advanced.storage;
  */
 
 import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.store.integrations.spring.boot.types.concurrent.Mutex;
 import org.eclipse.store.integrations.spring.boot.types.concurrent.Read;
 import org.eclipse.store.integrations.spring.boot.types.concurrent.Write;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@Mutex("muppets")
 public class MuppetsStorageImpl implements MuppetStorage
 {
 
@@ -44,7 +46,7 @@ public class MuppetsStorageImpl implements MuppetStorage
     public String oneMuppet(Integer id)
     {
         MuppetsRoot root = storageManager.root();
-        if (id > root.getMuppets().size())
+        if (id < 0 || id >= root.getMuppets().size())
         {
             throw new IllegalArgumentException("No muppet with this id");
         }

--- a/examples/spring-boot3-simple/src/main/java/org/microstream/spring/boot/example/simple/storage/JokesStorageImpl.java
+++ b/examples/spring-boot3-simple/src/main/java/org/microstream/spring/boot/example/simple/storage/JokesStorageImpl.java
@@ -42,7 +42,7 @@ public class JokesStorageImpl implements JokesStorage
     {
         String joke;
         Root root = storageManager.root();
-        if (id > root.getJokes().size())
+        if (id < 0 || id >= root.getJokes().size())
         {
             throw new IllegalArgumentException("No jokes with this id");
         }


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the example projects, focusing on concurrency handling, input validation, and dependency management.

**Concurrency and Thread Safety Enhancements:**

* Added the `@Mutex` annotation to both `JokesStorageImpl` and `MuppetsStorageImpl` classes to ensure thread-safe access to storage operations. [[1]](diffhunk://#diff-2453fd9730d5e9efe9a3929b4beb6bd68a787b68735346d4ff141ee930eb2b5bR31) [[2]](diffhunk://#diff-1babbc1b480f1b6b989064f2e47bddfa334b1585721b74167ce955f6897113b6R30)
* Imported the `Mutex` class in both storage implementation files to support the new concurrency annotations. [[1]](diffhunk://#diff-2453fd9730d5e9efe9a3929b4beb6bd68a787b68735346d4ff141ee930eb2b5bR18) [[2]](diffhunk://#diff-1babbc1b480f1b6b989064f2e47bddfa334b1585721b74167ce955f6897113b6R18)

**Input Validation Improvements:**

* Updated the `oneJoke` and `oneMuppet` methods in `JokesStorageImpl`, `MuppetsStorageImpl`, and the simple example to properly check for negative and out-of-bounds IDs, preventing invalid access and improving error handling. [[1]](diffhunk://#diff-2453fd9730d5e9efe9a3929b4beb6bd68a787b68735346d4ff141ee930eb2b5bL49-R51) [[2]](diffhunk://#diff-1babbc1b480f1b6b989064f2e47bddfa334b1585721b74167ce955f6897113b6L47-R49) [[3]](diffhunk://#diff-f02e73db1a89386784d3c8dab8c39fdd7a435231b2578c5a000223fd1b62c21bL45-R45)

**Dependency Management:**

* Added the `spring-boot-starter-aop` dependency to the advanced example's `pom.xml` to enable aspect-oriented programming features required for the concurrency annotations.

**Minor Code Cleanup:**

* Simplified the channel file existence check in the legacy type handler example by inlining the file path, improving readability.