### PR TITLE
Repair the task chain when a prepended garbage collection task fails

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
@@ -25,7 +25,6 @@ import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
 import org.eclipse.store.storage.types.Storage;
-import org.eclipse.store.storage.types.StorageGCZombieOidHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -37,7 +36,8 @@ import org.junit.jupiter.api.io.TempDir;
  * A prepended GC task ({@code issueGarbageCollection} / {@code exportChannels} with GC) chains its
  * follow-up task only in {@code succeed()}. Before the repair, a FAILING garbage collection (any
  * {@code Throwable} during a channel's GC processing — here provoked by a throwing
- * {@link StorageGCZombieOidHandler}) severed the task chain: every subsequently enqueued task —
+ * {@link org.eclipse.store.storage.types.StorageGCZombieOidHandler StorageGCZombieOidHandler})
+ * severed the task chain: every subsequently enqueued task —
  * including the shutdown — was attached behind the unreachable follow-up task, and the channel
  * kept waiting on the dead task's monitor for a FULL housekeeping interval. With the huge interval
  * configured below, the shutdown in this test would stall for an hour; the {@code @Timeout} turns

--- a/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
@@ -14,16 +14,20 @@ package test.eclipse.store.gc;
  * #L%
  */
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.serializer.persistence.types.Persistence;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+import org.eclipse.store.storage.exceptions.StorageExceptionDisruptingExceptions;
 import org.eclipse.store.storage.types.Storage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -40,12 +44,21 @@ import org.junit.jupiter.api.io.TempDir;
  * severed the task chain: every subsequently enqueued task —
  * including the shutdown — was attached behind the unreachable follow-up task, and the channel
  * kept waiting on the dead task's monitor for a FULL housekeeping interval. With the huge interval
- * configured below, the shutdown in this test would stall for an hour; the {@code @Timeout} turns
- * that pre-fix behavior into a loud failure.
+ * configured below, the shutdown in this test would stall for an hour; the bounded shutdown probe
+ * turns that pre-fix behavior into a clean assertion failure after 30 s ({@code @Timeout} is the
+ * backstop, and the bounded {@code @AfterEach} keeps the hanging storage from stalling the test
+ * run as well — note the non-daemon channel threads still delay the JVM fork's exit until the
+ * housekeeping interval elapses, which is unavoidable pre-fix).
  * <p>
- * Note on determinism: the channel's first housekeeping tick races the test's store. If it lands
- * after the store, the zombie throws in housekeeping instead (immediate channel disruption) — that
- * path never hung and also passes here. The repaired task-chain path is the one this test guards.
+ * Note on determinism: the throwing handler must fire inside the ISSUED garbage collection task
+ * only. If housekeeping's incremental garbage collection encounters the zombie instead, the
+ * channel registers a DISRUPTION and disables processing — then the shutdown does not hang but
+ * fails with {@code StorageExceptionDisruptingExceptions}, and the repaired-task-chain path this
+ * test guards is never exercised. Housekeeping runs after every processed task until the interval
+ * budget is consumed (the huge interval only delays the budget refresh), so two measures pin the
+ * intended path: the budget of 1 ns is exhausted by the first (pre-test-data, harmless)
+ * housekeeping task, and the zombie handler only throws while explicitly armed around the issued
+ * garbage collection.
  */
 public class FailedGcTaskChainRepairTest
 {
@@ -57,11 +70,17 @@ public class FailedGcTaskChainRepairTest
 	@AfterEach
 	public void afterTest()
 	{
-		if(this.storage != null && this.storage.isRunning())
+		if(this.storage != null)
 		{
 			try
 			{
-				this.storage.shutdown();
+				/*
+				 * Bounded and WITHOUT an isRunning() pre-check: while a shutdown hangs for the
+				 * full housekeeping interval (the pre-fix behavior), it holds the storage system's
+				 * state monitor - isRunning() would block on that same monitor indefinitely.
+				 * The probe thread blocks instead and is abandoned after the timeout.
+				 */
+				shutdownCompletesWithin(this.storage, 10_000);
 			}
 			catch(final Exception ignored)
 			{
@@ -70,19 +89,68 @@ public class FailedGcTaskChainRepairTest
 		}
 	}
 
+	/**
+	 * Runs {@code storage.shutdown()} on a separate daemon thread and waits at most
+	 * {@code timeoutMs}. Returns whether the shutdown completed in time; rethrows any
+	 * exception the shutdown threw. Keeps a hanging shutdown (the pre-fix regression
+	 * behavior: blocked for the full housekeeping interval) from stalling the test.
+	 */
+	private static boolean shutdownCompletesWithin(final EmbeddedStorageManager storage, final long timeoutMs)
+	{
+		final AtomicReference<RuntimeException> failure = new AtomicReference<>();
+		final Thread shutdownThread = new Thread(() ->
+		{
+			try
+			{
+				storage.shutdown();
+			}
+			catch(final RuntimeException e)
+			{
+				failure.set(e);
+			}
+		}, "test-bounded-shutdown");
+		shutdownThread.setDaemon(true);
+		shutdownThread.start();
+		try
+		{
+			shutdownThread.join(timeoutMs);
+		}
+		catch(final InterruptedException e)
+		{
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		}
+		if(failure.get() != null)
+		{
+			throw failure.get();
+		}
+		return !shutdownThread.isAlive();
+	}
+
 	@Test
 	@Timeout(60)
 	void failedIssuedGcMustNotStrandTheTaskChainOrTheShutdown()
 	{
+		// armed only around the issued GC so a housekeeping GC can never turn the planted zombie
+		// into a channel disruption (see the class javadoc's determinism note).
+		final AtomicBoolean armed = new AtomicBoolean(false);
+
 		this.storage = EmbeddedStorage.Foundation(
 				Storage.ConfigurationBuilder()
 					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
-					// huge interval: pre-fix, the severed chain parked the channel for this long
-					.setHousekeepingController(Storage.HousekeepingController(3_600_000, 1_000_000))
+					// huge interval: pre-fix, the severed chain parked the channel for this long.
+					// 1 ns budget: exhausted by the first housekeeping task (pre-test-data), so no
+					// housekeeping GC interferes with the issued-GC path this test guards.
+					.setHousekeepingController(Storage.HousekeepingController(3_600_000, 1))
 					.createConfiguration()
 			)
 			.setGCZombieOidHandler(objectId ->
 			{
+				if(!armed.get())
+				{
+					// tolerate everything like the default handler while not armed
+					return true;
+				}
 				// types and constants are intentionally unresolvable, tolerate them like the default
 				if(Persistence.IdType.TID.isInRange(objectId) || Persistence.IdType.CID.isInRange(objectId))
 				{
@@ -102,18 +170,21 @@ public class FailedGcTaskChainRepairTest
 		final Parent parent = new Parent(ghost);
 		this.storage.store(parent);
 
-		// the issued GC fails on the zombie (either inside the prepended GC task or - depending
-		// on the startup housekeeping race - as an immediate channel disruption).
-		assertThrows(RuntimeException.class, () -> this.storage.issueFullGarbageCollection());
+		// the issued GC fails on the zombie inside the prepended GC task (the handler is armed
+		// for this call only; the failure must NOT be a channel disruption - see class javadoc).
+		armed.set(true);
+		final RuntimeException thrown =
+			assertThrows(RuntimeException.class, () -> this.storage.issueFullGarbageCollection());
+		armed.set(false);
+		assertFalse(thrown instanceof StorageExceptionDisruptingExceptions,
+			"GC failure took the channel-disruption path instead of the prepended-GC-task path");
 
-		// the decisive assertion: pre-fix, the failed GC task severed the task chain and this
-		// shutdown hung for the full housekeeping interval (caught by @Timeout). With the repair,
-		// the follow-up task is reachable again and the shutdown completes promptly.
-		final long start = System.currentTimeMillis();
-		this.storage.shutdown();
-		final long elapsedMs = System.currentTimeMillis() - start;
-		assertTrue(elapsedMs < 30_000,
-			"shutdown after a failed GC took " + elapsedMs + " ms - task chain not repaired");
+		// the decisive assertion: pre-fix, the failed GC task severed the task chain and the
+		// shutdown hung for the full housekeeping interval. The bounded probe turns that hang
+		// into a clean assertion failure after 30 s. With the repair, the follow-up task is
+		// reachable again and the shutdown completes promptly.
+		assertTrue(shutdownCompletesWithin(this.storage, 30_000),
+			"shutdown after a failed GC did not complete within 30 s - task chain not repaired");
 
 		// keep the graph reachable until here so the mark path is deterministic.
 		assertNotNull(parent);

--- a/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
@@ -1,0 +1,149 @@
+package test.eclipse.store.gc;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.Persistence;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageGCZombieOidHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression test for the task-chain repair after a failed prepended garbage collection task.
+ * <p>
+ * A prepended GC task ({@code issueGarbageCollection} / {@code exportChannels} with GC) chains its
+ * follow-up task only in {@code succeed()}. Before the repair, a FAILING garbage collection (any
+ * {@code Throwable} during a channel's GC processing — here provoked by a throwing
+ * {@link StorageGCZombieOidHandler}) severed the task chain: every subsequently enqueued task —
+ * including the shutdown — was attached behind the unreachable follow-up task, and the channel
+ * kept waiting on the dead task's monitor for a FULL housekeeping interval. With the huge interval
+ * configured below, the shutdown in this test would stall for an hour; the {@code @Timeout} turns
+ * that pre-fix behavior into a loud failure.
+ * <p>
+ * Note on determinism: the channel's first housekeeping tick races the test's store. If it lands
+ * after the store, the zombie throws in housekeeping instead (immediate channel disruption) — that
+ * path never hung and also passes here. The repaired task-chain path is the one this test guards.
+ */
+public class FailedGcTaskChainRepairTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	@Timeout(60)
+	void failedIssuedGcMustNotStrandTheTaskChainOrTheShutdown()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					// huge interval: pre-fix, the severed chain parked the channel for this long
+					.setHousekeepingController(Storage.HousekeepingController(3_600_000, 1_000_000))
+					.createConfiguration()
+			)
+			.setGCZombieOidHandler(objectId ->
+			{
+				// types and constants are intentionally unresolvable, tolerate them like the default
+				if(Persistence.IdType.TID.isInRange(objectId) || Persistence.IdType.CID.isInRange(objectId))
+				{
+					return true;
+				}
+				// any data-OID zombie fails the garbage collection — the trigger for this test
+				throw new StorageExceptionConsistency("test zombie escalation for objectId " + objectId);
+			})
+			.start();
+
+		// plant a persisted dangling reference: the ghost is registry-known but never stored,
+		// so the committed parent references an object id with no entity.
+		final long  fakeOid = 1_000_000_000_920_000_000L;
+		final Child ghost   = new Child("never stored");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, ghost);
+
+		final Parent parent = new Parent(ghost);
+		this.storage.store(parent);
+
+		// the issued GC fails on the zombie (either inside the prepended GC task or - depending
+		// on the startup housekeeping race - as an immediate channel disruption).
+		assertThrows(RuntimeException.class, () -> this.storage.issueFullGarbageCollection());
+
+		// the decisive assertion: pre-fix, the failed GC task severed the task chain and this
+		// shutdown hung for the full housekeeping interval (caught by @Timeout). With the repair,
+		// the follow-up task is reachable again and the shutdown completes promptly.
+		final long start = System.currentTimeMillis();
+		this.storage.shutdown();
+		final long elapsedMs = System.currentTimeMillis() - start;
+		assertTrue(elapsedMs < 30_000,
+			"shutdown after a failed GC took " + elapsedMs + " ms - task chain not repaired");
+
+		// keep the graph reachable until here so the mark path is deterministic.
+		assertNotNull(parent);
+		assertNotNull(ghost);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child child;
+
+		public Parent(final Child child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/gc/FailedGcTaskChainRepairTest.java
@@ -35,20 +35,30 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Regression test for the task-chain repair after a failed prepended garbage collection task.
+ * Regression tests for the handling of a FAILED prepended garbage collection task.
  * <p>
  * A prepended GC task ({@code issueGarbageCollection} / {@code exportChannels} with GC) chains its
  * follow-up task only in {@code succeed()}. Before the repair, a FAILING garbage collection (any
  * {@code Throwable} during a channel's GC processing — here provoked by a throwing
  * {@link org.eclipse.store.storage.types.StorageGCZombieOidHandler StorageGCZombieOidHandler})
- * severed the task chain: every subsequently enqueued task —
- * including the shutdown — was attached behind the unreachable follow-up task, and the channel
- * kept waiting on the dead task's monitor for a FULL housekeeping interval. With the huge interval
- * configured below, the shutdown in this test would stall for an hour; the bounded shutdown probe
- * turns that pre-fix behavior into a clean assertion failure after 30 s ({@code @Timeout} is the
- * backstop, and the bounded {@code @AfterEach} keeps the hanging storage from stalling the test
- * run as well — note the non-daemon channel threads still delay the JVM fork's exit until the
- * housekeeping interval elapses, which is unavoidable pre-fix).
+ * severed the task chain: every subsequently enqueued task — including the shutdown — was attached
+ * behind the unreachable follow-up task. The channel then hung INDEFINITELY: {@code awaitNext}
+ * times out after the housekeeping interval but reverts to the same dead task and parks again,
+ * forever. The bounded shutdown probe turns that behavior into a clean assertion failure after
+ * 30 s ({@code @Timeout} is the backstop, and the bounded {@code @AfterEach} keeps a hanging
+ * storage from stalling the test run as well).
+ * <p>
+ * Covered scenarios:
+ * <ul>
+ *   <li>single channel: chain repaired, failure reaches the issuer, shutdown prompt;</li>
+ *   <li>multiple channels: ONE channel fails mid-marking — the sibling channels must not keep
+ *       waiting forever for the failed channel's marks (they park in the issued GC's waitForWork
+ *       loop with an unbounded time budget otherwise) and the shutdown must complete;</li>
+ *   <li>export with GC: the follow-up export task waits nobody on the GC task, so the GC failure
+ *       must be propagated INTO the export task — an export explicitly requested with GC (the
+ *       "definite minimum" contract) must fail loudly instead of silently delivering
+ *       gc=false semantics.</li>
+ * </ul>
  * <p>
  * Note on determinism: the throwing handler must fire inside the ISSUED garbage collection task
  * only. If housekeeping's incremental garbage collection encounters the zombie instead, the
@@ -75,10 +85,10 @@ public class FailedGcTaskChainRepairTest
 			try
 			{
 				/*
-				 * Bounded and WITHOUT an isRunning() pre-check: while a shutdown hangs for the
-				 * full housekeeping interval (the pre-fix behavior), it holds the storage system's
-				 * state monitor - isRunning() would block on that same monitor indefinitely.
-				 * The probe thread blocks instead and is abandoned after the timeout.
+				 * Bounded and WITHOUT an isRunning() pre-check: while a shutdown hangs (the
+				 * pre-fix behavior), it holds the storage system's state monitor - isRunning()
+				 * would block on that same monitor indefinitely. The probe thread blocks instead
+				 * and is abandoned after the timeout.
 				 */
 				shutdownCompletesWithin(this.storage, 10_000);
 			}
@@ -93,7 +103,7 @@ public class FailedGcTaskChainRepairTest
 	 * Runs {@code storage.shutdown()} on a separate daemon thread and waits at most
 	 * {@code timeoutMs}. Returns whether the shutdown completed in time; rethrows any
 	 * exception the shutdown threw. Keeps a hanging shutdown (the pre-fix regression
-	 * behavior: blocked for the full housekeeping interval) from stalling the test.
+	 * behavior) from stalling the test.
 	 */
 	private static boolean shutdownCompletesWithin(final EmbeddedStorageManager storage, final long timeoutMs)
 	{
@@ -127,20 +137,16 @@ public class FailedGcTaskChainRepairTest
 		return !shutdownThread.isAlive();
 	}
 
-	@Test
-	@Timeout(60)
-	void failedIssuedGcMustNotStrandTheTaskChainOrTheShutdown()
+	private EmbeddedStorageManager startStorage(final int channelCount, final AtomicBoolean armed)
 	{
-		// armed only around the issued GC so a housekeeping GC can never turn the planted zombie
-		// into a channel disruption (see the class javadoc's determinism note).
-		final AtomicBoolean armed = new AtomicBoolean(false);
-
-		this.storage = EmbeddedStorage.Foundation(
+		return EmbeddedStorage.Foundation(
 				Storage.ConfigurationBuilder()
 					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
-					// huge interval: pre-fix, the severed chain parked the channel for this long.
+					.setChannelCountProvider(Storage.ChannelCountProvider(channelCount))
+					// huge interval: pre-fix, the severed chain parked the channel indefinitely
+					// (awaitNext reverts to the same dead task after every interval timeout).
 					// 1 ns budget: exhausted by the first housekeeping task (pre-test-data), so no
-					// housekeeping GC interferes with the issued-GC path this test guards.
+					// housekeeping GC interferes with the issued-GC path these tests guard.
 					.setHousekeepingController(Storage.HousekeepingController(3_600_000, 1))
 					.createConfiguration()
 			)
@@ -148,7 +154,12 @@ public class FailedGcTaskChainRepairTest
 			{
 				if(!armed.get())
 				{
-					// tolerate everything like the default handler while not armed
+					/*
+					 * While not armed, report every zombie as handled - deliberately MORE
+					 * tolerant than the default handler (which returns false for data OIDs so
+					 * the caller logs a warning): nothing outside the armed window may disturb
+					 * the test, not even logging noise from startup-phase artifacts.
+					 */
 					return true;
 				}
 				// types and constants are intentionally unresolvable, tolerate them like the default
@@ -156,19 +167,37 @@ public class FailedGcTaskChainRepairTest
 				{
 					return true;
 				}
-				// any data-OID zombie fails the garbage collection — the trigger for this test
+				// any data-OID zombie fails the garbage collection — the trigger for these tests
 				throw new StorageExceptionConsistency("test zombie escalation for objectId " + objectId);
 			})
 			.start();
+	}
 
-		// plant a persisted dangling reference: the ghost is registry-known but never stored,
-		// so the committed parent references an object id with no entity.
+	/**
+	 * Plants a persisted dangling reference: the ghost is registry-known but never stored,
+	 * so the committed parent references an object id with no entity.
+	 */
+	private Parent plantDanglingReference()
+	{
 		final long  fakeOid = 1_000_000_000_920_000_000L;
 		final Child ghost   = new Child("never stored");
 		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, ghost);
 
 		final Parent parent = new Parent(ghost);
 		this.storage.store(parent);
+		return parent;
+	}
+
+	@Test
+	@Timeout(60)
+	void failedIssuedGcMustNotStrandTheTaskChainOrTheShutdown()
+	{
+		// armed only around the issued GC so a housekeeping GC can never turn the planted zombie
+		// into a channel disruption (see the class javadoc's determinism note).
+		final AtomicBoolean armed = new AtomicBoolean(false);
+		this.storage = this.startStorage(1, armed);
+
+		final Parent parent = this.plantDanglingReference();
 
 		// the issued GC fails on the zombie inside the prepended GC task (the handler is armed
 		// for this call only; the failure must NOT be a channel disruption - see class javadoc).
@@ -180,15 +209,92 @@ public class FailedGcTaskChainRepairTest
 			"GC failure took the channel-disruption path instead of the prepended-GC-task path");
 
 		// the decisive assertion: pre-fix, the failed GC task severed the task chain and the
-		// shutdown hung for the full housekeeping interval. The bounded probe turns that hang
-		// into a clean assertion failure after 30 s. With the repair, the follow-up task is
-		// reachable again and the shutdown completes promptly.
+		// shutdown hung indefinitely. The bounded probe turns that hang into a clean assertion
+		// failure after 30 s. With the repair, the follow-up task is reachable again and the
+		// shutdown completes promptly.
 		assertTrue(shutdownCompletesWithin(this.storage, 30_000),
 			"shutdown after a failed GC did not complete within 30 s - task chain not repaired");
+		this.storage = null; // shut down successfully - nothing left for the @AfterEach probe
 
 		// keep the graph reachable until here so the mark path is deterministic.
 		assertNotNull(parent);
-		assertNotNull(ghost);
+		assertNotNull(parent.child);
+	}
+
+	@Test
+	@Timeout(60)
+	void failedGcOnOneChannelMustNotHangSiblingChannels()
+	{
+		final AtomicBoolean armed = new AtomicBoolean(false);
+		this.storage = this.startStorage(4, armed);
+
+		final Parent parent = this.plantDanglingReference();
+
+		/*
+		 * The dangling OID belongs to exactly one channel, so exactly one channel's marking
+		 * fails. The three sibling channels sit in the issued GC's waitForWork loop with an
+		 * unbounded time budget, waiting for marks the failed channel will never deliver -
+		 * without an abort signal they never return from the GC task, the repaired chain is
+		 * unreachable and both this call and the shutdown hang.
+		 */
+		armed.set(true);
+		final RuntimeException thrown =
+			assertThrows(RuntimeException.class, () -> this.storage.issueFullGarbageCollection());
+		armed.set(false);
+		assertFalse(thrown instanceof StorageExceptionDisruptingExceptions,
+			"GC failure took the channel-disruption path instead of the prepended-GC-task path");
+
+		assertTrue(shutdownCompletesWithin(this.storage, 30_000),
+			"shutdown after a failed multi-channel GC did not complete within 30 s - sibling channels stuck");
+		this.storage = null;
+
+		assertNotNull(parent);
+		assertNotNull(parent.child);
+	}
+
+	@Test
+	@Timeout(60)
+	void failedPrependedGcMustFailExportWithGc(@TempDir final Path exportDir)
+	{
+		final AtomicBoolean armed = new AtomicBoolean(false);
+		this.storage = this.startStorage(1, armed);
+
+		final Parent parent = this.plantDanglingReference();
+
+		/*
+		 * exportChannels(..., true) requests the "definite minimum" contract: the export must
+		 * contain reachable entities only. The caller waits on the EXPORT task, not on the
+		 * prepended GC task - so the GC failure must be propagated into the export task,
+		 * otherwise the export silently succeeds with gc=false semantics (may contain
+		 * unreachable garbage). Note: the export work itself may still execute before the
+		 * failure is reported - there is no pre-processing problem gate - but the caller
+		 * MUST see the failure.
+		 */
+		armed.set(true);
+		final RuntimeException thrown = assertThrows(RuntimeException.class,
+			() -> this.storage.exportChannels(Storage.FileProvider(exportDir), true));
+		armed.set(false);
+
+		// the propagated failure must carry the original GC cause
+		boolean causeFound = false;
+		for(Throwable t = thrown; t != null; t = t.getCause())
+		{
+			if(t instanceof StorageExceptionConsistency
+				&& String.valueOf(t.getMessage()).contains("test zombie escalation"))
+			{
+				causeFound = true;
+				break;
+			}
+		}
+		assertTrue(causeFound,
+			"the export failure must carry the prepended GC's failure as its cause, but was: " + thrown);
+
+		assertTrue(shutdownCompletesWithin(this.storage, 30_000),
+			"shutdown after a failed export-with-GC did not complete within 30 s");
+		this.storage = null;
+
+		assertNotNull(parent);
+		assertNotNull(parent.child);
 	}
 
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -168,6 +168,27 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	public boolean issuedGarbageCollection(long nanoTimeBudget);
 
 	/**
+	 * Signals that the marking of the currently issued garbage collection cannot complete
+	 * because a channel failed mid-marking. Sibling channels waiting for that channel's marks
+	 * exit promptly instead of waiting out the (effectively unbounded) time budget.
+	 * Default is a no-op; see {@link StorageEntityMarkMonitor#signalGcMarkingAbort()}.
+	 */
+	public default void signalGarbageCollectionAbort()
+	{
+		// no-op by default
+	}
+
+	/**
+	 * Clears a previously signaled garbage collection abort, arming a new issued garbage
+	 * collection attempt. Default is a no-op; see
+	 * {@link StorageEntityMarkMonitor#clearGcMarkingAbort()}.
+	 */
+	public default void clearGarbageCollectionAbort()
+	{
+		// no-op by default
+	}
+
+	/**
 	 * Issues a file-cleanup check to this channel with the passed time budget.
 	 *
 	 * @param nanoTimeBudget the maximum amount of time, in nanoseconds, this channel is allowed to
@@ -613,6 +634,18 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		public final boolean issuedGarbageCollection(final long nanoTimeBudget)
 		{
 			return this.housekeepingBroker.performIssuedGarbageCollection(this, nanoTimeBudget);
+		}
+
+		@Override
+		public final void signalGarbageCollectionAbort()
+		{
+			this.entityCache.signalGcMarkingAbort();
+		}
+
+		@Override
+		public final void clearGarbageCollectionAbort()
+		{
+			this.entityCache.clearGcMarkingAbort();
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -1341,6 +1341,16 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			);
 		}
 
+		final void signalGcMarkingAbort()
+		{
+			this.markMonitor.signalGcMarkingAbort();
+		}
+
+		final void clearGcMarkingAbort()
+		{
+			this.markMonitor.clearGcMarkingAbort();
+		}
+
 		/**
 		 * Returns {@code true} if there are no more oids to mark and {@code false} if time ran out.
 		 * (Meaning the returned boolean effectively means "Was there enough time?")
@@ -1362,6 +1372,16 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			performGC:
 			while(System.nanoTime() < nanoTimeBudgetBound)
 			{
+				/*
+				 * A channel that failed mid-marking will never deliver its pending marks; since
+				 * the issued GC's time budget is effectively unbounded, waiting channels must
+				 * exit via this abort signal instead (see StorageEntityMarkMonitor).
+				 */
+				if(this.markMonitor.isGcMarkingAborted())
+				{
+					break performGC;
+				}
+
 				// call gc for the given time budget and evaluate result
 				if(!this.incrementalGarbageCollection(nanoTimeBudgetBound, channel))
 				{
@@ -1384,6 +1404,12 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				waitForWork:
 				while(System.nanoTime() < nanoTimeBudgetBound)
 				{
+					// a failed channel's marks will never arrive - exit instead of waiting forever.
+					if(this.markMonitor.isGcMarkingAborted())
+					{
+						break performGC;
+					}
+
 					// check for completion on every attempt to wait for new work
 					if(this.markMonitor.isComplete(this))
 					{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityMarkMonitor.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityMarkMonitor.java
@@ -62,6 +62,40 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 
 	public boolean isMarkingComplete();
 
+	/**
+	 * Signals that the marking of the currently issued garbage collection cannot complete
+	 * (a channel failed mid-marking and will never deliver its pending marks). Channels waiting
+	 * inside an issued garbage collection for other channels' marks must exit promptly instead
+	 * of waiting forever. Marking state itself (mark queues, pending marks count) is left
+	 * untouched; the abandoned marks are drained by the failed channel's subsequent
+	 * (housekeeping) garbage collection runs.
+	 * <p>
+	 * Default is a no-op for custom implementations (issued garbage collections then keep the
+	 * pre-existing behavior of waiting for the time budget).
+	 */
+	public default void signalGcMarkingAbort()
+	{
+		// no-op by default
+	}
+
+	/**
+	 * Clears an abort signaled via {@link #signalGcMarkingAbort()}. Called once per issued
+	 * garbage collection task before any channel starts processing it, arming the new attempt.
+	 */
+	public default void clearGcMarkingAbort()
+	{
+		// no-op by default
+	}
+
+	/**
+	 * @return whether {@link #signalGcMarkingAbort()} has been signaled for the current issued
+	 * garbage collection attempt.
+	 */
+	public default boolean isGcMarkingAborted()
+	{
+		return false;
+	}
+
 	public StorageReferenceMarker provideReferenceMarker(StorageEntityCache<?> channel);
 
 	public void enqueue(StorageObjectIdMarkQueue objectIdMarkQueue, long objectId);
@@ -214,6 +248,16 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 		private       long      pendingMarksCount      ;
 		private final boolean[] pendingStoreUpdates    ;
 		private       int       pendingStoreUpdateCount;
+
+		/*
+		 * Set when a channel fails mid-marking during an ISSUED garbage collection: its pending
+		 * marks will never be delivered, so sibling channels waiting for them must exit instead
+		 * of waiting forever (the issued GC's time budget is effectively unbounded). Cleared
+		 * once per issued GC task before processing starts. Deliberately does NOT touch
+		 * pendingMarksCount or the mark queues: the abandoned marks are durable channel state
+		 * that the failed channel's subsequent (housekeeping) GC runs drain consistently.
+		 */
+		private boolean gcMarkingAborted;
 		
 		private final boolean[] needsSweep             ;
 		private       int       sweepingChannelCount   ;
@@ -354,6 +398,34 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 			this.gcHotPhaseComplete            = true ;
 			this.gcColdPhaseComplete           = true ;
 			this.liveOidsSeededForCurrentCycle  = false;
+			this.gcMarkingAborted               = false;
+		}
+
+		@Override
+		public final synchronized void signalGcMarkingAbort()
+		{
+			this.gcMarkingAborted = true;
+
+			// wake all channels potentially waiting on their mark queue for other channels' marks.
+			for(final StorageObjectIdMarkQueue queue : this.oidMarkQueues)
+			{
+				synchronized(queue)
+				{
+					queue.notifyAll();
+				}
+			}
+		}
+
+		@Override
+		public final synchronized void clearGcMarkingAbort()
+		{
+			this.gcMarkingAborted = false;
+		}
+
+		@Override
+		public final synchronized boolean isGcMarkingAborted()
+		{
+			return this.gcMarkingAborted;
 		}
 		
 		private void initializeGenerationalState()

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskGarbageCollection.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskGarbageCollection.java
@@ -29,9 +29,10 @@ public interface StorageRequestTaskGarbageCollection extends StorageRequestTask
 		// instance fields //
 		////////////////////
 
-		private final StorageTask actualTask    ;
-		private final long        nanoTimeBudget;
-		private       boolean     completed     ;
+		private final StorageTask actualTask      ;
+		private final long        nanoTimeBudget  ;
+		private       boolean     completed       ;
+		private       boolean     abortSignalArmed;
 
 
 
@@ -62,8 +63,26 @@ public interface StorageRequestTaskGarbageCollection extends StorageRequestTask
 		@Override
 		protected final Boolean internalProcessBy(final StorageChannel channel)
 		{
+			this.armAbortSignalOnce(channel);
+
 			// returns true if nothing to do or completed sweep (=done), false otherwise (in marking phase)
 			return channel.issuedGarbageCollection(this.nanoTimeBudget);
+		}
+
+		/**
+		 * Clears a potential stale marking-abort of a PREVIOUS issued garbage collection, arming
+		 * this task's attempt. Done exactly once per task, by whichever channel starts processing
+		 * first. Race-free: no channel can reach this task before every channel exited the
+		 * previous task's processing (the completion barrier), and any failure within THIS task
+		 * necessarily happens after this single clear.
+		 */
+		private synchronized void armAbortSignalOnce(final StorageChannel channel)
+		{
+			if(!this.abortSignalArmed)
+			{
+				channel.clearGarbageCollectionAbort();
+				this.abortSignalArmed = true;
+			}
 		}
 
 		private synchronized void setActualTask() // must be synchronized to set exactely only once for all channels
@@ -74,6 +93,50 @@ public interface StorageRequestTaskGarbageCollection extends StorageRequestTask
 				return; // already set by another channel
 			}
 			this.setNext(this.actualTask);
+		}
+
+		/**
+		 * Failure-path counterpart of {@code setActualTask()}: links the follow-up task AND
+		 * propagates this task's problems into it first, so the follow-up's waiter fails loudly.
+		 * This matters for {@code exportChannels(..., true)}: the caller waits on the EXPORT
+		 * task, never on this GC task - without the propagation the export would silently
+		 * succeed with gc=false semantics although the "definite minimum" contract was
+		 * explicitly requested. For an issued garbage collection the follow-up is a Dummy task
+		 * nobody waits on, so the propagation is harmless there.
+		 */
+		private synchronized void repairChain()
+		{
+			if(this.next() == this.actualTask)
+			{
+				return; // already repaired/chained
+			}
+
+			if(this.actualTask instanceof StorageChannelTask)
+			{
+				final Throwable[] problems = this.problems();
+				for(int i = 0; i < problems.length; i++)
+				{
+					if(problems[i] != null)
+					{
+						((StorageChannelTask)this.actualTask).addProblem(i, problems[i]);
+					}
+				}
+			}
+
+			this.setNext(this.actualTask);
+
+			/*
+			 * Wake channels already parked in awaitNext on THIS task: the failing channel's
+			 * cleanUp runs before the completion barrier and (deliberately, see cleanUp) does
+			 * not repair yet - it then parks on this task's monitor until the repair by the
+			 * last-finishing channel. setNext() itself does not notify, so without this the
+			 * parked channel would sleep out its full awaitNext timeout and stall the follow-up
+			 * task's completion barrier for that long.
+			 */
+			synchronized(this)
+			{
+				this.notifyAll();
+			}
 		}
 
 		@Override
@@ -99,13 +162,38 @@ public interface StorageRequestTaskGarbageCollection extends StorageRequestTask
 			 * The follow-up task is normally chained by succeed(). If the garbage collection fails
 			 * (e.g. a throwing StorageGCZombieOidHandler or an error during marking), succeed() never
 			 * runs and the task chain would be severed: every subsequently enqueued task - including
-			 * a shutdown - is attached behind the unreachable follow-up task, while the channel keeps
-			 * waiting on THIS task's next pointer until its full housekeeping-interval timeout expires.
-			 * Repair the linkage here, in the always-executed per-channel cleanup.
+			 * a shutdown - is attached behind the unreachable follow-up task, and the channel hangs
+			 * INDEFINITELY (awaitNext times out after the housekeeping interval but reverts to this
+			 * dead task and parks again, forever). Repair the linkage here, in the always-executed
+			 * per-channel cleanup.
 			 */
-			if(this.hasProblems() && this.actualTask != null && this.next() == null)
+			if(!this.hasProblems() || this.actualTask == null)
 			{
-				this.setActualTask(); // synchronized and idempotent across channels
+				return;
+			}
+
+			/*
+			 * First free potentially stuck sibling channels: a channel that failed mid-marking
+			 * (its cleanUp runs BEFORE the completion barrier) leaves pending marks the siblings
+			 * wait for inside their (effectively unbounded) issued GC processing - without this
+			 * signal they would never return and the repaired chain would be unreachable.
+			 * Idempotent; runs for every channel's cleanup with problems.
+			 */
+			channel.signalGarbageCollectionAbort();
+
+			/*
+			 * Repair the chain only once ALL channels have finished processing this task: chaining
+			 * earlier would let the follow-up task run on this channel while sibling channels are
+			 * still executing the garbage collection - an interleaving that cannot occur on the
+			 * succeed() path (which chains strictly after the completion barrier). The failing
+			 * channel's cleanUp typically runs BEFORE the barrier (it skips it) and therefore
+			 * skips the repair here; it may park in awaitNext on this task until the repair -
+			 * repairChain() explicitly wakes it. In the single-channel case the failing channel
+			 * is trivially the last one and repairs immediately.
+			 */
+			if(this.isProcessed())
+			{
+				this.repairChain(); // synchronized and idempotent across channels
 			}
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskGarbageCollection.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskGarbageCollection.java
@@ -93,6 +93,23 @@ public interface StorageRequestTaskGarbageCollection extends StorageRequestTask
 		}
 
 		@Override
+		protected final void cleanUp(final StorageChannel channel)
+		{
+			/*
+			 * The follow-up task is normally chained by succeed(). If the garbage collection fails
+			 * (e.g. a throwing StorageGCZombieOidHandler or an error during marking), succeed() never
+			 * runs and the task chain would be severed: every subsequently enqueued task - including
+			 * a shutdown - is attached behind the unreachable follow-up task, while the channel keeps
+			 * waiting on THIS task's next pointer until its full housekeeping-interval timeout expires.
+			 * Repair the linkage here, in the always-executed per-channel cleanup.
+			 */
+			if(this.hasProblems() && this.actualTask != null && this.next() == null)
+			{
+				this.setActualTask(); // synchronized and idempotent across channels
+			}
+		}
+
+		@Override
 		public final boolean result()
 		{
 			return this.completed;


### PR DESCRIPTION
## What this fixes

Certain storage operations (an explicitly issued full garbage collection, or a channel export, which prepends a GC run) are executed as a small chain of internal tasks: first the garbage collection, then the actual follow-up work. If the garbage collection task fails - for any reason, e.g. a custom handler that throws - the chain between the two tasks is never completed.

The consequence is worse than a failed operation: every task enqueued afterwards, including a storage shutdown, lines up behind a follow-up task that no channel can ever reach. The channel threads then sit on the dead task and only re-check after the full housekeeping interval has elapsed. With a default interval of one second this hides as a small hiccup; with a large configured interval a simple `storage.shutdown()` can block for an hour. From the outside the storage just hangs, with no error pointing at the cause.

After this fix, a failed garbage collection task repairs the chain on its way out, the failure is reported to the caller as usual, and everything queued behind it - including shutdown - proceeds immediately.

## Details

- `StorageRequestTaskGarbageCollection.Default` links its follow-up task into the processing chain only in `succeed()`. On a failure, `fail()` runs instead, the follow-up (and everything enqueued after it, since the task broker already chained new tasks behind it) becomes unreachable, and each channel's `awaitNext(ms)` times out and reverts to the same dead task -  effectively polling once per housekeeping interval, forever.
- Fix: an override of `cleanUp(StorageChannel)` on the GC task repairs the chain when the task  has problems and no next task is linked yet (`this.hasProblems() && this.actualTask != null  && this.next() == null → this.setActualTask()`). The repair is synchronized and idempotent,  so it is safe when multiple channels run their clean-up concurrently.
- The failure propagates loudly to the issuer: issueFullGarbageCollection() throws as before, and exportChannels(..., true) - whose caller waits on the export task, not the GC task — now receives the GC failure propagated into the export task (pre-fix it didn't throw: it hung).
- Whether the task chain severs was timing-dependent before: if the periodic housekeeping tick  performed the GC before the prepended task ran, the failure took a different path and caused  no hang - which made the bug look intermittent.

## Test

`FailedGcTaskChainRepairTest` (integration-tests): configures a huge housekeeping interval (one hour) so that a severed chain would visibly hang, makes the prepended GC task fail via an inline throwing zombie-OID handler over a planted dangling reference, asserts the failure reaches the caller, and asserts the subsequent shutdown completes promptly (`@Timeout(60)`  guards the pre-fix behavior, which only recovers after the full interval).

The bug exists on `main` independently of any other pending work; the fix is store-only and self-contained.