### PR TITLE
Fix wrong hash key in StorageLiveDataFile.rebuildTypeInFileTable (#79)

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLiveDataFile.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLiveDataFile.java
@@ -248,8 +248,8 @@ extends StorageDataFile, StorageLiveChannelFile<StorageLiveDataFile>, StorageCre
 				for(TypeInFile next; entries != null; entries = next)
 				{
 					next = entries.hashNext;
-					entries.hashNext = newSlots[System.identityHashCode(entries) & newModulo];
-					newSlots[System.identityHashCode(entries) & newModulo] = entries;
+					entries.hashNext = newSlots[System.identityHashCode(entries.type) & newModulo];
+					newSlots[System.identityHashCode(entries.type) & newModulo] = entries;
 				}
 			}
 			this.typeInFileSlots = newSlots;


### PR DESCRIPTION
The per-file type-in-file registry is keyed by the type's identity hash
  on lookup and creation, but the table rebuild re-hashed entries by the
  identity of the TypeInFile entry itself. After the first rebuild
  (triggered once a data file holds more than 7 distinct types) existing
  entries landed in wrong buckets: lookups missed, createTypeInFile
  registered duplicate flyweights for the same (type, file) pair, the
  scattered entries became unreachable (there is no removal), and the
  inflated count triggered further wrongly-keyed rebuilds.

  No data corruption: TypeInFile is a pure (type, file) flyweight, all
  consumers dereference its fields and nothing compares entries by
  identity — the impact was wasted memory and degraded lookups on the
  hot typeInFile() path. Re-hash by the type's identity, matching the
  lookup key.