### PR TITLE
Import unmarked entities gc sweep dangling oid fix 80

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -240,8 +240,13 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 
 	// (19.07.2014 TM)TODO: refactor storage typing to avoid classes in public API
 	/**
-	 * Prepares this channel to receive imported data by switching its file manager into import
-	 * mode and returning the entity cache that the importer will populate.
+	 * Prepares this channel to receive imported data by registering the import with the storage
+	 * garbage collector (blocking new sweeps for the whole import task and quiescing an already
+	 * flagged one, see StorageEntityCache.Default#registerPendingImportUpdate), switching its file
+	 * manager into import mode and returning the entity cache that the importer will populate.
+	 * <p>
+	 * Every preparation must be paired with a {@link #cleanupImportData()} call once the import
+	 * task has ultimately completed (committed or rolled back).
 	 *
 	 * @return the channel's entity cache, ready to receive imported entities.
 	 */
@@ -269,6 +274,15 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	 * @param taskTimestamp the timestamp that identifies the import transaction.
 	 */
 	public void commitImportData(long taskTimestamp);
+
+	/**
+	 * Clears the garbage collection coordination state registered by
+	 * {@link #prepareImportData()}, releasing sweep initiation again. Must be called exactly once
+	 * per {@link #prepareImportData()} after the import task has ultimately completed, no matter
+	 * the outcome (committed or rolled back). Idempotent and robust if the preparation never ran
+	 * or failed halfway.
+	 */
+	public void cleanupImportData();
 
 	/**
 	 * Exports every entity of the passed type owned by this channel into the passed file.
@@ -962,6 +976,8 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		@Override
 		public StorageEntityCache.Default prepareImportData()
 		{
+			// gc coordination first: block new sweeps for the task's duration, quiesce a flagged one
+			this.entityCache.registerPendingImportUpdate();
 			this.fileManager.prepareImport();
 			return this.entityCache;
 		}
@@ -982,6 +998,12 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		public void commitImportData(final long taskTimestamp)
 		{
 			this.fileManager.commitImport(taskTimestamp);
+		}
+
+		@Override
+		public void cleanupImportData()
+		{
+			this.entityCache.clearPendingImportUpdate();
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -281,8 +281,14 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	 * per {@link #prepareImportData()} after the import task has ultimately completed, no matter
 	 * the outcome (committed or rolled back). Idempotent and robust if the preparation never ran
 	 * or failed halfway.
+	 * <p>
+	 * The default implementation is a no-op for {@link StorageChannel} implementations whose
+	 * {@link #prepareImportData()} does not register any garbage collection coordination state.
 	 */
-	public void cleanupImportData();
+	public default void cleanupImportData()
+	{
+		// no-op by default. To be overridden by implementations that register gc state in prepareImportData().
+	}
 
 	/**
 	 * Exports every entity of the passed type owned by this channel into the passed file.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -516,8 +516,14 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 
 			/*
 			 * Quiesce this channel's own already-flagged sweep, if any (see method javadoc).
-			 * The sweep aborts (returns false) while the application's object registry is briefly
-			 * locked; retrying mirrors the housekeeping behavior across its slices.
+			 * Deliberately NOT gated on the gc-enabled switch: a flagged sweep belongs to a cycle
+			 * that was initiated while gc was enabled, and its marking decision predates the
+			 * import. Leaving it pending (e.g. because the switch is currently off) would let it
+			 * execute AFTER the import commit once gc is re-enabled, deleting pre-existing white
+			 * entities the committed import durably references - the exact defect this
+			 * coordination exists to prevent. Unlike the store path, imported data has no
+			 * in-memory graph, so the sweep-time application-registry safety net cannot be relied
+			 * on to rescue the referents.
 			 * Once quiesced, no sweep can be flagged again until the import task's cleanUp: sweep
 			 * initiation is blocked by the pending store update signaled above (and by those of the
 			 * sibling channels, which quiesce likewise before the task's commit barrier), and an
@@ -525,15 +531,26 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			 * thread, which processes the import task. Hence #markEntityForChangedData takes the
 			 * gray-enqueue path for all imported entities, guaranteeing their references are
 			 * traversed before the next sweep decides what to delete.
-			 * With gc disabled (debug/test switch), no sweep can execute at all, so a still-flagged
-			 * sweep is left pending and the commit falls back to the plain pending-sweep handling
-			 * (black-marking, see #markEntityForChangedData and #registerImportCommit).
+			 * The sweep declines (returns false) while the application's object registry cannot be
+			 * processed right now (the default embedded implementation never declines, custom
+			 * LiveObjectIdsHandler implementations may); retrying mirrors the housekeeping
+			 * behavior across its slices. An interrupt of the channel thread aborts the retry loop
+			 * (and thereby fails the import task; the gc signal above is released by the task's
+			 * cleanUp), so a persistently declining handler cannot block shutdown indefinitely.
 			 */
-			while(gcEnabled && this.markMonitor.isPendingSweep(this))
+			while(this.markMonitor.isPendingSweep(this))
 			{
 				if(!this.sweep())
 				{
-					// sweep aborted due to a busy object registry. Yield and retry.
+					if(Thread.currentThread().isInterrupted())
+					{
+						throw new StorageException(
+							"Channel #" + this.channelIndex
+							+ " interrupted while quiescing a pending garbage collection sweep for a data import."
+						);
+					}
+
+					// sweep declined due to a busy object registry. Yield and retry.
 					Thread.yield();
 				}
 			}
@@ -555,11 +572,11 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				 * gc completion state between import preparation and commit. Mirrors the equivalent
 				 * re-reset in #postStorePutEntities.
 				 * Also (re-)read the pending sweep state for #markEntityForChangedData. After the
-				 * quiesce it can only be true with gc disabled (see #registerPendingImportUpdate).
-				 * The state read here is stable for the duration of the import commit: sweep
-				 * initiation is blocked by the import's pending store update, and an already flagged
-				 * sweep for this channel can only be executed by this channel's own thread, which is
-				 * busy processing the import task.
+				 * unconditional quiesce it is always false (defensive re-read nonetheless): sweep
+				 * initiation is blocked by the import's pending store update held since the
+				 * preparation, and an already flagged sweep for this channel can only be executed
+				 * by this channel's own thread, which is busy processing the import task. The state
+				 * read here is stable for the duration of the import commit for the same reasons.
 				 */
 				this.markMonitor.resetCompletion();
 				this.hasUpdatePendingSweep = this.markMonitor.isPendingSweep(this);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -558,6 +558,8 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 					}
 					catch(final InterruptedException e)
 					{
+						// restore the flag so the channel thread's outer logic still sees the interrupt
+						Thread.currentThread().interrupt();
 						throw new StorageException(
 							"Channel #" + this.channelIndex
 							+ " interrupted while quiescing a pending garbage collection sweep for a data import.",

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -70,8 +70,16 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 	implements StorageEntityCache<StorageEntity.Default>, Unpersistable
 	{
 		private final static Logger logger = Logging.getLogger(StorageEntityCache.class);
-		
-		
+
+		/**
+		 * Backoff between retries of a sweep declined by a busy object registry while quiescing
+		 * for a data import (see {@link #registerPendingImportUpdate()}). Long enough to not
+		 * busy-spin a core under sustained registry contention, short enough to add no relevant
+		 * import latency (the default embedded registry implementation never declines).
+		 */
+		private static final long SWEEP_QUIESCE_RETRY_BACKOFF_MS = 1L;
+
+
 		private static boolean gcEnabled = true;
 				
 		public static void setGarbageCollectionEnabled(final boolean enabled)
@@ -533,8 +541,9 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			 * traversed before the next sweep decides what to delete.
 			 * The sweep declines (returns false) while the application's object registry cannot be
 			 * processed right now (the default embedded implementation never declines, custom
-			 * LiveObjectIdsHandler implementations may); retrying mirrors the housekeeping
-			 * behavior across its slices. An interrupt of the channel thread aborts the retry loop
+			 * LiveObjectIdsHandler implementations may); backing off briefly and retrying mirrors
+			 * the housekeeping behavior across its slices without busy-spinning a core under
+			 * sustained contention. An interrupt of the channel thread aborts the retry loop
 			 * (and thereby fails the import task; the gc signal above is released by the task's
 			 * cleanUp), so a persistently declining handler cannot block shutdown indefinitely.
 			 */
@@ -542,16 +551,19 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			{
 				if(!this.sweep())
 				{
-					if(Thread.currentThread().isInterrupted())
+					// sweep declined due to a busy object registry. Back off briefly and retry.
+					try
+					{
+						Thread.sleep(SWEEP_QUIESCE_RETRY_BACKOFF_MS);
+					}
+					catch(final InterruptedException e)
 					{
 						throw new StorageException(
 							"Channel #" + this.channelIndex
-							+ " interrupted while quiescing a pending garbage collection sweep for a data import."
+							+ " interrupted while quiescing a pending garbage collection sweep for a data import.",
+							e
 						);
 					}
-
-					// sweep declined due to a busy object registry. Yield and retry.
-					Thread.yield();
 				}
 			}
 		}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -483,6 +483,95 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			this.markMonitor.clearPendingLoad(this);
 		}
 
+		/**
+		 * Import counterpart to {@link #registerPendingStoreUpdate()}, called once per channel at the
+		 * very start of an import task's processing phase (see StorageChannel#prepareImportData) and
+		 * held until the task's ultimate cleanUp (see {@link #clearPendingImportUpdate()}). Signaling
+		 * in the processing phase (before the task's commit barrier) instead of at commit time closes
+		 * the per-channel signal gaps: no channel can return to housekeeping and initiate a new sweep
+		 * while any sibling channel has not yet registered its imported entities.
+		 * <p>
+		 * Additionally, a sweep that was already flagged for this channel when the import task started
+		 * is quiesced (executed) here, BEFORE any import data is copied or registered. Such a sweep
+		 * executes a marking decision that predates the import; letting it execute after the import
+		 * commit would delete pre-existing entities that the committed import durably references,
+		 * leaving dangling references on disk. Executing it here gives the import happens-before
+		 * semantics: it behaves as if it arrived after any sweep cycle that was already initiated when
+		 * the task started. An import record referencing an entity thereby condemned consequently
+		 * yields the same result as importing any stale reference: consistent deletion before the
+		 * import and zombie-OID diagnostics from the next mark phase, never a partial rescue.
+		 */
+		final void registerPendingImportUpdate()
+		{
+			synchronized(this.markMonitor)
+			{
+				/*
+				 * Signal first (mirrors the store path): as long as any channel's pending store
+				 * update is signaled, no new sweep can be initiated, and re-arm the gc completion
+				 * state since the import introduces new data.
+				 */
+				this.markMonitor.signalPendingStoreUpdate(this);
+				this.markMonitor.resetCompletion();
+			}
+
+			/*
+			 * Quiesce this channel's own already-flagged sweep, if any (see method javadoc).
+			 * The sweep aborts (returns false) while the application's object registry is briefly
+			 * locked; retrying mirrors the housekeeping behavior across its slices.
+			 * Once quiesced, no sweep can be flagged again until the import task's cleanUp: sweep
+			 * initiation is blocked by the pending store update signaled above (and by those of the
+			 * sibling channels, which quiesce likewise before the task's commit barrier), and an
+			 * already flagged sweep for this channel can only be executed by this channel's own
+			 * thread, which processes the import task. Hence #markEntityForChangedData takes the
+			 * gray-enqueue path for all imported entities, guaranteeing their references are
+			 * traversed before the next sweep decides what to delete.
+			 * With gc disabled (debug/test switch), no sweep can execute at all, so a still-flagged
+			 * sweep is left pending and the commit falls back to the plain pending-sweep handling
+			 * (black-marking, see #markEntityForChangedData and #registerImportCommit).
+			 */
+			while(gcEnabled && this.markMonitor.isPendingSweep(this))
+			{
+				if(!this.sweep())
+				{
+					// sweep aborted due to a busy object registry. Yield and retry.
+					Thread.yield();
+				}
+			}
+		}
+
+		/**
+		 * Commit-time counterpart to {@link #registerPendingImportUpdate()}, called once per channel
+		 * at the start of the import commit (see StorageFileManager#commitImport), before the imported
+		 * entities are registered via {@link #putEntity(long, StorageEntityType.Default)} and
+		 * {@link #markEntityForChangedData(StorageEntity.Default)}.
+		 */
+		final void registerImportCommit()
+		{
+			synchronized(this.markMonitor)
+			{
+				/*
+				 * Reset the completion state again at commit time: a sweep quiesced in
+				 * #registerPendingImportUpdate (of this or a sibling channel) may have advanced the
+				 * gc completion state between import preparation and commit. Mirrors the equivalent
+				 * re-reset in #postStorePutEntities.
+				 * Also (re-)read the pending sweep state for #markEntityForChangedData. After the
+				 * quiesce it can only be true with gc disabled (see #registerPendingImportUpdate).
+				 * The state read here is stable for the duration of the import commit: sweep
+				 * initiation is blocked by the import's pending store update, and an already flagged
+				 * sweep for this channel can only be executed by this channel's own thread, which is
+				 * busy processing the import task.
+				 */
+				this.markMonitor.resetCompletion();
+				this.hasUpdatePendingSweep = this.markMonitor.isPendingSweep(this);
+			}
+		}
+
+		final void clearPendingImportUpdate()
+		{
+			// (see clearPendingStoreUpdate) potentially gets called after reset(), so it must be accordingly robust.
+			this.clearPendingStoreUpdate();
+		}
+
 		final long queryRootObjectId()
 		{
 			this.rootOidSelector.reset();
@@ -705,7 +794,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		 * by the GC and should actually not be necessary, however as the effort to do it at this point is rather minimal, it's done
 		 * nonetheless.
 		 */
-		private void markEntityForChangedData(final StorageEntity.Default entry)
+		final void markEntityForChangedData(final StorageEntity.Default entry)
 		{
 			/*
 			 * (01.08.2016 TM)NOTE:

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -2203,6 +2203,18 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			final long oldTotalLength = this.headFile.totalLength();
 			      long loopFileLength = oldTotalLength;
 
+			/*
+			 * GC coordination, mirroring the store path (see StorageEntityCache#postStorePutEntities):
+			 * without it, an import committed during an active GC cycle registers entities whose
+			 * references are never traversed (no gray enqueuing) and does not block the imminent
+			 * sweep - a pre-existing entity referenced only by imported data can then be swept,
+			 * leaving a dangling reference on disk ("No entity found for objectId" on load).
+			 * The task-scoped signal bracket (held from prepareImportData until the task's cleanUp,
+			 * see StorageEntityCache#registerPendingImportUpdate) guarantees that no sweep is
+			 * flagged or can be initiated while the entities register here.
+			 */
+			entityCache.registerImportCommit();
+
 			// (05.01.2015 TM)TODO: batch copying must ensure that entity position limit of 2 GB is not exceeded
 			for(final StorageChannelImportBatch batch : this.importHelper.importBatches)
 			{
@@ -2212,6 +2224,12 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 					final StorageEntity.Default actual = entityCache.putEntity(entity.objectId(), entity.type());
 					actual.updateStorageInformation(entity.length(), X.checkArrayRange(loopFileLength));
 					headFile.appendEntry(actual);
+
+					// gc-protect the imported entity and enqueue it for reference traversal,
+					// exactly like stored/changed data (file position is set above, so the
+					// mark phase can load its reference data).
+					entityCache.markEntityForChangedData(actual);
+
 					loopFileLength += entity.length();
 				}
 			}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -2204,13 +2204,13 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			      long loopFileLength = oldTotalLength;
 
 			/*
-			 * GC coordination, mirroring the store path (see StorageEntityCache#postStorePutEntities):
+			 * GC coordination, mirroring the store path (see StorageEntityCache.Default#postStorePutEntities):
 			 * without it, an import committed during an active GC cycle registers entities whose
 			 * references are never traversed (no gray enqueuing) and does not block the imminent
 			 * sweep - a pre-existing entity referenced only by imported data can then be swept,
 			 * leaving a dangling reference on disk ("No entity found for objectId" on load).
 			 * The task-scoped signal bracket (held from prepareImportData until the task's cleanUp,
-			 * see StorageEntityCache#registerPendingImportUpdate) guarantees that no sweep is
+			 * see StorageEntityCache.Default#registerPendingImportUpdate) guarantees that no sweep is
 			 * flagged or can be initiated while the entities register here.
 			 */
 			entityCache.registerImportCommit();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -2215,8 +2215,11 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			 */
 			entityCache.registerImportCommit();
 
+			// kept alive across cleanupImportHelper for the post-durability marking pass below
+			final BulkList<StorageChannelImportBatch> importBatches = this.importHelper.importBatches;
+
 			// (05.01.2015 TM)TODO: batch copying must ensure that entity position limit of 2 GB is not exceeded
-			for(final StorageChannelImportBatch batch : this.importHelper.importBatches)
+			for(final StorageChannelImportBatch batch : importBatches)
 			{
 				// register each entity in the batch (possibly just one)
 				for(StorageChannelImportEntity entity = batch.first(); entity != null; entity = entity.next())
@@ -2224,12 +2227,6 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 					final StorageEntity.Default actual = entityCache.putEntity(entity.objectId(), entity.type());
 					actual.updateStorageInformation(entity.length(), X.checkArrayRange(loopFileLength));
 					headFile.appendEntry(actual);
-
-					// gc-protect the imported entity and enqueue it for reference traversal,
-					// exactly like stored/changed data (file position is set above, so the
-					// mark phase can load its reference data).
-					entityCache.markEntityForChangedData(actual);
-
 					loopFileLength += entity.length();
 				}
 			}
@@ -2252,6 +2249,26 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				taskTimestamp          ,
 				loopFileLength + metaLength
 			);
+
+			/*
+			 * GC marking pass, deliberately AFTER the import became fully durable (transactions
+			 * entry written): gc-protect each imported entity and enqueue it for reference
+			 * traversal, exactly like stored/changed data (file positions were set in the
+			 * registration loop above, so the mark phase can load the reference data). If any
+			 * step above throws, no marks exist yet and the partially registered entities remain
+			 * white, exactly as before this coordination existed - the GC never actively
+			 * traverses a commit that did not complete. No sweep can interleave between
+			 * registration and this pass: the import's gc signal is held until the task's
+			 * cleanUp. The entities are guaranteed to still be registered here for the same
+			 * reason.
+			 */
+			for(final StorageChannelImportBatch batch : importBatches)
+			{
+				for(StorageChannelImportEntity entity = batch.first(); entity != null; entity = entity.next())
+				{
+					entityCache.markEntityForChangedData(entityCache.getEntry(entity.objectId()));
+				}
+			}
 		}
 
 		/**

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
@@ -315,11 +315,15 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 		{
 			/*
 			 * signal the channel to prepare for the import
-			 * (validate type dictionary, keep current head file and create a new one)
+			 * (register the import with the gc, keep current head file and create a new one).
+			 * Deliberately called outside the entityCaches lock: the preparation may quiesce a
+			 * pending gc sweep (see StorageEntityCache#registerPendingImportUpdate), which must
+			 * not be serialized across channels by the shared array's monitor.
 			 */
+			final StorageEntityCache.Default entityCache = channel.prepareImportData();
 			synchronized(this.entityCaches)
 			{
-				this.entityCaches[channel.channelIndex()] = channel.prepareImportData();
+				this.entityCaches[channel.channelIndex()] = entityCache;
 			}
 
 			/*
@@ -400,6 +404,18 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 			// on failure/abort, signal channel to rollback (delete newly created files and revert to last head file)
 			this.cleanUpResources();
 			channel.rollbackImportData(this.problemForChannel(channel));
+		}
+
+		@Override
+		protected final void cleanUp(final StorageChannel channel)
+		{
+			/*
+			 * Ultimate cleanup, no matter the task outcome (committed, rolled back, aborted):
+			 * release the gc coordination signal acquired in StorageChannel#prepareImportData,
+			 * allowing sweeps to be initiated again. Idempotent and robust if the preparation
+			 * never ran or failed halfway.
+			 */
+			channel.cleanupImportData();
 		}
 
 		private void cleanUpResources()

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
@@ -317,7 +317,7 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 			 * signal the channel to prepare for the import
 			 * (register the import with the gc, keep current head file and create a new one).
 			 * Deliberately called outside the entityCaches lock: the preparation may quiesce a
-			 * pending gc sweep (see StorageEntityCache#registerPendingImportUpdate), which must
+			 * pending gc sweep (see StorageEntityCache.Default#registerPendingImportUpdate), which must
 			 * not be serialized across channels by the shared array's monitor.
 			 */
 			final StorageEntityCache.Default entityCache = channel.prepareImportData();


### PR DESCRIPTION
## Summary

A data import (`StorageConnection.importFiles` / `importData`) that lands while a storage GC cycle
is active can cause the GC to delete pre-existing entities that the just-imported data durably
references. The corruption is silent at import time; after a restart the storage fails to load —
in the worst case it does not start at all, because root-graph loading is eager
(`StorageExceptionConsistency: No entity found for objectId <N>`). See #80 for the full analysis.

The root cause is that the import commit path had none of the GC coordination the store path has:
`StorageFileManager.commitImport` registered imported entities via bare `putEntity` — no sweep
blocking, no GC-cycle reset, no reference-traversal enqueuing.

This PR coordinates imports with the GC using the same building blocks as the store path, plus one
import-specific measure ("sweep quiescing") for GC cycles that are already in flight when the
import task starts. The mark monitor itself is unchanged.

## Semantic contract

> **An import behaves as if it happened after any sweep cycle that was already initiated when the
> import task started.**

Two scenarios follow from this, distinguished by *when* the GC decided about a pre-existing entity
referenced by the imported data:

1. **Referent not yet condemned** (mark phase not complete, or the entity is still registered in
   the application's object registry): the import keeps it alive. Imported entities are
   gc-protected and enqueued for reference traversal exactly like stored data, so everything
   reachable through the imported data is marked before any sweep decides what to delete. This
   covers the reported bug (mid-mark window) and application-live referents.
2. **Referent already condemned** (a completed mark phase found it unreachable and unregistered,
   only the sweep's execution was still outstanding): the import re-attaches data the GC has
   *correctly* decided is garbage. Such data is **not** rescued — deliberately. The result is the
   same, consistent and deterministic, as importing a record that references a long-deleted
   objectId: the condemned subgraph is deleted *together and before* the import registers
   anything, and the next mark phase reports loud zombie-objectId warnings for the stale
   references. Rescue is provably not implementable here: sparing the directly referenced entity
   only moves the dangling edge one level deeper (its children were condemned by the same
   completed marking), the transitive closure cannot be computed at commit time (entity records
   are channel-owned), and cancelling an in-flight sweep corrupts the mark state in both
   directions. A consistent, loudly-diagnosed deletion is strictly better than a half-rescued
   graph — an import arriving one second later would produce the identical result.

## How it works

- **Task-scoped GC signal bracket.** Every channel registers a pending store update (blocking new
  sweep initiation) at the very start of the import task's processing phase
  (`StorageChannel.prepareImportData()`) and releases it only in the task's ultimate `cleanUp`,
  after commit or rollback. Because the task's commit barrier guarantees all channels have
  registered before the first commit, no channel can initiate a fresh sweep anywhere in the
  cluster while any channel still has unregistered imported entities (this also closes the
  empty-batch-channel gap, where a per-commit bracket would open and close in microseconds).
- **Sweep quiescing.** A sweep that was already flagged for a channel when the task started
  executes a marking decision that predates the import — blocking only *new* sweeps cannot stop
  it. Each channel therefore executes ("quiesces") its own flagged sweep at processing start,
  before any import data is copied or registered. The quiesce is deliberately not gated on the
  GC-enabled debug switch (a flagged sweep belongs to a cycle initiated while GC was enabled;
  leaving it pending would let it run after the commit once GC is re-enabled), and the retry loop
  (the object registry may decline a sweep) is interruptible — an interrupt fails the import
  cleanly instead of hanging shutdown.
- **Gray-enqueue at commit, after durability.** `commitImport` re-arms the GC completion state and
  passes every imported entity through `markEntityForChangedData`, exactly like stored data —
  since quiescing guarantees no sweep is pending, imported entities always take the gray-enqueue
  path and their references are traversed before the next sweep. The marking pass runs only after
  the transaction-log entry was written: a commit that fails half-way leaves no GC marks behind,
  so the GC never actively traverses a commit that did not complete.

## Changes

- `StorageEntityCache`: new `registerPendingImportUpdate()` (signal + completion reset + quiesce
  loop), `registerImportCommit()` (commit-time completion re-reset, mirroring
  `postStorePutEntities`), `clearPendingImportUpdate()`; `markEntityForChangedData` widened from
  `private` to package-visible.
- `StorageChannel`: `prepareImportData()` performs the GC registration before switching the file
  manager into import mode; new interface method `cleanupImportData()` releases it.
- `StorageRequestTaskImportData`: `prepareImportData()` is called outside the shared
  `entityCaches` lock (a quiesce must not serialize the channels); new task-level `cleanUp`
  override releases the GC signal on every outcome (commit, rollback, abort).
- `StorageFileManager.commitImport`: GC state sync before the registration loop; post-durability
  marking pass over the imported batches.

No changes to `StorageEntityMarkMonitor`, no new configuration, no observable API change apart
from the added `StorageChannel.cleanupImportData()` (implemented by the single existing
implementation).