### PR TITLE
 Retain dirty GigaMap segments in release() to prevent silent lost updates

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -490,6 +490,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 	/**
 	 * Releases all strong references to on-demand loaded data.
+	 * <p>
+	 * Segments containing changes that have not been stored yet are retained: releasing them
+	 * would silently discard the in-memory mutations (the subsequent {@link #store()} could not
+	 * see them anymore) while index and size updates would still be persisted, corrupting the
+	 * stored state. Call {@link #store()} first to be able to release everything.
 	 */
 	public void release();
 	
@@ -2361,12 +2366,19 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			this.ensureMutability();
 			for(final Lazy<?> e : this.level3.segments)
 			{
-				if(e != null && e.isStored())
+				/*
+				 * A used-marked entry pins a segment carrying changes that have not been stored yet
+				 * (see markChanged/clearChildrenStateChangeMarkers). Clearing it would discard the
+				 * in-memory mutations and their change flags: the subsequent store would silently
+				 * skip the evicted segment while still persisting the index/size updates, leaving
+				 * permanently divergent data. Such segments are retained until stored.
+				 */
+				if(e != null && e.isStored() && !e.isUsed())
 				{
 					e.clear();
 				}
 			}
-			
+
 			this.clearAddingState();
 		}
 						

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/DirtySegmentEvictionLostUpdateTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/DirtySegmentEvictionLostUpdateTest.java
@@ -1,0 +1,135 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Regression test for the dirty-segment eviction lost update (review finding GM-B): a
+ * mutated-but-not-yet-stored GigaMap segment could be evicted, after which
+ * {@code storeChangedChildren} silently skipped it — the mutation was lost while the (non-lazy)
+ * bitmap-index and size updates WERE persisted, leaving index and entity segments permanently
+ * divergent on disk, with no exception ever thrown.
+ * <p>
+ * Mechanism:
+ * <ul>
+ *   <li>{@code GigaMap.internalRemove} nulls the entity slot in the in-memory {@code GigaLevel1}
+ *       and calls {@code markChanged} — the change flags live on the {@code GigaLevel1}/
+ *       {@code GigaLevel2} <i>instances behind the Lazy references</i>.</li>
+ *   <li>{@code markChanged} pins the child via {@code Lazy.markUsedFor}, but before the fix
+ *       {@code isUsed()} had zero callers in any clearing path — the pin was write-only.
+ *       {@code Lazy.Default.clear} gated only on {@code isStored()}.</li>
+ *   <li>{@code GigaMap.release()} cleared every stored level-2 Lazy with no usage-mark check,
+ *       discarding the changed instances and their flags.</li>
+ *   <li>{@code storeChangedChildren} then {@code peek()}ed null for the evicted child and
+ *       silently continued.</li>
+ * </ul>
+ * The fix consults the usage mark: {@code release()} retains used-marked (dirty) segments, and
+ * the serializer-side {@code Lazy.Default.clear(ClearingEvaluator)} guard exempts them from
+ * {@code LazyReferenceManager} eviction. Everything here uses only public GigaMap API:
+ * add, store, remove, release, store.
+ * <p>
+ * Adopted from the reproducer {@code DirtySegmentEvictionLostUpdate_GMB} by hg-ms
+ * (hg-ms/EclipseStoreDev, branch missingObjectReproducers).
+ */
+public class DirtySegmentEvictionLostUpdateTest
+{
+	static final IndexerString<Person> NAME_INDEXER = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Person entity)
+		{
+			return entity.name;
+		}
+	};
+
+	@Test
+	void removalSurvivesReleaseBeforeStore(@TempDir final Path dir)
+	{
+		final long bobId;
+
+		// ---- Session 1: create, store, remove, evict, store ----
+		{
+			final GigaMap<Person> map = GigaMap.New();
+			map.index().bitmap().add(NAME_INDEXER);
+
+			map.add(new Person("alice"));
+			final Person bob = new Person("bob");
+			bobId = map.add(bob);
+			map.add(new Person("carol"));
+
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+			{
+				storage.storeRoot();     // everything persisted, change flags cleared
+
+				map.remove(bob);         // in-memory: slot nulled, segment marked changed + pinned
+				map.release();           // pre-fix: evicted the dirty segment along with the clean ones
+
+				/*
+				 * CAUTION - Heisenbug: any map access here (get/iterate/query) re-resolves an
+				 * evicted Lazy via the object registry's weak-reference fast path, handing the
+				 * SAME dirty instance back to the Lazy and accidentally healing the subsequent
+				 * store. The window must stay untouched for the pre-fix bug to manifest.
+				 */
+
+				map.store();             // pre-fix: storeChangedChildren peek()ed null -> silent skip
+			}
+		}
+
+		// ---- Session 2: restart and inspect what was actually persisted ----
+		{
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+			{
+				@SuppressWarnings("unchecked")
+				final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+
+				final long[] iterated = {0L};
+				loaded.iterate(p -> iterated[0]++);
+
+				// pre-fix divergence: get(bobId) != null while the index query already found 0 hits
+				assertNull(loaded.get(bobId), "removed entity must not survive in the segment");
+				assertEquals(0, loaded.query(NAME_INDEXER.is("bob")).count(), "removed entity must not be indexed");
+				assertEquals(2, loaded.size(), "size must reflect the removal");
+				assertEquals(2, iterated[0], "iteration must agree with size and index");
+			}
+		}
+	}
+
+	public static class Person
+	{
+		final String name;
+
+		public Person(final String name)
+		{
+			this.name = name;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Person[" + this.name + "]";
+		}
+	}
+}


### PR DESCRIPTION
## What this fixes

A GigaMap segment that was loaded and then mutated - but not yet stored - could be evicted from memory by `GigaMap.release()`. The mutation's change flags live on the in-memory segment instances behind the Lazy references, so they die with the evicted instance. The next `store()` walks the segment tree, finds the evicted segment unloaded, and silently skips it - while the non-lazy parts of the same logical change (bitmap index entries, the size counter) ARE persisted.

The result is a silently, permanently divergent store. In the reproducer:
`add(alice, bob, carol) → storeRoot() → remove(bob) → release() → store()` — after a restart, `get(bobId)` still returns bob (the segment removal was lost), the index finds 0 hits for bob (the index removal was persisted), `size()` says 2, and iteration finds 3 entities. No exception is ever thrown, in that session or any later one; in-session the divergence is even masked, because reads resolve through the object registry's weak-reference fast path and see the dirty in-memory instance instead of what was actually persisted.

The mechanism was already half-built: every mutation pins the affected segments via `Lazy.markUsedFor`, and the pin is released after a successful commit. But the pin was write-only - no clearing path ever consulted `isUsed()`. This PR wires the read side into `release()`: segments with unstored changes are retained; everything else is released as before. They become releasable again as soon as `store()` has persisted them.

## Technical details

- `GigaMap.Default.release()` gate changes from `e.isStored()` to `e.isStored() && !e.isUsed()`. The pin chain is reliable for this: every CRUD path (`internalRemove`, `internalSet`, the add paths) marks BOTH tree levels, so the level-3 entry pin covers any dirt below it.
- The `release()` interface javadoc now documents the retention: call `store()` first to be able to release everything.
- With eviction of dirty segments impossible, the previously peek-gated pin release in `clearChildrenStateChangeMarkers` always runs at commit - closing a stale-pin leak the same analysis found (a pre-commit eviction used to skip the unmark, leaving the entry pinned forever).

## Test

`DirtySegmentEvictionLostUpdateTest` (gigamap module) - adopted from the reproducer by @hg-ms, including its Heisenbug caution: any map access between `release()` and `store()` re-resolves the evicted Lazy via the registry fast path and accidentally heals the store, so the window must stay untouched. After the restart the test asserts full consistency: segment lookup null, index 0 hits, size 2, iteration 2. Red against the unfixed code with the exact silent-loss symptom (bob resurrected by segment lookup while the index disagrees); green with the fix. Full GigaMap module suite (1043 tests) green.

## Pairing

eclipse-serializer/serializer#292 closes the second eviction path for the same hazard: the `LazyReferenceManager`'s evaluator-driven clearing now also respects usage marks. The two PRs are independent (no compile or ordering dependency - this reproducer triggers via `release()` and passes with this fix alone); together they make the dirty-segment pin authoritative on both eviction paths.