### PR TITLE
Document continuous-backup restore consistency and the sweep-retry contract

### DIFF
--- a/docs/modules/storage/pages/configuration/backup/continuous-backup.adoc
+++ b/docs/modules/storage/pages/configuration/backup/continuous-backup.adoc
@@ -105,3 +105,27 @@ backup-filesystem.sql.sqlite.url=jdbc:sqlite:eclipsestore_bkup_db_bkup_db
 
 backup-directory=backupDir
 ----
+
+== Restore Consistency
+
+The continuous backup is written asynchronously: committed stores are enqueued and copied to
+the backup target in commit order, after the fact. While the storage is running, the backup can
+therefore be behind the primary by the most recent stores.
+
+Because the stores are copied in order, a lagging backup normally represents an *older but
+self-consistent* state of the storage — restoring it simply restores the data as it was some
+stores ago. Missing-entity errors (`StorageExceptionConsistency: No entity found for objectId
+...`) can only arise from a lagging backup when an *earlier* store references an object that
+was persisted *later* — a forward reference across commits. Correct application store logic
+never produces this (every store persists the new objects it references); it indicates a gap
+such as splitting one logical graph change across multiple commits in the wrong order. Only in
+such rare application-logic gaps does backup lag turn into a restore-consistency problem.
+
+A continuous backup is fully synchronized with the primary once the storage has been shut down
+cleanly: the shutdown processes the remaining backup queue before completing. Two situations
+fall outside that guarantee:
+
+* a storage that was stopped by an error (a registered disruption also ends the backup
+  processing, possibly with items still queued);
+* a backup target copied while the storage is running — such a copy is a potentially lagging
+  (older-state) snapshot.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -1856,7 +1856,12 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			{
 				if(!this.sweep())
 				{
-					// sweep aborted due to locked object registry. Retry on next attempt.
+					/*
+					 * The object registry implementation rejected the live-id processing (see
+					 * PersistenceObjectRegistry#processLiveObjectIds: custom implementations may
+					 * reject instead of blocking; the default registry never does). Retry the
+					 * sweep on the next housekeeping attempt.
+					 */
 					return false;
 				}
 


### PR DESCRIPTION
- New "Restore Consistency" section in the continuous-backup docs: stores are copied to the backup in commit order, so a lagging backup is normally an older but self-consistent state. Missing-entity errors on restore require a forward reference across commits - an earlier store referencing an object persisted only later - which correct application store logic never produces; only such rare application-logic gaps turn backup lag into a consistency problem. A clean shutdown fully synchronizes the backup (the remaining queue is processed before completion); an error-stop or a copy taken from a running storage falls outside that guarantee.
- The sweep-retry branch's comment now states when it is actually live: custom object registries may reject the live-id processing instead of blocking; the default registry never does.