### PR TITLE
Add store-time reference validation to detect dangling references

### DIFF
--- a/docs/modules/storage/pages/configuration/properties.adoc
+++ b/docs/modules/storage/pages/configuration/properties.adoc
@@ -121,6 +121,10 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 |xref:#transaction-file-maximum-size[transaction-file-maximum-size]
 |Maximum file size for each channels transactions log file. If this limit is exceeded the file wile be cleaned up during housekeeping. Default is 100 MiB. Maximum value is 1 GiB.
 |xref:#type-bytes[Bytes]
+
+|reference-validation
+|Store-time validation of references whose target entities are not part of the store itself (`off`, `log` or `fail`). With `log` (the default), a store referencing a non-existing entity (dangling reference) is logged as an error but proceeds; with `fail` such a store is rejected atomically; `off` disables the validation entirely (zero overhead). See xref:../data-integrity.adoc[Data Integrity] for the failure mode this guards against.
+|xref:#type-string[String]
 |===
 
 == Property Types
@@ -330,4 +334,7 @@ This list shows which property configures which type, used by the foundation typ
 
 | transaction-file-maximum-size
 | `StorageDataFileEvaluator`
+
+| reference-validation
+| `StorageReferenceValidationPolicy`
 |===

--- a/docs/modules/storage/pages/data-integrity.adoc
+++ b/docs/modules/storage/pages/data-integrity.adoc
@@ -1,4 +1,6 @@
-= Data Integrity (Chunk Checksums)
+= Data Integrity
+
+{product-name} offers two independent data-integrity safeguards: per-chunk *checksums* that detect corruption of persisted bytes (this page, below), and store-time *reference validation* that detects dangling references before they are committed (see <<_reference_validation_dangling_references>>).
 
 {product-name} can protect the data in its storage files with per-chunk integrity checksums.
 Each time a batch of data (a "chunk") is written, a checksum covering those bytes is stored alongside it.
@@ -294,6 +296,44 @@ Chunk checksums are designed to detect accidental or partial corruption of persi
 If verification finds a corrupted chunk under a `FAIL` reaction, the start aborts with a `StorageExceptionChunkChecksumMismatch`, which reports the affected file, the chunk position and the expected versus actual hash. (The on-demand integrity check never throws; it collects anomalies into its result instead — see <<_on_demand_integrity_verification>>.)
 
 Off-line repair tooling that writes into a checksum-protected storage but cannot produce a compliant covered file (for example, configured with a mismatching algorithm) fails loudly with a `StorageExceptionChunkChecksumUnavailable` rather than silently appending unprotected data.
+
+== Reference Validation (Dangling References)
+
+Independent of chunk checksums, {product-name} can validate at *store time* that every reference a store writes actually points to an existing entity.
+
+A store's data may contain references to object ids whose entities are not part of the store itself: the storer found the referenced instance in its object registry (or an unloaded `Lazy` reference carries a cached id) and trusts that its data already exists in the storage.
+That trust can be wrong — most commonly when the storage-level garbage collector reclaimed the entity after its last persisted reference was removed, while the Java instance survived in application memory and was later re-attached to the graph.
+Without validation, such a store silently persists a *dangling reference* that only surfaces after a later restart as:
+
+----
+StorageExceptionConsistency: No entity found for objectId N
+----
+
+With validation enabled, the trusted reference ids travel with the store to the storage engine, and each channel checks them against its entity registry *inside the store task, before the data is written* — atomically with the store, so the check cannot be raced by garbage collection.
+
+The behavior is controlled by the `reference-validation` configuration property (see xref:configuration/properties.adoc[Properties]) or `StorageConfiguration.Builder#setReferenceValidationPolicy`:
+
+[cols="1,3"]
+|===
+| Mode | Effect
+
+| `log` (default)
+| Detected dangling references are logged as an error (and reported to the `StorageEventLogger` via `logStoreDetectedDanglingReferences`), but the store proceeds.
+
+| `fail`
+| A store containing dangling references is rejected atomically with a `StorageExceptionConsistencyDanglingReference` naming the missing object ids; nothing of the store is committed and the storage remains fully usable.
+
+| `off`
+| The ids are not collected at all — zero overhead, pre-feature behavior.
+|===
+
+[NOTE]
+====
+At the calling code, the rejection surfaces wrapped: the thrown exception is a `PersistenceExceptionTransfer` whose cause chain contains the `StorageExceptionConsistencyDanglingReference`.
+====
+
+To recover from a rejected store, make the missing entities exist again and retry: include the referenced instances explicitly in the same store (e.g. `storer.storeAll(parent, child)`) or store them with an eager storer first.
+References registered via `Storer#skip` variants are an explicit user assertion and are not validated.
 
 == Limitations
 

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/BatchStorerDanglingReferenceTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/BatchStorerDanglingReferenceTest.java
@@ -1,0 +1,135 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import org.eclipse.serializer.persistence.types.BatchStorer;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Smoke test: the batching storer inherits the trusted-id capture and commit-time transport from
+ * the default storer, so a batch flush containing a dangling reference must be rejected the same
+ * way an ordinary store is.
+ */
+public class BatchStorerDanglingReferenceTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void batchFlushWithDanglingReferenceIsRejected() throws Exception
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+
+		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 40;
+		final Child child   = new Child("never stored");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, child);
+
+		// use a controller that never flushes on its own, so the explicit flush below is the
+		// only commit and the rejection surfaces deterministically on this thread.
+		final BatchStorer storer = this.storage.createBatchStorer(
+			(pendingObjectCount, msSinceFirstPending) -> false,
+			Duration.ofHours(1)
+		);
+		try
+		{
+			storer.store(new Parent(child));
+
+			final RuntimeException thrown = assertThrows(RuntimeException.class, storer::flush);
+			assertNotNull(
+				DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class),
+				"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+			);
+		}
+		finally
+		{
+			try
+			{
+				storer.close();
+			}
+			catch(final Exception ignored)
+			{
+				// the close-time final flush of the still-pending dangling data may fail again
+			}
+		}
+
+		// the storage itself must remain usable.
+		assertDoesNotThrow(() -> this.storage.store(new Child("independent data")));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child child;
+
+		public Parent(final Child child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/DanglingRefTestUtil.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/DanglingRefTestUtil.java
@@ -1,0 +1,68 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared helpers for the dangling-reference validation tests.
+ */
+final class DanglingRefTestUtil
+{
+	/**
+	 * A fabricated object id safely inside the OID range (which starts at one quintillion + 1)
+	 * but far above anything a small test storage will ever assign.
+	 */
+	static final long FAKE_OID_BASE = 1_000_000_000_900_000_000L;
+
+	/**
+	 * Walks the cause chain (including suppressed exceptions) for a throwable of the given type.
+	 */
+	static <T extends Throwable> T findInCauseChain(final Throwable root, final Class<T> type)
+	{
+		final List<Throwable> queue = new ArrayList<>();
+		queue.add(root);
+		for(int i = 0; i < queue.size(); i++)
+		{
+			final Throwable current = queue.get(i);
+			if(current == null)
+			{
+				continue;
+			}
+			if(type.isInstance(current))
+			{
+				return type.cast(current);
+			}
+			if(current.getCause() != null && !queue.contains(current.getCause()))
+			{
+				queue.add(current.getCause());
+			}
+			for(final Throwable suppressed : current.getSuppressed())
+			{
+				if(!queue.contains(suppressed))
+				{
+					queue.add(suppressed);
+				}
+			}
+		}
+		return null;
+	}
+
+	private DanglingRefTestUtil()
+	{
+		throw new UnsupportedOperationException();
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/GigaMapDanglingReferenceTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/GigaMapDanglingReferenceTest.java
@@ -1,0 +1,133 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Dangling-reference validation through the GigaMap store path.
+ * <p>
+ * {@code BinaryHandlerGigaLevel1} stores its entity array via {@code storeReferences}, i.e. the
+ * lazy {@code apply} path that skips registry-known instances. An entity whose object id is in the
+ * registry but whose entity data does not exist in the storage would therefore be persisted as a
+ * dangling reference inside a segment. Fail-mode validation must reject the {@code gigaMap.store()}.
+ */
+public class GigaMapDanglingReferenceTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void gigaMapStoreWithDanglingEntityReferenceIsRejected()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+
+		final GigaMap<Entity> gigaMap = this.storage.ensureRoot(GigaMap::New);
+		gigaMap.add(new Entity("regular"));
+		assertDoesNotThrow(() ->
+		{
+			gigaMap.store();
+		}, "a regular GigaMap store must pass validation");
+
+		// plant a never-stored entity in the registry under a fabricated object id, then
+		// add it to the map: the segment handler's lazy apply will skip storing it.
+		final long   fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 30;
+		final Entity ghost   = new Entity("ghost");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, ghost);
+
+		gigaMap.add(ghost);
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() ->
+			{
+				gigaMap.store();
+			},
+			"storing a GigaMap segment referencing a non-existing entity must be rejected"
+		);
+		final StorageExceptionConsistencyDanglingReference danglingReference =
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class);
+		assertNotNull(
+			danglingReference,
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+		assertArrayEquals(new long[]{fakeOid}, danglingReference.missingObjectIds());
+
+		// restart: the rejected store must not have persisted anything of the ghost entity.
+		this.storage.shutdown();
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		@SuppressWarnings("unchecked")
+		final GigaMap<Entity> reloaded = (GigaMap<Entity>)this.storage.root();
+		assertNotNull(reloaded);
+		assertEquals(1L, reloaded.size(), "only the regular entity may have been persisted");
+		assertEquals("regular", reloaded.get(0L).data);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Entity
+	{
+		public String data;
+
+		public Entity(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/LazyDanglingReferenceTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/LazyDanglingReferenceTest.java
@@ -1,0 +1,138 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Dangling-reference validation for the {@code Lazy} cached-id path.
+ * <p>
+ * When an unloaded {@code Lazy} reference is stored, its handler writes the cached object id
+ * directly ({@code BinaryHandlerLazyDefault} case 3) — without consulting the object registry or
+ * storing a referent. If that cached id points to a non-existing entity (e.g. left over from a
+ * failed commit whose {@code $link} was never rolled back, or crash artifacts), the store would
+ * silently persist a dangling reference. This test builds such a stale {@code Lazy} the same way
+ * the framework's own handler constructs unloaded ones (subject {@code null}, cached id, the
+ * storage's loader) and asserts that fail-mode validation rejects the store.
+ */
+public class LazyDanglingReferenceTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void staleLazyCachedIdIsDetectedInFailMode() throws Exception
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+
+		// store a real Lazy first to obtain the storage's loader, the same instance
+		// BinaryHandlerLazyDefault links into every Lazy it stores or loads.
+		final Holder realHolder = new Holder(Lazy.Reference(new Payload("real")));
+		this.storage.store(realHolder);
+		final ObjectSwizzling loader = ((Lazy.Default<?>)realHolder.lazy).$getLoader();
+		assertNotNull(loader, "storing must have linked the loader into the Lazy");
+
+		// an unloaded Lazy whose cached object id points to a non-existing entity,
+		// constructed exactly like the handler constructs unloaded Lazies on load.
+		final long fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 20;
+		final Constructor<Lazy.Default> constructor =
+			Lazy.Default.class.getDeclaredConstructor(Object.class, long.class, ObjectSwizzling.class);
+		constructor.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		final Lazy<Payload> staleLazy = constructor.newInstance(null, fakeOid, loader);
+
+		final Holder staleHolder = new Holder(staleLazy);
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.store(staleHolder),
+			"storing an unloaded Lazy with a dangling cached id must be rejected"
+		);
+		final StorageExceptionConsistencyDanglingReference danglingReference =
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class);
+		assertNotNull(
+			danglingReference,
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+		assertArrayEquals(new long[]{fakeOid}, danglingReference.missingObjectIds());
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Holder
+	{
+		public Lazy<Payload> lazy;
+
+		public Holder(final Lazy<Payload> lazy)
+		{
+			super();
+			this.lazy = lazy;
+		}
+	}
+
+	public static class Payload
+	{
+		public String data;
+
+		public Payload(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelDanglingReferenceTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelDanglingReferenceTest.java
@@ -1,0 +1,161 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Dangling-reference validation across multiple channels: the trusted object ids are partitioned to
+ * their owning channels by the object id hash, so fabricated ids covering all channels must be
+ * detected wherever they land, and a rejected store must be rolled back on every channel.
+ */
+public class MultiChannelDanglingReferenceTest
+{
+	static final int CHANNEL_COUNT = 4;
+
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void danglingReferencesOnAllChannelsAreDetectedAndRolledBack()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setChannelCountProvider(Storage.ChannelCountProvider(CHANNEL_COUNT))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		// one fabricated id per channel: consecutive ids cover all (oid & 3) residues.
+		final List<Child> children = new ArrayList<>();
+		final long[]      fakeOids = new long[CHANNEL_COUNT];
+		for(int i = 0; i < CHANNEL_COUNT; i++)
+		{
+			final Child child = new Child("never stored #" + i);
+			fakeOids[i] = DanglingRefTestUtil.FAKE_OID_BASE + i;
+			registry.registerObject(fakeOids[i], child);
+			children.add(child);
+		}
+
+		final Parent parent = new Parent(children);
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.store(parent)
+		);
+		final StorageExceptionConsistencyDanglingReference danglingReference =
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class);
+		assertNotNull(
+			danglingReference,
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+		assertTrue(
+			danglingReference.missingObjectIds().length >= 1,
+			"the detecting channel must report at least one missing object id"
+		);
+		for(final long missing : danglingReference.missingObjectIds())
+		{
+			boolean known = false;
+			for(final long fakeOid : fakeOids)
+			{
+				known |= missing == fakeOid;
+			}
+			assertTrue(known, "reported id " + missing + " is not one of the fabricated ids");
+		}
+
+		// the whole store must have been rolled back on every channel: a restart loads cleanly
+		// and no partial data of the rejected store survives.
+		assertDoesNotThrow(() -> this.storage.store(new Child("independent data")));
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setChannelCountProvider(Storage.ChannelCountProvider(CHANNEL_COUNT))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+		assertNull(this.storage.root(), "no root was set; restart must still load cleanly");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public List<Child> children;
+
+		public Parent(final List<Child> children)
+		{
+			super();
+			this.children = children;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/PostFailureRecoveryTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/PostFailureRecoveryTest.java
@@ -1,0 +1,148 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Recovery after a fail-mode rejection. The documented remedy — make the missing entity exist by
+ * storing it together with (or before) the referencing parent — must succeed. In particular,
+ * {@code storer.storeAll(parent, child)} exercises the commit-time prune: the child's registry-known
+ * object id is both referenced and force-stored in the same commit, so it must NOT be reported as a
+ * dangling reference.
+ */
+public class PostFailureRecoveryTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void explicitReStoreOfMissingChildInSameCommitSucceeds()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 10;
+		final Child child   = new Child("lost child");
+		registry.registerObject(fakeOid, child);
+
+		final Parent parent = new Parent(child);
+
+		// 1) the plain lazy store is rejected: child is registry-known but has no entity.
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.store(parent)
+		);
+		assertNotNull(
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class),
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+
+		// 2) the documented remedy: force-store the child in the same commit. The child's entity
+		//    is then part of the store itself, so the prune removes its id from the trusted set.
+		final Storer storer = this.storage.createStorer();
+		storer.storeAll(parent, child);
+		assertDoesNotThrow(storer::commit, "re-storing the missing child in the same commit must succeed");
+
+		// 3) subsequent plain stores referencing the now-existing child must also pass validation.
+		assertDoesNotThrow(() -> this.storage.store(new Parent(child)));
+
+		// 4) restart: the persisted graph is consistent, the child's data is present.
+		this.storage.setRoot(parent);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+		final Parent reloaded = (Parent)this.storage.root();
+		assertNotNull(reloaded);
+		assertNotNull(reloaded.child, "the re-stored child must be loadable after restart");
+		assertEquals("lost child", reloaded.child.data);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child child;
+
+		public Parent(final Child child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/RegistryTrustedSkipValidationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/RegistryTrustedSkipValidationTest.java
@@ -1,0 +1,221 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageEventLogger;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Exercises the store-time validation of registry-trusted reference object ids.
+ * <p>
+ * The lazy storer skips storing an instance whose object id is already known to the global object
+ * registry, trusting that its entity already exists in the storage. These tests plant a never-stored
+ * instance in the registry under a fabricated object id and then store a parent referencing it,
+ * asserting the behavior of all three {@link StorageReferenceValidationPolicy} modes.
+ */
+public class RegistryTrustedSkipValidationTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	private EmbeddedStorageManager startStorage(
+		final StorageReferenceValidationPolicy policy     ,
+		final StorageEventLogger               eventLogger
+	)
+	{
+		return this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(policy)
+					.createConfiguration()
+			)
+			.setEventLogger(eventLogger != null ? eventLogger : StorageEventLogger.Default())
+			.start();
+	}
+
+	@Test
+	void failModeRejectsDanglingReferenceAtomicallyAndStorageStaysUsable()
+	{
+		this.startStorage(StorageReferenceValidationPolicy.FAIL, null);
+
+		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE;
+		final Child child   = new Child("never stored");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, child);
+
+		// the parent also references an enum constant: constant ids (CIDs) must be
+		// filtered from the trusted set, otherwise they would be reported as missing too.
+		final Parent parent = new Parent(child, Color.RED);
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.store(parent),
+			"storing a reference to a never-stored registry-known instance must be rejected"
+		);
+		final StorageExceptionConsistencyDanglingReference danglingReference =
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class);
+		assertNotNull(
+			danglingReference,
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+		assertArrayEquals(
+			new long[]{fakeOid},
+			danglingReference.missingObjectIds(),
+			"exactly the fabricated object id must be reported (in particular no enum CIDs)"
+		);
+
+		// nothing of the rejected store may have been committed and the storage must stay usable.
+		assertDoesNotThrow(() -> this.storage.store(new Child("independent data")));
+
+		this.storage.shutdown();
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		assertDoesNotThrow(() -> this.storage.store(new Child("after restart")));
+	}
+
+	@Test
+	void logModeReportsDanglingReferenceButCommits()
+	{
+		final RecordingEventLogger recorder = new RecordingEventLogger();
+		this.startStorage(StorageReferenceValidationPolicy.LOG, recorder);
+
+		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 1;
+		final Child child   = new Child("never stored");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, child);
+
+		final Parent parent = new Parent(child, Color.GREEN);
+		assertDoesNotThrow(() -> this.storage.store(parent), "log mode must not reject the store");
+
+		assertEquals(1, recorder.reportedObjectIds.size(), "exactly one dangling-reference event expected");
+		assertArrayEquals(new long[]{fakeOid}, recorder.reportedObjectIds.get(0));
+	}
+
+	@Test
+	void offModeIsSilent()
+	{
+		final RecordingEventLogger recorder = new RecordingEventLogger();
+		this.startStorage(StorageReferenceValidationPolicy.OFF, recorder);
+
+		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 2;
+		final Child child   = new Child("never stored");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, child);
+
+		final Parent parent = new Parent(child, Color.BLUE);
+		assertDoesNotThrow(() -> this.storage.store(parent), "off mode must not reject the store");
+
+		assertTrue(recorder.reportedObjectIds.isEmpty(), "off mode must not report anything");
+	}
+
+	@Test
+	void validStoreWithOnlyExistingReferencesPassesFailMode()
+	{
+		this.startStorage(StorageReferenceValidationPolicy.FAIL, null);
+
+		// store the child first, then a parent referencing the now registry-known child:
+		// the trusted id exists in the storage, so validation must pass.
+		final Child child = new Child("properly stored");
+		this.storage.store(child);
+
+		final Parent parent = new Parent(child, Color.RED);
+		assertDoesNotThrow(() -> this.storage.store(parent));
+
+		this.storage.shutdown();
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		assertNull(this.storage.root(), "no root was set; restart must still load cleanly");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public enum Color
+	{
+		RED, GREEN, BLUE
+	}
+
+	public static class Parent
+	{
+		public Child child;
+		public Color color;
+
+		public Parent(final Child child, final Color color)
+		{
+			super();
+			this.child = child;
+			this.color = color;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+
+	static final class RecordingEventLogger implements StorageEventLogger
+	{
+		final List<long[]> reportedObjectIds = new ArrayList<>();
+
+		@Override
+		public void logStoreDetectedDanglingReferences(final int channelIndex, final long[] objectIds)
+		{
+			synchronized(this.reportedObjectIds)
+			{
+				this.reportedObjectIds.add(objectIds);
+			}
+		}
+	}
+}

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
@@ -222,6 +222,14 @@ public enum ConfigurationCoreProperties
 	),
 
 	/**
+	 * Store-time validation of trusted reference object ids: off, log or fail. Default log.
+	 */
+	REFERENCE_VALIDATION(
+			Constants.PREFIX + "reference.validation",
+			EmbeddedStorageConfigurationPropertyNames.REFERENCE_VALIDATION
+	),
+
+	/**
 	 * Primary chunk-checksum algorithm: none, crc32c or sha256-chained. Default sha256-chained.
 	 */
 	CHUNK_CHECKSUM_ALGORITHM(

--- a/integrations/cdi4/src/test/java/org/eclipse/store/integrations/cdi/types/ConfigurationCorePropertiesTest.java
+++ b/integrations/cdi4/src/test/java/org/eclipse/store/integrations/cdi/types/ConfigurationCorePropertiesTest.java
@@ -164,6 +164,16 @@ class ConfigurationCorePropertiesTest
 	}
 
 	@Test
+	void shouldMapReferenceValidation()
+	{
+		final String keyMicroProfile = PREFIX + "reference.validation";
+		final Optional<ConfigurationCoreProperties> property = ConfigurationCoreProperties.get(keyMicroProfile);
+		Assertions.assertTrue(property.isPresent());
+		Assertions.assertEquals(ConfigurationCoreProperties.REFERENCE_VALIDATION, property.get());
+		Assertions.assertEquals("reference-validation", property.get().getEclipseStore(keyMicroProfile));
+	}
+
+	@Test
 	void shouldMapChunkChecksumAlgorithm()
 	{
 		final String keyMicroProfile = PREFIX + "chunk.checksum.algorithm";

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -181,6 +181,12 @@ public class EclipseStoreProperties
     private String dataFileCleanupHeadFile;
 
     /**
+     * Store-time validation of trusted reference object ids: {@code off}, {@code log} or {@code fail}.
+     * Default is {@code log}.
+     */
+    private String referenceValidation;
+
+    /**
      * Per-chunk data-integrity checksum configuration. Bound from {@code org.eclipse.store.chunk-checksum.*}.
      */
     @NestedConfigurationProperty
@@ -504,6 +510,16 @@ public class EclipseStoreProperties
     public void setDataFileCleanupHeadFile(final String dataFileCleanupHeadFile)
     {
         this.dataFileCleanupHeadFile = dataFileCleanupHeadFile;
+    }
+
+    public String getReferenceValidation()
+    {
+        return this.referenceValidation;
+    }
+
+    public void setReferenceValidation(final String referenceValidation)
+    {
+        this.referenceValidation = referenceValidation;
     }
 
     public ChunkChecksum getChunkChecksum()

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -82,6 +82,9 @@ public class EclipseStoreConfigConverter
     protected static final String DATA_FILE_MINIMUM_USE_RATIO = EmbeddedStorageConfigurationPropertyNames.DATA_FILE_MINIMUM_USE_RATIO;
     protected static final String DATA_FILE_CLEANUP_HEAD_FILE = EmbeddedStorageConfigurationPropertyNames.DATA_FILE_CLEANUP_HEAD_FILE;
 
+    // Field for the store-time reference validation (data integrity) configuration
+    protected static final String REFERENCE_VALIDATION = EmbeddedStorageConfigurationPropertyNames.REFERENCE_VALIDATION;
+
     // Fields for the chunk-checksum (data integrity) configuration
     protected static final String CHUNK_CHECKSUM_ALGORITHM = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ALGORITHM;
     protected static final String CHUNK_CHECKSUM_PROFILE = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_PROFILE;
@@ -146,6 +149,7 @@ public class EclipseStoreConfigConverter
         configValues.put(DATA_FILE_MAXIMUM_SIZE, properties.getDataFileMaximumSize());
         configValues.put(DATA_FILE_MINIMUM_USE_RATIO, properties.getDataFileMinimumUseRatio());
         configValues.put(DATA_FILE_CLEANUP_HEAD_FILE, properties.getDataFileCleanupHeadFile());
+        configValues.put(REFERENCE_VALIDATION, properties.getReferenceValidation());
 
         if (properties.getChunkChecksum() != null)
         {

--- a/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java
+++ b/integrations/spring-boot3/src/test/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverterTest.java
@@ -111,6 +111,27 @@ class EclipseStoreConfigConverterTest
     }
 
     @Test
+    void testReferenceValidationConversion()
+    {
+        final EclipseStoreProperties properties = new EclipseStoreProperties();
+        properties.setReferenceValidation("fail");
+
+        final Map<String, String> result = this.converter.convertConfigurationToMap(properties);
+
+        assertEquals("fail", result.get(EclipseStoreConfigConverter.REFERENCE_VALIDATION));
+    }
+
+    @Test
+    void testReferenceValidationUnsetIsRemoved()
+    {
+        final EclipseStoreProperties properties = new EclipseStoreProperties();
+
+        final Map<String, String> result = this.converter.convertConfigurationToMap(properties);
+
+        assertNull(result.get(EclipseStoreConfigConverter.REFERENCE_VALIDATION));
+    }
+
+    @Test
     void testChunkChecksumConversion()
     {
         final ChunkChecksum chunkChecksum = new ChunkChecksum();

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
@@ -335,6 +335,15 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 	public EmbeddedStorageConfigurationBuilder setTransactionFileMaximumSize(ByteSize transactionFileMaximumSize);
 
 	/**
+	 * Store-time validation of trusted reference object ids: {@code off}, {@code log} or {@code fail}.
+	 * Default is {@code log}.
+	 *
+	 * @param referenceValidation the policy token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setReferenceValidation(String referenceValidation);
+
+	/**
 	 * The primary chunk-checksum algorithm: {@code none}, {@code crc32c} or
 	 * {@code sha256-chained}. Default is {@code sha256-chained}. Setting any {@code chunk-checksum-*} property
 	 * activates declarative configuration of the feature; leaving them all unset keeps the framework default.
@@ -769,6 +778,14 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 		)
 		{
 			return this.set(TRANSACTION_FILE_MAXIMUM_SIZE, transactionFileMaximumSize.toString());
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setReferenceValidation(
+			final String referenceValidation
+		)
+		{
+			return this.set(REFERENCE_VALIDATION, referenceValidation);
 		}
 
 		@Override

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
@@ -176,6 +176,17 @@ public interface EmbeddedStorageConfigurationPropertyNames
 	public final static String DATA_FILE_CLEANUP_HEAD_FILE   = "data-file-cleanup-head-file";
 
 	/**
+	 * Store-time validation of trusted reference object ids (references written into a store's data
+	 * whose entities are not part of the store itself): {@code off}, {@code log} or {@code fail}.
+	 * Default (unset) is {@code log}: detected dangling references are logged as an error but the
+	 * store proceeds. {@code fail} rejects such a store atomically; {@code off} disables collection
+	 * and validation entirely (zero overhead).
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setReferenceValidation(String)
+	 */
+	public final static String REFERENCE_VALIDATION             = "reference-validation";
+
+	/**
 	 * Primary chunk-checksum algorithm: {@code none}, {@code crc32c} or
 	 * {@code sha256-chained}. When this key is unset but another {@code chunk-checksum-*} key is present,
 	 * the default is {@code sha256-chained}; setting no {@code chunk-checksum-*} key at all keeps the

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -41,6 +41,7 @@ import org.eclipse.store.storage.types.StorageEntityCacheEvaluator;
 import org.eclipse.store.storage.types.StorageFileNameProvider;
 import org.eclipse.store.storage.types.StorageHousekeepingController;
 import org.eclipse.store.storage.types.StorageLiveFileProvider;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 
 
 /**
@@ -151,6 +152,11 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 			{
 				configBuilder.setChunkChecksumProvider(ccp);
 			}
+
+			this.configuration.opt(REFERENCE_VALIDATION)
+				.map(StorageReferenceValidationPolicy::parse)
+				.ifPresent(configBuilder::setReferenceValidationPolicy)
+			;
 
 			foundation.setConfiguration(configBuilder.createConfiguration());
 

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
@@ -402,7 +402,9 @@ extends BinaryPersistenceFoundation<F>
 		{
 			return BinaryStorer.Creator(
 				this.getStorageSystem().channelCountProvider(),
-				this.isByteOrderMismatch()
+				this.isByteOrderMismatch(),
+				// capture is only worthwhile when the storage-side validation is enabled; single config knob.
+				this.getStorageSystem().configuration().referenceValidationPolicy().isValidating()
 			);
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
@@ -16,6 +16,8 @@ package org.eclipse.store.storage.exceptions;
 
 import java.util.Arrays;
 
+import org.eclipse.serializer.util.X;
+
 /**
  * Thrown when a store's data references object ids for which no entity exists in the storage &mdash;
  * dangling references. The referenced instances were trusted to already exist (they were found in the
@@ -50,7 +52,8 @@ public class StorageExceptionConsistencyDanglingReference extends StorageExcepti
 		final long[] missingObjectIds
 	)
 	{
-		super(buildMessage(channelIndex, missingObjectIds));
+		// notNull: fail with a clear location instead of an NPE from message construction.
+		super(buildMessage(channelIndex, X.notNull(missingObjectIds)));
 		this.channelIndex     = channelIndex            ;
 		// defensive copy: the exception state must stay immutable for later logging/inspection.
 		this.missingObjectIds = missingObjectIds.clone();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
@@ -1,0 +1,90 @@
+package org.eclipse.store.storage.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.util.Arrays;
+
+/**
+ * Thrown when a store's data references object ids for which no entity exists in the storage &mdash;
+ * dangling references. The referenced instances were trusted to already exist (they were found in the
+ * global object registry or cached by unloaded {@code Lazy} references), but their entities are gone,
+ * typically because the storage-level garbage collector reclaimed them after the last persisted
+ * reference was removed while the instances survived in application memory.
+ * <p>
+ * The store was rejected atomically; the storage remains fully usable. To resolve, re-store the
+ * referenced objects so their data exists again &mdash; e.g. include them explicitly in the store
+ * ({@code storer.storeAll(parent, child)}) or store them with an eager storer &mdash; and retry.
+ * <p>
+ * Note that at the caller, this exception is wrapped: it appears as the cause of a
+ * {@code PersistenceExceptionTransfer} / {@code StorageException} chain.
+ */
+public class StorageExceptionConsistencyDanglingReference extends StorageExceptionConsistency
+{
+	///////////////////////////////////////////////////////////////////////////
+	// instance fields //
+	////////////////////
+
+	private final int    channelIndex    ;
+	private final long[] missingObjectIds;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public StorageExceptionConsistencyDanglingReference(
+		final int    channelIndex    ,
+		final long[] missingObjectIds
+	)
+	{
+		super(buildMessage(channelIndex, missingObjectIds));
+		this.channelIndex     = channelIndex    ;
+		this.missingObjectIds = missingObjectIds;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+
+	/**
+	 * @return the index of the channel that detected the dangling references.
+	 */
+	public int channelIndex()
+	{
+		return this.channelIndex;
+	}
+
+	/**
+	 * @return the referenced object ids for which no entity exists.
+	 */
+	public long[] missingObjectIds()
+	{
+		return this.missingObjectIds;
+	}
+
+	private static String buildMessage(final int channelIndex, final long[] missingObjectIds)
+	{
+		return "Store rejected: data references " + missingObjectIds.length
+			+ " object id(s) with no existing entity (dangling references) in channel #" + channelIndex
+			+ ": " + Arrays.toString(missingObjectIds)
+			+ ". The referenced instances were trusted to already exist in the storage."
+			+ " Re-store the referenced objects (e.g. with an eager storer) and retry."
+		;
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
@@ -51,8 +51,9 @@ public class StorageExceptionConsistencyDanglingReference extends StorageExcepti
 	)
 	{
 		super(buildMessage(channelIndex, missingObjectIds));
-		this.channelIndex     = channelIndex    ;
-		this.missingObjectIds = missingObjectIds;
+		this.channelIndex     = channelIndex            ;
+		// defensive copy: the exception state must stay immutable for later logging/inspection.
+		this.missingObjectIds = missingObjectIds.clone();
 	}
 
 
@@ -70,11 +71,11 @@ public class StorageExceptionConsistencyDanglingReference extends StorageExcepti
 	}
 
 	/**
-	 * @return the referenced object ids for which no entity exists.
+	 * @return the referenced object ids for which no entity exists (a defensive copy).
 	 */
 	public long[] missingObjectIds()
 	{
-		return this.missingObjectIds;
+		return this.missingObjectIds.clone();
 	}
 
 	private static String buildMessage(final int channelIndex, final long[] missingObjectIds)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -903,6 +903,9 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			final StorageReferenceValidationPolicy policy
 		)
 		{
+			// fail fast on broken wiring; a null policy mid-validation would mask the actual store failure.
+			notNull(policy);
+
 			if(objectIds == null || objectIds.length == 0 || !policy.isValidating())
 			{
 				return;

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -21,6 +21,7 @@ import static org.eclipse.serializer.util.X.notNull;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import org.eclipse.serializer.afs.types.AWritableFile;
@@ -38,6 +39,7 @@ import org.eclipse.serializer.typing.KeyValue;
 import org.eclipse.serializer.util.BufferSizeProviderIncremental;
 import org.eclipse.serializer.util.X;
 import org.eclipse.serializer.util.logging.Logging;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
 import org.eclipse.store.storage.monitoring.StorageChannelHousekeepingMonitor;
 import org.eclipse.store.storage.types.StorageAdjacencyDataExporter.AdjacencyFiles;
 import org.slf4j.Logger;
@@ -120,6 +122,33 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	 * @return a key/value pair of the written buffers and their assigned on-disk storage positions.
 	 */
 	public KeyValue<ByteBuffer[], long[]> storeEntities(long timestamp, Chunk chunkData);
+
+	/**
+	 * Validates that each passed object id resolves to an existing entity in this channel. The ids are a
+	 * store's "trusted references": object ids the storer wrote into the data without storing the
+	 * referenced entity itself, trusting that it already exists.
+	 * <p>
+	 * Depending on the passed policy, missing entities are logged
+	 * ({@link StorageReferenceValidationPolicy#LOG}) or rejected by throwing a
+	 * {@link org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference}
+	 * ({@link StorageReferenceValidationPolicy#FAIL}), which fails the surrounding store task and rolls
+	 * the whole store back atomically.
+	 * <p>
+	 * This check is race-free with respect to the storage garbage collector: GC sweeping for a channel
+	 * runs exclusively on that channel's own thread between tasks, and this method is invoked on the same
+	 * thread inside the store task, before the store commits. An entity found here therefore cannot be
+	 * deleted before the surrounding store is committed.
+	 *
+	 * @param objectIds the trusted reference object ids assigned to this channel; may be {@code null} or empty.
+	 * @param policy    the validation policy to apply.
+	 */
+	public default void validateTrustedReferences(
+		final long[]                           objectIds,
+		final StorageReferenceValidationPolicy policy
+	)
+	{
+		// no-op by default
+	}
 
 	/**
 	 * Reverts the most recent {@link #storeEntities(long, Chunk) store} on this channel, discarding
@@ -866,6 +895,54 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			
 			// set new data flag, even if chunk has no data to account for (potential) data in other channels
 			return X.KeyValue(buffers, this.fileManager.storeChunks(timestamp, buffers));
+		}
+
+		@Override
+		public void validateTrustedReferences(
+			final long[]                           objectIds,
+			final StorageReferenceValidationPolicy policy
+		)
+		{
+			if(objectIds == null || objectIds.length == 0 || !policy.isValidating())
+			{
+				return;
+			}
+
+			long[] missing = null;
+			int    count   = 0;
+			for(final long objectId : objectIds)
+			{
+				if(this.entityCache.getEntry(objectId) == null)
+				{
+					if(missing == null)
+					{
+						missing = new long[objectIds.length];
+					}
+					missing[count++] = objectId;
+				}
+			}
+
+			if(missing == null)
+			{
+				return;
+			}
+
+			final long[] missingObjectIds = count == missing.length
+				? missing
+				: Arrays.copyOf(missing, count)
+			;
+
+			logger.error(
+				"StorageChannel#{} store references non-existing entities (dangling references): {}",
+				this.channelIndex,
+				Arrays.toString(missingObjectIds)
+			);
+			this.eventLogger.logStoreDetectedDanglingReferences(this.channelIndex, missingObjectIds);
+
+			if(policy.isFailing())
+			{
+				throw new StorageExceptionConsistencyDanglingReference(this.channelIndex, missingObjectIds);
+			}
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConfiguration.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConfiguration.java
@@ -107,6 +107,21 @@ public interface StorageConfiguration
 		return StorageChunkChecksumProvider.New();
 	}
 
+	/**
+	 * Returns the {@link StorageReferenceValidationPolicy} governing store-time validation of trusted
+	 * reference object ids (references written into a store's data whose entities are not part of the
+	 * store itself). See {@link StorageReferenceValidationPolicy} for the failure mode this guards against.
+	 * <p>
+	 * Defined as a default method returning {@link StorageReferenceValidationPolicy#LOG} so that
+	 * pre-existing {@link StorageConfiguration} implementations remain source- and binary-compatible.
+	 *
+	 * @return the configured {@link StorageReferenceValidationPolicy}; never {@code null}.
+	 */
+	public default StorageReferenceValidationPolicy referenceValidationPolicy()
+	{
+		return StorageReferenceValidationPolicy.LOG;
+	}
+
 
 	/**
 	 * Pseudo-constructor method to create a new {@link StorageConfiguration} instance
@@ -210,14 +225,53 @@ public interface StorageConfiguration
 		final StorageChunkChecksumProvider  chunkChecksumProvider
 	)
 	{
+		return New(
+			channelCountProvider  ,
+			housekeepingController,
+			fileProvider          ,
+			dataFileEvaluator     ,
+			entityCacheEvaluator  ,
+			backupSetup           ,
+			chunkChecksumProvider ,
+			StorageReferenceValidationPolicy.LOG
+		);
+	}
+
+	/**
+	 * Pseudo-constructor method to create a new {@link StorageConfiguration} instance from the
+	 * passed strategy parts, including an explicit {@link StorageReferenceValidationPolicy}.
+	 *
+	 * @param channelCountProvider      the {@link StorageChannelCountProvider} to use; must be non-{@code null}.
+	 * @param housekeepingController    the {@link StorageHousekeepingController} to use; must be non-{@code null}.
+	 * @param fileProvider              the {@link StorageLiveFileProvider} to use; must be non-{@code null}.
+	 * @param dataFileEvaluator         the {@link StorageDataFileEvaluator} to use; must be non-{@code null}.
+	 * @param entityCacheEvaluator      the {@link StorageEntityCacheEvaluator} to use; must be non-{@code null}.
+	 * @param backupSetup               the {@link StorageBackupSetup} to use, or {@code null} to disable backup.
+	 * @param chunkChecksumProvider     the {@link StorageChunkChecksumProvider} to use; must be non-{@code null}.
+	 * @param referenceValidationPolicy the {@link StorageReferenceValidationPolicy} to use; must be non-{@code null}.
+	 *
+	 * @return a new {@link StorageConfiguration} instance with the passed parts.
+	 */
+	public static StorageConfiguration New(
+		final StorageChannelCountProvider      channelCountProvider     ,
+		final StorageHousekeepingController    housekeepingController   ,
+		final StorageLiveFileProvider          fileProvider             ,
+		final StorageDataFileEvaluator         dataFileEvaluator        ,
+		final StorageEntityCacheEvaluator      entityCacheEvaluator     ,
+		final StorageBackupSetup               backupSetup              ,
+		final StorageChunkChecksumProvider     chunkChecksumProvider    ,
+		final StorageReferenceValidationPolicy referenceValidationPolicy
+	)
+	{
 		return new StorageConfiguration.Default(
-			notNull(channelCountProvider)  ,
-			notNull(housekeepingController),
-			notNull(fileProvider)          ,
-			notNull(dataFileEvaluator)     ,
-			notNull(entityCacheEvaluator)  ,
-			mayNull(backupSetup)           ,
-			notNull(chunkChecksumProvider)
+			notNull(channelCountProvider)     ,
+			notNull(housekeepingController)   ,
+			notNull(fileProvider)             ,
+			notNull(dataFileEvaluator)        ,
+			notNull(entityCacheEvaluator)     ,
+			mayNull(backupSetup)              ,
+			notNull(chunkChecksumProvider)    ,
+			notNull(referenceValidationPolicy)
 		);
 	}
 
@@ -231,13 +285,14 @@ public interface StorageConfiguration
 		// instance fields //
 		////////////////////
 
-		private final StorageChannelCountProvider   channelCountProvider  ;
-		private final StorageHousekeepingController housekeepingController;
-		private final StorageLiveFileProvider           fileProvider          ;
-		private final StorageDataFileEvaluator      dataFileEvaluator     ;
-		private final StorageEntityCacheEvaluator   entityCacheEvaluator  ;
-		private final StorageBackupSetup            backupSetup           ;
-		private final StorageChunkChecksumProvider  chunkChecksumProvider ;
+		private final StorageChannelCountProvider      channelCountProvider     ;
+		private final StorageHousekeepingController    housekeepingController   ;
+		private final StorageLiveFileProvider          fileProvider             ;
+		private final StorageDataFileEvaluator         dataFileEvaluator        ;
+		private final StorageEntityCacheEvaluator      entityCacheEvaluator     ;
+		private final StorageBackupSetup               backupSetup              ;
+		private final StorageChunkChecksumProvider     chunkChecksumProvider    ;
+		private final StorageReferenceValidationPolicy referenceValidationPolicy;
 
 
 
@@ -246,23 +301,25 @@ public interface StorageConfiguration
 		/////////////////
 
 		Default(
-			final StorageChannelCountProvider   channelCountProvider  ,
-			final StorageHousekeepingController housekeepingController,
-			final StorageLiveFileProvider           fileProvider          ,
-			final StorageDataFileEvaluator      dataFileEvaluator     ,
-			final StorageEntityCacheEvaluator   entityCacheEvaluator  ,
-			final StorageBackupSetup            backupSetup           ,
-			final StorageChunkChecksumProvider  chunkChecksumProvider
+			final StorageChannelCountProvider      channelCountProvider     ,
+			final StorageHousekeepingController    housekeepingController   ,
+			final StorageLiveFileProvider          fileProvider             ,
+			final StorageDataFileEvaluator         dataFileEvaluator        ,
+			final StorageEntityCacheEvaluator      entityCacheEvaluator     ,
+			final StorageBackupSetup               backupSetup              ,
+			final StorageChunkChecksumProvider     chunkChecksumProvider    ,
+			final StorageReferenceValidationPolicy referenceValidationPolicy
 		)
 		{
 			super();
-			this.channelCountProvider   = channelCountProvider  ;
-			this.housekeepingController = housekeepingController;
-			this.entityCacheEvaluator   = entityCacheEvaluator  ;
-			this.fileProvider           = fileProvider          ;
-			this.dataFileEvaluator      = dataFileEvaluator     ;
-			this.backupSetup            = backupSetup           ;
-			this.chunkChecksumProvider  = chunkChecksumProvider ;
+			this.channelCountProvider      = channelCountProvider     ;
+			this.housekeepingController    = housekeepingController   ;
+			this.entityCacheEvaluator      = entityCacheEvaluator     ;
+			this.fileProvider              = fileProvider             ;
+			this.dataFileEvaluator         = dataFileEvaluator        ;
+			this.backupSetup               = backupSetup              ;
+			this.chunkChecksumProvider     = chunkChecksumProvider    ;
+			this.referenceValidationPolicy = referenceValidationPolicy;
 		}
 
 
@@ -314,6 +371,12 @@ public interface StorageConfiguration
 		}
 
 		@Override
+		public StorageReferenceValidationPolicy referenceValidationPolicy()
+		{
+			return this.referenceValidationPolicy;
+		}
+
+		@Override
 		public String toString()
 		{
 			return VarString.New()
@@ -325,6 +388,7 @@ public interface StorageConfiguration
 				.add(this.dataFileEvaluator     ).lf()
 				.add(this.backupSetup == null ? StorageBackupSetup.class.getName() + ": null": this.backupSetup).lf()
 				.add(this.chunkChecksumProvider ).lf()
+				.add(StorageReferenceValidationPolicy.class.getName()).add(": ").add(this.referenceValidationPolicy.name()).lf()
 				.toString()
 			;
 		}
@@ -484,6 +548,24 @@ public interface StorageConfiguration
 		public B setChunkChecksumProvider(StorageChunkChecksumProvider chunkChecksumProvider);
 
 		/**
+		 * Returns the currently configured {@link StorageReferenceValidationPolicy}.
+		 *
+		 * @return the current {@link StorageReferenceValidationPolicy}.
+		 */
+		public StorageReferenceValidationPolicy referenceValidationPolicy();
+
+		/**
+		 * Sets the {@link StorageReferenceValidationPolicy} to be used by the resulting configuration.
+		 * Passing {@code null} resets the value to the framework default
+		 * ({@link StorageReferenceValidationPolicy#LOG}).
+		 *
+		 * @param referenceValidationPolicy the new {@link StorageReferenceValidationPolicy}, or {@code null} to reset.
+		 *
+		 * @return this builder, for fluent chaining.
+		 */
+		public B setReferenceValidationPolicy(StorageReferenceValidationPolicy referenceValidationPolicy);
+
+		/**
 		 * Builds a new {@link StorageConfiguration} from the strategy parts currently held by this
 		 * builder.
 		 * <p>
@@ -509,13 +591,14 @@ public interface StorageConfiguration
 			// instance fields //
 			////////////////////
 
-			private StorageChannelCountProvider   channelCountProvider   = this.initializeChannelCountProvider();
-			private StorageHousekeepingController housekeepingController = this.initializeHousekeepingController();
-			private StorageLiveFileProvider       storageFileProvider    = this.initializeLiveFileProvider();
-			private StorageDataFileEvaluator      dataFileEvaluator      = this.initializeDataFileEvaluator();
-			private StorageEntityCacheEvaluator   entityCacheEvaluator   = this.initializeEntityCacheEvaluator();
-			private StorageChunkChecksumProvider  chunkChecksumProvider  = this.initializeChunkChecksumProvider();
-			private StorageBackupSetup            backupSetup           ; // optional
+			private StorageChannelCountProvider      channelCountProvider      = this.initializeChannelCountProvider();
+			private StorageHousekeepingController    housekeepingController    = this.initializeHousekeepingController();
+			private StorageLiveFileProvider          storageFileProvider       = this.initializeLiveFileProvider();
+			private StorageDataFileEvaluator         dataFileEvaluator         = this.initializeDataFileEvaluator();
+			private StorageEntityCacheEvaluator      entityCacheEvaluator      = this.initializeEntityCacheEvaluator();
+			private StorageChunkChecksumProvider     chunkChecksumProvider     = this.initializeChunkChecksumProvider();
+			private StorageReferenceValidationPolicy referenceValidationPolicy = this.initializeReferenceValidationPolicy();
+			private StorageBackupSetup               backupSetup              ; // optional
 			
 			
 			
@@ -562,6 +645,11 @@ public interface StorageConfiguration
 			protected StorageChunkChecksumProvider initializeChunkChecksumProvider()
 			{
 				return Storage.ChunkChecksumProvider();
+			}
+
+			protected StorageReferenceValidationPolicy initializeReferenceValidationPolicy()
+			{
+				return StorageReferenceValidationPolicy.LOG;
 			}
 			
 			@SuppressWarnings("unchecked")
@@ -682,16 +770,33 @@ public interface StorageConfiguration
 			}
 
 			@Override
+			public StorageReferenceValidationPolicy referenceValidationPolicy()
+			{
+				return this.referenceValidationPolicy;
+			}
+
+			@Override
+			public B setReferenceValidationPolicy(final StorageReferenceValidationPolicy referenceValidationPolicy)
+			{
+				this.referenceValidationPolicy = referenceValidationPolicy == null
+					? this.initializeReferenceValidationPolicy()
+					: referenceValidationPolicy
+				;
+				return this.$();
+			}
+
+			@Override
 			public StorageConfiguration createConfiguration()
 			{
 				return StorageConfiguration.New(
-					this.channelCountProvider  ,
-					this.housekeepingController,
-					this.storageFileProvider   ,
-					this.dataFileEvaluator     ,
-					this.entityCacheEvaluator  ,
-					this.backupSetup           ,
-					this.chunkChecksumProvider
+					this.channelCountProvider     ,
+					this.housekeepingController   ,
+					this.storageFileProvider      ,
+					this.dataFileEvaluator        ,
+					this.entityCacheEvaluator     ,
+					this.backupSetup              ,
+					this.chunkChecksumProvider    ,
+					this.referenceValidationPolicy
 				);
 			}
 			

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEventLogger.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEventLogger.java
@@ -18,6 +18,7 @@ import static org.eclipse.serializer.util.X.notNull;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.function.Consumer;
 
 /**
@@ -133,8 +134,20 @@ public interface StorageEventLogger
 	{
 		// no-op by default
 	}
-	
-	
+
+	/**
+	 * Called when a store's data references object ids for which no entity exists in the storage
+	 * (dangling references), detected by the store-time reference validation.
+	 *
+	 * @param channelIndex the channel that detected the dangling references.
+	 * @param objectIds    the referenced object ids with no existing entity.
+	 */
+	public default void logStoreDetectedDanglingReferences(final int channelIndex, final long[] objectIds)
+	{
+		// no-op by default
+	}
+
+
 	/**
 	 * Creates a NoOp StorageEventLogger that does really nothing.
 	 * 
@@ -335,7 +348,16 @@ public interface StorageEventLogger
 		{
 			this.log("GC marking encountered zombie ObjectId " + objectId);
 		}
-		
+
+		@Override
+		public void logStoreDetectedDanglingReferences(final int channelIndex, final long[] objectIds)
+		{
+			this.log(
+				StorageChannel.class.getSimpleName() + '#' + channelIndex
+				+ " store references non-existing entities (dangling references): " + Arrays.toString(objectIds)
+			);
+		}
+
 		@Override
 		public void logGarbageCollectorNotNeeded()
 		{
@@ -460,7 +482,14 @@ public interface StorageEventLogger
 			this.first.logGarbageCollectorEncounteredZombieObjectId(objectId);
 			this.second.logGarbageCollectorEncounteredZombieObjectId(objectId);
 		}
-		
+
+		@Override
+		public void logStoreDetectedDanglingReferences(final int channelIndex, final long[] objectIds)
+		{
+			this.first.logStoreDetectedDanglingReferences(channelIndex, objectIds);
+			this.second.logStoreDetectedDanglingReferences(channelIndex, objectIds);
+		}
+
 	}
 	
 }

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFoundation.java
@@ -1070,7 +1070,8 @@ public interface StorageFoundation<F extends StorageFoundation<?>> extends Insta
 		protected StorageRequestTaskCreator ensureRequestTaskCreator()
 		{
 			return new StorageRequestTaskCreator.Default(
-				this.getTimestampProvider()
+				this.getTimestampProvider(),
+				this.getConfiguration().referenceValidationPolicy()
 			);
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
@@ -77,11 +77,18 @@ public enum StorageReferenceValidationPolicy
 	 *
 	 * @return the parsed policy.
 	 *
-	 * @throws IllegalArgumentException on any other value.
+	 * @throws IllegalArgumentException on {@code null} or any other value.
 	 */
 	public static StorageReferenceValidationPolicy parse(final String value)
 	{
-		switch(value.trim().toLowerCase())
+		if(value == null)
+		{
+			throw new IllegalArgumentException(
+				"Reference validation policy must not be null. Valid values are: off, log, fail."
+			);
+		}
+		// Locale.ROOT: config parsing must not depend on the platform locale (e.g. Turkish dotless i).
+		switch(value.trim().toLowerCase(java.util.Locale.ROOT))
 		{
 			case "off" : return OFF ;
 			case "log" : return LOG ;

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
@@ -1,0 +1,95 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * Policy controlling whether and how the storage validates "trusted" reference object ids at store time.
+ * <p>
+ * A store's data may contain references to object ids whose entities are not part of the store itself:
+ * the storer trusted them to already exist in the storage (instances found in the global object registry,
+ * or unloaded {@code Lazy} references' cached ids). If that trust is wrong &mdash; e.g. the referenced
+ * entity was garbage-collected on disk while its instance survived in memory &mdash; the store would
+ * silently persist a dangling reference that only surfaces as a
+ * {@code StorageExceptionConsistency: No entity found for objectId} after a later restart.
+ * <p>
+ * With validation enabled, each channel checks the trusted ids assigned to it against its entity registry
+ * before writing the store's data:
+ * <ul>
+ *   <li>{@link #OFF} &mdash; no validation; the ids are not even collected by the storer (zero overhead).</li>
+ *   <li>{@link #LOG} &mdash; missing ids are logged as an error and reported to the
+ *       {@link StorageEventLogger}, but the store proceeds.</li>
+ *   <li>{@link #FAIL} &mdash; the store is rejected atomically with a
+ *       {@link org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference}.</li>
+ * </ul>
+ */
+public enum StorageReferenceValidationPolicy
+{
+	/**
+	 * No validation; trusted object ids are not collected at all.
+	 */
+	OFF,
+
+	/**
+	 * Validate and log detected dangling references, but let the store proceed.
+	 */
+	LOG,
+
+	/**
+	 * Validate and reject a store containing dangling references atomically.
+	 */
+	FAIL;
+
+
+	/**
+	 * @return whether trusted object ids are collected and validated at all.
+	 */
+	public boolean isValidating()
+	{
+		return this != OFF;
+	}
+
+	/**
+	 * @return whether a detected dangling reference rejects the store.
+	 */
+	public boolean isFailing()
+	{
+		return this == FAIL;
+	}
+
+
+	/**
+	 * Parses the external configuration value ({@code "off"}, {@code "log"} or {@code "fail"},
+	 * case-insensitive).
+	 *
+	 * @param value the configuration value.
+	 *
+	 * @return the parsed policy.
+	 *
+	 * @throws IllegalArgumentException on any other value.
+	 */
+	public static StorageReferenceValidationPolicy parse(final String value)
+	{
+		switch(value.trim().toLowerCase())
+		{
+			case "off" : return OFF ;
+			case "log" : return LOG ;
+			case "fail": return FAIL;
+			default    : throw new IllegalArgumentException(
+				"Invalid reference validation policy: \"" + value + "\". Valid values are: off, log, fail."
+			);
+		}
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
@@ -152,7 +152,8 @@ public interface StorageRequestTaskCreator
 
 		public Default(final StorageTimestampProvider timestampProvider)
 		{
-			this(timestampProvider, StorageReferenceValidationPolicy.OFF);
+			// falls back to the documented product default (see StorageConfiguration).
+			this(timestampProvider, StorageReferenceValidationPolicy.LOG);
 		}
 
 		public Default(

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
@@ -141,7 +141,8 @@ public interface StorageRequestTaskCreator
 		// instance fields //
 		////////////////////
 
-		private final StorageTimestampProvider timestampProvider;
+		private final StorageTimestampProvider         timestampProvider        ;
+		private final StorageReferenceValidationPolicy referenceValidationPolicy;
 
 
 
@@ -151,8 +152,17 @@ public interface StorageRequestTaskCreator
 
 		public Default(final StorageTimestampProvider timestampProvider)
 		{
+			this(timestampProvider, StorageReferenceValidationPolicy.OFF);
+		}
+
+		public Default(
+			final StorageTimestampProvider         timestampProvider        ,
+			final StorageReferenceValidationPolicy referenceValidationPolicy
+		)
+		{
 			super();
-			this.timestampProvider = notNull(timestampProvider);
+			this.timestampProvider         = notNull(timestampProvider)        ;
+			this.referenceValidationPolicy = notNull(referenceValidationPolicy);
 		}
 
 
@@ -196,7 +206,8 @@ public interface StorageRequestTaskCreator
 			return new StorageRequestTaskStoreEntities.Default(
 				this.timestampProvider.currentNanoTimestamp(),
 				data,
-				operationController
+				operationController,
+				this.referenceValidationPolicy
 			);
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
@@ -54,7 +54,8 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 
 		Default(final long timestamp, final Binary data, final StorageOperationController controller)
 		{
-			this(timestamp, data, controller, StorageReferenceValidationPolicy.OFF);
+			// falls back to the documented product default (see StorageConfiguration).
+			this(timestamp, data, controller, StorageReferenceValidationPolicy.LOG);
 		}
 
 		Default(

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
@@ -42,7 +42,9 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 		// instance fields //
 		////////////////////
 
-		private final Binary data;
+		private final Binary                           data                      ;
+		private final StorageReferenceValidationPolicy referenceValidationPolicy ;
+		private final long[][]                         trustedObjectIdsPerChannel;
 
 
 
@@ -52,9 +54,58 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 
 		Default(final long timestamp, final Binary data, final StorageOperationController controller)
 		{
+			this(timestamp, data, controller, StorageReferenceValidationPolicy.OFF);
+		}
+
+		Default(
+			final long                             timestamp                ,
+			final Binary                           data                     ,
+			final StorageOperationController       controller               ,
+			final StorageReferenceValidationPolicy referenceValidationPolicy
+		)
+		{
 			// every channel has to store at least a chunk header, so progress count is always equal to channel count
 			super(timestamp, data.channelCount(), controller);
-			this.data = data;
+			this.data                       = data;
+			this.referenceValidationPolicy  = referenceValidationPolicy;
+			this.trustedObjectIdsPerChannel = referenceValidationPolicy.isValidating()
+				? partitionPerChannel(data.trustedObjectIds(), data.channelCount())
+				: null
+			;
+		}
+
+		/**
+		 * Partitions the passed trusted object ids by their owning channel, using the same
+		 * objectId-to-channel hash the entity registry uses. Runs once on the issuing thread,
+		 * off the channel threads. Returns {@code null} if there is nothing to validate.
+		 */
+		private static long[][] partitionPerChannel(final long[] trustedObjectIds, final int channelCount)
+		{
+			if(trustedObjectIds == null || trustedObjectIds.length == 0)
+			{
+				return null;
+			}
+
+			final int   channelHashModulo = channelCount - 1;
+			final int[] counts            = new int[channelCount];
+			for(final long objectId : trustedObjectIds)
+			{
+				counts[StorageEntityCache.Default.oidChannelIndex(objectId, channelHashModulo)]++;
+			}
+
+			final long[][] perChannel = new long[channelCount][];
+			for(int i = 0; i < channelCount; i++)
+			{
+				perChannel[i] = new long[counts[i]];
+				counts[i] = 0;
+			}
+			for(final long objectId : trustedObjectIds)
+			{
+				final int channelIndex = StorageEntityCache.Default.oidChannelIndex(objectId, channelHashModulo);
+				perChannel[channelIndex][counts[channelIndex]++] = objectId;
+			}
+
+			return perChannel;
 		}
 
 
@@ -66,6 +117,16 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 		@Override
 		protected final KeyValue<ByteBuffer[], long[]> internalProcessBy(final StorageChannel channel)
 		{
+			if(this.trustedObjectIdsPerChannel != null)
+			{
+				// validate before writing: a detected dangling reference fails this channel's processing,
+				// which causes the task-wide fail/rollback of whatever the other channels already wrote.
+				channel.validateTrustedReferences(
+					this.trustedObjectIdsPerChannel[channel.channelIndex()],
+					this.referenceValidationPolicy
+				);
+			}
+
 			return channel.storeEntities(this.timestamp(), this.data.channelChunk(channel.channelIndex()));
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 
 import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.typing.KeyValue;
+import org.eclipse.serializer.util.X;
 
 public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 {
@@ -68,7 +69,7 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 			// every channel has to store at least a chunk header, so progress count is always equal to channel count
 			super(timestamp, data.channelCount(), controller);
 			this.data                       = data;
-			this.referenceValidationPolicy  = referenceValidationPolicy;
+			this.referenceValidationPolicy  = X.notNull(referenceValidationPolicy);
 			this.trustedObjectIdsPerChannel = referenceValidationPolicy.isValidating()
 				? partitionPerChannel(data.trustedObjectIds(), data.channelCount())
 				: null


### PR DESCRIPTION
## What this adds

When a store writes a reference to an object it does not store itself, it trusts that the referenced entity already exists in the storage. If that trust is misplaced - data lost to a crash, a restore from a lagging backup, pre-existing corruption, or a stale cached id of an unloaded `Lazy` reference — the commit silently persists a reference to nothing. Nothing fails at that moment; the first symptom is a `StorageExceptionConsistency: No entity found for objectId N` at some later load or restart, long after the cause, with nothing connecting the two.

With this feature, every store validates its trusted references against the entity cache INSIDE the store task, atomically, before anything is written:

  | Mode | Effect |
  |---|---|
  | `off` | No capture, no validation — zero overhead. |
  | `log` (default) | Missing ids are logged at ERROR level and reported to the `StorageEventLogger`; the store proceeds. |
  | `fail` | The store is rejected with a typed exception naming the missing ids; the whole commit rolls back atomically across all channels. |

A silent, restart-time corruption becomes an immediate, diagnosable store-time signal - with the object ids and the remedy (re-store the referenced objects eagerly, retry) in the message. `log` is the default: existing applications keep their exact behavior plus a loud signal; `fail` is the strict opt-in.

## Technical details

- The serializer side (merged, #293-counterpart) attaches the commit's trusted-but-not-stored object ids to the written `Binary`. `StorageRequestTaskStoreEntities` partitions them per channel (same hash as entity residency) on the issuing thread, and each channel validates its slice via the new `StorageChannel.validateTrustedReferences(long[], policy)` before `storeEntities(...)` - resolving the long-standing pre-write-validation FIXME at that spot.
- Race-freedom for the check: validation runs on the channel thread inside the store task, and the storage GC's sweep runs on the same thread between tasks - an entity present at validation time cannot vanish before the write commits.
- `fail` mode throws `StorageExceptionConsistencyDanglingReference` (carrying channel index and missing ids), which rides the existing two-phase task failure: every channel rolls back its chunk write, the storage stays fully usable. Callers see the established wrapping (`PersistenceExceptionTransfer` → `StorageException("Problem in channel #i")` → the typed exception as cause).
- Recovery paths are first-class: re-storing parent and lost child in one commit works (the commit-time prune on the serializer side keeps same-commit ids out of the trusted set), as does eager-storing the child first - both covered by tests.
- Configuration: `StorageConfiguration.referenceValidationPolicy()` (wired like the existing chunk-checksum feature), external config property `reference-validation`, plus the spring-boot3 and CDI mappings and documentation (properties reference + a new data-integrity page section explaining the exception chain and recovery).
 - The storer-side capture is enabled from the same single knob (`EmbeddedStorageConnectionFoundation` derives it from the policy), so `off` really is end-to-end zero overhead.

## Why validation, when skipped instances are already pinned

The merged pinning fix prevents the main runtime cause on the storer's apply path. Validation is the complementary layer with a strictly larger scope: it also catches dangling state that pre-exists the store (crash artifacts, backup-lag restores), and for references written from cached object ids without any live instance - an unloaded `Lazy`'s cached id, or custom type handlers with the same pattern - there is nothing a pin could hold; write-time validation is the mechanism-level protection there, not merely detection.

## Tests

Nine integration tests in `test.eclipse.store.danglingref`: mode matrix on registry-trusted skips (fail/log/off incl. event-logger verification and CID filtering), unloaded-Lazy cached ids, multi-channel reporting with full atomic rollback and clean restart, post-failure recovery via both paths (exercising the prune), GigaMap entities through the same lazy path, and batching storers (per-flush capture isolation).

## Dependencies

Requires the serializer-side capture — already merged. 