### PR TITLE
Add regression tests for lazy-skip instance pinning (eclipse-serializer/serializer#289)

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
@@ -17,6 +17,7 @@ package test.eclipse.store.zombie;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.ref.WeakReference;
 import java.nio.file.Path;
@@ -37,7 +38,8 @@ import org.junit.jupiter.api.io.TempDir;
  * binding at {@code commit()} time. Without a strong reference, the instance could be collected in
  * between, its registry entry reaped, and the storage GC would legitimately delete the entity — the
  * commit would then persist a dangling reference. The storer must pin skipped instances for the
- * lifetime of the store operation.
+ * lifetime of the store operation - and release them on commit, or long-lived storers would leak
+ * every skipped instance they ever referenced (both directions are covered here).
  * <p>
  * Requires the serializer-side pin ({@code registerSkippedOptional} / pin items in
  * {@code BinaryStorer}); fails without it.
@@ -96,8 +98,9 @@ public class SkipPinningTest
 			root.payload = null;
 			this.storage.storeRoot();
 
-			// long-lived storer: skip decision at store() time, binding only at commit() time.
-			storer = this.storage.createStorer();
+			// long-lived LAZY storer (only lazy storing logic skips known instances):
+			// skip decision at store() time, binding only at commit() time.
+			storer = this.storage.createLazyStorer();
 			final Parent parent = new Parent(x);
 			storer.store(parent); // X is registry-known -> skipped, its oid written into the chunk
 
@@ -120,7 +123,14 @@ public class SkipPinningTest
 			System.gc();
 			Thread.sleep(50);
 		}
-		assertNotNull(payloadProbe.get(),
+		/*
+		 * The decisive assertion - and, in the pass case, the strong capture: after commit() the
+		 * pin is released and nothing else holds X, so all later steps must use this reference
+		 * instead of re-polling the (then collectable) probe. Capturing here does not weaken the
+		 * red direction: on an unfixed build the test already fails right here.
+		 */
+		final Payload pinned = payloadProbe.get();
+		assertNotNull(pinned,
 			"the storer must pin the skipped instance until commit - it was collected");
 
 		// the t1..t4 window of internal#73: reap attempt + full storage GC. With the pin alive,
@@ -133,11 +143,11 @@ public class SkipPinningTest
 		// reference is not dangling.
 		assertDoesNotThrow(storer::commit,
 			"committing the store whose skipped referent must have been pinned failed");
-		assertEquals(payloadOid, registry.lookupObjectId(payloadProbe.get()),
+		assertEquals(payloadOid, registry.lookupObjectId(pinned),
 			"the pinned instance must keep its object id");
 
 		// re-attach for reachability and restart: the graph must be intact.
-		root.payload = payloadProbe.get();
+		root.payload = pinned;
 		this.storage.storeRoot();
 		this.storage.shutdown();
 
@@ -146,6 +156,65 @@ public class SkipPinningTest
 		assertNotNull(reloaded);
 		assertNotNull(reloaded.payload, "payload must have survived the store-commit window");
 		assertEquals("pinned payload", reloaded.payload.data);
+	}
+
+	@Test
+	@Timeout(120)
+	void pinIsReleasedOnCommit() throws Exception
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.createConfiguration()
+			)
+			.start();
+
+		final DataRoot root = new DataRoot();
+		this.storage.setRoot(root);
+
+		final WeakReference<Payload> payloadProbe;
+		final Storer                 storer      ;
+		{
+			Payload x = new Payload("released payload");
+			root.payload = x;
+			this.storage.storeRoot();
+
+			root.payload = null;
+			this.storage.storeRoot();
+
+			storer = this.storage.createLazyStorer();
+			final Parent parent = new Parent(x);
+			storer.store(parent); // X registry-known -> skipped and pinned
+
+			parent.payload = null; // see the sibling test: the pin must be the only strong path
+			payloadProbe = new WeakReference<>(x);
+			x = null;
+		}
+
+		// precondition, identical to the sibling test: pinned during the store-commit window.
+		for(int i = 0; i < 5; i++)
+		{
+			System.gc();
+			Thread.sleep(50);
+		}
+		assertNotNull(payloadProbe.get(),
+			"precondition failed: the skipped instance must be pinned during the store-commit window");
+
+		storer.commit();
+
+		/*
+		 * The counterpart contract: the pin must die with the commit. With no other strong path
+		 * left, X must become collectable again - otherwise every long-lived or batching storer
+		 * would leak all skipped instances it ever referenced.
+		 */
+		boolean collected = false;
+		for(int i = 0; i < 20 && !(collected = payloadProbe.get() == null); i++)
+		{
+			System.gc();
+			Thread.sleep(50);
+		}
+		assertTrue(collected,
+			"the pin must be released on commit - the skipped instance is still strongly reachable");
 	}
 
 

--- a/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
@@ -87,7 +87,6 @@ public class SkipPinningTest
 		final long                     payloadOid  ;
 		final WeakReference<Payload>   payloadProbe;
 		final Storer                   storer      ;
-		final Parent                   parent      ;
 		{
 			Payload x = new Payload("pinned payload");
 			root.payload = x;
@@ -99,8 +98,17 @@ public class SkipPinningTest
 
 			// long-lived storer: skip decision at store() time, binding only at commit() time.
 			storer = this.storage.createStorer();
-			parent = new Parent(x);
+			final Parent parent = new Parent(x);
 			storer.store(parent); // X is registry-known -> skipped, its oid written into the chunk
+
+			/*
+			 * Drop EVERY application-side strong path to X, including parent's field: the storer
+			 * holds parent itself strongly (regular store item), so a payload still referenced
+			 * through parent would keep X alive trivially and the pin assertion below would be
+			 * vacuous. parent's serialized state was captured by store() - clearing the field
+			 * afterwards does not alter what gets committed.
+			 */
+			parent.payload = null;
 
 			payloadProbe = new WeakReference<>(x);
 			x = null; // drop the last application reference inside this block

--- a/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
@@ -206,12 +206,21 @@ public class SkipPinningTest
 		 * The counterpart contract: the pin must die with the commit. With no other strong path
 		 * left, X must become collectable again - otherwise every long-lived or batching storer
 		 * would leak all skipped instances it ever referenced.
+		 * GC is not obliged to collect promptly on every JVM/CI configuration, so the loop
+		 * combines a generous deadline with bounded memory pressure to make collection of the
+		 * weakly reachable payload overwhelmingly likely before failing.
 		 */
 		boolean collected = false;
-		for(int i = 0; i < 20 && !(collected = payloadProbe.get() == null); i++)
+		final long deadline = System.currentTimeMillis() + 30_000;
+		while(!(collected = payloadProbe.get() == null) && System.currentTimeMillis() < deadline)
 		{
+			final byte[][] pressure = new byte[16][];
+			for(int i = 0; i < pressure.length; i++)
+			{
+				pressure[i] = new byte[1 << 20];
+			}
 			System.gc();
-			Thread.sleep(50);
+			Thread.sleep(100);
 		}
 		assertTrue(collected,
 			"the pin must be released on commit - the skipped instance is still strongly reachable");

--- a/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
@@ -1,0 +1,174 @@
+package test.eclipse.store.zombie;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.ref.WeakReference;
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Pinning of lazily-skipped instances (internal issue #73): when the lazy storer skips a
+ * registry-known instance, the skip decision is made at {@code store()} time but only becomes
+ * binding at {@code commit()} time. Without a strong reference, the instance could be collected in
+ * between, its registry entry reaped, and the storage GC would legitimately delete the entity — the
+ * commit would then persist a dangling reference. The storer must pin skipped instances for the
+ * lifetime of the store operation.
+ * <p>
+ * Requires the serializer-side pin ({@code registerSkippedOptional} / pin items in
+ * {@code BinaryStorer}); fails without it.
+ */
+public class SkipPinningTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	@Timeout(120)
+	void skippedInstanceSurvivesStoreCommitWindow() throws Exception
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.createConfiguration()
+			)
+			.start();
+
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		// X persisted, then unlinked from the root graph (unlink committed): on disk it now
+		// survives only via the GC's registry safety net, i.e. as long as its instance is alive.
+		final DataRoot root = new DataRoot();
+		this.storage.setRoot(root);
+
+		final long                     payloadOid  ;
+		final WeakReference<Payload>   payloadProbe;
+		final Storer                   storer      ;
+		final Parent                   parent      ;
+		{
+			Payload x = new Payload("pinned payload");
+			root.payload = x;
+			this.storage.storeRoot();
+			payloadOid = registry.lookupObjectId(x);
+
+			root.payload = null;
+			this.storage.storeRoot();
+
+			// long-lived storer: skip decision at store() time, binding only at commit() time.
+			storer = this.storage.createStorer();
+			parent = new Parent(x);
+			storer.store(parent); // X is registry-known -> skipped, its oid written into the chunk
+
+			payloadProbe = new WeakReference<>(x);
+			x = null; // drop the last application reference inside this block
+		}
+
+		// try hard to collect X: with the storer's pin in place, it MUST survive.
+		for(int i = 0; i < 5; i++)
+		{
+			System.gc();
+			Thread.sleep(50);
+		}
+		assertNotNull(payloadProbe.get(),
+			"the storer must pin the skipped instance until commit - it was collected");
+
+		// the t1..t4 window of internal#73: reap attempt + full storage GC. With the pin alive,
+		// the registry entry stays and the safety net keeps X's entity on disk.
+		registry.cleanUp();
+		this.storage.issueFullGarbageCollection();
+		Thread.sleep(200);
+
+		// the commit's skip decision must still be valid: X's entity still exists, the committed
+		// reference is not dangling.
+		assertDoesNotThrow(storer::commit,
+			"committing the store whose skipped referent must have been pinned failed");
+		assertEquals(payloadOid, registry.lookupObjectId(payloadProbe.get()),
+			"the pinned instance must keep its object id");
+
+		// re-attach for reachability and restart: the graph must be intact.
+		root.payload = payloadProbe.get();
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		final DataRoot reloaded = (DataRoot)this.storage.root();
+		assertNotNull(reloaded);
+		assertNotNull(reloaded.payload, "payload must have survived the store-commit window");
+		assertEquals("pinned payload", reloaded.payload.data);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class DataRoot
+	{
+		public Payload payload;
+	}
+
+	public static class Parent
+	{
+		public Payload payload;
+
+		public Parent(final Payload payload)
+		{
+			super();
+			this.payload = payload;
+		}
+	}
+
+	public static class Payload
+	{
+		public String data;
+
+		public Payload(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/zombie/StorerCommitWindowDanglingReferenceReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/StorerCommitWindowDanglingReferenceReproTest.java
@@ -1,0 +1,305 @@
+package test.eclipse.store.zombie;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.ref.WeakReference;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.serializer.reference.Swizzling;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageGCZombieOidHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Reproducer: the lazy storer skips an already-registered
+ * instance by writing its OID into the chunk without pinning it; between
+ * {@link Storer#store(Object)} and {@link Storer#commit()} the storage GC can
+ * delete the skipped target, so the commit persists a dangling reference that
+ * surfaces as {@code StorageExceptionConsistency: No entity found for objectId}
+ * after a restart.
+ *
+ * <p>Deterministic implementation of the issue's "Variant B" timeline — the
+ * framework severs the reference itself, no user threading fault involved:
+ * <ol>
+ * <li>{@code BinaryHandlerLazyDefault.store} calls {@code Lazy.$link} during
+ *     serialization, i.e. while {@code store()} builds the chunk — <b>before</b>
+ *     {@code commit()}. From that moment {@link Lazy#isStored()} reports
+ *     {@code true} and clearing is permitted (the {@code LazyReferenceManager}
+ *     applies exactly this gate when clearing under memory pressure; the test
+ *     mirrors it with an explicit guarded {@code clear()}).</li>
+ * <li>Clearing drops the last strong reference to the referent; JVM GC collects
+ *     it and {@code registry.cleanUp()} reaps the registry entry.</li>
+ * <li>The storage GC cannot see OIDs referenced only by an uncommitted chunk
+ *     (the mark seed walks the persistent root and registry-resident OIDs;
+ *     skipped instances create no storer Item, so the
+ *     {@code PersistenceLiveStorerRegistry} pin chain misses them too). The
+ *     referent's entity — detached from the persistent root in an earlier
+ *     commit — is swept, and the file check physically reclaims it.</li>
+ * <li>{@code commit()} writes the chunk containing the swept OID without any
+ *     validation (acknowledged FIXME priv#74, {@code StorageChannel}).</li>
+ * </ol>
+ *
+ * <p><b>This test asserts correct behavior and therefore FAILS while the defect
+ * exists</b>: no zombie OID may appear and the re-attached referent must be
+ * loadable after a restart. It passes once a fix lands (pinning lazily-skipped
+ * targets, pre-write reference validation, or post-commit {@code $link}).
+ *
+ * <p>The companion test {@link #heldInstanceScenarioIsMitigatedBySafetyNet()}
+ * documents the boundary of the defect: as long as the application holds the
+ * instance, the #669 registry safety net (sweep predicate + transitive mark
+ * seed, see {@code GC.md} §7–§10) protects the entity — that path does NOT
+ * corrupt the storage. Only the uncommitted-chunk window does.
+ */
+public class StorerCommitWindowDanglingReferenceReproTest
+{
+    @TempDir
+    Path tempDir;
+
+    EmbeddedStorageManager storage;
+    EmbeddedStorageManager reloaded;
+
+    @AfterEach
+    public void afterTest()
+    {
+        if (this.reloaded != null) {
+            try {
+                this.reloaded.shutdown();
+            } catch (final Exception ignored) { /* best effort */ }
+        }
+        if (this.storage != null && this.storage.isRunning()) {
+            try {
+                this.storage.shutdown();
+            } catch (final Exception ignored) { /* best effort */ }
+        }
+    }
+
+    @Test
+    @Timeout(120)
+    void storerCommitWindowMustNotCommitDanglingReference() throws Exception
+    {
+        final CountingZombieOidHandler zombieHandler = new CountingZombieOidHandler();
+        this.storage = this.startStorage(zombieHandler);
+
+        final PersistenceObjectRegistry registry = this.storage.persistenceManager().objectRegistry();
+
+        // Phase 1: store root -> Lazy -> Holder, committed.
+        final DataRoot root = new DataRoot();
+        Holder holder = new Holder("must survive the commit window");
+        root.lazyHolder = Lazy.Reference(holder);
+        this.storage.setRoot(root);
+        this.storage.storeRoot();
+
+        final long holderOid = registry.lookupObjectId(holder);
+        assertNotEquals(Swizzling.notFoundId(), holderOid, "Holder must be registered after initial store");
+        final WeakReference<Holder> holderProbe = new WeakReference<>(holder);
+
+        // Phase 2: detach in a committed state. Holder is now unreachable from
+        // the persistent root on disk; only the application's strong reference
+        // (and the registry entry it implies) keeps its entity alive.
+        root.lazyHolder = null;
+        this.storage.storeRoot();
+
+        // Phase 3: re-attach through a NEW Lazy and store via an explicit
+        // storer — chunk built, NOT yet committed. BinaryHandlerLazyDefault
+        // $links the new Lazy during serialization, so it may already report
+        // isStored() == true although nothing has been committed.
+        final Storer storer = this.storage.createLazyStorer();
+        root.lazyHolder = Lazy.Reference(holder);
+        storer.store(root);
+
+        // Phase 4: the framework-sanctioned clear. This is the LazyReferenceManager
+        // gate verbatim: any Lazy reporting isStored() may be cleared under memory
+        // pressure. If a fix makes the uncommitted Lazy report false here, the
+        // reference survives and the test passes.
+        if (root.lazyHolder.isStored()) {
+            root.lazyHolder.clear();
+        }
+        holder = null;
+
+        if (holderProbe.get() != null) {
+            for (int i = 0; i < 10 && holderProbe.get() != null; i++) {
+                System.gc();
+                Thread.sleep(50);
+            }
+            // Still strongly reachable (e.g. pinned by a fixed storer) is a PASS
+            // condition, not a test-setup failure — only proceed with the GC dance
+            // if the instance is really gone.
+        }
+        if (holderProbe.get() == null) {
+            registry.cleanUp();
+        }
+
+        // Phase 5: full storage GC + file check while the chunk is still
+        // uncommitted. A correct implementation must keep the entity referenced
+        // by the pending commit alive (or fail the commit later).
+        this.storage.issueFullGarbageCollection();
+        this.storage.issueFullFileCheck();
+
+        // Phase 6: commit the chunk. With the defect present this silently
+        // persists a reference to the swept OID.
+        storer.commit();
+
+        // Correctness assertion 1, same session: the next mark cycle walks
+        // root -> new Lazy -> Holder OID; no zombie may surface.
+        this.storage.issueFullGarbageCollection();
+        assertEquals(0, zombieHandler.count(),
+                "DATA LOSS: commit persisted a dangling reference; zombie OIDs " + zombieHandler.oids()
+                        + " (Holder OID " + holderOid + ")");
+
+        // Correctness assertion 2, user-visible: restart and navigate.
+        this.storage.shutdown();
+        this.reloaded = EmbeddedStorage.Foundation(
+                        Storage.ConfigurationBuilder()
+                                .setStorageFileProvider(Storage.FileProvider(this.tempDir))
+                                .createConfiguration()
+                )
+                .start();
+
+        final DataRoot reloadedRoot = (DataRoot) this.reloaded.root();
+        assertNotNull(reloadedRoot.lazyHolder, "reloaded root must hold the committed Lazy");
+        final Holder reloadedHolder = assertDoesNotThrow(
+                () -> reloadedRoot.lazyHolder.get(),
+                "DATA LOSS: committed reference is dangling — referent cannot be loaded after restart");
+        assertNotNull(reloadedHolder, "reloaded Holder must not be null");
+        assertEquals("must survive the commit window", reloadedHolder.data,
+                "reloaded Holder data must match the originally stored value");
+    }
+
+    /**
+     * Boundary check: child strongly held in memory while detached on disk
+     * (issue #70 cause-#1 literal recipe). Green = the #669 registry safety net
+     * holds; the corruption requires the uncommitted-chunk window above.
+     */
+    @Test
+    @Timeout(120)
+    void heldInstanceScenarioIsMitigatedBySafetyNet() throws Exception
+    {
+        final CountingZombieOidHandler zombieHandler = new CountingZombieOidHandler();
+        this.storage = this.startStorage(zombieHandler);
+
+        final DataRoot root = new DataRoot();
+        final Holder heldChild = new Holder("kept alive by the application");
+        root.lazyHolder = Lazy.Reference(heldChild);
+        this.storage.setRoot(root);
+        this.storage.storeRoot();
+
+        // Detach on disk, keep the instance strongly held.
+        root.lazyHolder = null;
+        this.storage.storeRoot();
+
+        // Repeated full GC + file check: the sweep predicate keeps every
+        // registry-resident OID, so the held child must survive.
+        for (int i = 0; i < 3; i++) {
+            this.storage.issueFullGarbageCollection();
+            this.storage.issueFullFileCheck();
+        }
+
+        // Re-attach and store lazily — the storer skips the already-registered
+        // child; its entity must still exist.
+        root.lazyHolder = Lazy.Reference(heldChild);
+        this.storage.storeRoot();
+        this.storage.issueFullGarbageCollection();
+        assertEquals(0, zombieHandler.count(),
+                "safety net must prevent zombies for held instances; got " + zombieHandler.oids());
+
+        this.storage.shutdown();
+        this.reloaded = EmbeddedStorage.Foundation(
+                        Storage.ConfigurationBuilder()
+                                .setStorageFileProvider(Storage.FileProvider(this.tempDir))
+                                .createConfiguration()
+                )
+                .start();
+
+        final DataRoot reloadedRoot = (DataRoot) this.reloaded.root();
+        assertNotNull(reloadedRoot.lazyHolder, "reloaded lazy must be present");
+        assertEquals("kept alive by the application", reloadedRoot.lazyHolder.get().data,
+                "held child must survive detach + full GC + re-attach");
+    }
+
+    private EmbeddedStorageManager startStorage(final CountingZombieOidHandler zombieHandler)
+    {
+        return EmbeddedStorage.Foundation(
+                        Storage.ConfigurationBuilder()
+                                .setChannelCountProvider(Storage.ChannelCountProvider(1))
+                                .setHousekeepingController(Storage.HousekeepingController(100, 1_000_000_000))
+                                .setDataFileEvaluator(Storage.DataFileEvaluator(1024, 2048, 1.0))
+                                .setStorageFileProvider(Storage.FileProvider(this.tempDir))
+                                .createConfiguration()
+                )
+                .setGCZombieOidHandler(zombieHandler)
+                .start();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // data types //
+    ////////////////
+
+    public static class DataRoot
+    {
+        public Lazy<Holder> lazyHolder;
+    }
+
+    public static class Holder
+    {
+        public final String data;
+
+        public Holder(final String data)
+        {
+            super();
+            this.data = data;
+        }
+    }
+
+    static final class CountingZombieOidHandler implements StorageGCZombieOidHandler
+    {
+        final AtomicInteger zombieCount = new AtomicInteger();
+        final List<Long> zombieOids = new ArrayList<>();
+
+        @Override
+        public boolean handleZombieOid(final long objectId)
+        {
+            this.zombieCount.incrementAndGet();
+            synchronized (this.zombieOids) {
+                this.zombieOids.add(objectId);
+            }
+            return true;
+        }
+
+        public int count()
+        {
+            return this.zombieCount.get();
+        }
+
+        public List<Long> oids()
+        {
+            synchronized (this.zombieOids) {
+                return new ArrayList<>(this.zombieOids);
+            }
+        }
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/zombie/StorerCommitWindowDanglingReferenceReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/StorerCommitWindowDanglingReferenceReproTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.io.TempDir;
  * surfaces as {@code StorageExceptionConsistency: No entity found for objectId}
  * after a restart.
  *
- * <p>Deterministic implementation of the issue's "Variant B" timeline — the
+ * <p>Implements the issue's "Variant B" timeline — the
  * framework severs the reference itself, no user threading fault involved:
  * <ol>
  * <li>{@code BinaryHandlerLazyDefault.store} calls {@code Lazy.$link} during
@@ -64,10 +64,15 @@ import org.junit.jupiter.api.io.TempDir;
  *     validation (acknowledged FIXME priv#74, {@code StorageChannel}).</li>
  * </ol>
  *
- * <p><b>This test asserts correct behavior and therefore FAILS while the defect
- * exists</b>: no zombie OID may appear and the re-attached referent must be
- * loadable after a restart. It passes once a fix lands (pinning lazily-skipped
- * targets, pre-write reference validation, or post-commit {@code $link}).
+ * <p><b>This test asserts correct behavior</b>: no zombie OID may appear and the
+ * re-attached referent must be loadable after a restart. On an unfixed build it
+ * fails whenever the JVM actually collects the referent inside the store→commit
+ * window — the usual outcome of the explicit GC loop, but not guaranteed: if the
+ * referent stays reachable (e.g. because a fixed storer pins it, or the JVM
+ * declines to collect), the window never opens and the test passes without
+ * exercising the defect. With a fix in place (pinning lazily-skipped targets,
+ * pre-write reference validation, or post-commit {@code $link}) it passes
+ * deterministically.
  *
  * <p>The companion test {@link #heldInstanceScenarioIsMitigatedBySafetyNet()}
  * documents the boundary of the defect: as long as the application holds the


### PR DESCRIPTION
## What this covers

eclipse-serializer/serializer#289 fixed a data-consistency hazard: when a store skips an object because it is already known to the persistence context, nothing used to keep that object alive between the skip decision (`store()`) and the actual write (`commit()`). If the application dropped its last reference in that window, the JVM could garbage-collect the instance, the storage-side garbage collector could then legitimately delete the entity from disk — and the in-flight commit still wrote a reference to it. The damage stayed invisible until a later load failed with `StorageExceptionConsistency: No entity found for objectId N`,  typically after a restart.

The fix pins skipped instances in the storer until the commit completes. Whether that pin actually protects the on-disk entity can only be proven against a real storage — the scenario needs the storage garbage collector, the registry safety nets, and a restart. That is why the regression tests live here and not in the serializer repo.

## The tests

- `StorerCommitWindowDanglingReferenceReproTest` - the commit-window scenario end to end: a long-lived storer stores a parent referencing an already-known child, the test then drops every application reference to the child inside the store→commit window, forces JVM GC, registry clean-up, and a full storage garbage collection, and only then commits. After a restart the whole graph must be loadable. Without the pin, the child's entity is deleted while the parent's committed data still references it.
- `SkipPinningTest` — the pin contract at unit level, both directions: the skipped instance is retained during the store→commit window (the decisive regression assertion — fails deterministically on a pre-fix serializer build), and released on commit (with no remaining strong path the instance must become collectable again, or long-lived and batching storers would leak every skipped instance). Pin deduplication is serializer-internal; invisibility of pins to explicit stores is covered end-to-end by the recovery-path test in the follow-up validation PR.

## Verification

- Against a serializer build WITHOUT the fix (pre-#289 main): `SkipPinningTest` fails hard (the reproducer can soft-pass under lucky JVM-GC timing, by design — it documents this).
- Against serializer main WITH the fix (merged #289): all 3 tests green.

Store-only test addition; no production code changes.