### PR TITLE
Extend byte-count validation to all backup-relevant copy and write sites

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupHandler.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupHandler.java
@@ -545,8 +545,12 @@ public interface StorageBackupHandler extends Runnable, StorageActivePart
 				
 				try
 				{
-					sourceFile.copyTo(backupTargetFile, sourcePosition, length);
-					
+					// a short copy must fail loudly, not pass as success.
+					StorageFileWriter.validateIoByteCount(
+						length,
+						sourceFile.copyTo(backupTargetFile, sourcePosition, length)
+					);
+
 					// (16.06.2020 TM)TODO: nasty instanceof
 					if(backupTargetFile instanceof StorageBackupDataFile)
 					{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntity.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntity.java
@@ -541,7 +541,11 @@ public interface StorageEntity
 		@Override
 		public final long exportTo(final AWritableFile file)
 		{
-			return this.typeInFile.file.copyTo(file, this.storagePosition, this.length);
+			// a short copy must fail loudly, not produce a truncated export.
+			return StorageFileWriter.validateIoByteCount(
+				this.length,
+				this.typeInFile.file.copyTo(file, this.storagePosition, this.length)
+			);
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriter.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriter.java
@@ -46,7 +46,7 @@ public interface StorageFileWriter
 
 		throw new StorageExceptionIoWriting(
 			"Inconsistent IO operation: actual byte count " + actualByteCount
-			+ " does not match the specified byte count if  " + specifiedByteCount + "."
+			+ " does not match the specified byte count of  " + specifiedByteCount + "."
 		);
 	}
 	

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriter.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriter.java
@@ -30,6 +30,13 @@ import org.eclipse.store.storage.exceptions.StorageExceptionIoWriting;
  */
 public interface StorageFileWriter
 {
+	/**
+	 * Validates that an IO operation processed exactly {@code specifiedByteCount} bytes,
+	 * since some implementations report a short count instead of throwing.
+	 *
+	 * @return the validated byte count.
+	 * @throws StorageExceptionIoWriting if the counts differ.
+	 */
 	public static long validateIoByteCount(final long specifiedByteCount, final long actualByteCount)
 	{
 		if(specifiedByteCount == actualByteCount)
@@ -72,9 +79,13 @@ public interface StorageFileWriter
 		final StorageLiveDataFile targetFile
 	)
 	{
-		return source.copyTo(targetFile, sourceOffset, copyLength);
+		// a short copy must fail loudly, not be reported as success.
+		return validateIoByteCount(
+			copyLength,
+			source.copyTo(targetFile, sourceOffset, copyLength)
+		);
 	}
-	
+
 	public default long writeTransfer(
 		final StorageLiveDataFile sourceFile  ,
 		final long                sourceOffset,
@@ -82,7 +93,11 @@ public interface StorageFileWriter
 		final StorageLiveDataFile targetFile
 	)
 	{
-		return sourceFile.copyTo(targetFile, sourceOffset, copyLength);
+		// a short copy must fail loudly, not be reported as success.
+		return validateIoByteCount(
+			copyLength,
+			sourceFile.copyTo(targetFile, sourceOffset, copyLength)
+		);
 	}
 	
 	public default long writeTransactionEntryCreate(

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriterBackupping.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriterBackupping.java
@@ -52,6 +52,19 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		// methods //
 		////////////
 			
+		/**
+		 * Sum of remaining bytes across the buffers, computed before the write consumes them.
+		 */
+		private static long totalRemaining(final Iterable<? extends ByteBuffer> byteBuffers)
+		{
+			long total = 0L;
+			for(final ByteBuffer byteBuffer : byteBuffers)
+			{
+				total += byteBuffer.remaining();
+			}
+			return total;
+		}
+
 		@Override
 		public final long writeStore(
 			final StorageLiveDataFile            targetFile ,
@@ -59,11 +72,14 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldTargetFileLength = targetFile.size();
-			final long byteCount = this.delegate.writeStore(targetFile, byteBuffers);
-						
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				totalRemaining(byteBuffers),
+				this.delegate.writeStore(targetFile, byteBuffers)
+			);
+
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.
 			this.itemEnqueuer.enqueueCopyingItem(targetFile, oldTargetFileLength, byteCount);
-			
+
 			return byteCount;
 		}
 		
@@ -76,12 +92,17 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldTargetFileLength = targetFile.size();
-			this.delegate.writeImport(source, sourceOffset, copyLength, targetFile);
-			
+
+			// validate before enqueueing: no backup item for a short copy.
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				copyLength,
+				this.delegate.writeImport(source, sourceOffset, copyLength, targetFile)
+			);
+
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.
-			this.itemEnqueuer.enqueueCopyingItem(targetFile, oldTargetFileLength, copyLength);
-			
-			return copyLength;
+			this.itemEnqueuer.enqueueCopyingItem(targetFile, oldTargetFileLength, byteCount);
+
+			return byteCount;
 		}
 		
 		@Override
@@ -93,12 +114,17 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldTargetFileLength = targetFile.size();
-			this.delegate.writeTransfer(sourceFile, sourceOffset, length, targetFile);
-			
+
+			// validate before enqueueing: no backup item for a short copy.
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				length,
+				this.delegate.writeTransfer(sourceFile, sourceOffset, length, targetFile)
+			);
+
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.
-			this.itemEnqueuer.enqueueCopyingItem(targetFile, oldTargetFileLength, length);
-			
-			return length;
+			this.itemEnqueuer.enqueueCopyingItem(targetFile, oldTargetFileLength, byteCount);
+
+			return byteCount;
 		}
 		
 		@Override
@@ -109,10 +135,13 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldLength = transactionFile.size();
-			final long byteCount = this.delegate.writeTransactionEntryCreate(
-				transactionFile,
-				byteBuffers    ,
-				dataFile
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				totalRemaining(byteBuffers),
+				this.delegate.writeTransactionEntryCreate(
+					transactionFile,
+					byteBuffers    ,
+					dataFile
+				)
 			);
 			
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.
@@ -131,12 +160,15 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldLength = transactionFile.size();
-			final long byteCount = this.delegate.writeTransactionEntryStore(
-				transactionFile,
-				byteBuffers    ,
-				dataFile       ,
-				dataFileOffset ,
-				storeLength
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				totalRemaining(byteBuffers),
+				this.delegate.writeTransactionEntryStore(
+					transactionFile,
+					byteBuffers    ,
+					dataFile       ,
+					dataFileOffset ,
+					storeLength
+				)
 			);
 			
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.
@@ -155,12 +187,15 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldLength = transactionFile.size();
-			final long byteCount = this.delegate.writeTransactionEntryTransfer(
-				transactionFile,
-				byteBuffers    ,
-				dataFile       ,
-				dataFileOffset ,
-				storeLength
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				totalRemaining(byteBuffers),
+				this.delegate.writeTransactionEntryTransfer(
+					transactionFile,
+					byteBuffers    ,
+					dataFile       ,
+					dataFileOffset ,
+					storeLength
+				)
 			);
 			
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.
@@ -177,10 +212,13 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldLength = transactionFile.size();
-			final long byteCount = this.delegate.writeTransactionEntryDelete(
-				transactionFile,
-				byteBuffers    ,
-				dataFile
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				totalRemaining(byteBuffers),
+				this.delegate.writeTransactionEntryDelete(
+					transactionFile,
+					byteBuffers    ,
+					dataFile
+				)
 			);
 			
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.
@@ -198,11 +236,14 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 		)
 		{
 			final long oldLength = transactionFile.size();
-			final long byteCount = this.delegate.writeTransactionEntryTruncate(
-				transactionFile,
-				byteBuffers    ,
-				file           ,
-				newFileLength
+			final long byteCount = StorageFileWriter.validateIoByteCount(
+				totalRemaining(byteBuffers),
+				this.delegate.writeTransactionEntryTruncate(
+					transactionFile,
+					byteBuffers    ,
+					file           ,
+					newFileLength
+				)
 			);
 			
 			// backup item is enqueued and will be processed by the backup thread, which then decrements the user count.


### PR DESCRIPTION
- StorageFileWriterBackupping now validates the delegate's count on writeStore and the writeTransactionEntry* methods as well, using the buffers' total remaining bytes determined before the write. This completes the custom-writer defense: no wrong-length backup item can be enqueued through any method of the wrapper.
  - StorageBackupHandler.copyFilePart validates its own copy, which previously discarded the silently-clamping copyTo return; transaction file items had no compensating validation at all, and a later truncation could never repair a short-copied backup file.
  - StorageEntity.exportTo validates the copied count against the entity length instead of reporting a silently truncated export as success.
  - validateIoByteCount documents the exact-count-or-throw contract.

Validate copied byte count in writeTransfer/writeImport

The same-filesystem copy implementations (XIO.copyFile, blobstore connectors) silently clamp to the available source bytes instead of throwing, while the cross-filesystem generic copy already throws. A short copy reported as success corrupts file-length accounting: the transfer caller's short-copy guard was unreachable with backup enabled (the backupping writer discarded the delegate's count) and the import caller ignores the count entirely, so housekeeping could delete the source file of never-copied bytes — unrecoverable data loss.

The default writer methods now validate the copied count and throw StorageExceptionIoWriting on a short copy, unifying the semantics for all configurations and storage backends. The backupping writer additionally validates before enqueueing the backup copy item, so a custom writer without validation can never cause a partial-copy item  to be appended to (and permanently diverge) the backup.