### PR TITLE
Add automatic self-healing mode to reference validation

### DIFF
--- a/docs/modules/storage/pages/configuration/properties.adoc
+++ b/docs/modules/storage/pages/configuration/properties.adoc
@@ -123,7 +123,7 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 |xref:#type-bytes[Bytes]
 
 |reference-validation
-|Store-time validation of references whose target entities are not part of the store itself (`off`, `log` or `fail`). With `log` (the default), a store referencing a non-existing entity (dangling reference) is logged as an error but proceeds; with `fail` such a store is rejected atomically; `off` disables the validation entirely (zero overhead). See xref:../data-integrity.adoc[Data Integrity] for the failure mode this guards against.
+|Store-time validation of references whose target entities are not part of the store itself (`off`, `log`, `fail` or `heal`). With `log` (the default), a store referencing a non-existing entity (dangling reference) is logged as an error but proceeds; with `fail` such a store is rejected atomically; with `heal` a rejected store is additionally repaired automatically (the still-live referenced instances are re-stored under their existing object ids and the store is retried); `off` disables the validation entirely (zero overhead). See xref:../data-integrity.adoc[Data Integrity] for the failure mode this guards against.
 |xref:#type-string[String]
 |===
 

--- a/docs/modules/storage/pages/data-integrity.adoc
+++ b/docs/modules/storage/pages/data-integrity.adoc
@@ -340,7 +340,7 @@ References registered via `Storer#skip` variants are an explicit user assertion 
 
 === Automatic Self-Healing
 
-With `reference-validation=heal`, a store rejected for dangling references is repaired automatically and transparently: a dangling id is an id whose *data* is missing while the referenced *instance* is still alive in application memory — so the storer re-serializes that instance **under its existing object id** in a compensating store, then retries the original store. The retried data is byte-identical (the already-serialized buffers are reused), so the repair is invisible to the caller apart from a WARN log per healing round.
+With `reference-validation=heal`, a store rejected for dangling references is repaired automatically and transparently: a dangling id is an id whose *data* is missing while the referenced *instance* is still alive in application memory — so the storer re-serializes that instance **under its existing object id** in a compensating store, then retries the original store. The retried data is byte-identical (the already-serialized buffers are reused), so the repair is invisible to the caller apart from WARN-level logging per healing round (one entry from the rejecting channel, one from the healing storer; the `StorageEventLogger` dangling-reference event still fires per attempt for monitoring).
 
 Details and bounds:
 

--- a/docs/modules/storage/pages/data-integrity.adoc
+++ b/docs/modules/storage/pages/data-integrity.adoc
@@ -323,6 +323,9 @@ The behavior is controlled by the `reference-validation` configuration property 
 | `fail`
 | A store containing dangling references is rejected atomically with a `StorageExceptionConsistencyDanglingReference` naming the missing object ids; nothing of the store is committed and the storage remains fully usable.
 
+| `heal`
+| Like `fail`, but the storer automatically repairs the rejected store — see <<_automatic_self_healing>>.
+
 | `off`
 | The ids are not collected at all — zero overhead, pre-feature behavior.
 |===
@@ -334,6 +337,18 @@ At the calling code, the rejection surfaces wrapped: the thrown exception is a `
 
 To recover from a rejected store, make the missing entities exist again and retry: include the referenced instances explicitly in the same store (e.g. `storer.storeAll(parent, child)`) or store them with an eager storer first.
 References registered via `Storer#skip` variants are an explicit user assertion and are not validated.
+
+=== Automatic Self-Healing
+
+With `reference-validation=heal`, a store rejected for dangling references is repaired automatically and transparently: a dangling id is an id whose *data* is missing while the referenced *instance* is still alive in application memory — so the storer re-serializes that instance **under its existing object id** in a compensating store, then retries the original store. The retried data is byte-identical (the already-serialized buffers are reused), so the repair is invisible to the caller apart from a WARN log per healing round.
+
+Details and bounds:
+
+* Healing is *reactive*: it only runs when a store was actually rejected — the happy path is unchanged.
+* The healed data is the instance's *current* in-memory state (the storage had nothing for that id, so this is strictly an improvement).
+* The compensating store is a separate commit. If the retried store then fails for an unrelated reason, the healed entities are simply unreachable and are reclaimed by the storage garbage collector.
+* Transitive dangling references (a healed instance itself referencing a missing id) are healed recursively, bounded by a maximum depth; the number of retry rounds is bounded by the channel count.
+* **Unhealable:** an unloaded `Lazy` reference's cached id has no in-memory instance — if such an id is missing, the data is genuinely gone and the store fails exactly like `fail` mode.
 
 == Limitations
 

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/DanglingRefTestUtil.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/DanglingRefTestUtil.java
@@ -15,6 +15,7 @@ package test.eclipse.store.danglingref;
  */
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -88,9 +89,9 @@ final class DanglingRefTestUtil
 	 */
 	static final class RecordingEventLogger implements StorageEventLogger
 	{
-		final List<long[]> reportedObjectIds = new ArrayList<>();
+		final List<long[]> reportedObjectIds = Collections.synchronizedList(new ArrayList<>());
 
-		private final Set<Integer> reportingChannels = new HashSet<>();
+		private final Set<Integer> reportingChannels = Collections.synchronizedSet(new HashSet<>());
 
 		@Override
 		public void logStoreDetectedDanglingReferences(final int channelIndex, final long[] objectIds)

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/DanglingRefTestUtil.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/DanglingRefTestUtil.java
@@ -15,7 +15,11 @@ package test.eclipse.store.danglingref;
  */
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import org.eclipse.store.storage.types.StorageEventLogger;
 
 /**
  * Shared helpers for the dangling-reference validation tests.
@@ -59,6 +63,60 @@ final class DanglingRefTestUtil
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Precondition assertion for heal-success tests: healing coverage exists only if the store
+	 * was actually rejected at least once. Without this, a change to the lazy storer's skip
+	 * semantics would silently turn the heal tests into plain store tests that stay green with
+	 * zero heal coverage.
+	 */
+	static void assertRejectionsRecorded(final RecordingEventLogger recorder)
+	{
+		if(recorder.eventCount() == 0)
+		{
+			throw new AssertionError(
+				"precondition failed: no dangling-reference rejection was reported"
+				+ " - the store never went through the healing path, the test covers nothing"
+			);
+		}
+	}
+
+	/**
+	 * Records every dangling-reference rejection event with its channel. Thread-safe: channels
+	 * report concurrently from their own threads.
+	 */
+	static final class RecordingEventLogger implements StorageEventLogger
+	{
+		final List<long[]> reportedObjectIds = new ArrayList<>();
+
+		private final Set<Integer> reportingChannels = new HashSet<>();
+
+		@Override
+		public void logStoreDetectedDanglingReferences(final int channelIndex, final long[] objectIds)
+		{
+			synchronized(this.reportedObjectIds)
+			{
+				this.reportedObjectIds.add(objectIds);
+				this.reportingChannels.add(channelIndex);
+			}
+		}
+
+		int eventCount()
+		{
+			synchronized(this.reportedObjectIds)
+			{
+				return this.reportedObjectIds.size();
+			}
+		}
+
+		int distinctReportingChannels()
+		{
+			synchronized(this.reportedObjectIds)
+			{
+				return this.reportingChannels.size();
+			}
+		}
 	}
 
 	private DanglingRefTestUtil()

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/HealModeTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/HealModeTest.java
@@ -1,0 +1,125 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Automatic self-healing (heal mode): a store whose data references a registry-known but
+ * never-stored instance must succeed transparently — the storer re-stores the instance under its
+ * existing object id and retries. The persisted graph must be fully intact after a restart.
+ */
+public class HealModeTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void danglingReferenceIsHealedTransparently()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
+					.createConfiguration()
+			)
+			.start();
+
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 50;
+		final Child child   = new Child("healed child");
+		registry.registerObject(fakeOid, child);
+
+		final Parent parent = new Parent(child);
+
+		// the plain lazy store skips the registry-known child; validation detects the missing
+		// entity, healing re-stores the child under fakeOid and the retry succeeds — transparently.
+		assertDoesNotThrow(() -> this.storage.store(parent), "heal mode must repair the store transparently");
+
+		// the healed child must have kept its object id.
+		assertEquals(fakeOid, registry.lookupObjectId(child), "the healed child must keep its object id");
+
+		// persist as root and restart: the graph must be fully intact.
+		this.storage.setRoot(parent);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		final Parent reloaded = (Parent)this.storage.root();
+		assertNotNull(reloaded);
+		assertNotNull(reloaded.child, "the healed child must be loadable after restart");
+		assertEquals("healed child", reloaded.child.data);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child child;
+
+		public Parent(final Child child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/HealModeTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/HealModeTest.java
@@ -17,17 +17,21 @@ package test.eclipse.store.danglingref;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 
 import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.reference.Lazy;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.eclipse.store.storage.types.Storage;
 import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -35,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
  * never-stored instance must succeed transparently — the storer re-stores the instance under its
  * existing object id and retries. The persisted graph must be fully intact after a restart.
  */
+@Timeout(60)
 public class HealModeTest
 {
 	@TempDir
@@ -78,7 +83,12 @@ public class HealModeTest
 		final Child child   = new Child("healed child");
 		registry.registerObject(fakeOid, child);
 
-		final Parent parent = new Parent(child);
+		// a fresh Lazy in the same store: its link (set during serialization, rolled back on
+		// terminal commit failure) must survive the intermediate, subsequently-healed rejection.
+		final Lazy<Payload> lazy   = Lazy.Reference(new Payload("lazy payload"));
+		final Parent        parent = new Parent(child, lazy);
+
+		assertFalse(lazy.isStored(), "precondition: a fresh Lazy must be unstored");
 
 		// the plain lazy store skips the registry-known child; validation detects the missing
 		// entity, healing re-stores the child under fakeOid and the retry succeeds — transparently.
@@ -88,6 +98,10 @@ public class HealModeTest
 		DanglingRefTestUtil.assertRejectionsRecorded(recorder);
 		assertArrayEquals(new long[]{fakeOid}, recorder.reportedObjectIds.get(0),
 			"the rejection must report exactly the ghost's object id");
+
+		// the healed store committed successfully, so the Lazy must remain linked: an $unlink
+		// rollback wrongly firing on the healed (non-terminal) rejection round would show here.
+		assertTrue(lazy.isStored(), "a successfully healed store must leave the fresh Lazy linked");
 
 		// the healed child must have kept its object id.
 		assertEquals(fakeOid, registry.lookupObjectId(child), "the healed child must keep its object id");
@@ -102,6 +116,8 @@ public class HealModeTest
 		assertNotNull(reloaded);
 		assertNotNull(reloaded.child, "the healed child must be loadable after restart");
 		assertEquals("healed child", reloaded.child.data);
+		assertNotNull(reloaded.lazy.get(), "the Lazy referent must be loadable after restart");
+		assertEquals("lazy payload", reloaded.lazy.get().data);
 	}
 
 
@@ -111,12 +127,25 @@ public class HealModeTest
 
 	public static class Parent
 	{
-		public Child child;
+		public Child         child;
+		public Lazy<Payload> lazy ;
 
-		public Parent(final Child child)
+		public Parent(final Child child, final Lazy<Payload> lazy)
 		{
 			super();
 			this.child = child;
+			this.lazy  = lazy ;
+		}
+	}
+
+	public static class Payload
+	{
+		public String data;
+
+		public Payload(final String data)
+		{
+			super();
+			this.data = data;
 		}
 	}
 

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/HealModeTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/HealModeTest.java
@@ -14,6 +14,7 @@ package test.eclipse.store.danglingref;
  * #L%
  */
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -60,12 +61,14 @@ public class HealModeTest
 	@Test
 	void danglingReferenceIsHealedTransparently()
 	{
+		final DanglingRefTestUtil.RecordingEventLogger recorder = new DanglingRefTestUtil.RecordingEventLogger();
 		this.storage = EmbeddedStorage.Foundation(
 				Storage.ConfigurationBuilder()
 					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
 					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
 					.createConfiguration()
 			)
+			.setEventLogger(recorder)
 			.start();
 
 		final PersistenceObjectRegistry registry =
@@ -80,6 +83,11 @@ public class HealModeTest
 		// the plain lazy store skips the registry-known child; validation detects the missing
 		// entity, healing re-stores the child under fakeOid and the retry succeeds — transparently.
 		assertDoesNotThrow(() -> this.storage.store(parent), "heal mode must repair the store transparently");
+
+		// precondition: the store must actually have been rejected once, otherwise nothing was healed.
+		DanglingRefTestUtil.assertRejectionsRecorded(recorder);
+		assertArrayEquals(new long[]{fakeOid}, recorder.reportedObjectIds.get(0),
+			"the rejection must report exactly the ghost's object id");
 
 		// the healed child must have kept its object id.
 		assertEquals(fakeOid, registry.lookupObjectId(child), "the healed child must keep its object id");

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/HealedSubgraphLazyTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/HealedSubgraphLazyTest.java
@@ -1,0 +1,156 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A fresh {@code Lazy} inside the HEALED subgraph (serialized by the healing storer, not by the
+ * rejected original store): its deferred {@code $link} is routed to the root storer and must fire
+ * exactly with the outer commit's success — the store returns with the Lazy properly linked, and
+ * the referent is loadable after a restart. (The failure-side counterpart — a terminally failed
+ * retry must leave such a Lazy unlinked — lives serializer-side in {@code HealingDeferredLinkTest},
+ * since real storage cannot deterministically fail the retry after a successful healing round.)
+ */
+@Timeout(60)
+public class HealedSubgraphLazyTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void lazyInsideHealedSubgraphIsLinkedWithTheOuterCommit()
+	{
+		final DanglingRefTestUtil.RecordingEventLogger recorder = new DanglingRefTestUtil.RecordingEventLogger();
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
+					.createConfiguration()
+			)
+			.setEventLogger(recorder)
+			.start();
+
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		// the ghost child's subgraph holds a fresh Lazy - only the HEALING commit serializes it.
+		final Lazy<Payload> freshLazy = Lazy.Reference(new Payload("healed lazy payload"));
+		final long          fakeOid   = DanglingRefTestUtil.FAKE_OID_BASE + 90;
+		final Child         child     = new Child("healed child", freshLazy);
+		registry.registerObject(fakeOid, child);
+
+		final Parent parent = new Parent(child);
+
+		assertFalse(freshLazy.isStored(), "precondition: a fresh Lazy must be unstored");
+
+		assertDoesNotThrow(() -> this.storage.store(parent), "heal mode must repair the store transparently");
+
+		// precondition: the healing path must actually have been exercised.
+		DanglingRefTestUtil.assertRejectionsRecorded(recorder);
+
+		// the healing storer serialized the Lazy; its transferred $link must have fired with the
+		// outer commit's success - as if the store had never been rejected.
+		assertTrue(freshLazy.isStored(), "the healed subgraph's Lazy must be linked after the successful store");
+
+		// restart: the whole healed subgraph including the Lazy referent must be intact.
+		this.storage.setRoot(parent);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		final Parent reloaded = (Parent)this.storage.root();
+		assertNotNull(reloaded);
+		assertNotNull(reloaded.child, "the healed child must be loadable after restart");
+		assertEquals("healed child", reloaded.child.data);
+		assertNotNull(reloaded.child.lazy.get(), "the healed subgraph's Lazy referent must be loadable after restart");
+		assertEquals("healed lazy payload", reloaded.child.lazy.get().data);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child child;
+
+		public Parent(final Child child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Child
+	{
+		public String        data;
+		public Lazy<Payload> lazy;
+
+		public Child(final String data, final Lazy<Payload> lazy)
+		{
+			super();
+			this.data = data;
+			this.lazy = lazy;
+		}
+	}
+
+	public static class Payload
+	{
+		public String data;
+
+		public Payload(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/LazyUnlinkRollbackTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/LazyUnlinkRollbackTest.java
@@ -32,6 +32,7 @@ import org.eclipse.store.storage.types.Storage;
 import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
  * disk — making it legally clearable and a later successful store would persist the phantom id.
  * The registered rollback hook must {@code $unlink} the Lazy on terminal commit failure.
  */
+@Timeout(60)
 public class LazyUnlinkRollbackTest
 {
 	@TempDir

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/LazyUnlinkRollbackTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/LazyUnlinkRollbackTest.java
@@ -1,0 +1,162 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Commit-failure rollback of {@code Lazy.$link}: storing links the referent's object id into the
+ * {@code Lazy} instance during serialization, BEFORE the commit write. Without rollback, a failed
+ * commit would leave the Lazy reporting {@code isStored() == true} with an id that never reached
+ * disk — making it legally clearable and a later successful store would persist the phantom id.
+ * The registered rollback hook must {@code $unlink} the Lazy on terminal commit failure.
+ */
+public class LazyUnlinkRollbackTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void failedCommitUnlinksFreshlyLinkedLazy()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.FAIL)
+					.createConfiguration()
+			)
+			.start();
+
+		// a ghost reference guarantees the commit is rejected...
+		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 80;
+		final Child ghost   = new Child("never stored");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, ghost);
+
+		// ...while the same commit freshly links a Lazy (unset -> set transition during serialization).
+		final Lazy<Payload> lazy   = Lazy.Reference(new Payload("payload"));
+		final Holder        holder = new Holder(lazy, ghost);
+
+		assertFalse(lazy.isStored(), "precondition: fresh Lazy must be unstored");
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.store(holder)
+		);
+		assertNotNull(
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class),
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+
+		// the rollback hook must have unlinked the Lazy: it is unstored again...
+		assertFalse(lazy.isStored(), "failed commit must roll back the Lazy link");
+		// ...and therefore not clearable (this call would silently succeed on a stale link).
+		assertThrows(IllegalStateException.class, lazy::clear,
+			"an unstored Lazy may not be clearable");
+
+		// a subsequent correct store (ghost included in the same commit) succeeds and re-links.
+		final Storer storer = this.storage.createStorer();
+		storer.storeAll(holder, ghost);
+		assertDoesNotThrow(storer::commit);
+		assertTrue(lazy.isStored(), "successful commit must link the Lazy again");
+
+		// restart: graph intact, Lazy loadable.
+		this.storage.setRoot(holder);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		final Holder reloaded = (Holder)this.storage.root();
+		assertNotNull(reloaded);
+		assertNotNull(reloaded.lazy.get(), "Lazy referent must be loadable after restart");
+		assertEquals("payload", reloaded.lazy.get().data);
+		assertEquals("never stored", reloaded.ghost.data);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Holder
+	{
+		public Lazy<Payload> lazy ;
+		public Child         ghost;
+
+		public Holder(final Lazy<Payload> lazy, final Child ghost)
+		{
+			super();
+			this.lazy  = lazy ;
+			this.ghost = ghost;
+		}
+	}
+
+	public static class Payload
+	{
+		public String data;
+
+		public Payload(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/MaxHealDepthTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/MaxHealDepthTest.java
@@ -1,0 +1,188 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Recursion limit of the healing storer ({@code BinaryStorer.MAX_HEAL_DEPTH} = 4). In a chain of
+ * registry-known but never-stored ghosts, ghost level {@code k} is healed by a storer at heal
+ * depth {@code k}; a storer at the maximum depth gives up on a rejection of its own commit. So a
+ * chain of 4 ghost levels is the deepest healable graph, 5 levels must fail terminally with the
+ * typed dangling-reference exception - and the storage must remain usable.
+ */
+@Timeout(60)
+public class MaxHealDepthTest
+{
+	/** Mirrors {@code BinaryStorer.MAX_HEAL_DEPTH} (not visible from here). */
+	static final int MAX_HEAL_DEPTH = 4;
+
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	final DanglingRefTestUtil.RecordingEventLogger recorder = new DanglingRefTestUtil.RecordingEventLogger();
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	private void startStorage()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
+					.createConfiguration()
+			)
+			.setEventLogger(this.recorder)
+			.start();
+	}
+
+	/**
+	 * Builds parent -> ghost1 -> ... -> ghostN where every ghost is registry-known but never
+	 * stored, and returns the ghost chain's fake object ids (index 0 = ghost1).
+	 */
+	private Node buildGhostChain(final int ghostLevels, final long oidBase, final long[] fakeOids)
+	{
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		Node next = null;
+		for(int level = ghostLevels; level >= 1; level--)
+		{
+			final Node ghost = new Node("ghost level " + level, next);
+			fakeOids[level - 1] = oidBase + level;
+			registry.registerObject(fakeOids[level - 1], ghost);
+			next = ghost;
+		}
+		return new Node("parent", next);
+	}
+
+	@Test
+	void chainAtMaxHealDepthIsHealed()
+	{
+		this.startStorage();
+
+		final long[] fakeOids = new long[MAX_HEAL_DEPTH];
+		final Node   parent   = buildGhostChain(MAX_HEAL_DEPTH, DanglingRefTestUtil.FAKE_OID_BASE + 200, fakeOids);
+
+		assertDoesNotThrow(() -> this.storage.store(parent),
+			"a ghost chain of exactly MAX_HEAL_DEPTH levels must still be healable");
+
+		// one rejection/heal round per ghost level, in chain order (single channel).
+		DanglingRefTestUtil.assertRejectionsRecorded(this.recorder);
+		assertEquals(MAX_HEAL_DEPTH, this.recorder.eventCount(),
+			"exactly one heal round per ghost level expected");
+		for(int level = 0; level < MAX_HEAL_DEPTH; level++)
+		{
+			assertArrayEquals(new long[]{fakeOids[level]}, this.recorder.reportedObjectIds.get(level),
+				"heal round " + (level + 1) + " must reject exactly ghost level " + (level + 1));
+		}
+
+		// restart: the whole chain must be persisted intact.
+		this.storage.setRoot(parent);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		Node node = (Node)this.storage.root();
+		assertNotNull(node);
+		for(int level = 1; level <= MAX_HEAL_DEPTH; level++)
+		{
+			node = node.next;
+			assertNotNull(node, "ghost level " + level + " must be loadable after restart");
+			assertEquals("ghost level " + level, node.data);
+		}
+	}
+
+	@Test
+	void chainBeyondMaxHealDepthFailsTerminally()
+	{
+		this.startStorage();
+
+		final int    ghostLevels = MAX_HEAL_DEPTH + 1;
+		final long[] fakeOids    = new long[ghostLevels];
+		final Node   parent      = buildGhostChain(ghostLevels, DanglingRefTestUtil.FAKE_OID_BASE + 210, fakeOids);
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.store(parent),
+			"a ghost chain exceeding MAX_HEAL_DEPTH must fail"
+		);
+		final StorageExceptionConsistencyDanglingReference danglingReference =
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class);
+		assertNotNull(
+			danglingReference,
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+		assertArrayEquals(
+			new long[]{fakeOids[ghostLevels - 1]},
+			danglingReference.missingObjectIds(),
+			"the surfaced rejection must be the deepest ghost's - where healing gave up"
+		);
+
+		// the storage itself must remain usable.
+		assertDoesNotThrow(() -> this.storage.store(new Node("independent data", null)));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Node
+	{
+		public String data;
+		public Node   next;
+
+		public Node(final String data, final Node next)
+		{
+			super();
+			this.data = data;
+			this.next = next;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelHealTest.java
@@ -29,6 +29,7 @@ import org.eclipse.store.storage.types.Storage;
 import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
  * rewind between rounds (peer channels that already wrote are rolled back and must rewrite
  * byte-identical data on retry).
  */
+@Timeout(60)
 public class MultiChannelHealTest
 {
 	static final int CHANNEL_COUNT = 4;
@@ -100,6 +102,15 @@ public class MultiChannelHealTest
 		DanglingRefTestUtil.assertRejectionsRecorded(recorder);
 		assertEquals(CHANNEL_COUNT, recorder.distinctReportingChannels(),
 			"every channel must have rejected (and thus healed) its own ghost");
+		/*
+		 * Pin the multi-ROUND retry: healing repairs only the surfaced (first failing) channel's
+		 * ids per round, while every channel still holding a ghost re-rejects on each retry -
+		 * 4+3+2+1 events for 4 channels. A validation aggregating all channels into one rejection
+		 * would heal everything in a single round (exactly CHANNEL_COUNT events) and silently
+		 * stop covering the round loop and the buffer rewind between rounds.
+		 */
+		assertEquals(CHANNEL_COUNT * (CHANNEL_COUNT + 1) / 2, recorder.eventCount(),
+			"one heal round per channel expected, with every remaining ghost channel re-rejecting per round");
 
 		for(int i = 0; i < CHANNEL_COUNT; i++)
 		{
@@ -118,7 +129,6 @@ public class MultiChannelHealTest
 					.createConfiguration()
 			)
 			.start();
-		@SuppressWarnings("unchecked")
 		final Parent reloaded = (Parent)this.storage.root();
 		assertNotNull(reloaded);
 		assertEquals(CHANNEL_COUNT, reloaded.children.size());

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelHealTest.java
@@ -1,0 +1,150 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Multi-channel healing: with dangling references on every channel, each rejection surfaces only
+ * the first failing channel's missing ids, so healing proceeds one channel per round — this test
+ * exercises the multi-round retry (attempt cap = channel count + 1) and, critically, the buffer
+ * rewind between rounds (peer channels that already wrote are rolled back and must rewrite
+ * byte-identical data on retry).
+ */
+public class MultiChannelHealTest
+{
+	static final int CHANNEL_COUNT = 4;
+
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void danglingReferencesOnAllChannelsAreHealed()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setChannelCountProvider(Storage.ChannelCountProvider(CHANNEL_COUNT))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
+					.createConfiguration()
+			)
+			.start();
+
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		// one ghost per channel: consecutive ids cover all (oid & 3) residues.
+		final List<Child> children = new ArrayList<>();
+		final long[]      fakeOids = new long[CHANNEL_COUNT];
+		for(int i = 0; i < CHANNEL_COUNT; i++)
+		{
+			final Child child = new Child("ghost #" + i);
+			fakeOids[i] = DanglingRefTestUtil.FAKE_OID_BASE + 100 + i;
+			registry.registerObject(fakeOids[i], child);
+			children.add(child);
+		}
+
+		final Parent parent = new Parent(children);
+
+		assertDoesNotThrow(() -> this.storage.store(parent), "multi-round healing must succeed");
+
+		for(int i = 0; i < CHANNEL_COUNT; i++)
+		{
+			assertEquals(fakeOids[i], registry.lookupObjectId(children.get(i)),
+				"healed child #" + i + " must keep its object id");
+		}
+
+		this.storage.setRoot(parent);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setChannelCountProvider(Storage.ChannelCountProvider(CHANNEL_COUNT))
+					.createConfiguration()
+			)
+			.start();
+		@SuppressWarnings("unchecked")
+		final Parent reloaded = (Parent)this.storage.root();
+		assertNotNull(reloaded);
+		assertEquals(CHANNEL_COUNT, reloaded.children.size());
+		for(int i = 0; i < CHANNEL_COUNT; i++)
+		{
+			assertEquals("ghost #" + i, reloaded.children.get(i).data,
+				"healed child #" + i + " must be intact after restart");
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public List<Child> children;
+
+		public Parent(final List<Child> children)
+		{
+			super();
+			this.children = children;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/MultiChannelHealTest.java
@@ -66,6 +66,7 @@ public class MultiChannelHealTest
 	@Test
 	void danglingReferencesOnAllChannelsAreHealed()
 	{
+		final DanglingRefTestUtil.RecordingEventLogger recorder = new DanglingRefTestUtil.RecordingEventLogger();
 		this.storage = EmbeddedStorage.Foundation(
 				Storage.ConfigurationBuilder()
 					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
@@ -73,6 +74,7 @@ public class MultiChannelHealTest
 					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
 					.createConfiguration()
 			)
+			.setEventLogger(recorder)
 			.start();
 
 		final PersistenceObjectRegistry registry =
@@ -92,6 +94,12 @@ public class MultiChannelHealTest
 		final Parent parent = new Parent(children);
 
 		assertDoesNotThrow(() -> this.storage.store(parent), "multi-round healing must succeed");
+
+		// precondition: healing coverage requires actual rejections; a ghost can only be healed
+		// after its own channel rejected it, so every channel must have reported at least once.
+		DanglingRefTestUtil.assertRejectionsRecorded(recorder);
+		assertEquals(CHANNEL_COUNT, recorder.distinctReportingChannels(),
+			"every channel must have rejected (and thus healed) its own ghost");
 
 		for(int i = 0; i < CHANNEL_COUNT; i++)
 		{

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/RegistryTrustedSkipValidationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/RegistryTrustedSkipValidationTest.java
@@ -23,8 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -123,7 +121,7 @@ public class RegistryTrustedSkipValidationTest
 	@Test
 	void logModeReportsDanglingReferenceButCommits()
 	{
-		final RecordingEventLogger recorder = new RecordingEventLogger();
+		final DanglingRefTestUtil.RecordingEventLogger recorder = new DanglingRefTestUtil.RecordingEventLogger();
 		this.startStorage(StorageReferenceValidationPolicy.LOG, recorder);
 
 		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 1;
@@ -140,7 +138,7 @@ public class RegistryTrustedSkipValidationTest
 	@Test
 	void offModeIsSilent()
 	{
-		final RecordingEventLogger recorder = new RecordingEventLogger();
+		final DanglingRefTestUtil.RecordingEventLogger recorder = new DanglingRefTestUtil.RecordingEventLogger();
 		this.startStorage(StorageReferenceValidationPolicy.OFF, recorder);
 
 		final long  fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 2;
@@ -205,17 +203,4 @@ public class RegistryTrustedSkipValidationTest
 		}
 	}
 
-	static final class RecordingEventLogger implements StorageEventLogger
-	{
-		final List<long[]> reportedObjectIds = new ArrayList<>();
-
-		@Override
-		public void logStoreDetectedDanglingReferences(final int channelIndex, final long[] objectIds)
-		{
-			synchronized(this.reportedObjectIds)
-			{
-				this.reportedObjectIds.add(objectIds);
-			}
-		}
-	}
 }

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/TransitiveHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/TransitiveHealTest.java
@@ -14,6 +14,7 @@ package test.eclipse.store.danglingref;
  * #L%
  */
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -60,12 +61,14 @@ public class TransitiveHealTest
 	@Test
 	void transitiveDanglingReferencesAreHealedRecursively()
 	{
+		final DanglingRefTestUtil.RecordingEventLogger recorder = new DanglingRefTestUtil.RecordingEventLogger();
 		this.storage = EmbeddedStorage.Foundation(
 				Storage.ConfigurationBuilder()
 					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
 					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
 					.createConfiguration()
 			)
+			.setEventLogger(recorder)
 			.start();
 
 		final PersistenceObjectRegistry registry =
@@ -88,6 +91,16 @@ public class TransitiveHealTest
 		 * recursively at depth + 1.
 		 */
 		assertDoesNotThrow(() -> this.storage.store(parent), "transitive healing must succeed");
+
+		// precondition: two heal rounds must have happened - the initial store rejected for the
+		// child, then the child's healing commit itself rejected for the grandchild. A single
+		// (or zero) rejection means the recursive path was not exercised.
+		DanglingRefTestUtil.assertRejectionsRecorded(recorder);
+		assertEquals(2, recorder.eventCount(), "exactly two heal rounds expected (child, then grandchild)");
+		assertArrayEquals(new long[]{fakeChildOid}, recorder.reportedObjectIds.get(0),
+			"round 1 must reject the ghost child");
+		assertArrayEquals(new long[]{fakeGrandchildOid}, recorder.reportedObjectIds.get(1),
+			"round 2 (the healing commit) must reject the ghost grandchild");
 
 		assertEquals(fakeChildOid,      registry.lookupObjectId(child)     );
 		assertEquals(fakeGrandchildOid, registry.lookupObjectId(grandchild));

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/TransitiveHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/TransitiveHealTest.java
@@ -28,6 +28,7 @@ import org.eclipse.store.storage.types.Storage;
 import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.io.TempDir;
  * instance. The compensating store's own commit detects and heals the transitive dangling reference
  * (at healing depth + 1); the whole graph must be persisted intact.
  */
+@Timeout(60)
 public class TransitiveHealTest
 {
 	@TempDir

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/TransitiveHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/TransitiveHealTest.java
@@ -1,0 +1,125 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Recursive healing: the healed instance itself references another registry-known but never-stored
+ * instance. The compensating store's own commit detects and heals the transitive dangling reference
+ * (at healing depth + 1); the whole graph must be persisted intact.
+ */
+public class TransitiveHealTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void transitiveDanglingReferencesAreHealedRecursively()
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
+					.createConfiguration()
+			)
+			.start();
+
+		final PersistenceObjectRegistry registry =
+			this.storage.persistenceManager().objectRegistry();
+
+		final long fakeChildOid      = DanglingRefTestUtil.FAKE_OID_BASE + 60;
+		final long fakeGrandchildOid = DanglingRefTestUtil.FAKE_OID_BASE + 61;
+
+		final Node grandchild = new Node("ghost grandchild", null);
+		final Node child      = new Node("ghost child", grandchild);
+		registry.registerObject(fakeChildOid,      child     );
+		registry.registerObject(fakeGrandchildOid, grandchild);
+
+		final Node parent = new Node("parent", child);
+
+		/*
+		 * Storing parent skips child (registry-known). Validation reports fakeChildOid missing;
+		 * the healing commit re-stores child - whose serialization skips the registry-known
+		 * grandchild, so the healing commit itself is rejected for fakeGrandchildOid and heals
+		 * recursively at depth + 1.
+		 */
+		assertDoesNotThrow(() -> this.storage.store(parent), "transitive healing must succeed");
+
+		assertEquals(fakeChildOid,      registry.lookupObjectId(child)     );
+		assertEquals(fakeGrandchildOid, registry.lookupObjectId(grandchild));
+
+		this.storage.setRoot(parent);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+
+		this.storage = EmbeddedStorage.start(this.tempDir);
+		final Node reloaded = (Node)this.storage.root();
+		assertNotNull(reloaded);
+		assertNotNull(reloaded.next, "healed child must be loadable");
+		assertEquals("ghost child", reloaded.next.data);
+		assertNotNull(reloaded.next.next, "recursively healed grandchild must be loadable");
+		assertEquals("ghost grandchild", reloaded.next.next.data);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Node
+	{
+		public String data;
+		public Node   next;
+
+		public Node(final String data, final Node next)
+		{
+			super();
+			this.data = data;
+			this.next = next;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/UnhealableLazyHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/UnhealableLazyHealTest.java
@@ -31,6 +31,7 @@ import org.eclipse.store.storage.types.Storage;
 import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
  * to re-store — the data is genuinely gone. In heal mode such a store must still fail with the
  * typed exception (like fail mode), and the storage must remain usable.
  */
+@Timeout(60)
 public class UnhealableLazyHealTest
 {
 	@TempDir

--- a/integration-tests/src/test/java/test/eclipse/store/danglingref/UnhealableLazyHealTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/danglingref/UnhealableLazyHealTest.java
@@ -1,0 +1,134 @@
+package test.eclipse.store.danglingref;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Healing limits: an unloaded {@code Lazy} reference's dangling cached id has no in-memory instance
+ * to re-store — the data is genuinely gone. In heal mode such a store must still fail with the
+ * typed exception (like fail mode), and the storage must remain usable.
+ */
+public class UnhealableLazyHealTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void unhealableLazyCachedIdStillFailsInHealMode() throws Exception
+	{
+		this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.HEAL)
+					.createConfiguration()
+			)
+			.start();
+
+		// obtain the storage's loader via a properly stored Lazy (same pattern as LazyDanglingReferenceTest).
+		final Holder realHolder = new Holder(Lazy.Reference(new Payload("real")));
+		this.storage.store(realHolder);
+		final ObjectSwizzling loader = ((Lazy.Default<?>)realHolder.lazy).$getLoader();
+		assertNotNull(loader);
+
+		// an unloaded Lazy whose cached id points to a non-existing entity: nothing to heal.
+		final long fakeOid = DanglingRefTestUtil.FAKE_OID_BASE + 70;
+		final Constructor<Lazy.Default> constructor =
+			Lazy.Default.class.getDeclaredConstructor(Object.class, long.class, ObjectSwizzling.class);
+		constructor.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		final Lazy<Payload> staleLazy = constructor.newInstance(null, fakeOid, loader);
+
+		final Holder staleHolder = new Holder(staleLazy);
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.store(staleHolder),
+			"an unhealable dangling Lazy cached id must still fail in heal mode"
+		);
+		final StorageExceptionConsistencyDanglingReference danglingReference =
+			DanglingRefTestUtil.findInCauseChain(thrown, StorageExceptionConsistencyDanglingReference.class);
+		assertNotNull(
+			danglingReference,
+			"cause chain must contain a StorageExceptionConsistencyDanglingReference, but was: " + thrown
+		);
+		assertArrayEquals(new long[]{fakeOid}, danglingReference.missingObjectIds());
+
+		// the storage itself must remain usable.
+		assertDoesNotThrow(() -> this.storage.store(new Payload("independent data")));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Holder
+	{
+		public Lazy<Payload> lazy;
+
+		public Holder(final Lazy<Payload> lazy)
+		{
+			super();
+			this.lazy = lazy;
+		}
+	}
+
+	public static class Payload
+	{
+		public String data;
+
+		public Payload(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+}

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
@@ -222,7 +222,7 @@ public enum ConfigurationCoreProperties
 	),
 
 	/**
-	 * Store-time validation of trusted reference object ids: off, log or fail. Default log.
+	 * Store-time validation of trusted reference object ids: off, log, fail or heal. Default log.
 	 */
 	REFERENCE_VALIDATION(
 			Constants.PREFIX + "reference.validation",

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -181,8 +181,8 @@ public class EclipseStoreProperties
     private String dataFileCleanupHeadFile;
 
     /**
-     * Store-time validation of trusted reference object ids: {@code off}, {@code log} or {@code fail}.
-     * Default is {@code log}.
+     * Store-time validation of trusted reference object ids: {@code off}, {@code log}, {@code fail}
+     * or {@code heal}. Default is {@code log}.
      */
     private String referenceValidation;
 

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
@@ -335,8 +335,8 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 	public EmbeddedStorageConfigurationBuilder setTransactionFileMaximumSize(ByteSize transactionFileMaximumSize);
 
 	/**
-	 * Store-time validation of trusted reference object ids: {@code off}, {@code log} or {@code fail}.
-	 * Default is {@code log}.
+	 * Store-time validation of trusted reference object ids: {@code off}, {@code log}, {@code fail}
+	 * or {@code heal}. Default is {@code log}.
 	 *
 	 * @param referenceValidation the policy token
 	 * @return this

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
@@ -177,10 +177,12 @@ public interface EmbeddedStorageConfigurationPropertyNames
 
 	/**
 	 * Store-time validation of trusted reference object ids (references written into a store's data
-	 * whose entities are not part of the store itself): {@code off}, {@code log} or {@code fail}.
-	 * Default (unset) is {@code log}: detected dangling references are logged as an error but the
-	 * store proceeds. {@code fail} rejects such a store atomically; {@code off} disables collection
-	 * and validation entirely (zero overhead).
+	 * whose entities are not part of the store itself): {@code off}, {@code log}, {@code fail} or
+	 * {@code heal}. Default (unset) is {@code log}: detected dangling references are logged as an
+	 * error but the store proceeds. {@code fail} rejects such a store atomically; {@code heal}
+	 * additionally repairs it automatically (re-storing the still-live referenced instances under
+	 * their existing object ids and retrying); {@code off} disables collection and validation
+	 * entirely (zero overhead).
 	 *
 	 * @see EmbeddedStorageConfigurationBuilder#setReferenceValidation(String)
 	 */

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
@@ -28,6 +28,7 @@ import org.eclipse.serializer.persistence.types.PersistenceManager;
 import org.eclipse.serializer.persistence.types.PersistenceStorer;
 import org.eclipse.serializer.reference.Reference;
 import org.eclipse.store.storage.types.StorageConnection;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 import org.eclipse.store.storage.types.StorageRequestAcceptor;
 import org.eclipse.store.storage.types.StorageSystem;
 import org.eclipse.store.storage.types.StorageWriteController;
@@ -400,11 +401,15 @@ extends BinaryPersistenceFoundation<F>
 		@Override
 		protected BinaryStorer.Creator ensureStorerCreator()
 		{
+			// capture/heal derive from the storage-side validation policy; single config knob.
+			final StorageReferenceValidationPolicy referenceValidationPolicy =
+				this.getStorageSystem().configuration().referenceValidationPolicy();
+
 			return BinaryStorer.Creator(
 				this.getStorageSystem().channelCountProvider(),
-				this.isByteOrderMismatch(),
-				// capture is only worthwhile when the storage-side validation is enabled; single config knob.
-				this.getStorageSystem().configuration().referenceValidationPolicy().isValidating()
+				this.isByteOrderMismatch()                    ,
+				referenceValidationPolicy.isValidating()      ,
+				referenceValidationPolicy.isHealing()
 			);
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyDanglingReference.java
@@ -16,6 +16,7 @@ package org.eclipse.store.storage.exceptions;
 
 import java.util.Arrays;
 
+import org.eclipse.serializer.persistence.exceptions.PersistenceDanglingReferences;
 import org.eclipse.serializer.util.X;
 
 /**
@@ -28,11 +29,15 @@ import org.eclipse.serializer.util.X;
  * The store was rejected atomically; the storage remains fully usable. To resolve, re-store the
  * referenced objects so their data exists again &mdash; e.g. include them explicitly in the store
  * ({@code storer.storeAll(parent, child)}) or store them with an eager storer &mdash; and retry.
+ * With the {@code heal} validation policy, the storer performs that repair automatically and this
+ * exception only surfaces when healing is impossible (no live instance for a missing id).
  * <p>
  * Note that at the caller, this exception is wrapped: it appears as the cause of a
  * {@code PersistenceExceptionTransfer} / {@code StorageException} chain.
  */
-public class StorageExceptionConsistencyDanglingReference extends StorageExceptionConsistency
+public class StorageExceptionConsistencyDanglingReference
+extends StorageExceptionConsistency
+implements PersistenceDanglingReferences
 {
 	///////////////////////////////////////////////////////////////////////////
 	// instance fields //
@@ -76,6 +81,7 @@ public class StorageExceptionConsistencyDanglingReference extends StorageExcepti
 	/**
 	 * @return the referenced object ids for which no entity exists (a defensive copy).
 	 */
+	@Override
 	public long[] missingObjectIds()
 	{
 		return this.missingObjectIds.clone();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -138,6 +138,10 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	 * runs exclusively on that channel's own thread between tasks, and this method is invoked on the same
 	 * thread inside the store task, before the store commits. An entity found here therefore cannot be
 	 * deleted before the surrounding store is committed.
+	 * <p>
+	 * Contract for rejections: a failing validation reports ALL missing ids of this channel in one
+	 * exception (the complete miss list is collected before throwing). The storer-side self-healing
+	 * relies on this to bound its retry attempts at one healing round per channel.
 	 *
 	 * @param objectIds the trusted reference object ids assigned to this channel; may be {@code null} or empty.
 	 * @param policy    the validation policy to apply.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -959,11 +959,25 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 				: Arrays.copyOf(missing, count)
 			;
 
-			logger.error(
-				"StorageChannel#{} store references non-existing entities (dangling references): {}",
-				this.channelIndex,
-				Arrays.toString(missingObjectIds)
-			);
+			if(policy.isHealing())
+			{
+				// under heal, a rejection is EXPECTED to be repaired by the storer - WARN, not ERROR.
+				// If healing gives up, the failure surfaces loudly via the thrown exception anyway.
+				logger.warn(
+					"StorageChannel#{} store references non-existing entities (dangling references): {}"
+					+ " - rejecting for the storer to heal.",
+					this.channelIndex,
+					Arrays.toString(missingObjectIds)
+				);
+			}
+			else
+			{
+				logger.error(
+					"StorageChannel#{} store references non-existing entities (dangling references): {}",
+					this.channelIndex,
+					Arrays.toString(missingObjectIds)
+				);
+			}
 			this.eventLogger.logStoreDetectedDanglingReferences(this.channelIndex, missingObjectIds);
 
 			if(policy.isFailing())

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
@@ -102,7 +102,7 @@ public enum StorageReferenceValidationPolicy
 		if(value == null)
 		{
 			throw new IllegalArgumentException(
-				"Reference validation policy must not be null. Valid values are: off, log, fail."
+				"Reference validation policy must not be null. Valid values are: off, log, fail, heal."
 			);
 		}
 		// Locale.ROOT: config parsing must not depend on the platform locale (e.g. Turkish dotless i).

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageReferenceValidationPolicy.java
@@ -32,6 +32,10 @@ package org.eclipse.store.storage.types;
  *       {@link StorageEventLogger}, but the store proceeds.</li>
  *   <li>{@link #FAIL} &mdash; the store is rejected atomically with a
  *       {@link org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference}.</li>
+ *   <li>{@link #HEAL} &mdash; like {@link #FAIL} storage-side, but the storer automatically repairs the
+ *       rejected store: it re-stores the still-live referenced instances under their existing object
+ *       ids and retries — transparently to the caller. Unhealable ids (e.g. an unloaded {@code Lazy}
+ *       reference's cached id, whose data is genuinely gone) still fail like {@link #FAIL}.</li>
  * </ul>
  */
 public enum StorageReferenceValidationPolicy
@@ -49,7 +53,13 @@ public enum StorageReferenceValidationPolicy
 	/**
 	 * Validate and reject a store containing dangling references atomically.
 	 */
-	FAIL;
+	FAIL,
+
+	/**
+	 * Validate, reject, and automatically heal: re-store the referenced instances under their
+	 * existing object ids and retry the store. Falls back to failing when healing is impossible.
+	 */
+	HEAL;
 
 
 	/**
@@ -65,13 +75,21 @@ public enum StorageReferenceValidationPolicy
 	 */
 	public boolean isFailing()
 	{
-		return this == FAIL;
+		return this == FAIL || this == HEAL;
+	}
+
+	/**
+	 * @return whether a rejected store is automatically healed and retried by the storer.
+	 */
+	public boolean isHealing()
+	{
+		return this == HEAL;
 	}
 
 
 	/**
-	 * Parses the external configuration value ({@code "off"}, {@code "log"} or {@code "fail"},
-	 * case-insensitive).
+	 * Parses the external configuration value ({@code "off"}, {@code "log"}, {@code "fail"} or
+	 * {@code "heal"}, case-insensitive).
 	 *
 	 * @param value the configuration value.
 	 *
@@ -93,8 +111,9 @@ public enum StorageReferenceValidationPolicy
 			case "off" : return OFF ;
 			case "log" : return LOG ;
 			case "fail": return FAIL;
+			case "heal": return HEAL;
 			default    : throw new IllegalArgumentException(
-				"Invalid reference validation policy: \"" + value + "\". Valid values are: off, log, fail."
+				"Invalid reference validation policy: \"" + value + "\". Valid values are: off, log, fail, heal."
 			);
 		}
 	}


### PR DESCRIPTION
## What this adds

Reference validation (merged) can detect and reject a store whose data references object ids with no existing entity. This PR adds the fourth policy value: `reference-validation = heal`. Instead of just rejecting such a store, the storer repairs it automatically - the referenced instances are still alive in application memory (that is why their ids were trusted), so they are re-stored under their existing object ids in a small compensating commit and the original store is retried, byte-identical. The caller notices nothing but a WARN log per healing round.

  | Mode | Effect |
  |---|---|
  | `off` | no capture, no validation - zero overhead |
  | `log` (default, unchanged) | missing ids logged and reported, store proceeds |
  | `fail` | store rejected atomically with the typed exception |
  | `heal` | like `fail` storage-side - but the storer heals the rejection and retries |

What heal can NOT fix stays loud: an unloaded `Lazy` reference's cached id has no in-memory instance - if its data is missing, it is genuinely gone and the store fails exactly like `fail` mode.

## Technical details

- Storage-side, `HEAL` behaves identically to `FAIL`: validate per channel before writing, reject with `StorageExceptionConsistencyDanglingReference`, roll the store back atomically. The healing loop lives entirely in the storer (merged serializer side): it recognizes the rejection via the `PersistenceDanglingReferences` interface - which the storage exception now implements - heals, rewinds the buffers, retries.
- `validateTrustedReferences` now documents the rejection contract the healing bound relies on: a failing validation reports ALL missing ids of its channel in one exception, so healing is bounded at one round per channel.
- The compensating commit is a separate commit - deliberately: if the retried store then fails for an unrelated reason, the healed entities are simply unreachable data and the storage garbage collector reclaims them. No partial state, no new atomicity requirements.
- The healed data is the instance's CURRENT in-memory state - strictly an improvement, since the storage had nothing at all for that id.
- Wiring: `StorageReferenceValidationPolicy.HEAL` (`isFailing()` covers FAIL and HEAL, new `isHealing()`), the connection foundation passes the heal flag to the storer creator, the `reference-validation` property accepts `heal` across embedded-configuration, Spring Boot and CDI, and the data-integrity documentation gains an "Automatic Self-Healing" section covering semantics and bounds.

## Tests

Six additions to the danglingref suite (full suite green, restart verification everywhere):

- `HealModeTest` - a rejected store heals transparently; the healed instance keeps its object id; the graph is intact after restart.
- `TransitiveHealTest` - a healed instance itself referencing a missing id heals recursively.
- `MultiChannelHealTest` - 4 channels, one missing id per channel: multi-round healing, proving both the attempt bound and the buffer rewind (peer channels wrote, rolled back, and re-wrote byte-identical data).
- `UnhealableLazyHealTest` - an unloaded Lazy's stale cached id still fails loudly under heal.
- `LazyUnlinkRollbackTest` - after a rejected store, a freshly linked Lazy reports unstored again and a subsequent correct store succeeds (guarding the deferred post-commit linking  semantics under validation failures).
- Plus the existing detection tests, unchanged.

## Dependencies

Requires the storer-side self-healing — merged (eclipse-serializer/serializer#294). `heal` is opt-in; the default remains `log`.