### PR TITLE
Fix duplicate entity-cache entries on typeId change in StorageEntityCache.putEntity (#77)

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -590,8 +590,31 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final StorageEntity.Default entry;
 			if((entry = this.getEntry(objectId)) != null)
 			{
-				this.resetExistingEntityForUpdate(entry);
-				return entry;
+				if(entry.typeId() == type.typeId)
+				{
+					this.resetExistingEntityForUpdate(entry);
+					return entry;
+				}
+
+				/*
+				 * See #putEntity(long) on typeId changes. Defensive here: the import path
+				 * validates every record via #validateEntity beforehand, so this branch is
+				 * normally unreachable with a mismatching type.
+				 */
+				logger.warn(
+					"Entity {} typeId changed, old: {}, new: {} - disposing obsolete entry",
+					entry.objectId(),
+					entry.typeId(),
+					type.typeId
+				);
+				this.disposeObsoleteEntries(objectId, type.typeId);
+
+				final StorageEntity.Default remaining;
+				if((remaining = this.getEntry(objectId)) != null)
+				{
+					this.resetExistingEntityForUpdate(remaining);
+					return remaining;
+				}
 			}
 
 			return this.createEntity(objectId, type);
@@ -613,15 +636,38 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			if((entry = this.getEntry(Binary.getEntityObjectIdRawValue(entityAddress))) != null)
 			{
 				final long entityTypeId = Binary.getEntityTypeIdRawValue(entityAddress);
-				if(entry.typeId() == entityTypeId) {
+				if(entry.typeId() == entityTypeId)
+				{
 					this.resetExistingEntityForUpdate(entry);
 					return entry;
 				}
-				
-				logger.debug("Entity {} typeId changed, old: {}, new: {}",
+
+				/*
+				 * TypeId change: the routine result of re-storing a legacy-mapped instance after
+				 * type evolution. The registered entry belongs to an obsolete type version and
+				 * must be disposed like a sweep would dispose it BEFORE the new-type entry is
+				 * created. Otherwise two entries for the same objectId coexist: the obsolete one
+				 * is rescued every sweep by the id-only application safety net while the instance
+				 * is held; every OID hash table rebuild reverses the bucket chain order, so
+				 * lookups (loads AND gc marking) can resolve to the obsolete entry — serving
+				 * stale data and, worse, letting the sweep delete the CURRENT record (permanent
+				 * data loss); and the obsolete file record stays accounted as live content.
+				 */
+				logger.warn(
+					"Entity {} typeId changed, old: {}, new: {} - disposing obsolete entry",
 					entry.objectId(),
 					entry.typeId(),
-					entityTypeId);
+					entityTypeId
+				);
+				this.disposeObsoleteEntries(entry.objectId(), entityTypeId);
+
+				// a current-type entry may have been sitting behind an obsolete chain head
+				final StorageEntity.Default remaining;
+				if((remaining = this.getEntry(Binary.getEntityObjectIdRawValue(entityAddress))) != null)
+				{
+					this.resetExistingEntityForUpdate(remaining);
+					return remaining;
+				}
 			}
 
 			/* the added try-catch showed no change in performance in a test.
@@ -815,9 +861,68 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 
 			// 5.) mark entity as deleted
 			entity.setDeleted();
-						
+
 			// decrement size, otherwise the cache can't shrink
 			this.oidSize--;
+		}
+
+		/**
+		 * Disposes every registered entry for the passed objectId whose typeId differs from the
+		 * passed current typeId. Such entries are obsolete type versions left behind by a typeId
+		 * change (see {@link #putEntity(long)}) and must be removed exactly like a sweep removes
+		 * entities; there can be more than one (repeated type evolution), potentially in
+		 * different obsolete types.
+		 * <p>
+		 * Deleting requires the predecessor in the singly-linked type list, hence the disposal
+		 * runs as a {@link StorageEntityType.Default#removeAll} pass over each affected obsolete
+		 * type, which disposes all matching entries of that type in one iteration. The rescan
+		 * loop is necessary because the disposal mutates the OID hash chain being examined.
+		 */
+		final void disposeObsoleteEntries(final long objectId, final long currentTypeId)
+		{
+			scan:
+			while(true)
+			{
+				for(StorageEntity.Default e = this.getOidHashChainHead(objectId); e != null; e = e.hashNext)
+				{
+					if(e.objectId() == objectId && e.typeId() != currentTypeId)
+					{
+						e.typeInFile.type.removeAll(new ObsoleteEntityDeleter(objectId, currentTypeId));
+						continue scan;
+					}
+				}
+				return;
+			}
+		}
+
+		final class ObsoleteEntityDeleter implements StorageEntityType.Default.EntityDeleter
+		{
+			private final long objectId     ;
+			private final long currentTypeId;
+
+			ObsoleteEntityDeleter(final long objectId, final long currentTypeId)
+			{
+				super();
+				this.objectId      = objectId     ;
+				this.currentTypeId = currentTypeId;
+			}
+
+			@Override
+			public boolean test(final StorageEntity.Default entity)
+			{
+				return entity.objectId() == this.objectId && entity.typeId() != this.currentTypeId;
+			}
+
+			@Override
+			public void delete(
+				final StorageEntity.Default     entity        ,
+				final StorageEntityType.Default type          ,
+				final StorageEntity.Default     previousInType
+			)
+			{
+				Default.this.deleteEntity(entity, type, previousInType);
+			}
+
 		}
 
 		void checkForCacheClear(final StorageEntity.Default entry, final long evalTime)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -117,6 +117,9 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		
 		private long    usedCacheSize;
 		private boolean hasUpdatePendingSweep;
+
+		// obsolete typeIds already warned about on a typeId change (see #handleTypeIdChange)
+		private final Set_long warnedObsoleteTypeIds = Set_long.New();
 		
 		// Statistics for debugging / monitoring / checking to compare with other channels and with the markmonitor
 		private long sweepGeneration, lastSweepStart, lastSweepEnd;
@@ -237,6 +240,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			this.resetLiveCursor();
 
 			this.usedCacheSize  = 0L;
+			this.warnedObsoleteTypeIds.clear();
 
 			// create a new root type instance on every clear. Everything else is not worth the reset&register-hassle.
 			this.rootType       = this.getType(this.rootTypeId);
@@ -597,22 +601,13 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				}
 
 				/*
-				 * See #putEntity(long) on typeId changes. Defensive here: the import path
-				 * validates every record via #validateEntity beforehand, so this branch is
-				 * normally unreachable with a mismatching type.
+				 * See #handleTypeIdChange. Defensive here: the import path validates every
+				 * record via #validateEntity beforehand, so this branch is normally
+				 * unreachable with a mismatching type.
 				 */
-				logger.warn(
-					"Entity {} typeId changed, old: {}, new: {} - disposing obsolete entry",
-					entry.objectId(),
-					entry.typeId(),
-					type.typeId
-				);
-				this.disposeObsoleteEntries(objectId, type.typeId);
-
 				final StorageEntity.Default remaining;
-				if((remaining = this.getEntry(objectId)) != null)
+				if((remaining = this.handleTypeIdChange(objectId, entry.typeId(), type.typeId)) != null)
 				{
-					this.resetExistingEntityForUpdate(remaining);
 					return remaining;
 				}
 			}
@@ -642,30 +637,9 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 					return entry;
 				}
 
-				/*
-				 * TypeId change: the routine result of re-storing a legacy-mapped instance after
-				 * type evolution. The registered entry belongs to an obsolete type version and
-				 * must be disposed like a sweep would dispose it BEFORE the new-type entry is
-				 * created. Otherwise two entries for the same objectId coexist: the obsolete one
-				 * is rescued every sweep by the id-only application safety net while the instance
-				 * is held; every OID hash table rebuild reverses the bucket chain order, so
-				 * lookups (loads AND gc marking) can resolve to the obsolete entry — serving
-				 * stale data and, worse, letting the sweep delete the CURRENT record (permanent
-				 * data loss); and the obsolete file record stays accounted as live content.
-				 */
-				logger.warn(
-					"Entity {} typeId changed, old: {}, new: {} - disposing obsolete entry",
-					entry.objectId(),
-					entry.typeId(),
-					entityTypeId
-				);
-				this.disposeObsoleteEntries(entry.objectId(), entityTypeId);
-
-				// a current-type entry may have been sitting behind an obsolete chain head
 				final StorageEntity.Default remaining;
-				if((remaining = this.getEntry(Binary.getEntityObjectIdRawValue(entityAddress))) != null)
+				if((remaining = this.handleTypeIdChange(entry.objectId(), entry.typeId(), entityTypeId)) != null)
 				{
-					this.resetExistingEntityForUpdate(remaining);
 					return remaining;
 				}
 			}
@@ -812,6 +786,24 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final StorageEntityType.Default type
 		)
 		{
+			/*
+			 * Hard invariant: at most one entry may ever be registered per objectId. Every caller
+			 * must have handled an existing entry beforehand (update reuse, obsolete-entry
+			 * disposal on a typeId change, initialization deduplication). A silently created
+			 * duplicate would cause stale reads and let the GC sweep the current record (see
+			 * #handleTypeIdChange), so a violation must fail loudly here, at the single point
+			 * where the duplicate would be created.
+			 */
+			final StorageEntity.Default existing;
+			if((existing = this.getEntry(objectId)) != null)
+			{
+				throw new StorageExceptionConsistency(
+					"Duplicate entity entry for objectId " + objectId
+					+ ": already registered with typeId " + existing.typeId()
+					+ ", to be created with typeId " + type.typeId + "."
+				);
+			}
+
 			// increment size and check for necessary (and reasonable) rebuild
 			if(this.oidSize >= this.oidModulo && this.oidModulo < Integer.MAX_VALUE)
 			{
@@ -867,9 +859,58 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		}
 
 		/**
+		 * Handles a typeId change for a registered entity: the routine result of re-storing a
+		 * legacy-mapped instance after type evolution. The registered entry belongs to an
+		 * obsolete type version and must be disposed like a sweep would dispose it BEFORE the
+		 * new-type entry is created. Otherwise two entries for the same objectId coexist: the
+		 * obsolete one is rescued every sweep by the id-only application safety net while the
+		 * instance is held; every OID hash table rebuild reverses the bucket chain order, so
+		 * lookups (loads AND gc marking) can resolve to the obsolete entry — serving stale data
+		 * and, worse, letting the sweep delete the CURRENT record (permanent data loss); and the
+		 * obsolete file record stays accounted as live content.
+		 *
+		 * @return the surviving current-type entry, already reset for the update, or {@code null}
+		 *         if none remains and the caller must create a new entry.
+		 */
+		private StorageEntity.Default handleTypeIdChange(
+			final long objectId      ,
+			final long obsoleteTypeId,
+			final long currentTypeId
+		)
+		{
+			/*
+			 * Since a type change affects every re-stored legacy instance of that type, warning
+			 * per entity would flood the logs during bulk migrations. Warn once per obsolete
+			 * typeId, keep the per-entity detail on debug level.
+			 */
+			if(this.warnedObsoleteTypeIds.add(obsoleteTypeId))
+			{
+				logger.warn(
+					"Entity type changed from typeId {} to typeId {} - disposing obsolete entity entries"
+					+ " (logged once per obsolete typeId, per-entity details on debug level)",
+					obsoleteTypeId,
+					currentTypeId
+				);
+			}
+			logger.debug("Entity {} typeId changed, old: {}, new: {} - disposing obsolete entry",
+				objectId,
+				obsoleteTypeId,
+				currentTypeId
+			);
+
+			final StorageEntity.Default remaining;
+			if((remaining = this.disposeObsoleteEntries(objectId, currentTypeId)) != null)
+			{
+				// a current-type entry was sitting behind an obsolete chain head: normal update
+				this.resetExistingEntityForUpdate(remaining);
+			}
+
+			return remaining;
+		}
+
+		/**
 		 * Disposes every registered entry for the passed objectId whose typeId differs from the
-		 * passed current typeId. Such entries are obsolete type versions left behind by a typeId
-		 * change (see {@link #putEntity(long)}) and must be removed exactly like a sweep removes
+		 * passed current typeId (see {@link #handleTypeIdChange}) exactly like a sweep removes
 		 * entities; there can be more than one (repeated type evolution), potentially in
 		 * different obsolete types.
 		 * <p>
@@ -877,21 +918,33 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		 * runs as a {@link StorageEntityType.Default#removeAll} pass over each affected obsolete
 		 * type, which disposes all matching entries of that type in one iteration. The rescan
 		 * loop is necessary because the disposal mutates the OID hash chain being examined.
+		 *
+		 * @return the surviving entry with the passed current typeId, or {@code null} if none is
+		 *         registered.
 		 */
-		final void disposeObsoleteEntries(final long objectId, final long currentTypeId)
+		private StorageEntity.Default disposeObsoleteEntries(final long objectId, final long currentTypeId)
 		{
+			final ObsoleteEntityDeleter deleter = new ObsoleteEntityDeleter(objectId, currentTypeId);
+
 			scan:
 			while(true)
 			{
+				StorageEntity.Default survivor = null;
 				for(StorageEntity.Default e = this.getOidHashChainHead(objectId); e != null; e = e.hashNext)
 				{
-					if(e.objectId() == objectId && e.typeId() != currentTypeId)
+					if(e.objectId() != objectId)
 					{
-						e.typeInFile.type.removeAll(new ObsoleteEntityDeleter(objectId, currentTypeId));
+						continue;
+					}
+					if(e.typeId() != currentTypeId)
+					{
+						e.typeInFile.type.removeAll(deleter);
 						continue scan;
 					}
+					survivor = e;
 				}
-				return;
+
+				return survivor;
 			}
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -752,13 +752,18 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				 * mismatch against an already registered entry — but validation runs as a separate
 				 * phase before any record of the same import is registered, so an import source
 				 * containing the same objectId under two different typeIds passes validation for
-				 * both records and reaches this branch with the second one.
+				 * both records and reaches this branch with the second one. That is anomalous
+				 * enough (unlike the routine bulk-migration case on the store path, which
+				 * #handleTypeIdChange throttles to once per obsolete typeId) to warrant a
+				 * per-entity warning.
 				 */
-				final StorageEntity.Default remaining;
-				if((remaining = this.handleTypeIdChange(objectId, entry.typeId(), type.typeId)) != null)
-				{
-					return remaining;
-				}
+				logger.warn(
+					"Imported entity {} changes its typeId from {} to {} within the same import",
+					objectId,
+					entry.typeId(),
+					type.typeId
+				);
+				this.handleTypeIdChange(entry, type.typeId);
 			}
 
 			return this.createEntity(objectId, type);
@@ -795,11 +800,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				 */
 				this.getType(entityTypeId);
 
-				final StorageEntity.Default remaining;
-				if((remaining = this.handleTypeIdChange(entry.objectId(), entry.typeId(), entityTypeId)) != null)
-				{
-					return remaining;
-				}
+				this.handleTypeIdChange(entry, entityTypeId);
 			}
 
 			/* the added try-catch showed no change in performance in a test.
@@ -1006,28 +1007,32 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final StorageEntityType.Default type
 		)
 		{
+			// increment size and check for necessary (and reasonable) rebuild
+			if(this.oidSize >= this.oidModulo && this.oidModulo < Integer.MAX_VALUE)
+			{
+				this.enlargeOidHashTable();
+			}
+
 			/*
 			 * Hard invariant: at most one entry may ever be registered per objectId. Every caller
 			 * must have handled an existing entry beforehand (update reuse, obsolete-entry
 			 * disposal on a typeId change, initialization deduplication). A silently created
 			 * duplicate would cause stale reads and let the GC sweep the current record (see
 			 * #handleTypeIdChange), so a violation must fail loudly here, at the single point
-			 * where the duplicate would be created.
+			 * where the duplicate would be created. The guard walk reuses the chain head lookup
+			 * needed for the insertion below anyway, costing only the walk of the bucket chain.
 			 */
-			final StorageEntity.Default existing;
-			if((existing = this.getEntry(objectId)) != null)
+			final StorageEntity.Default chainHead = this.getOidHashChainHead(objectId);
+			for(StorageEntity.Default e = chainHead; e != null; e = e.hashNext)
 			{
-				throw new StorageExceptionConsistency(
-					"Duplicate entity entry for objectId " + objectId
-					+ ": already registered with typeId " + existing.typeId()
-					+ ", to be created with typeId " + type.typeId + "."
-				);
-			}
-
-			// increment size and check for necessary (and reasonable) rebuild
-			if(this.oidSize >= this.oidModulo && this.oidModulo < Integer.MAX_VALUE)
-			{
-				this.enlargeOidHashTable();
+				if(e.objectId() == objectId)
+				{
+					throw new StorageExceptionConsistency(
+						"Duplicate entity entry for objectId " + objectId
+						+ ": already registered with typeId " + e.typeId()
+						+ ", to be created with typeId " + type.typeId + "."
+					);
+				}
 			}
 
 			// create and put entry
@@ -1037,7 +1042,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				entity = StorageEntity.Default.New(
 					objectId,
 					type.dummy,
-					this.getOidHashChainHead(objectId),
+					chainHead,
 					type.hasReferences(),
 					type.simpleReferenceDataCount()
 				)
@@ -1088,105 +1093,67 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		 * lookups (loads AND gc marking) can resolve to the obsolete entry — serving stale data
 		 * and, worse, letting the sweep delete the CURRENT record (permanent data loss); and the
 		 * obsolete file record stays accounted as live content.
-		 *
-		 * @return the surviving current-type entry, already reset for the update, or {@code null}
-		 *         if none remains and the caller must create a new entry.
+		 * <p>
+		 * The passed entry is the only entry registered for its objectId (enforced by the
+		 * duplicate guard in {@link #createEntity}), so disposing it suffices; the caller must
+		 * create the new-type entry afterwards.
+		 * <p>
+		 * Deleting requires the predecessor in the singly-linked type list, hence the disposal
+		 * runs as a {@link StorageEntityType.Default#removeFirst} walk over the obsolete type,
+		 * stopping at the entry: a full {@link StorageEntityType.Default#removeAll} pass per
+		 * re-stored entity would make bulk migrations quadratic in the obsolete type's size.
 		 */
-		private StorageEntity.Default handleTypeIdChange(
-			final long objectId      ,
-			final long obsoleteTypeId,
-			final long currentTypeId
-		)
+		private void handleTypeIdChange(final StorageEntity.Default entry, final long currentTypeId)
 		{
 			/*
 			 * Since a type change affects every re-stored legacy instance of that type, warning
 			 * per entity would flood the logs during bulk migrations. Warn once per obsolete
 			 * typeId, keep the per-entity detail on debug level.
 			 */
-			if(this.warnedObsoleteTypeIds.add(obsoleteTypeId))
+			if(this.warnedObsoleteTypeIds.add(entry.typeId()))
 			{
 				logger.warn(
 					"Entity type changed from typeId {} to typeId {} - disposing obsolete entity entries"
 					+ " (logged once per obsolete typeId, per-entity details on debug level)",
-					obsoleteTypeId,
+					entry.typeId(),
 					currentTypeId
 				);
 			}
 			logger.debug("Entity {} typeId changed, old: {}, new: {} - disposing obsolete entry",
-				objectId,
-				obsoleteTypeId,
+				entry.objectId(),
+				entry.typeId(),
 				currentTypeId
 			);
 
-			final StorageEntity.Default remaining;
-			if((remaining = this.disposeObsoleteEntries(objectId, currentTypeId)) != null)
+			if(!entry.typeInFile.type.removeFirst(new ObsoleteEntityDeleter(entry)))
 			{
-				// a current-type entry was sitting behind an obsolete chain head: normal update
-				this.resetExistingEntityForUpdate(remaining);
-			}
-
-			return remaining;
-		}
-
-		/**
-		 * Disposes every registered entry for the passed objectId whose typeId differs from the
-		 * passed current typeId (see {@link #handleTypeIdChange}) exactly like a sweep removes
-		 * entities; there can be more than one (repeated type evolution), potentially in
-		 * different obsolete types.
-		 * <p>
-		 * Deleting requires the predecessor in the singly-linked type list, hence the disposal
-		 * runs as a {@link StorageEntityType.Default#removeFirst} walk over the affected obsolete
-		 * type, stopping at the match: per obsolete type there is at most one entry for the
-		 * objectId (see the duplicate guard in {@link #createEntity}), so scanning past it would
-		 * only burn time — a full {@link StorageEntityType.Default#removeAll} pass per re-stored
-		 * entity makes bulk migrations quadratic in the obsolete type's size. The rescan loop is
-		 * necessary because the disposal mutates the OID hash chain being examined.
-		 *
-		 * @return the surviving entry with the passed current typeId, or {@code null} if none is
-		 *         registered.
-		 */
-		private StorageEntity.Default disposeObsoleteEntries(final long objectId, final long currentTypeId)
-		{
-			final ObsoleteEntityDeleter deleter = new ObsoleteEntityDeleter(objectId, currentTypeId);
-
-			scan:
-			while(true)
-			{
-				StorageEntity.Default survivor = null;
-				for(StorageEntity.Default e = this.getOidHashChainHead(objectId); e != null; e = e.hashNext)
-				{
-					if(e.objectId() != objectId)
-					{
-						continue;
-					}
-					if(e.typeId() != currentTypeId)
-					{
-						e.typeInFile.type.removeFirst(deleter);
-						continue scan;
-					}
-					survivor = e;
-				}
-
-				return survivor;
+				/*
+				 * The entry's absence from its own type chain means corrupted chain state: fail
+				 * loudly instead of proceeding to create a second entry for a still-registered
+				 * objectId (which the guard in #createEntity would reject anyway, but with a
+				 * misleading message).
+				 */
+				throw new StorageExceptionConsistency(
+					"Entity " + entry.objectId() + " with typeId " + entry.typeId()
+					+ " is not contained in its type's entity chain."
+				);
 			}
 		}
 
 		final class ObsoleteEntityDeleter implements StorageEntityType.Default.EntityDeleter
 		{
-			private final long objectId     ;
-			private final long currentTypeId;
+			private final StorageEntity.Default subject;
 
-			ObsoleteEntityDeleter(final long objectId, final long currentTypeId)
+			ObsoleteEntityDeleter(final StorageEntity.Default subject)
 			{
 				super();
-				this.objectId      = objectId     ;
-				this.currentTypeId = currentTypeId;
+				this.subject = subject;
 			}
 
 			@Override
 			public boolean test(final StorageEntity.Default entity)
 			{
-				return entity.objectId() == this.objectId && entity.typeId() != this.currentTypeId;
+				return entity == this.subject;
 			}
 
 			@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -748,9 +748,11 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				}
 
 				/*
-				 * See #handleTypeIdChange. Defensive here: the import path validates every
-				 * record via #validateEntity beforehand, so this branch is normally
-				 * unreachable with a mismatching type.
+				 * See #handleTypeIdChange. On the import path, #validateEntity rejects a typeId
+				 * mismatch against an already registered entry — but validation runs as a separate
+				 * phase before any record of the same import is registered, so an import source
+				 * containing the same objectId under two different typeIds passes validation for
+				 * both records and reaches this branch with the second one.
 				 */
 				final StorageEntity.Default remaining;
 				if((remaining = this.handleTypeIdChange(objectId, entry.typeId(), type.typeId)) != null)
@@ -784,6 +786,15 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 					return entry;
 				}
 
+				/*
+				 * Resolve (and thereby validate) the new typeId BEFORE the destructive disposal:
+				 * #getType throws for an unresolvable typeId, and such a failure must leave the
+				 * registered entry intact instead of rendering the objectId unresolvable.
+				 * The result is discarded; the createEntity call below re-fetches it cheaply
+				 * from the then-registered type table.
+				 */
+				this.getType(entityTypeId);
+
 				final StorageEntity.Default remaining;
 				if((remaining = this.handleTypeIdChange(entry.objectId(), entry.typeId(), entityTypeId)) != null)
 				{
@@ -802,6 +813,11 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 					Binary.getEntityObjectIdRawValue(entityAddress),
 					this.getType(Binary.getEntityTypeIdRawValue(entityAddress))
 				);
+			}
+			catch(final StorageExceptionConsistency e)
+			{
+				// deliberate fail-loud invariant violation (see #createEntity); must not be masked by the generic wrapper below
+				throw e;
 			}
 			catch(final Exception e)
 			{
@@ -1119,9 +1135,12 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		 * different obsolete types.
 		 * <p>
 		 * Deleting requires the predecessor in the singly-linked type list, hence the disposal
-		 * runs as a {@link StorageEntityType.Default#removeAll} pass over each affected obsolete
-		 * type, which disposes all matching entries of that type in one iteration. The rescan
-		 * loop is necessary because the disposal mutates the OID hash chain being examined.
+		 * runs as a {@link StorageEntityType.Default#removeFirst} walk over the affected obsolete
+		 * type, stopping at the match: per obsolete type there is at most one entry for the
+		 * objectId (see the duplicate guard in {@link #createEntity}), so scanning past it would
+		 * only burn time — a full {@link StorageEntityType.Default#removeAll} pass per re-stored
+		 * entity makes bulk migrations quadratic in the obsolete type's size. The rescan loop is
+		 * necessary because the disposal mutates the OID hash chain being examined.
 		 *
 		 * @return the surviving entry with the passed current typeId, or {@code null} if none is
 		 *         registered.
@@ -1142,7 +1161,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 					}
 					if(e.typeId() != currentTypeId)
 					{
-						e.typeInFile.type.removeAll(deleter);
+						e.typeInFile.type.removeFirst(deleter);
 						continue scan;
 					}
 					survivor = e;

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityType.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityType.java
@@ -263,6 +263,19 @@ public interface StorageEntityType<E extends StorageEntity>
 			return deleter;
 		}
 
+		public boolean removeFirst(final EntityDeleter deleter)
+		{
+			for(StorageEntity.Default last, entity = this.head; (entity = (last = entity).typeNext) != null;)
+			{
+				if(deleter.test(entity))
+				{
+					deleter.delete(entity, this, last);
+					return true;
+				}
+			}
+			return false;
+		}
+
 		@Override
 		public final StorageEntityTypeHandler typeHandler()
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -2227,12 +2227,20 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 					final StorageEntity.Default actual = entityCache.putEntity(entity.objectId(), entity.type());
 					actual.updateStorageInformation(entity.length(), X.checkArrayRange(loopFileLength));
 					headFile.appendEntry(actual);
+					/*
+					 * Account the entity's bytes immediately instead of bulk-adding copyLength after
+					 * the loop: a later record of this same import may dispose this just-appended
+					 * entry again (same objectId under a changed typeId, see putEntity), and its
+					 * removal decrements fileDataLength for these very bytes - deferred accounting
+					 * would let fileDataLength transiently under-count.
+					 */
+					headFile.increaseContentLength(entity.length());
 					loopFileLength += entity.length();
 				}
 			}
 
+			// content length was already accounted per entity in the loop above
 			final long copyLength = loopFileLength - oldTotalLength;
-			headFile.increaseContentLength(copyLength);
 
 			// The imported entity bytes were appended contiguously (zero-copy transfer) with no covering
 			// ChunkChecksumV1. Emit one now over the whole imported run [oldTotalLength, loopFileLength)


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                   
  When an entity is re-stored after structural type evolution — the routine result of storing a legacy-mapped instance — StorageEntityCache.putEntity encounters a registered cache entry whose typeId differs from the incoming record's typeId.  
  Previously this branch only logged a debug line and fell through to createEntity, silently registering a second entry for the same objectId while the obsolete entry stayed in the OID hash chain, in its type's entity list, and bound to its   
  stale file record.                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                   
  Two amplifiers turn the duplicate into user-visible corruption:                                                                                                                                                                                  
                                                                                                                                                                                                                                                   
  1. The sweep's application safety net is id-only, so while the application holds the instance, both same-OID entries are rescued every GC cycle. A type export then emits the entity once per type, and re-importing that export fails           
  validation.                                                                                                                                                                                                                                      
  2. Every OID hash-table rebuild reverses bucket-chain order, so after a rebuild the stale entry can become the chain head. getEntry(objectId) — used by loads and by GC marking — then resolves to the obsolete entry: reloads serve pre-update  
  data, and in the worst case the mark phase marks only the stale entry, the sweep deletes the current record, and after a restart the entity has permanently rolled back to its pre-update state.                                                 
                                                                                                                                                                                                                                                   
 ## Fix                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                   
  A typeId change now disposes the obsolete entry — exactly like a sweep would (deleteEntity: unregister from the OID table, detach from its file, remove from the type chain, drop cached data, mark deleted) — before the new-type entry is      
  created:                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                   
  - handleTypeIdChange(entry, currentTypeId) is invoked from both putEntity variants on a typeId mismatch. Since the type-chain list is singly linked, the disposal runs as a StorageEntityType.Default.removeFirst walk that stops at the entry; a
  full removeAll pass per re-stored entity would make bulk migrations quadratic in the obsolete type's size. If the entry is unexpectedly absent from its own type chain, the disposal throws StorageExceptionConsistency instead of proceeding.   
  - createEntity now enforces the underlying invariant at the single point where a duplicate could be created: at most one entry per objectId, violation fails loudly with StorageExceptionConsistency. The guard is folded into the chain-head    
  lookup the insertion performs anyway, so it costs only the walk of the bucket chain. In putEntity(entityAddress) the consistency exception is rethrown as-is rather than wrapped into the generic StorageException, so the corruption signal     
  keeps its type.                                                                                                                                                                                                                                  
  - Failure atomicity: in the store path the incoming typeId is resolved via getType (which throws for an unresolvable typeId) before the destructive disposal, so a validation failure leaves the registered entry intact instead of leaving the  
  objectId unresolvable for the rest of the session.                                                                                                                                                                                               
                                                                                                                                                                                                                                                   
##  Import path                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                   
  Import validation runs as a separate phase before any record of the same import is registered, so an import source containing the same objectId under two different typeIds passes validation for both records and legitimately reaches the      
  typeId-change branch during commitImport. Two adjustments account for this:                                                                                                                                                                      
                                                                                                                                                                                                                                                   
  - commitImport now accounts each imported entity's bytes immediately after appending it, instead of bulk-adding the copy length after the loop — otherwise a later record disposing an earlier just-appended entry would transiently under-count 
  the file's data length. Final accounting values are unchanged.                                                                                                                                                                                   
  - An intra-import typeId change is anomalous (unlike the routine bulk-migration case on the store path) and is logged as a per-entity warning; the store path throttles its warning to once per obsolete typeId to avoid flooding the log during 
  bulk migrations, with per-entity detail at debug level.

##  Notes                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                   
  - Storage-side only; no serializer changes, no API changes.                                                                                                                                                                                      
  - Restart behavior is unaffected: initialization already deduplicates by objectId (newest record wins) and reclassifies superseded records as gaps.