### PR TITLE
Add strict zombie-OID escalation

### DIFF
--- a/docs/modules/storage/pages/configuration/properties.adoc
+++ b/docs/modules/storage/pages/configuration/properties.adoc
@@ -125,6 +125,10 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 |reference-validation
 |Store-time validation of references whose target entities are not part of the store itself (`off`, `log`, `fail` or `heal`). With `log` (the default), a store referencing a non-existing entity (dangling reference) is logged as an error but proceeds; with `fail` such a store is rejected atomically; with `heal` a rejected store is additionally repaired automatically (the still-live referenced instances are re-stored under their existing object ids and the store is retried); `off` disables the validation entirely (zero overhead). See xref:../data-integrity.adoc[Data Integrity] for the failure mode this guards against.
 |xref:#type-string[String]
+
+|gc-zombie-oid-handling
+|Reaction of the storage garbage collector to an encountered zombie object id — a persisted binary record referencing a non-existing entity, i.e. a dangling reference already present in the storage (`log` or `fail`). With `log` (the default), the zombie is logged as a warning and reported to the event logger, and garbage collection continues; with `fail` a `StorageExceptionConsistencyZombieOid` is thrown, halting the affected channel while the evidence may still be recoverable. See xref:../data-integrity.adoc[Data Integrity].
+|xref:#type-string[String]
 |===
 
 == Property Types

--- a/docs/modules/storage/pages/data-integrity.adoc
+++ b/docs/modules/storage/pages/data-integrity.adoc
@@ -350,6 +350,25 @@ Details and bounds:
 * Transitive dangling references (a healed instance itself referencing a missing id) are healed recursively, bounded by a maximum depth; the number of retry rounds is bounded by the channel count.
 * **Unhealable:** an unloaded `Lazy` reference's cached id has no in-memory instance — if such an id is missing, the data is genuinely gone and the store fails exactly like `fail` mode.
 
+== Zombie Object Id Escalation
+
+Reference validation guards *new* stores. A dangling reference that is *already persisted* (pre-existing corruption, crash artifacts, data written by older versions) is first noticed by the storage garbage collector's marking, when it walks a binary record and hits an object id with no entity — a *zombie object id*. By default this is only logged as a warning (and reported via `StorageEventLogger#logGarbageCollectorEncounteredZombieObjectId`); the first hard failure then typically happens at a much later load or restart, after housekeeping may have physically reclaimed related data.
+
+The `gc-zombie-oid-handling` configuration property (or `EmbeddedStorageFoundation#setGCZombieOidHandler(StorageGCZombieOidHandler.Strict())`) escalates this:
+
+[cols="1,3"]
+|===
+| Mode | Effect
+
+| `log` (default)
+| The zombie is WARN-logged and reported to the event logger; garbage collection continues.
+
+| `fail`
+| A `StorageExceptionConsistencyZombieOid` (carrying the object id) is thrown at mark time, halting the affected storage channel. This sacrifices availability for integrity visibility: the failure happens while the swept entity's bytes may still be physically present in the data files (the startup scanner can resurrect uncompacted entities), maximizing the chance of diagnosis and recovery.
+|===
+
+Treat any zombie warning as a data-integrity alarm: it means a dangling reference exists on disk, whatever its origin.
+
 == Limitations
 
 * Verification runs automatically only at startup; it does not re-check individual lazy/cache loads during normal operation. A running storage can be re-verified explicitly with an on-demand integrity check (see <<_on_demand_integrity_verification>>).

--- a/integration-tests/src/test/java/test/eclipse/store/zombie/StrictZombieOidHandlerTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/StrictZombieOidHandlerTest.java
@@ -1,0 +1,202 @@
+package test.eclipse.store.zombie;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyZombieOid;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageGCZombieOidHandler;
+import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Escalation of zombie object ids: a dangling reference that is ALREADY persisted (here planted by
+ * committing a store with reference validation off) is first noticed by the GC's marking. The
+ * default handler tolerates it (WARN + event, GC continues); the strict handler must throw a
+ * {@link StorageExceptionConsistencyZombieOid} carrying the object id, so the corruption surfaces
+ * while the evidence is still recoverable instead of at a much later restart.
+ */
+public class StrictZombieOidHandlerTest
+{
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	@AfterEach
+	public void afterTest()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	private EmbeddedStorageManager startStorage(final StorageGCZombieOidHandler zombieHandler)
+	{
+		return this.storage = EmbeddedStorage.Foundation(
+				Storage.ConfigurationBuilder()
+					.setStorageFileProvider(Storage.FileProvider(this.tempDir))
+					// validation off so the dangling reference can actually be committed
+					.setReferenceValidationPolicy(StorageReferenceValidationPolicy.OFF)
+					// huge housekeeping interval: the zombie surfaces deterministically in the
+					// ISSUED gc task below, whose failure propagates to the calling thread.
+					.setHousekeepingController(Storage.HousekeepingController(3_600_000, 1_000_000))
+					.createConfiguration()
+			)
+			.setGCZombieOidHandler(zombieHandler)
+			.start();
+	}
+
+	private Parent plantPersistedDanglingReference(final long fakeOid)
+	{
+		final Child ghost = new Child("never stored");
+		this.storage.persistenceManager().objectRegistry().registerObject(fakeOid, ghost);
+
+		// commits a reference to fakeOid without any entity existing for it (validation is off).
+		// keeping the parent instance strongly held makes it registry-resident, so the GC's
+		// live-OID seed marks it and the mark phase walks its binary into the zombie id.
+		final Parent parent = new Parent(ghost);
+		this.storage.store(parent);
+		return parent;
+	}
+
+	@Test
+	@Timeout(60) // guards the task-chain repair: a failed issued GC must not strand the shutdown
+	void strictHandlerThrowsAtMarkTimeWithTheZombieOid()
+	{
+		this.startStorage(StorageGCZombieOidHandler.Strict());
+
+		final long   fakeOid = 1_000_000_000_910_000_000L;
+		final Parent parent  = this.plantPersistedDanglingReference(fakeOid);
+
+		final RuntimeException thrown = assertThrows(
+			RuntimeException.class,
+			() -> this.storage.issueFullGarbageCollection(),
+			"the strict handler must fail the GC on the persisted dangling reference"
+		);
+		final StorageExceptionConsistencyZombieOid zombie =
+			findInCauseChain(thrown, StorageExceptionConsistencyZombieOid.class);
+		assertNotNull(zombie,
+			"cause chain must contain a StorageExceptionConsistencyZombieOid, but was: " + thrown);
+		assertEquals(fakeOid, zombie.objectId(), "the zombie exception must carry the dangling object id");
+
+		// keep the parent reachable until here so the seed path is deterministic.
+		assertNotNull(parent);
+	}
+
+	@Test
+	@Timeout(60)
+	void toleratingHandlerReportsTheZombieAndGcCompletes()
+	{
+		final CountingZombieOidHandler counting = new CountingZombieOidHandler();
+		this.startStorage(counting);
+
+		final long   fakeOid = 1_000_000_000_910_000_001L;
+		final Parent parent  = this.plantPersistedDanglingReference(fakeOid);
+
+		// pre-fix behavior, unchanged: the zombie is reported but the GC completes.
+		assertDoesNotThrow(() -> this.storage.issueFullGarbageCollection());
+		assertTrue(counting.zombieOids.contains(fakeOid),
+			"the tolerating handler must still report the zombie id, got: " + counting.zombieOids);
+
+		assertNotNull(parent);
+	}
+
+	private static <T extends Throwable> T findInCauseChain(final Throwable root, final Class<T> type)
+	{
+		Throwable slow = root, fast = root;
+		while(fast != null)
+		{
+			if(type.isInstance(fast))
+			{
+				return type.cast(fast);
+			}
+			fast = fast.getCause();
+			if(type.isInstance(fast)) // isInstance(null) is false
+			{
+				return type.cast(fast);
+			}
+			fast = fast == null ? null : fast.getCause();
+			slow = slow.getCause();
+			if(fast != null && fast == slow)
+			{
+				break; // cause cycle
+			}
+		}
+		return null;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class Parent
+	{
+		public Child child;
+
+		public Parent(final Child child)
+		{
+			super();
+			this.child = child;
+		}
+	}
+
+	public static class Child
+	{
+		public String data;
+
+		public Child(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+
+	static final class CountingZombieOidHandler implements StorageGCZombieOidHandler
+	{
+		final List<Long> zombieOids = Collections.synchronizedList(new ArrayList<>());
+
+		@Override
+		public boolean handleZombieOid(final long objectId)
+		{
+			this.zombieOids.add(objectId);
+			return true;
+		}
+	}
+}

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
@@ -230,6 +230,14 @@ public enum ConfigurationCoreProperties
 	),
 
 	/**
+	 * Reaction of the storage garbage collector to an encountered zombie object id: log or fail. Default log.
+	 */
+	GC_ZOMBIE_OID_HANDLING(
+			Constants.PREFIX + "gc.zombie.oid.handling",
+			EmbeddedStorageConfigurationPropertyNames.GC_ZOMBIE_OID_HANDLING
+	),
+
+	/**
 	 * Primary chunk-checksum algorithm: none, crc32c or sha256-chained. Default sha256-chained.
 	 */
 	CHUNK_CHECKSUM_ALGORITHM(

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -187,6 +187,12 @@ public class EclipseStoreProperties
     private String referenceValidation;
 
     /**
+     * Reaction of the storage garbage collector to an encountered zombie object id:
+     * {@code log} or {@code fail}. Default is {@code log}.
+     */
+    private String gcZombieOidHandling;
+
+    /**
      * Per-chunk data-integrity checksum configuration. Bound from {@code org.eclipse.store.chunk-checksum.*}.
      */
     @NestedConfigurationProperty
@@ -520,6 +526,16 @@ public class EclipseStoreProperties
     public void setReferenceValidation(final String referenceValidation)
     {
         this.referenceValidation = referenceValidation;
+    }
+
+    public String getGcZombieOidHandling()
+    {
+        return this.gcZombieOidHandling;
+    }
+
+    public void setGcZombieOidHandling(final String gcZombieOidHandling)
+    {
+        this.gcZombieOidHandling = gcZombieOidHandling;
     }
 
     public ChunkChecksum getChunkChecksum()

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -85,6 +85,9 @@ public class EclipseStoreConfigConverter
     // Field for the store-time reference validation (data integrity) configuration
     protected static final String REFERENCE_VALIDATION = EmbeddedStorageConfigurationPropertyNames.REFERENCE_VALIDATION;
 
+    // Field for the GC zombie object id reaction (data integrity) configuration
+    protected static final String GC_ZOMBIE_OID_HANDLING = EmbeddedStorageConfigurationPropertyNames.GC_ZOMBIE_OID_HANDLING;
+
     // Fields for the chunk-checksum (data integrity) configuration
     protected static final String CHUNK_CHECKSUM_ALGORITHM = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_ALGORITHM;
     protected static final String CHUNK_CHECKSUM_PROFILE = EmbeddedStorageConfigurationPropertyNames.CHUNK_CHECKSUM_PROFILE;
@@ -150,6 +153,7 @@ public class EclipseStoreConfigConverter
         configValues.put(DATA_FILE_MINIMUM_USE_RATIO, properties.getDataFileMinimumUseRatio());
         configValues.put(DATA_FILE_CLEANUP_HEAD_FILE, properties.getDataFileCleanupHeadFile());
         configValues.put(REFERENCE_VALIDATION, properties.getReferenceValidation());
+        configValues.put(GC_ZOMBIE_OID_HANDLING, properties.getGcZombieOidHandling());
 
         if (properties.getChunkChecksum() != null)
         {

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
@@ -344,6 +344,15 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 	public EmbeddedStorageConfigurationBuilder setReferenceValidation(String referenceValidation);
 
 	/**
+	 * Reaction of the storage garbage collector to an encountered zombie object id:
+	 * {@code log} or {@code fail}. Default is {@code log}.
+	 *
+	 * @param gcZombieOidHandling the reaction token
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setGcZombieOidHandling(String gcZombieOidHandling);
+
+	/**
 	 * The primary chunk-checksum algorithm: {@code none}, {@code crc32c} or
 	 * {@code sha256-chained}. Default is {@code sha256-chained}. Setting any {@code chunk-checksum-*} property
 	 * activates declarative configuration of the feature; leaving them all unset keeps the framework default.
@@ -786,6 +795,14 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 		)
 		{
 			return this.set(REFERENCE_VALIDATION, referenceValidation);
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setGcZombieOidHandling(
+			final String gcZombieOidHandling
+		)
+		{
+			return this.set(GC_ZOMBIE_OID_HANDLING, gcZombieOidHandling);
 		}
 
 		@Override

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
@@ -189,6 +189,18 @@ public interface EmbeddedStorageConfigurationPropertyNames
 	public final static String REFERENCE_VALIDATION             = "reference-validation";
 
 	/**
+	 * Reaction of the storage garbage collector to an encountered zombie object id (a persisted
+	 * binary record referencing a non-existing entity, i.e. a dangling reference already present in
+	 * the storage): {@code log} or {@code fail}. Default (unset) is {@code log}: the zombie is
+	 * WARN-logged and reported to the event logger, the garbage collection continues. {@code fail}
+	 * throws a {@code StorageExceptionConsistencyZombieOid}, halting the affected channel while the
+	 * evidence may still be recoverable (diagnosis-focused deployments).
+	 *
+	 * @see EmbeddedStorageConfigurationBuilder#setGcZombieOidHandling(String)
+	 */
+	public final static String GC_ZOMBIE_OID_HANDLING           = "gc-zombie-oid-handling";
+
+	/**
 	 * Primary chunk-checksum algorithm: {@code none}, {@code crc32c} or
 	 * {@code sha256-chained}. When this key is unset but another {@code chunk-checksum-*} key is present,
 	 * the default is {@code sha256-chained}; setting no {@code chunk-checksum-*} key at all keeps the

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -40,6 +40,7 @@ import org.eclipse.store.storage.types.StorageDataFileEvaluator;
 import org.eclipse.store.storage.types.StorageEntityCacheEvaluator;
 import org.eclipse.store.storage.types.StorageFileNameProvider;
 import org.eclipse.store.storage.types.StorageHousekeepingController;
+import org.eclipse.store.storage.types.StorageGCZombieOidHandler;
 import org.eclipse.store.storage.types.StorageLiveFileProvider;
 import org.eclipse.store.storage.types.StorageReferenceValidationPolicy;
 
@@ -157,6 +158,24 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 				.map(StorageReferenceValidationPolicy::parse)
 				.ifPresent(configBuilder::setReferenceValidationPolicy)
 			;
+
+			this.configuration.opt(GC_ZOMBIE_OID_HANDLING).ifPresent(value ->
+			{
+				switch(value.trim().toLowerCase())
+				{
+					case "log":
+						// default behavior, nothing to set
+						break;
+					case "fail":
+						foundation.setGCZombieOidHandler(StorageGCZombieOidHandler.Strict());
+						break;
+					default:
+						throw new IllegalArgumentException(
+							"Invalid " + GC_ZOMBIE_OID_HANDLING + ": \"" + value
+							+ "\". Valid values are: log, fail."
+						);
+				}
+			});
 
 			foundation.setConfiguration(configBuilder.createConfiguration());
 

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -17,6 +17,7 @@ package org.eclipse.store.storage.embedded.configuration.types;
 import static org.eclipse.serializer.util.X.notNull;
 
 import java.time.Duration;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 import org.eclipse.serializer.afs.types.ADirectory;
@@ -161,7 +162,8 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 
 			this.configuration.opt(GC_ZOMBIE_OID_HANDLING).ifPresent(value ->
 			{
-				switch(value.trim().toLowerCase())
+				// Locale.ROOT: config parsing must not depend on the platform locale.
+				switch(value.trim().toLowerCase(Locale.ROOT))
 				{
 					case "log":
 						// default behavior, nothing to set
@@ -170,9 +172,10 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 						foundation.setGCZombieOidHandler(StorageGCZombieOidHandler.Strict());
 						break;
 					default:
-						throw new IllegalArgumentException(
-							"Invalid " + GC_ZOMBIE_OID_HANDLING + ": \"" + value
-							+ "\". Valid values are: log, fail."
+						throw new ConfigurationException(
+							this.configuration,
+							"Invalid " + GC_ZOMBIE_OID_HANDLING + ": '" + value
+							+ "' (expected log or fail)."
 						);
 				}
 			});

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyZombieOid.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionConsistencyZombieOid.java
@@ -1,0 +1,70 @@
+package org.eclipse.store.storage.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * Thrown by the strict {@link org.eclipse.store.storage.types.StorageGCZombieOidHandler} when the
+ * storage garbage collector's marking encounters a reference to a data object id that does not
+ * resolve to an entity &mdash; a "zombie" object id. A zombie means some persisted binary record
+ * references an entity that no longer exists: the storage already contains a dangling reference
+ * that would otherwise surface only as a
+ * {@code StorageExceptionConsistency: No entity found for objectId} on a later load or restart,
+ * typically after housekeeping has destroyed the evidence.
+ * <p>
+ * Failing at mark time halts the affected storage channel while the swept entity's bytes may
+ * still be physically present in the data files (the startup scanner can resurrect uncompacted
+ * entities), maximizing the chance of diagnosis and recovery. This is a deliberate, opt-in
+ * diagnostic trade-off: availability is sacrificed for data-integrity visibility.
+ */
+public class StorageExceptionConsistencyZombieOid extends StorageExceptionConsistency
+{
+	///////////////////////////////////////////////////////////////////////////
+	// instance fields //
+	////////////////////
+
+	private final long objectId;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public StorageExceptionConsistencyZombieOid(final long objectId)
+	{
+		super(
+			"Storage GC marking encountered zombie objectId " + objectId
+			+ ": a persisted binary record references an entity that does not exist (dangling reference"
+			+ " already present in the storage). Failing now preserves the best chance of diagnosis and"
+			+ " recovery before housekeeping physically reclaims related data."
+		);
+		this.objectId = objectId;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+
+	/**
+	 * @return the unresolvable data object id encountered by the garbage collector's marking.
+	 */
+	public long objectId()
+	{
+		return this.objectId;
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageGCZombieOidHandler.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageGCZombieOidHandler.java
@@ -15,6 +15,7 @@ package org.eclipse.store.storage.types;
  */
 
 import org.eclipse.serializer.persistence.types.Persistence;
+import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyZombieOid;
 
 /**
  * Note on zombie OID / null entry during GC:
@@ -24,7 +25,10 @@ import org.eclipse.serializer.persistence.types.Persistence;
  * deleted the entity and then a store reestablishes the reference to the then deleted entity.
  * This might be a bug in the user code or in the storer or object registry or whatever, but it should
  * be recognized and handled at that point, not break the GC.
- * For that reason, handling an encountered zombie OID is modularized with the default of ignoring it.
+ * For that reason, handling an encountered zombie OID is modularized with the default of ignoring it
+ * ({@link #New()}: WARN log + {@link StorageEventLogger} event, GC continues). For deployments where a
+ * dangling reference must be caught while the evidence is still recoverable, {@link #Strict()} throws
+ * instead, halting the affected channel (see the {@code gc-zombie-oid-handling} configuration property).
  *
  * Note that ConstantIds for JLS constants and TypeIds are intentionally unresolvable in the persistent state.
  * @see Persistence.IdType#TID
@@ -36,6 +40,31 @@ public interface StorageGCZombieOidHandler
 {
 	public boolean handleZombieOid(long objectId);
 
+
+	/**
+	 * Pseudo-constructor method to create the tolerating default handler: encountered data-OID zombies
+	 * are reported by the caller (WARN log + event) and the garbage collection continues.
+	 *
+	 * @return a new tolerating {@link StorageGCZombieOidHandler}.
+	 */
+	public static StorageGCZombieOidHandler New()
+	{
+		return new StorageGCZombieOidHandler.Default();
+	}
+
+	/**
+	 * Pseudo-constructor method to create the strict handler: an encountered data-OID zombie throws a
+	 * {@link StorageExceptionConsistencyZombieOid}, halting the affected storage channel. This turns a
+	 * silent dangling reference into an immediate, diagnosable failure while the swept entity's bytes
+	 * may still be physically present (housekeeping has not yet reclaimed them) — a deliberate
+	 * availability-for-integrity trade-off intended for diagnosis-focused deployments.
+	 *
+	 * @return a new strict {@link StorageGCZombieOidHandler}.
+	 */
+	public static StorageGCZombieOidHandler Strict()
+	{
+		return new StorageGCZombieOidHandler.Strict();
+	}
 
 
 	public final class Default implements StorageGCZombieOidHandler
@@ -60,6 +89,25 @@ public interface StorageGCZombieOidHandler
 			}
 
 			return false;
+		}
+	}
+
+	/**
+	 * Strict implementation: tolerates the intentionally unresolvable TypeIds and ConstantIds like
+	 * {@link Default}, but throws a {@link StorageExceptionConsistencyZombieOid} for any data object id.
+	 */
+	public final class Strict implements StorageGCZombieOidHandler
+	{
+		@Override
+		public final boolean handleZombieOid(final long objectId)
+		{
+			if(Persistence.IdType.TID.isInRange(objectId) || Persistence.IdType.CID.isInRange(objectId))
+			{
+				// intentionally unresolvable in the persistent state, see Default.
+				return true;
+			}
+
+			throw new StorageExceptionConsistencyZombieOid(objectId);
 		}
 	}
 }


### PR DESCRIPTION
## What this adds

Reference validation (merged) guards NEW stores. A dangling reference that is ALREADY persisted - pre-existing corruption, crash artifacts, data written by older versions - is first noticed much later, by the storage garbage collector's marking: it walks a persisted record and hits an object id with no entity, a "zombie object id". Today that is only a WARN log plus an event-logger callback; the first hard failure typically happens at a much later load or restart, after housekeeping may have physically reclaimed related data - the worst possible moment for diagnosis.

This PR makes that escalatable:

| Mode | Effect |
|---|---|
| `log` (default, unchanged) | zombie is WARN-logged and reported to the event logger; GC continues |
| `fail` | a typed `StorageExceptionConsistencyZombieOid` (carrying the object id) is thrown at mark time |

`fail` deliberately trades availability for integrity visibility: the failure happens while the swept entity's bytes may still be physically present in the data files (the startup scanner can resurrect uncompacted entities), maximizing the chance of diagnosis and recovery. For integrity-critical deployments, any zombie is an alarm worth stopping for.

## Technical details

- `StorageGCZombieOidHandler.Strict()` factory: throws on data-OID zombies; type and constant ids remain tolerated like the default (they resolve at runtime, not via entities).
- New `StorageExceptionConsistencyZombieOid` carrying the object id.
- Configuration property `gc-zombie-oid-handling = log | fail` (default `log`), applied at the foundation level; mapped through embedded-configuration, Spring Boot and CDI; documented in the properties reference and a new "Zombie Object Id Escalation" section of the data-integrity page.
- A failing issued garbage collection is safe since the task-chain repair (merged): the failure propagates to the issuer and nothing hangs - the strict handler is precisely the scenario those regression tests exercise.

## Tests

`StrictZombieOidHandlerTest` (@Timeout-guarded): the strict handler surfaces a planted dangling reference with the exact object id via an issued full GC and the storage shuts down promptly afterwards; the tolerating mode reports the zombie, completes collection and stays operational.

## Dependencies

None - store-only, independent of any open work. This is the final PR of the reference-integrity series (detection, healing, pinning, GC race, chain repair - all merged).