### PR TITLE
Support opt-in null embeddings in GigaMap VectorIndex

### DIFF
--- a/docs/modules/gigamap/pages/indexing/jvector/advanced.adoc
+++ b/docs/modules/gigamap/pages/indexing/jvector/advanced.adoc
@@ -293,11 +293,45 @@ public class TextVectorizer extends Vectorizer<Document>
 
 CAUTION: When using computed vectors with an external service, be aware of potential latency during indexing operations. Consider pre-computing embeddings and storing them in the entity for better performance.
 
-IMPORTANT: The `vectorize()` method must never return `null`. If it does, an `IllegalStateException` is thrown when the entity is added, updated, or re-indexed. If some entities cannot produce a vector, they should be excluded before adding them to the GigaMap, or the vectorizer must provide a fallback vector.
+IMPORTANT: By default the `vectorize()` method must never return `null`. If it does, an `IllegalStateException` is thrown when the entity is added, updated, or re-indexed -- this fail-fast behavior catches accidental bugs in vectorizer implementations.
+
+==== Entities Without an Embedding
+
+If some entities legitimately have no embedding, override `Vectorizer.allowsNullVectors()` to return `true`. A `null` vector then means "this entity has no embedding": the entity remains in the `GigaMap` and all of its other indices, but is excluded from the vector index's HNSW graph and never appears in vector search results. In computed mode no vector store entry is kept for it, and `getVector(entityId)` returns `null`.
+
+[source, java]
+----
+public class ProductVectorizer extends Vectorizer<Product>
+{
+    @Override
+    public float[] vectorize(Product product)
+    {
+        return product.embedding(); // may be null for products not yet embedded
+    }
+
+    @Override
+    public boolean allowsNullVectors()
+    {
+        return true;
+    }
+}
+----
+
+Vector transitions on update behave as follows:
+
+* non-null &rarr; `null`: the entity is removed from the vector index.
+* `null` &rarr; non-null: the entity is added to the vector index.
+* `null` &rarr; `null`: no-op.
+
+An entity whose vector is `null` cannot be used as a similarity query (`search(entity, k)`); doing so throws `IllegalArgumentException`.
+
+NOTE: When eventual indexing is enabled, an entity whose vector was just set to `null` may still appear in search results for a short window until the background worker applies the graph mutation -- the same consistency window that already applies to removals.
 
 === Batch Vectorization
 
 When adding multiple entities via `GigaMap.addAll()`, the vectorizer's `vectorizeAll()` method is called instead of `vectorize()` for each entity individually. The default implementation delegates to `vectorize()` one by one, but you can override it to use a more efficient batch API -- for example, sending all texts to an embedding service in a single request.
+
+The list returned by `vectorizeAll()` must have exactly the same size as the input, with positional correspondence (element _i_ is the vector of entity _i_). When `allowsNullVectors()` returns `true`, individual elements may be `null`; otherwise every element must be non-null.
 
 This is especially useful with external embedding APIs like LangChain4j, where a single batch call is significantly faster than many individual calls due to reduced network overhead and server-side batching.
 

--- a/docs/modules/gigamap/pages/indexing/jvector/defining.adoc
+++ b/docs/modules/gigamap/pages/indexing/jvector/defining.adoc
@@ -28,6 +28,9 @@ public class Product
 
 |`onDisk`
 |Whether the index is stored on disk; requires a directory (see below). Defaults to `false`.
+
+|`allowNull`
+|Whether the annotated member may be `null` for some entities. When `true`, an entity with a `null` vector has no embedding: it stays in the `GigaMap` but is excluded from the vector index and never appears in search results. Defaults to `false` (a `null` vector throws). See xref:indexing/jvector/advanced.adoc[Advanced Topics].
 |===
 
 The vector is read from the entity on demand (embedded mode), so it is not stored a second time by the index.

--- a/docs/modules/gigamap/pages/indexing/jvector/index.adoc
+++ b/docs/modules/gigamap/pages/indexing/jvector/index.adoc
@@ -299,7 +299,7 @@ VectorIndex<Document> index = vectorIndices.get("embeddings");
 
 == Limitations
 
-* *Null vectors are not accepted*: The `Vectorizer.vectorize()` method must never return `null`. If it does, an `IllegalStateException` is thrown. Ensure that every entity added to the GigaMap can produce a valid vector.
+* *Null vectors are rejected by default*: `Vectorizer.vectorize()` must not return `null` unless the vectorizer opts in via `Vectorizer.allowsNullVectors()`. By default a `null` vector throws an `IllegalStateException`. When opted in, a `null` vector means the entity has no embedding: it stays in the GigaMap but is excluded from the vector index and never appears in search results (see xref:indexing/jvector/advanced.adoc[Advanced Topics]).
 * *~2.1 billion vectors per index*: JVector uses `int` for graph node ordinals. For larger datasets, implement sharding across multiple indices.
 * *PQ compression requires maxDegree=32*: FusedPQ algorithm constraint (auto-enforced).
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
@@ -18,7 +18,10 @@ import org.eclipse.serializer.branching.ThrowBreak;
 import org.eclipse.serializer.collections.XSort;
 import org.eclipse.serializer.persistence.types.Storer;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.ObjLongConsumer;
 import java.util.function.Predicate;
 
 
@@ -215,8 +218,66 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 				}
 				logic.accept(entry.key());
 			}
-			
+
 			return logic;
+		}
+	}
+
+	@Override
+	public void iterateKeyEntityPairs(final ObjLongConsumer<? super Long> consumer)
+	{
+		final BinaryIndexer<? super I> indexer = this.indexer;
+		if(indexer == null)
+		{
+			// sub indices are their own sub indexer and carry no key-encoding to invert.
+			throw new UnsupportedOperationException(
+				"iterateKeyEntityPairs is not supported without a binary indexer"
+			);
+		}
+
+		synchronized(this.parentMap())
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap.Default<E> parent = (GigaMap.Default<E>)this.parentMap();
+			final long idBound = parent.nextFreeId();
+
+			// entityId (position in the owning GigaMap) -> stored long, accumulated bit by bit.
+			// A binary index keeps no whole key: bit position i's bitmap holds the ids whose stored
+			// long has bit i set, so the key is reconstructed by OR-ing 1L<<i over the positions that
+			// contain each id. No entity is loaded — only the index's own bitmaps are read.
+			final Map<Long, Long> storedByEntityId = new HashMap<>();
+
+			final BitmapEntry<E, I, Long>[] entries = this.entries;
+			for(int i = 0; i < entries.length; i++)
+			{
+				final BitmapEntry<E, I, Long> entry = entries[i];
+				if(entry == null)
+				{
+					continue;
+				}
+				final long bit = 1L << i; // == arrayIndexToKey(i)
+				final BitmapResult[] results = {entry.createResult()};
+
+				// Bare id collector, mirroring GigaMap.Default#materializeEntityIds: no resolver, no
+				// reader-lifecycle registration — it only walks the bitmap segments for entity ids.
+				final AbstractBitmapIterating<E> collector = new AbstractBitmapIterating<E>(
+					EntityIdMatcher.NoOp(), 0, idBound, results, -1
+				)
+				{
+					@Override
+					protected boolean handleEntityId(final long entityId)
+					{
+						storedByEntityId.merge(entityId, bit, (a, b) -> a | b);
+						return false; // keep iterating
+					}
+				};
+				collector.execute();
+			}
+
+			for(final Map.Entry<Long, Long> e : storedByEntityId.entrySet())
+			{
+				consumer.accept(indexer.binaryToKey(e.getValue()), e.getKey());
+			}
 		}
 	}
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexer.java
@@ -56,15 +56,22 @@ public interface BinaryIndexer<E> extends Indexer<E, Long>
 	 * lets {@link BitmapIndex#iterateKeyEntityPairs(java.util.function.ObjLongConsumer)} recover the
 	 * key for each entity from the index's per-bit-position bitmaps without loading the entity itself.
 	 * <p>
-	 * The default is the identity mapping. Indexers that reserve a sentinel bit pattern (e.g.
-	 * {@link BinaryIndexerLong}'s zero sentinel) must override this to undo it.
+	 * The default throws {@link UnsupportedOperationException}: since indexers generally apply a
+	 * non-identity encoding (unsigned mapping, zero sentinels, sortable float bits), a blanket identity
+	 * inverse would silently emit encoded/sentinel values instead of real keys. Each indexer whose
+	 * encoding can be inverted overrides this (currently {@link BinaryIndexerLong} and the integer
+	 * indexers); {@code iterateKeyEntityPairs} therefore fails fast on indexers that do not support
+	 * reconstruction rather than yielding wrong keys.
 	 *
 	 * @param stored the raw stored {@code long} bit pattern
 	 * @return the reconstructed key
+	 * @throws UnsupportedOperationException if this indexer's encoding cannot be inverted
 	 */
 	public default Long binaryToKey(final long stored)
 	{
-		return stored;
+		throw new UnsupportedOperationException(
+			this.getClass().getSimpleName() + " does not support key reconstruction (binaryToKey)"
+		);
 	}
 	
 	/**

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexer.java
@@ -49,6 +49,23 @@ public interface BinaryIndexer<E> extends Indexer<E, Long>
 	 * @return the long identifier corresponding to the given entity
 	 */
 	public long indexBinary(E entity);
+
+	/**
+	 * Reconstructs the index key from the raw {@code long} bit pattern that a binary bitmap index
+	 * stores for an entity — the inverse of {@link #indexBinary(Object)}'s internal encoding. This
+	 * lets {@link BitmapIndex#iterateKeyEntityPairs(java.util.function.ObjLongConsumer)} recover the
+	 * key for each entity from the index's per-bit-position bitmaps without loading the entity itself.
+	 * <p>
+	 * The default is the identity mapping. Indexers that reserve a sentinel bit pattern (e.g.
+	 * {@link BinaryIndexerLong}'s zero sentinel) must override this to undo it.
+	 *
+	 * @param stored the raw stored {@code long} bit pattern
+	 * @return the reconstructed key
+	 */
+	public default Long binaryToKey(final long stored)
+	{
+		return stored;
+	}
 	
 	/**
 	 * Creates an equality condition for the given key. This condition checks whether

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerByte.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerByte.java
@@ -61,6 +61,17 @@ public interface BinaryIndexerByte<E> extends BinaryIndexerNumber<E, Byte>
 			return Byte.toUnsignedLong(number);
 		}
 
+		/**
+		 * Inverse of {@link #toLong(Byte)}: the {@code 1L << Byte.SIZE} sentinel maps back to
+		 * {@code 0}; otherwise re-narrowing the stored unsigned value with {@code (byte)} recovers the
+		 * signed key.
+		 */
+		@Override
+		public Long binaryToKey(final long stored)
+		{
+			return stored == (1L << Byte.SIZE) ? 0L : (long)(byte)stored;
+		}
+
 		protected abstract Byte getByte(final E entity);
 
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerInteger.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerInteger.java
@@ -61,6 +61,17 @@ public interface BinaryIndexerInteger<E> extends BinaryIndexerNumber<E, Integer>
 			return Integer.toUnsignedLong(number);
 		}
 
+		/**
+		 * Inverse of {@link #toLong(Integer)}: the {@code 1L << Integer.SIZE} sentinel maps back to
+		 * {@code 0}; every other stored value is the unsigned representation of the original int, so
+		 * re-narrowing its low 32 bits with {@code (int)} recovers the signed key.
+		 */
+		@Override
+		public Long binaryToKey(final long stored)
+		{
+			return stored == (1L << Integer.SIZE) ? 0L : (long)(int)stored;
+		}
+
 		protected abstract Integer getInteger(final E entity);
 
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerLong.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerLong.java
@@ -92,6 +92,17 @@ public interface BinaryIndexerLong<E> extends BinaryIndexerNumber<E, Long>
 			return number;
 		}
 
+		/**
+		 * Undoes the zero sentinel applied by {@link #toLong(Long)}: the stored
+		 * {@code Long.MAX_VALUE} bit pattern maps back to the key {@code 0}; all other
+		 * stored values are their own key.
+		 */
+		@Override
+		public Long binaryToKey(final long stored)
+		{
+			return stored == Long.MAX_VALUE ? 0L : stored;
+		}
+
 		protected abstract Long getLong(final E entity);
 
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerShort.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerShort.java
@@ -61,6 +61,17 @@ public interface BinaryIndexerShort<E> extends BinaryIndexerNumber<E, Short>
 			return Short.toUnsignedLong(number);
 		}
 
+		/**
+		 * Inverse of {@link #toLong(Short)}: the {@code 1L << Short.SIZE} sentinel maps back to
+		 * {@code 0}; otherwise re-narrowing the stored unsigned value with {@code (short)} recovers the
+		 * signed key.
+		 */
+		@Override
+		public Long binaryToKey(final long stored)
+		{
+			return stored == (1L << Short.SIZE) ? 0L : (long)(short)stored;
+		}
+
 		protected abstract Short getShort(final E entity);
 
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
@@ -23,6 +23,7 @@ import org.eclipse.serializer.typing.KeyValue;
 import org.eclipse.serializer.util.X;
 
 import java.util.function.Consumer;
+import java.util.function.ObjLongConsumer;
 import java.util.function.Predicate;
 
 
@@ -124,8 +125,30 @@ public interface BitmapIndex<E, K> extends IndexIdentifier<E, K>, GigaIndex<E>
 	 * @return the same {@link Consumer} instance passed as the parameter, after it has been applied to all keys
 	 */
 	public <C extends Consumer<? super K>> C iterateKeys(C logic);
-	
-	
+
+	/**
+	 * Iterates the {@code (key, entityId)} pairs held by this index — one call per indexed entity —
+	 * <b>without loading the indexed entities themselves</b>. The mapping is reconstructed from the
+	 * index's own bitmap structures, so this is cheap even for indices whose entities carry large
+	 * payloads.
+	 * <p>
+	 * Order is unspecified. The consumer receives the reconstructed key and the entity id
+	 * (the entity's position in the owning {@code GigaMap}).
+	 * <p>
+	 * Not every index family supports this yet; the default throws {@link UnsupportedOperationException}.
+	 * It is currently implemented by the binary (bit-sliced) indices.
+	 *
+	 * @param consumer receives {@code (key, entityId)} for each indexed entity; must not be null
+	 * @throws UnsupportedOperationException if this index family does not support pair enumeration
+	 */
+	public default void iterateKeyEntityPairs(final ObjLongConsumer<? super K> consumer)
+	{
+		throw new UnsupportedOperationException(
+			this.getClass().getSimpleName() + " does not support iterateKeyEntityPairs"
+		);
+	}
+
+
 	@Override
 	public default boolean test(final E entity, final K key)
 	{
@@ -299,7 +322,19 @@ public interface BitmapIndex<E, K> extends IndexIdentifier<E, K>, GigaIndex<E>
 		protected abstract K indexEntity(I entity);
 		
 		public abstract <C extends Consumer<? super K>> C iterateKeys(C logic);
-		
+
+		/**
+		 * See {@link BitmapIndex#iterateKeyEntityPairs(ObjLongConsumer)}. Concrete (not abstract) so
+		 * only the index families that support value-free pair enumeration need override it; the rest
+		 * inherit this unsupported default.
+		 */
+		public void iterateKeyEntityPairs(final ObjLongConsumer<? super K> consumer)
+		{
+			throw new UnsupportedOperationException(
+				this.getClass().getSimpleName() + " does not support iterateKeyEntityPairs"
+			);
+		}
+
 		public abstract boolean internalContains(I entity);
 		
 		

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexKeyEntityPairsTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexKeyEntityPairsTest.java
@@ -14,6 +14,8 @@ package org.eclipse.store.gigamap.indexer;
  * #L%
  */
 
+import org.eclipse.store.gigamap.types.BinaryIndexerFloat;
+import org.eclipse.store.gigamap.types.BinaryIndexerInteger;
 import org.eclipse.store.gigamap.types.BinaryIndexerLong;
 import org.eclipse.store.gigamap.types.BitmapIndex;
 import org.eclipse.store.gigamap.types.GigaMap;
@@ -23,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -110,5 +113,69 @@ class BitmapIndexKeyEntityPairsTest
 
         final Map<Long, Long> actual = pairsViaIterateKeyEntityPairs(map);
         assertEquals(0, actual.size(), "empty index must yield no pairs");
+    }
+
+    // ---- non-Long binary indexers: integer keys reconstruct, float fails fast ----
+
+    static final class IntEntity
+    {
+        final int value;
+        IntEntity(final int value) { this.value = value; }
+    }
+
+    static final class IntValueIndexer extends BinaryIndexerInteger.Abstract<IntEntity>
+    {
+        @Override public String name() { return "value"; }
+        @Override protected Integer getInteger(final IntEntity entity) { return entity.value; }
+    }
+
+    static final class FloatEntity
+    {
+        final float value;
+        FloatEntity(final float value) { this.value = value; }
+    }
+
+    static final class FloatValueIndexer extends BinaryIndexerFloat.Abstract<FloatEntity>
+    {
+        @Override public String name() { return "value"; }
+        @Override protected Float getFloat(final FloatEntity entity) { return entity.value; }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void reconstructsIntegerKeys_withSentinelAndNegatives()
+    {
+        final GigaMap<IntEntity> map = GigaMap.<IntEntity>Builder()
+            .withBitmapIdentityIndex(new IntValueIndexer())
+            .build();
+
+        // Zero (sentinel 1L<<32), negatives (unsigned upper half), Integer.MIN_VALUE (bit 31), positives.
+        map.addAll(java.util.List.of(
+            new IntEntity(0), new IntEntity(1), new IntEntity(-1),
+            new IntEntity(Integer.MIN_VALUE), new IntEntity(1_234_567_890)));
+
+        final Map<Long, Long> expected = new HashMap<>(); // entityId -> key (as long)
+        map.iterateIndexed((id, entity) -> expected.put(id, (long)entity.value));
+
+        final Map<Long, Long> actual = new HashMap<>();
+        final BitmapIndex<IntEntity, Long> index = map.index().bitmap().get(Long.class, "value");
+        index.iterateKeyEntityPairs((key, entityId) -> actual.put(entityId, key));
+
+        assertEquals(expected, actual, "integer keys must be reconstructed to their original values");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void floatIndex_failsFastAsUnsupported()
+    {
+        final GigaMap<FloatEntity> map = GigaMap.<FloatEntity>Builder()
+            .withBitmapIdentityIndex(new FloatValueIndexer())
+            .build();
+        map.add(new FloatEntity(1.5f));
+
+        final BitmapIndex<FloatEntity, Long> index = map.index().bitmap().get(Long.class, "value");
+        // Float's sortable-bit encoding has no binaryToKey inverse → fail fast, not emit encoded bits.
+        assertThrows(UnsupportedOperationException.class,
+            () -> index.iterateKeyEntityPairs((key, entityId) -> { }));
     }
 }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexKeyEntityPairsTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexKeyEntityPairsTest.java
@@ -1,0 +1,114 @@
+package org.eclipse.store.gigamap.indexer;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.BitmapIndex;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link BitmapIndex#iterateKeyEntityPairs} for the binary (bit-sliced) index family: it must
+ * reconstruct the exact {@code (key, entityId)} mapping from the index bitmaps alone — including the
+ * {@code 0}/{@code Long.MAX_VALUE} sentinel, negative keys (bit 63), duplicate keys, and deletion
+ * holes — without loading the indexed entities.
+ */
+class BitmapIndexKeyEntityPairsTest
+{
+    static final class LongEntity
+    {
+        final long value;
+        LongEntity(final long value) { this.value = value; }
+    }
+
+    static final class ValueIndexer extends BinaryIndexerLong.Abstract<LongEntity>
+    {
+        @Override public String name() { return "value"; }
+        @Override protected Long getLong(final LongEntity entity) { return entity.value; }
+    }
+
+    private static BitmapIndex<LongEntity, Long> valueIndex(final GigaMap<LongEntity> map)
+    {
+        return map.index().bitmap().get(Long.class, "value");
+    }
+
+    private static Map<Long, Long> pairsViaIterateKeyEntityPairs(final GigaMap<LongEntity> map)
+    {
+        final Map<Long, Long> actual = new HashMap<>(); // entityId -> key
+        valueIndex(map).iterateKeyEntityPairs((key, entityId) ->
+        {
+            final Long prev = actual.put(entityId, key);
+            assertTrue(prev == null, "entityId reported more than once: " + entityId);
+        });
+        return actual;
+    }
+
+    private static Map<Long, Long> pairsViaIterateIndexed(final GigaMap<LongEntity> map)
+    {
+        final Map<Long, Long> expected = new HashMap<>(); // entityId -> key
+        map.iterateIndexed((id, entity) -> expected.put(id, entity.value));
+        return expected;
+    }
+
+    @Test
+    void reconstructsAllPairs_withSentinelNegativesDuplicatesAndHoles()
+    {
+        final GigaMap<LongEntity> map = GigaMap.<LongEntity>Builder()
+            .withBitmapIdentityIndex(new ValueIndexer())
+            .build();
+
+        // Keys spanning the tricky cases: 0 (stored as the Long.MAX_VALUE sentinel), small positives,
+        // duplicates (identity indices do not enforce uniqueness), negatives and Long.MIN_VALUE
+        // (sign bit / bit 63), and a large positive.
+        map.add(new LongEntity(0L));
+        map.add(new LongEntity(1L));
+        map.add(new LongEntity(2L));
+        map.add(new LongEntity(2L));            // duplicate key
+        map.add(new LongEntity(-5L));
+        map.add(new LongEntity(Long.MIN_VALUE));
+        map.add(new LongEntity(1_234_567_890L));
+        final long holeId = map.add(new LongEntity(42L));
+        map.add(new LongEntity(0L));            // second zero-key entity
+
+        // Create a deletion hole: its id must NOT appear in the reconstructed pairs.
+        map.removeById(holeId);
+
+        final Map<Long, Long> expected = pairsViaIterateIndexed(map);
+        final Map<Long, Long> actual   = pairsViaIterateKeyEntityPairs(map);
+
+        assertEquals(expected, actual, "reconstructed (entityId -> key) must match iterateIndexed");
+        assertTrue(actual.values().stream().anyMatch(v -> v == 0L), "zero key reconstructed");
+        assertTrue(actual.containsValue(Long.MIN_VALUE), "Long.MIN_VALUE key reconstructed");
+        assertTrue(actual.containsValue(-5L), "negative key reconstructed");
+        assertTrue(actual.keySet().stream().noneMatch(id -> id == holeId), "deleted id excluded");
+    }
+
+    @Test
+    void emptyIndex_yieldsNoPairs()
+    {
+        final GigaMap<LongEntity> map = GigaMap.<LongEntity>Builder()
+            .withBitmapIdentityIndex(new ValueIndexer())
+            .build();
+
+        final Map<Long, Long> actual = pairsViaIterateKeyEntityPairs(map);
+        assertEquals(0, actual.size(), "empty index must yield no pairs");
+    }
+}

--- a/gigamap/jvector/ARCHITECTURE.md
+++ b/gigamap/jvector/ARCHITECTURE.md
@@ -697,12 +697,12 @@ Bumping the version invalidates existing files; they are silently rebuilt from `
 
 ### Write path
 
-`DiskIndexManager.writeIndex(index, ravv, pqManager)`:
+`DiskIndexManager.writeIndex(index, ravv, pqManager, metaState)`:
 
 1. `Files.createDirectories(indexDirectory)`.
 2. If `pqManager != null && pqManager.isTrained() && pqManager.getPQ() != null` → `writeIndexWithFusedPQ` (parallel or sequential depending on `parallelOnDiskWrite`).
-3. Otherwise → `OnDiskGraphIndex.write(index, ravv, graphPath)` (simple, no compression).
-4. `writeMetadata(metaPath)` — pulls `expectedVectorCount`, `highestEntityId`, and `structuralModCount` from the `IndexStateProvider` callback (= `VectorIndex.Default`). The `.meta` layout is: `int version`, `int dimension`, `long expectedVectorCount`, `long highestEntityId`, `long structuralModCount` (version 3). On load, `verifyMetadata` rejects the disk graph — forcing a rebuild from source — if any of these diverges from the current store state; `structuralModCount` is what catches a vec↔null transition that left count/highestId unchanged.
+3. Otherwise → `OnDiskGraphIndex.write(index, ravv, identityOrdinalMap(index), graphPath)` (simple, no compression; identity map keeps on-disk node ids equal to graph ordinals).
+4. `writeMetadata(metaPath, metaState)` — stamps the `expectedVectorCount`, `highestEntityId`, and `structuralModCount` **captured in persist Phase 1** (the `DiskIndexManager.MetaState` sampled under the `parentMap` monitor next to `capturedIndex`), NOT re-read live from the `IndexStateProvider` — Phase 2 runs with the monitor released, so a live read could let a concurrent vec↔null mutation advance the witnesses past the written graph and reopen the crash-restart hole. The `.meta` layout is: `int version`, `int dimension`, `long expectedVectorCount`, `long highestEntityId`, `long structuralModCount` (version 3). On load, `verifyMetadata` (which still reads the `IndexStateProvider` live — it compares the persisted witness against the freshly-loaded store state) rejects the disk graph — forcing a rebuild from source — if any of these diverges; `structuralModCount` is what catches a vec↔null transition that left count/highestId unchanged.
 
 ### Load path
 

--- a/gigamap/jvector/ARCHITECTURE.md
+++ b/gigamap/jvector/ARCHITECTURE.md
@@ -331,7 +331,7 @@ Both handlers' parents (`AbstractBinaryHandlerStateChangeFlagged`) call `storeCh
 - `VectorIndex.Internal<E>` — public + GigaMap-internal API
 - `BackgroundTaskManager.Callback` — the seam where background ops apply graph mutations and trigger optimize/persist
 - `PQCompressionManager.VectorProvider` — supplies vectors for codebook training
-- `DiskIndexManager.IndexStateProvider` — supplies metadata (`expectedVectorCount`, `highestEntityId`) for on-disk format verification
+- `DiskIndexManager.IndexStateProvider` — supplies metadata (`expectedVectorCount`, `highestEntityId`, `structuralModCount`) for on-disk format verification
 
 ### Diagram 4 — Initialization sequence
 
@@ -702,7 +702,7 @@ Bumping the version invalidates existing files; they are silently rebuilt from `
 1. `Files.createDirectories(indexDirectory)`.
 2. If `pqManager != null && pqManager.isTrained() && pqManager.getPQ() != null` → `writeIndexWithFusedPQ` (parallel or sequential depending on `parallelOnDiskWrite`).
 3. Otherwise → `OnDiskGraphIndex.write(index, ravv, graphPath)` (simple, no compression).
-4. `writeMetadata(metaPath)` — pulls `expectedVectorCount` and `highestEntityId` from the `IndexStateProvider` callback (= `VectorIndex.Default`).
+4. `writeMetadata(metaPath)` — pulls `expectedVectorCount`, `highestEntityId`, and `structuralModCount` from the `IndexStateProvider` callback (= `VectorIndex.Default`). The `.meta` layout is: `int version`, `int dimension`, `long expectedVectorCount`, `long highestEntityId`, `long structuralModCount` (version 3). On load, `verifyMetadata` rejects the disk graph — forcing a rebuild from source — if any of these diverges from the current store state; `structuralModCount` is what catches a vec↔null transition that left count/highestId unchanged.
 
 ### Load path
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/AnnotationVectorizer.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/AnnotationVectorizer.java
@@ -35,15 +35,22 @@ public final class AnnotationVectorizer<E> extends Vectorizer<E>
 	private final Class<?> declaringClass;
 	private final String   memberName;
 	private final boolean  method;
+	private final boolean  allowNull;
 
 	private transient AccessibleObject member;
 
-	AnnotationVectorizer(final Class<?> declaringClass, final String memberName, final boolean method)
+	AnnotationVectorizer(
+		final Class<?> declaringClass,
+		final String   memberName,
+		final boolean  method,
+		final boolean  allowNull
+	)
 	{
 		super();
 		this.declaringClass = declaringClass;
 		this.memberName     = memberName;
 		this.method         = method;
+		this.allowNull      = allowNull;
 	}
 
 	private AccessibleObject member()
@@ -87,5 +94,11 @@ public final class AnnotationVectorizer<E> extends Vectorizer<E>
 	public boolean isEmbedded()
 	{
 		return true;
+	}
+
+	@Override
+	public boolean allowsNullVectors()
+	{
+		return this.allowNull;
 	}
 }

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
@@ -41,14 +41,16 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
         BINARY_OFFSET_name             = BINARY_OFFSET_parent        + Binary.objectIdByteLength(),
         BINARY_OFFSET_configuration    = BINARY_OFFSET_name          + Binary.objectIdByteLength(),
         BINARY_OFFSET_vectorizer       = BINARY_OFFSET_configuration + Binary.objectIdByteLength(),
-        BINARY_OFFSET_vectorStore      = BINARY_OFFSET_vectorizer    + Binary.objectIdByteLength(),
-        BINARY_LENGTH                  = BINARY_OFFSET_vectorStore   + Binary.objectIdByteLength(),
+        BINARY_OFFSET_vectorStore        = BINARY_OFFSET_vectorizer    + Binary.objectIdByteLength(),
+        BINARY_OFFSET_structuralModCount = BINARY_OFFSET_vectorStore   + Binary.objectIdByteLength(),
+        BINARY_LENGTH                    = BINARY_OFFSET_structuralModCount + Long.BYTES,
 
-        MEMORY_OFFSET_parent           = getClassDeclaredFieldOffset(genericType(), "parent"       ),
-        MEMORY_OFFSET_name             = getClassDeclaredFieldOffset(genericType(), "name"         ),
-        MEMORY_OFFSET_configuration    = getClassDeclaredFieldOffset(genericType(), "configuration"),
-        MEMORY_OFFSET_vectorizer       = getClassDeclaredFieldOffset(genericType(), "vectorizer"   ),
-        MEMORY_OFFSET_vectorStore      = getClassDeclaredFieldOffset(genericType(), "vectorStore"  )
+        MEMORY_OFFSET_parent             = getClassDeclaredFieldOffset(genericType(), "parent"            ),
+        MEMORY_OFFSET_name               = getClassDeclaredFieldOffset(genericType(), "name"              ),
+        MEMORY_OFFSET_configuration      = getClassDeclaredFieldOffset(genericType(), "configuration"     ),
+        MEMORY_OFFSET_vectorizer         = getClassDeclaredFieldOffset(genericType(), "vectorizer"        ),
+        MEMORY_OFFSET_vectorStore        = getClassDeclaredFieldOffset(genericType(), "vectorStore"       ),
+        MEMORY_OFFSET_structuralModCount = getClassDeclaredFieldOffset(genericType(), "structuralModCount")
     ;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -73,11 +75,12 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
         super(
             genericType(),
             CustomFields(
-                CustomField(VectorIndices.class           , "parent"          ),
-                CustomField(String.class                  , "name"            ),
-                CustomField(VectorIndexConfiguration.class, "configuration"   ),
-                CustomField(Vectorizer.class              , "vectorizer"      ),
-                CustomField(GigaMap.class                 , "vectorStore"     )
+                CustomField(VectorIndices.class           , "parent"            ),
+                CustomField(String.class                  , "name"              ),
+                CustomField(VectorIndexConfiguration.class, "configuration"     ),
+                CustomField(Vectorizer.class              , "vectorizer"        ),
+                CustomField(GigaMap.class                 , "vectorStore"       ),
+                CustomField(long.class                    , "structuralModCount")
             )
         );
     }
@@ -101,6 +104,7 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
         data.storeReference(BINARY_OFFSET_configuration, handler, instance.configuration);
         data.storeReference(BINARY_OFFSET_vectorizer   , handler, instance.vectorizer   );
         data.storeReference(BINARY_OFFSET_vectorStore  , handler, instance.vectorStore  );
+        data.store_long    (BINARY_OFFSET_structuralModCount, instance.structuralModCount);
     }
 
     @Override
@@ -136,12 +140,17 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
         final GigaMap<float[]> vectorStore = (GigaMap<float[]>)data.readReference(
             BINARY_OFFSET_vectorStore, handler
         );
+        // Legacy stores written before this field default to 0 here (the automatic legacy type
+        // mapping zero-fills an added primitive), which is safe: any pre-existing on-disk graph is
+        // rebuilt anyway because GRAPH_FILE_VERSION was bumped, so a 0 is never compared to a stale .meta.
+        final long structuralModCount = data.read_long(BINARY_OFFSET_structuralModCount);
 
         XMemory.setObject(instance, MEMORY_OFFSET_parent       , parent       );
         XMemory.setObject(instance, MEMORY_OFFSET_name         , name         );
         XMemory.setObject(instance, MEMORY_OFFSET_configuration, configuration);
         XMemory.setObject(instance, MEMORY_OFFSET_vectorizer   , vectorizer   );
         XMemory.setObject(instance, MEMORY_OFFSET_vectorStore  , vectorStore  );
+        XMemory.set_long (instance, MEMORY_OFFSET_structuralModCount, structuralModCount);
     }
 
     @Override

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
@@ -137,7 +137,7 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
         final Vectorizer<?> vectorizer = (Vectorizer<?>)data.readReference(
             BINARY_OFFSET_vectorizer, handler
         );
-        final GigaMap<float[]> vectorStore = (GigaMap<float[]>)data.readReference(
+        final GigaMap<VectorEntry> vectorStore = (GigaMap<VectorEntry>)data.readReference(
             BINARY_OFFSET_vectorStore, handler
         );
         // Legacy stores written before this field default to 0 here (the automatic legacy type

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -58,12 +58,16 @@ interface DiskIndexManager extends Closeable
      *   <li>{@code 1} — version, dimension, vectorCount.</li>
      *   <li>{@code 2} — adds highestEntityId to detect count-collision corruption
      *       (equal numbers of additions and removals between persists).</li>
+     *   <li>{@code 3} — adds structuralModCount, a persisted counter bumped on every
+     *       graph-affecting mutation (including vec↔null transitions, which leave count
+     *       and highestEntityId unchanged). Catches the crash-restart window where the
+     *       store advanced past the on-disk graph but the two proxies stayed equal.</li>
      * </ul>
      * Bumping this constant invalidates existing on-disk indices; they are
      * rebuilt from the GigaMap-stored source vectors on first load — no data
      * loss, but a one-time cold-start cost.
      */
-    final static int GRAPH_FILE_VERSION = 2;
+    final static int GRAPH_FILE_VERSION = 3;
 
     /**
      * File extension for graph files.
@@ -142,6 +146,18 @@ interface DiskIndexManager extends Closeable
          * @return the highest allocated entity id, or {@code -1} if no entities exist
          */
         public long getHighestEntityId();
+
+        /**
+         * Returns a monotonically increasing count of graph-affecting mutations
+         * (add / remove / vec↔null transition). Unlike {@link #getExpectedVectorCount()}
+         * and {@link #getHighestEntityId()}, this value changes on a vec↔null transition,
+         * so comparing the store-recovered value against the one stamped into the disk
+         * {@code .meta} detects the crash-restart window where a stale on-disk graph would
+         * otherwise be accepted (a nulled entity still returned, a new embedding missing).
+         *
+         * @return the persisted structural-change counter
+         */
+        public long getStructuralModCount();
     }
 
 
@@ -273,6 +289,17 @@ interface DiskIndexManager extends Closeable
                     return false;
                 }
 
+                final long structuralModCount = dis.readLong();
+                final long expectedStructuralModCount = this.provider.getStructuralModCount();
+                if(structuralModCount != expectedStructuralModCount)
+                {
+                    // The store advanced past the on-disk graph since it was written (e.g. a
+                    // vec↔null transition committed via storeRoot() but not yet persistToDisk()).
+                    // Reject the disk graph so it is rebuilt from the current source vectors.
+                    LOG.debug("Structural mod count mismatch: expected {}, got {}", expectedStructuralModCount, structuralModCount);
+                    return false;
+                }
+
                 return true;
             }
         }
@@ -377,6 +404,7 @@ interface DiskIndexManager extends Closeable
                 dos.writeInt(this.dimension);
                 dos.writeLong(this.provider.getExpectedVectorCount());
                 dos.writeLong(this.provider.getHighestEntityId());
+                dos.writeLong(this.provider.getStructuralModCount());
             }
         }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -34,6 +34,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.IntFunction;
 
@@ -324,8 +325,10 @@ interface DiskIndexManager extends Closeable
             }
             else
             {
-                // Use simple write for non-compressed indices
-                OnDiskGraphIndex.write(index, ravv, graphPath);
+                // Use simple write for non-compressed indices. Pass an identity ordinal map (not the
+                // default sequentialRenumbering) so on-disk node ids stay equal to the graph ordinals
+                // (= source entity ids) — see identityOrdinalMap.
+                OnDiskGraphIndex.write(index, ravv, identityOrdinalMap(index), graphPath);
             }
 
             // Write metadata
@@ -364,10 +367,15 @@ interface DiskIndexManager extends Closeable
                 new FusedPQ.State(view, pqVectors, nodeId)
             );
 
+            // Preserve graph ordinals on disk (identity map, not the default sequentialRenumbering)
+            // so on-disk node ids stay equal to the source entity ids the integration keys on.
+            final Map<Integer, Integer> ordinalMap = identityOrdinalMap(index);
+
             if(this.parallelOnDiskWrite)
             {
                 try(final OnDiskParallelGraphIndexWriter writer = new OnDiskParallelGraphIndexWriter.Builder(index, graphPath)
                     .withParallelDirectBuffers(true)
+                    .withMap(ordinalMap)
                     .with(inlineVectors)
                     .with(fusedPQ)
                     .build())
@@ -378,6 +386,7 @@ interface DiskIndexManager extends Closeable
             else
             {
                 try(final OnDiskGraphIndexWriter writer = new OnDiskGraphIndexWriter.Builder(index, graphPath)
+                    .withMap(ordinalMap)
                     .with(inlineVectors)
                     .with(fusedPQ)
                     .build())
@@ -391,6 +400,34 @@ interface DiskIndexManager extends Closeable
 
             LOG.info("Wrote index '{}' with FusedPQ compression ({} nodes, parallel={})",
                 this.name, index.size(0), this.parallelOnDiskWrite);
+        }
+
+        /**
+         * Builds an identity old→new ordinal map over the graph's present nodes, so the on-disk write
+         * PRESERVES graph ordinals (leaving {@code OMITTED} holes) instead of compacting them via the
+         * default {@code sequentialRenumbering}.
+         * <p>
+         * The whole {@link VectorIndex} integration keys on the invariant "graph ordinal == source
+         * entity id": search results are converted straight back to entity ids
+         * ({@code convertSearchResult}), computed-mode scoring resolves vectors by source entity id
+         * ({@code lookupComputedVector} / {@code computedIdIndex}), and incremental deletes track
+         * ordinals ({@code diskDeletedOrdinals}). Compacting to a dense 0..n-1 range would renumber
+         * disk nodes and scramble that mapping whenever the ordinal space has holes — i.e. after any
+         * null embedding or deletion. Preserving ordinals costs a placeholder slot per hole on disk,
+         * which is acceptable given entity ids are allocated densely.
+         */
+        private static Map<Integer, Integer> identityOrdinalMap(final OnHeapGraphIndex index)
+        {
+            final Map<Integer, Integer> map = new HashMap<>();
+            final int idUpperBound = index.getIdUpperBound();
+            for(int ordinal = 0; ordinal < idUpperBound; ordinal++)
+            {
+                if(index.containsNode(ordinal))
+                {
+                    map.put(ordinal, ordinal);
+                }
+            }
+            return map;
         }
 
         /**

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -107,12 +107,15 @@ interface DiskIndexManager extends Closeable
      * @param index     the in-memory graph index
      * @param ravv      random access vector values for writing vectors
      * @param pqManager the PQ compression manager (may be null if compression disabled)
+     * @param metaState the {@code .meta} witness values captured together with {@code index}
+     *                  under the {@code parentMap} monitor (see {@link MetaState})
      * @throws IOException if writing fails
      */
     public void writeIndex(
         OnHeapGraphIndex         index    ,
         RandomAccessVectorValues ravv     ,
-        PQCompressionManager     pqManager
+        PQCompressionManager     pqManager,
+        MetaState                metaState
     ) throws IOException;
 
     /**
@@ -159,6 +162,38 @@ interface DiskIndexManager extends Closeable
          * @return the persisted structural-change counter
          */
         public long getStructuralModCount();
+    }
+
+
+    /**
+     * Immutable snapshot of the three {@code .meta} witness values.
+     * <p>
+     * These describe the <em>written graph</em>, so they must be sampled at the same instant the
+     * in-memory graph is captured — inside {@code synchronized(parentMap)} in persist Phase 1 — and
+     * then stamped verbatim into the {@code .meta}. Reading them live during Phase 2 (after the
+     * monitor is released) would let a {@code vec↔null} mutation landing mid-write advance
+     * {@link IndexStateProvider#getStructuralModCount() structuralModCount} before the metadata is
+     * written, stamping a post-mutation counter over a pre-mutation graph. A crash before the next
+     * persist would then leave the store counter equal to the {@code .meta} counter, so the stale
+     * graph would be wrongly accepted on restart (the nulled entity reappearing in search).
+     * Capturing all three keeps the {@code .meta} internally consistent with the captured graph.
+     */
+    public static final class MetaState
+    {
+        final long expectedVectorCount;
+        final long highestEntityId    ;
+        final long structuralModCount ;
+
+        public MetaState(
+            final long expectedVectorCount,
+            final long highestEntityId    ,
+            final long structuralModCount
+        )
+        {
+            this.expectedVectorCount = expectedVectorCount;
+            this.highestEntityId     = highestEntityId    ;
+            this.structuralModCount  = structuralModCount ;
+        }
     }
 
 
@@ -309,7 +344,8 @@ interface DiskIndexManager extends Closeable
         public void writeIndex(
             final OnHeapGraphIndex         index    ,
             final RandomAccessVectorValues ravv     ,
-            final PQCompressionManager     pqManager
+            final PQCompressionManager     pqManager,
+            final MetaState                metaState
         ) throws IOException
         {
             Files.createDirectories(this.indexDirectory);
@@ -331,8 +367,9 @@ interface DiskIndexManager extends Closeable
                 OnDiskGraphIndex.write(index, ravv, identityOrdinalMap(index), graphPath);
             }
 
-            // Write metadata
-            this.writeMetadata(metaPath);
+            // Write metadata using the witnesses captured with the graph in Phase 1 (see MetaState):
+            // NOT re-read live here, since Phase 2 runs with the parentMap monitor released.
+            this.writeMetadata(metaPath, metaState);
 
             LOG.info("Persisted index '{}' to disk with {} vectors", this.name, index.size(0));
         }
@@ -433,15 +470,15 @@ interface DiskIndexManager extends Closeable
         /**
          * Writes the metadata file.
          */
-        private void writeMetadata(final Path metaPath) throws IOException
+        private void writeMetadata(final Path metaPath, final MetaState metaState) throws IOException
         {
             try(final DataOutputStream dos = new DataOutputStream(new FileOutputStream(metaPath.toFile())))
             {
                 dos.writeInt(GRAPH_FILE_VERSION);
                 dos.writeInt(this.dimension);
-                dos.writeLong(this.provider.getExpectedVectorCount());
-                dos.writeLong(this.provider.getHighestEntityId());
-                dos.writeLong(this.provider.getStructuralModCount());
+                dos.writeLong(metaState.expectedVectorCount);
+                dos.writeLong(metaState.highestEntityId);
+                dos.writeLong(metaState.structuralModCount);
             }
         }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/EntityBackedVectorValues.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/EntityBackedVectorValues.java
@@ -50,7 +50,12 @@ class EntityBackedVectorValues<E> implements RandomAccessVectorValues
     @Override
     public int size()
     {
-        return (int)this.entityMap.size();
+        // The dense ordinal upper bound (getVector must be valid for [0, size())), not the entity
+        // count: the graph ordinal is the entity id, so deletion holes and null-embedding entities
+        // (still counted in entityMap.size()) push the highest ordinal beyond the count. Matching the
+        // id space keeps PQ encodeAll() (which builds a dense array of length size() and is indexed by
+        // ordinal) from skipping/overflowing high ordinals.
+        return (int)(this.entityMap.highestUsedId() + 1);
     }
 
     @Override

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/EntityBackedVectorValues.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/EntityBackedVectorValues.java
@@ -54,8 +54,9 @@ class EntityBackedVectorValues<E> implements RandomAccessVectorValues
         // count: the graph ordinal is the entity id, so deletion holes and null-embedding entities
         // (still counted in entityMap.size()) push the highest ordinal beyond the count. Matching the
         // id space keeps PQ encodeAll() (which builds a dense array of length size() and is indexed by
-        // ordinal) from skipping/overflowing high ordinals.
-        return (int)(this.entityMap.highestUsedId() + 1);
+        // ordinal) from skipping/overflowing high ordinals. toIntExact fails fast rather than silently
+        // overflowing to a negative size() near the int ordinal ceiling.
+        return Math.toIntExact(this.entityMap.highestUsedId() + 1);
     }
 
     @Override

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/GigaMapBackedVectorValues.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/GigaMapBackedVectorValues.java
@@ -62,7 +62,7 @@ class GigaMapBackedVectorValues implements RandomAccessVectorValues
         final VectorTypeSupport    vectorTypeSupport
     )
     {
-        this(storeLookup(vectorStore), () -> (int)vectorStore.size(), dimension, vectorTypeSupport);
+        this(storeLookup(vectorStore), () -> Math.toIntExact(vectorStore.size()), dimension, vectorTypeSupport);
     }
 
     private static IntFunction<float[]> storeLookup(final GigaMap<VectorEntry> vectorStore)

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/GigaMapBackedVectorValues.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/GigaMapBackedVectorValues.java
@@ -9,7 +9,7 @@ package org.eclipse.store.gigamap.jvector;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
@@ -21,32 +21,63 @@ import org.eclipse.store.gigamap.types.GigaMap;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntFunction;
+import java.util.function.IntSupplier;
 
 /**
  * RandomAccessVectorValues backed by a GigaMap.
- * Uses entity ID directly as ordinal.
+ * <p>
+ * The graph ordinal is the source entity id. Resolution is delegated to a caller-supplied
+ * lookup rather than being positional, since the vector store's own id allocator can drift
+ * from the source entity ids (e.g. when some entities have no embedding). The lookup returns
+ * the raw {@code float[]} for an ordinal, or {@code null} if the entity has no vector.
  */
 class GigaMapBackedVectorValues implements RandomAccessVectorValues
 {
-    protected final GigaMap<VectorEntry> vectorStore      ;
+    protected final IntFunction<float[]> vectorLookup     ;
+    protected final IntSupplier          sizeSupplier     ;
     protected final int                  dimension        ;
     protected final VectorTypeSupport    vectorTypeSupport;
 
+    GigaMapBackedVectorValues(
+        final IntFunction<float[]> vectorLookup     ,
+        final IntSupplier          sizeSupplier     ,
+        final int                  dimension        ,
+        final VectorTypeSupport    vectorTypeSupport
+    )
+    {
+        this.vectorLookup      = vectorLookup     ;
+        this.sizeSupplier      = sizeSupplier     ;
+        this.dimension         = dimension        ;
+        this.vectorTypeSupport = vectorTypeSupport;
+    }
+
+    /**
+     * Convenience constructor that resolves ordinals directly against a vector store by source
+     * entity id (see {@link VectorEntry#lookup(GigaMap, long)}).
+     */
     GigaMapBackedVectorValues(
         final GigaMap<VectorEntry> vectorStore      ,
         final int                  dimension        ,
         final VectorTypeSupport    vectorTypeSupport
     )
     {
-        this.vectorStore       = vectorStore      ;
-        this.dimension         = dimension        ;
-        this.vectorTypeSupport = vectorTypeSupport;
+        this(storeLookup(vectorStore), () -> (int)vectorStore.size(), dimension, vectorTypeSupport);
+    }
+
+    private static IntFunction<float[]> storeLookup(final GigaMap<VectorEntry> vectorStore)
+    {
+        return ordinal ->
+        {
+            final VectorEntry entry = VectorEntry.lookup(vectorStore, ordinal);
+            return entry == null ? null : entry.vector;
+        };
     }
 
     @Override
     public int size()
     {
-        return (int)this.vectorStore.size();
+        return this.sizeSupplier.getAsInt();
     }
 
     @Override
@@ -58,13 +89,12 @@ class GigaMapBackedVectorValues implements RandomAccessVectorValues
     @Override
     public VectorFloat<?> getVector(final int ordinal)
     {
-        // Ordinal IS the entity ID
-        final VectorEntry entry = this.vectorStore.get(ordinal);
-        if(entry == null)
+        final float[] vector = this.vectorLookup.apply(ordinal);
+        if(vector == null)
         {
             return null;
         }
-        return this.vectorTypeSupport.createFloatVector(entry.vector);
+        return this.vectorTypeSupport.createFloatVector(vector);
     }
 
     @Override
@@ -77,7 +107,8 @@ class GigaMapBackedVectorValues implements RandomAccessVectorValues
     public RandomAccessVectorValues copy()
     {
         return new GigaMapBackedVectorValues(
-            this.vectorStore,
+            this.vectorLookup,
+            this.sizeSupplier,
             this.dimension,
             this.vectorTypeSupport
         );
@@ -91,6 +122,16 @@ class GigaMapBackedVectorValues implements RandomAccessVectorValues
     static class Caching extends GigaMapBackedVectorValues
     {
         private final Map<Integer, VectorFloat<?>> cache = new ConcurrentHashMap<>();
+
+        Caching(
+            final IntFunction<float[]> vectorLookup     ,
+            final IntSupplier          sizeSupplier     ,
+            final int                  dimension        ,
+            final VectorTypeSupport    vectorTypeSupport
+        )
+        {
+            super(vectorLookup, sizeSupplier, dimension, vectorTypeSupport);
+        }
 
         Caching(
             final GigaMap<VectorEntry> vectorStore      ,
@@ -111,7 +152,8 @@ class GigaMapBackedVectorValues implements RandomAccessVectorValues
         public RandomAccessVectorValues copy()
         {
             return new Caching(
-                this.vectorStore,
+                this.vectorLookup,
+                this.sizeSupplier,
                 this.dimension,
                 this.vectorTypeSupport
             );

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorAnnotationHandler.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorAnnotationHandler.java
@@ -133,7 +133,7 @@ public final class VectorAnnotationHandler<E> implements GigaIndexAnnotationHand
 		vectorIndices.ensure(
 			name,
 			builder.build(),
-			new AnnotationVectorizer<>(member.getDeclaringClass(), member.getName(), method)
+			new AnnotationVectorizer<>(member.getDeclaringClass(), member.getName(), method, annotation.allowNull())
 		);
 	}
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorEntry.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorEntry.java
@@ -15,7 +15,7 @@ package org.eclipse.store.gigamap.jvector;
  */
 
 import org.eclipse.store.gigamap.types.BinaryIndexerLong;
-import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -39,6 +39,40 @@ final class VectorEntry
             return entry.sourceEntityId;
         }
     };
+
+    /**
+     * Looks up the stored entry for the given source entity ID via the
+     * {@link #SOURCE_ENTITY_ID_INDEXER} identity index. Keyed lookup by source entity ID
+     * rather than positional access, since the vector store's own id allocator can drift
+     * from the parent map's entity ids.
+     *
+     * @param store          the computed-mode vector store
+     * @param sourceEntityId the parent entity id to look up
+     * @return the stored entry, or {@code null} if the entity has no vector entry
+     */
+    static VectorEntry lookup(final GigaMap<VectorEntry> store, final long sourceEntityId)
+    {
+        return store.query(SOURCE_ENTITY_ID_INDEXER.is(sourceEntityId)).findFirst().orElse(null);
+    }
+
+    /**
+     * Resolves the vector store's <i>internal</i> entity id for the entry with the given source
+     * entity id. Returned as a store-native id so callers can mutate via {@code set(id, ...)} /
+     * {@code removeById(id)} (which do not depend on the store's own id allocator matching the
+     * parent map's, and which avoid the {@code like(...)} key round-trip that would reject a
+     * zero source entity id).
+     *
+     * @param store          the computed-mode vector store
+     * @param sourceEntityId the parent entity id to look up
+     * @return the store-internal entity id, or {@code -1} if no entry exists
+     */
+    static long lookupId(final GigaMap<VectorEntry> store, final long sourceEntityId)
+    {
+        final long[] found = {-1L};
+        store.query(SOURCE_ENTITY_ID_INDEXER.is(sourceEntityId))
+            .executeWithId((id, entry) -> found[0] = id);
+        return found[0];
+    }
 
 
     final long    sourceEntityId;

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorEntry.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorEntry.java
@@ -55,24 +55,6 @@ final class VectorEntry
         return store.query(SOURCE_ENTITY_ID_INDEXER.is(sourceEntityId)).findFirst().orElse(null);
     }
 
-    /**
-     * Resolves the vector store's <i>internal</i> entity id for the entry with the given source
-     * entity id. Returned as a store-native id so callers can mutate via {@code set(id, ...)} /
-     * {@code removeById(id)} (which do not depend on the store's own id allocator matching the
-     * parent map's, and which avoid the {@code like(...)} key round-trip that would reject a
-     * zero source entity id).
-     *
-     * @param store          the computed-mode vector store
-     * @param sourceEntityId the parent entity id to look up
-     * @return the store-internal entity id, or {@code -1} if no entry exists
-     */
-    static long lookupId(final GigaMap<VectorEntry> store, final long sourceEntityId)
-    {
-        final long[] found = {-1L};
-        store.query(SOURCE_ENTITY_ID_INDEXER.is(sourceEntityId))
-            .executeWithId((id, entry) -> found[0] = id);
-        return found[0];
-    }
 
 
     final long    sourceEntityId;

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -792,8 +792,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // bitmaps (cheap, loads no VectorEntry / no vectors) once the store is queryable, falling back
         // to a positional store scan during the deserialization window when the index registry is not
         // yet wired. Deferring the build off the load path is what keeps incremental on-disk startup
-        // O(1) in the vector payload. Volatile: read lock-free by search threads (fast path), written
-        // under the vector store's own monitor (a leaf lock — see computedIdIndex()).
+        // O(1) in the vector payload.
+        //
+        // Concurrency: a ConcurrentHashMap. The volatile FIELD is published (assigned) once under the
+        // vector store's own monitor by the double-checked lazy build in computedIdIndex() (a leaf
+        // lock — see there); search threads read it lock-free. Per-entry put/remove by mutations are
+        // not synchronized on that monitor — they rely on the map's own thread-safety and are serialized
+        // against each other by the parent GigaMap monitor the mutation already holds.
         private transient volatile Map<Long, Long> computedIdIndex;
 
         // Incremental on-disk mode: after disk reload, use disk index for search
@@ -1538,8 +1543,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             final boolean contentChanged;
             if(embedded)
             {
-                final float[] oldVector = replacedEntity == null ? null : this.vectorize(replacedEntity);
-                contentChanged = !(oldVector == null && vector == null); // null→null is the only no-op
+                // A non-null new vector is always a change (null→vec or vec→vec). Only a null new vector
+                // needs the old vector — to tell vec→null (a change) from null→null (the only no-op) —
+                // so re-vectorize replacedEntity solely on that path, not on the common non-null update.
+                contentChanged = vector != null
+                    || (replacedEntity != null && this.vectorize(replacedEntity) != null);
             }
             else
             {
@@ -2260,7 +2268,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // PQ encodeAll() builds a dense PQVectors of this length and FusedPQ / PQ search then
                     // index it by graph ordinal — an under-reported count skips/overflows high ordinals
                     // (IndexOutOfBoundsException). Match the graph's ordinal space (see getHighestEntityId()).
-                    () -> (int)(this.parentMap().highestUsedId() + 1),
+                    () -> Math.toIntExact(this.parentMap().highestUsedId() + 1),
                     this.configuration.dimension(),
                     this.vectorTypeSupport
                 );
@@ -2780,7 +2788,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // PQ encodeAll() builds a dense PQVectors of this length and FusedPQ / PQ search then
                     // index it by graph ordinal — an under-reported count skips/overflows high ordinals
                     // (IndexOutOfBoundsException). Match the graph's ordinal space (see getHighestEntityId()).
-                    () -> (int)(this.parentMap().highestUsedId() + 1),
+                    () -> Math.toIntExact(this.parentMap().highestUsedId() + 1),
                     this.configuration.dimension(),
                     this.vectorTypeSupport
                 );

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -438,12 +438,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
      * Searches for the k nearest neighbors to the given entity's vector with an explicit
      * per-query search beam width.
      *
-     * @param queryEntity     the query entity whose vector will be extracted via the vectorizer
+     * @param queryEntity     the query entity whose vector will be extracted via the vectorizer;
+     *                        must not be null
      * @param k               the number of nearest neighbors to return; must be positive
      * @param searchBeamWidth the beam width to use for this query; must be positive
      * @return the search result
-     * @throws IllegalArgumentException if the vectorizer returns null for the entity (an entity
-     *                                  without an embedding cannot be used as a similarity query)
+     * @throws IllegalArgumentException if queryEntity is null, {@code k} / {@code searchBeamWidth}
+     *                                  are not positive, or the vectorizer returns null for the
+     *                                  entity (an entity without an embedding cannot be used as
+     *                                  a similarity query)
      * @see #search(float[], int, int)
      */
     public default VectorSearchResult<E> search(final E queryEntity, final int k, final int searchBeamWidth)

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -2405,6 +2405,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     final RandomAccessVectorValues capturedRavv   ;
                     final PQCompressionManager     capturedPqMgr  ;
                     final DiskIndexManager         capturedDiskMgr;
+                    final DiskIndexManager.MetaState capturedMeta ;
 
                     final GraphIndexBuilder        capturedBuilder;
 
@@ -2453,6 +2454,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                         );
                         capturedPqMgr   = this.pqManager;
                         capturedDiskMgr = this.diskManager;
+
+                        // Sample the .meta witnesses at the same instant the graph is captured, under
+                        // the monitor, so a Phase-2 vec↔null mutation cannot advance them past the
+                        // written graph (see DiskIndexManager.MetaState).
+                        capturedMeta    = new DiskIndexManager.MetaState(
+                            this.getExpectedVectorCount(),
+                            this.getHighestEntityId(),
+                            this.getStructuralModCount()
+                        );
                     }
 
                     // Phase 2: Cleanup and disk write outside synchronized(parentMap).
@@ -2470,7 +2480,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     }
 
                     capturedBuilder.cleanup();
-                    capturedDiskMgr.writeIndex(capturedIndex, capturedRavv, capturedPqMgr);
+                    capturedDiskMgr.writeIndex(capturedIndex, capturedRavv, capturedPqMgr, capturedMeta);
 
                     // After writing, re-enter incremental mode for fast subsequent operation
                     this.reenterIncrementalMode();

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -1546,24 +1546,24 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 contentChanged = changed;
             }
 
-            // In incremental mode, mark the ordinal as deleted from disk graph
-            // so disk search excludes the stale version immediately,
-            // regardless of whether indexing is synchronous or eventual.
-            if(this.incrementalMode && this.diskDeletedOrdinals != null)
+            // In incremental mode, mark the ordinal as deleted from disk graph so disk search excludes
+            // the stale version immediately, regardless of whether indexing is synchronous or eventual.
+            // Gated on contentChanged: a null→null no-op has no stale disk version to exclude, and
+            // adding it would only bloat diskDeletedOrdinals and enlarge the boolean[maxOrdinal+1] mask
+            // rebuilt in createDiskAcceptBits() on every search.
+            if(contentChanged && this.incrementalMode && this.diskDeletedOrdinals != null)
             {
                 this.diskDeletedOrdinals.add(ordinal);
             }
 
             if(this.isEventualIndexing())
             {
-                // Computed-mode null→null (no store entry existed, vector still null) is a
-                // complete no-op — don't generate background work for it. The store and
-                // computedIdIndex are updated synchronously, so !changed is a reliable witness.
-                // Embedded mode has no synchronous witness for the old state (graph mutations
-                // are queued, so containsNode is racy against pending ops) and must always
-                // defer to applyGraphUpdate, which derives the actual transition
-                // (add / delete / delete+re-add) from the entry's vector nullness.
-                if(embedded || changed)
+                // Only a real (id→vector) transition needs background graph work. null→null is a no-op
+                // in both modes; contentChanged is the reliable synchronous witness (for embedded it is
+                // derived from the old vector above, so — unlike the raw graph-op flag — it is not racy
+                // against queued mutations). applyGraphUpdate then derives the actual transition
+                // (add / delete / delete+re-add) from the enqueued entry's vector nullness.
+                if(contentChanged)
                 {
                     this.backgroundTaskManager.enqueueUpdate(new VectorEntry(entityId, vector));
                 }

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -39,7 +39,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -422,14 +424,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
      *                    must not be null
      * @param k           the number of nearest neighbors to return; must be positive
      * @return the search result containing up to k entries; never null
-     * @throws IllegalArgumentException if queryEntity is null or k &lt;= 0
-     * @throws NullPointerException if the vectorizer returns null for the entity
+     * @throws IllegalArgumentException if queryEntity is null, k &lt;= 0, or the vectorizer
+     *                                  returns null for the entity (an entity without an
+     *                                  embedding cannot be used as a similarity query)
      * @see #search(float[], int)
      * @see Vectorizer#vectorize(Object)
      */
     public default VectorSearchResult<E> search(final E queryEntity, final int k)
     {
-        return this.search(this.vectorizer().vectorize(queryEntity), k);
+        return this.search(this.requireQueryVector(queryEntity), k);
     }
 
     /**
@@ -440,11 +443,34 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
      * @param k               the number of nearest neighbors to return; must be positive
      * @param searchBeamWidth the beam width to use for this query; must be positive
      * @return the search result
+     * @throws IllegalArgumentException if the vectorizer returns null for the entity (an entity
+     *                                  without an embedding cannot be used as a similarity query)
      * @see #search(float[], int, int)
      */
     public default VectorSearchResult<E> search(final E queryEntity, final int k, final int searchBeamWidth)
     {
-        return this.search(this.vectorizer().vectorize(queryEntity), k, searchBeamWidth);
+        return this.search(this.requireQueryVector(queryEntity), k, searchBeamWidth);
+    }
+
+    /**
+     * Extracts the query vector from the given entity, rejecting a null result: an entity
+     * without an embedding has no meaningful similarity and cannot be used as a query.
+     *
+     * @param queryEntity the query entity
+     * @return the non-null query vector
+     * @throws IllegalArgumentException if the vectorizer returns null for the entity
+     */
+    private float[] requireQueryVector(final E queryEntity)
+    {
+        final float[] queryVector = this.vectorizer().vectorize(queryEntity);
+        if(queryVector == null)
+        {
+            throw new IllegalArgumentException(
+                "Query entity has no vector: the vectorizer returned null. "
+                    + "Entities without embeddings cannot be used as similarity queries."
+            );
+        }
+        return queryVector;
     }
 
     /**
@@ -614,7 +640,9 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
      * }</pre>
      *
      * @param entityId the entity ID whose vector to retrieve
-     * @return the vector as a float array, or {@code null} if no vector is found for the given entity ID
+     * @return the vector as a float array, or {@code null} if the entity has no vector — either
+     *         because no such entity is indexed, or because the entity has no embedding (when
+     *         the vectorizer {@link Vectorizer#allowsNullVectors() allows null vectors})
      */
     public float[] getVector(long entityId);
 
@@ -736,6 +764,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // GraphSearcher pool for thread-local reuse
         private transient ExplicitThreadLocal<GraphSearcher> inMemorySearcherPool;
 
+        // Non-null only for the duration of a graph rebuild from the computed-mode vector store.
+        // Maps ordinal (source entity id) -> raw vector for the entries being rebuilt. The
+        // rebuild runs during deserialization (complete()), when the vector store's own indices
+        // may not be wired yet, so scoring must not query the store — it reads this overlay
+        // instead. Cleared once the rebuild finishes, after which live lookups query the store.
+        private transient Map<Integer, float[]> rebuildOverlay;
+
         // Incremental on-disk mode: after disk reload, use disk index for search
         // and in-memory builder only for new mutations. Full rebuild deferred to persistToDisk().
         // Volatile: written under writeLock (reenterIncrementalMode, exitIncrementalMode)
@@ -842,7 +877,40 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 return;
             }
 
-            this.addGraphNodesSequential(entries);
+            // Serve scoring from an in-memory overlay for the duration of the rebuild: this runs
+            // during deserialization, when the computed-mode vector store's indices may not yet be
+            // wired, so lookupComputedVector() must not query the store. (Embedded mode ignores the
+            // overlay — it scores via EntityBackedVectorValues over the parent map.)
+            final Map<Integer, float[]> overlay = new HashMap<>(entries.size());
+            for(final VectorEntry entry : entries)
+            {
+                overlay.put(toOrdinal(entry.sourceEntityId), entry.vector);
+            }
+            this.rebuildOverlay = overlay;
+            try
+            {
+                this.addGraphNodesSequential(entries);
+            }
+            finally
+            {
+                this.rebuildOverlay = null;
+            }
+        }
+
+        /**
+         * Resolves the raw vector for a graph ordinal (source entity id) in computed mode.
+         * During a rebuild the in-memory overlay is authoritative (the store's indices may not be
+         * ready); otherwise the entry is looked up by source entity id via the identity index.
+         */
+        private float[] lookupComputedVector(final int ordinal)
+        {
+            final Map<Integer, float[]> overlay = this.rebuildOverlay;
+            if(overlay != null)
+            {
+                return overlay.get(ordinal);
+            }
+            final VectorEntry entry = VectorEntry.lookup(this.vectorStore, ordinal);
+            return entry == null ? null : entry.vector;
         }
 
         private List<VectorEntry> collectStoredVectors()
@@ -854,15 +922,26 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 this.parentMap().iterateIndexed((entityId, entity) ->
                 {
                     final float[] vector = this.vectorize(entity);
-                    entries.add(new VectorEntry(entityId, vector));
+                    // Entities without an embedding (opted-in null vectors) are not graph nodes.
+                    if(vector != null)
+                    {
+                        entries.add(new VectorEntry(entityId, vector));
+                    }
                 });
             }
             else
             {
-                // Computed mode: rebuild from vector store
+                // Computed mode: rebuild from vector store. Null-vector entries are never
+                // stored, but keep a defensive filter in case of legacy data.
                 if(this.vectorStore != null && !this.vectorStore.isEmpty())
                 {
-                    this.vectorStore.iterate(entries::add);
+                    this.vectorStore.iterate(entry ->
+                    {
+                        if(entry.vector != null)
+                        {
+                            entries.add(entry);
+                        }
+                    });
                 }
             }
 
@@ -1157,9 +1236,16 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         {
             if(vector == null)
             {
+                // Null means "this entity has no embedding" when the vectorizer opts in;
+                // it is then excluded from the graph. Otherwise fail fast.
+                if(this.vectorizer.allowsNullVectors())
+                {
+                    return null;
+                }
                 throw new IllegalStateException(
                     "Null vector returned from vectorizer in index \"" + this.name()
-                        + "\" (vectorizer: " + this.vectorizer.getClass().getName() + ")"
+                        + "\" (vectorizer: " + this.vectorizer.getClass().getName() + "). "
+                        + "Override Vectorizer.allowsNullVectors() to permit entities without embeddings."
                 );
             }
 
@@ -1234,6 +1320,14 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             this.ensureIndexInitialized();
 
             final float[] vector = this.vectorize(entity);
+
+            // Null vector (opted-in): the entity has no embedding — keep it out of the vector
+            // store and the graph entirely, so it never appears in search results.
+            if(vector == null)
+            {
+                return;
+            }
+
             final VectorEntry vectorEntry = new VectorEntry(entityId, vector);
 
             // Store based on vectorizer type
@@ -1290,18 +1384,43 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             // No synchronized(parentMap) needed — called from GigaMap's synchronized methods.
             this.ensureIndexInitialized();
 
-            final float[] vector = this.vectorize(entity);
-            final VectorEntry vectorEntry = new VectorEntry(entityId, vector);
+            final float[]  vector   = this.vectorize(entity);
+            final int      ordinal  = toOrdinal(entityId);
+            final boolean  embedded = this.isEmbedded();
 
-            // Update based on vectorizer type
-            if(!this.isEmbedded())
+            // Update the computed-mode vector store to reflect the new (possibly absent) vector.
+            // Keyed by source entity id (not positionally), so the four vec/null transitions map
+            // cleanly onto add / replace / remove.
+            boolean changed = false;
+            if(!embedded)
             {
-                this.vectorStore.set(entityId, vectorEntry);
+                // Resolve the store-internal id by source entity id, then mutate via id-based
+                // ops (set / removeById). These avoid the like(...) key round-trip, which would
+                // reject a source entity id of 0 (encoded to the Long.MAX_VALUE sentinel).
+                final long storeId = VectorEntry.lookupId(this.vectorStore, entityId);
+                if(vector == null)
+                {
+                    // vec→null: drop the stored entry so the entity is no longer indexed.
+                    // null→null: nothing stored, nothing to do.
+                    if(storeId >= 0)
+                    {
+                        this.vectorStore.removeById(storeId);
+                        changed = true;
+                    }
+                }
+                else if(storeId >= 0)
+                {
+                    // vec→vec
+                    this.vectorStore.set(storeId, new VectorEntry(entityId, vector));
+                    changed = true;
+                }
+                else
+                {
+                    // null→vec: the entity gains an embedding.
+                    this.vectorStore.add(new VectorEntry(entityId, vector));
+                    changed = true;
+                }
             }
-
-            this.markStateChangeChildren();
-
-            final int ordinal = toOrdinal(entityId);
 
             // In incremental mode, mark the ordinal as deleted from disk graph
             // so disk search excludes the stale version immediately,
@@ -1313,8 +1432,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
             if(this.isEventualIndexing())
             {
-                // Defer graph update to background thread
-                this.backgroundTaskManager.enqueueUpdate(vectorEntry);
+                // Defer graph update to background thread. applyGraphUpdate derives the actual
+                // transition (add / delete / delete+re-add) from the entry's vector nullness.
+                this.backgroundTaskManager.enqueueUpdate(new VectorEntry(entityId, vector));
+                this.markStateChangeChildren();
             }
             else
             {
@@ -1326,18 +1447,39 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     this.drainDeferredBuilderOps();
                 }
 
-                if(this.isEmbedded())
+                final boolean inGraph = this.index != null && this.index.containsNode(ordinal);
+
+                if(vector == null)
                 {
-                    // For embedded vectorizers: removeDeletedNodes() uses ForkJoinPool
-                    // whose workers call parentMap.get(), deadlocking with the GigaMap
-                    // monitor we hold. Instead, let the next optimize/persist cycle
-                    // rebuild the graph connections. The updated entity is already in
-                    // the GigaMap, so EntityBackedVectorValues will return the new
-                    // vector for similarity scoring during search.
+                    // vec→null / null→null: remove the node from the in-memory graph if present.
+                    // No removeDeletedNodes() — unnecessary (markNodeDeleted already excludes it
+                    // from liveNodes), and its ForkJoinPool would deadlock with the GigaMap
+                    // monitor we hold for embedded vectorizers.
+                    if(inGraph)
+                    {
+                        this.executeOrDeferBuilderOp(() -> this.builder.markNodeDeleted(ordinal));
+                        changed = true;
+                    }
+                }
+                else if(embedded)
+                {
+                    // vec→vec: leave the graph as-is — removeDeletedNodes() uses a ForkJoinPool
+                    // whose workers call parentMap.get(), deadlocking with the GigaMap monitor we
+                    // hold. The updated entity is already in the GigaMap, so
+                    // EntityBackedVectorValues returns the new vector during search, and the next
+                    // optimize/persist cycle rebuilds the graph connections.
+                    // null→vec: the node was never added — add it now. addGraphNode alone is
+                    // monitor-safe (no removeDeletedNodes), the same call internalAdd makes.
+                    if(!inGraph)
+                    {
+                        final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
+                        this.executeOrDeferBuilderOp(() -> this.builder.addGraphNode(ordinal, vf));
+                    }
+                    changed = true;
                 }
                 else
                 {
-                    // For computed vectorizers: vectors are stored separately, so
+                    // Computed, non-null (vec→vec or null→vec): vectors are stored separately, so
                     // removeDeletedNodes() won't call parentMap.get(). Safe to inline.
                     final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
                     this.executeOrDeferBuilderOp(() ->
@@ -1349,10 +1491,14 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                         }
                         this.builder.addGraphNode(ordinal, vf);
                     });
+                    changed = true;
                 }
 
-                // Mark dirty for background managers
-                this.markDirtyForBackgroundManagers(1);
+                if(changed)
+                {
+                    this.markStateChangeChildren();
+                    this.markDirtyForBackgroundManagers(1);
+                }
             }
         }
 
@@ -1386,10 +1532,24 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         /**
          * Adds vector entries to the index.
          */
-        private void addVectorEntries(final List<VectorEntry> entries)
+        private void addVectorEntries(final List<VectorEntry> entriesIncludingNulls)
         {
             // No synchronized(parentMap) needed — called from GigaMap's synchronized methods.
             this.ensureIndexInitialized();
+
+            // Drop entries without a vector (opted-in null embeddings): they get neither a
+            // vector store entry nor a graph node, so they never appear in search results.
+            // The kept entries carry their own sourceEntityId, so filtering does not disturb
+            // id alignment.
+            final List<VectorEntry> entries = entriesIncludingNulls.stream()
+                .filter(e -> e.vector != null)
+                .toList()
+            ;
+
+            if(entries.isEmpty())
+            {
+                return;
+            }
 
             if(!this.isEmbedded())
             {
@@ -1441,6 +1601,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         {
             entries.forEach(entry ->
             {
+                if(entry.vector == null)
+                {
+                    // Entities without an embedding are excluded from the graph.
+                    return;
+                }
                 final int ordinal = toOrdinal(entry.sourceEntityId);
                 final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(entry.vector);
                 this.builder.addGraphNode(ordinal, vf);
@@ -1456,7 +1621,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             final int ordinal = toOrdinal(entityId);
             if(!this.isEmbedded())
             {
-                this.vectorStore.removeById(entityId);
+                // Look up by source entity id rather than positionally; a never-indexed
+                // entity (null embedding) simply has no entry and nothing is removed.
+                final long storeId = VectorEntry.lookupId(this.vectorStore, entityId);
+                if(storeId >= 0)
+                {
+                    this.vectorStore.removeById(storeId);
+                }
             }
 
             this.markStateChangeChildren();
@@ -1552,7 +1723,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 return this.vectorizer.vectorize(entity);
             }
 
-            final VectorEntry entry = this.vectorStore.get(entityId);
+            final VectorEntry entry = VectorEntry.lookup(this.vectorStore, entityId);
             if(entry == null)
             {
                 return null;
@@ -1574,6 +1745,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
         private VectorSearchResult<E> doSearch(final float[] queryVector, final int k, final int rerankK)
         {
+            if(queryVector == null)
+            {
+                throw new IllegalArgumentException("Query vector must not be null");
+            }
             this.validateDimension(queryVector);
 
             // Acquire read lock — blocks during cleanup/persistence/removeAll/close,
@@ -1894,7 +2069,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     this.vectorTypeSupport
                 )
                 : new GigaMapBackedVectorValues.Caching(
-                    this.vectorStore,
+                    this::lookupComputedVector,
+                    () -> (int)this.vectorStore.size(),
                     this.configuration.dimension(),
                     this.vectorTypeSupport
                 );
@@ -2398,7 +2574,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     this.vectorTypeSupport
                 )
                 : new GigaMapBackedVectorValues(
-                    this.vectorStore,
+                    this::lookupComputedVector,
+                    () -> (int)this.vectorStore.size(),
                     this.configuration.dimension(),
                     this.vectorTypeSupport
                 );
@@ -2425,14 +2602,26 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             if(this.isEmbedded())
             {
                 this.parentMap().iterate(entity ->
-                    vectors.add(this.vectorTypeSupport.createFloatVector(this.vectorize(entity)))
-                );
+                {
+                    final float[] vector = this.vectorize(entity);
+                    // Skip entities without an embedding — they are not part of the graph and
+                    // must not feed PQ codebook training.
+                    if(vector != null)
+                    {
+                        vectors.add(this.vectorTypeSupport.createFloatVector(vector));
+                    }
+                });
             }
             else if(this.vectorStore != null)
             {
+                // Computed mode never stores null-vector entries; guard defensively anyway.
                 this.vectorStore.iterate(entry ->
-                    vectors.add(this.vectorTypeSupport.createFloatVector(entry.vector))
-                );
+                {
+                    if(entry.vector != null)
+                    {
+                        vectors.add(this.vectorTypeSupport.createFloatVector(entry.vector));
+                    }
+                });
             }
 
             return vectors;
@@ -2443,6 +2632,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         @Override
         public long getExpectedVectorCount()
         {
+            // Counts indexed entities, NOT graph nodes. In computed mode the two are equal
+            // (null-vector entities have no store entry). In embedded mode this can over-count
+            // when some entities have no embedding — that is fine for the disk metadata check,
+            // which compares this value against itself on write and read, and for the PQ
+            // training gate, which trains on the actually-collected (non-null) vectors.
             if(this.isEmbedded())
             {
                 return this.parentMap().size();
@@ -2475,6 +2669,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             // Called from the background indexing worker thread (not from GigaMap's
             // synchronized methods), so we use builderLock.readLock() to coordinate
             // with cleanup (writeLock).
+            if(entry.vector == null)
+            {
+                // Entity has no embedding — nothing to add to the graph. Callers already
+                // filter these out; this is a defensive guard on the worker thread.
+                return;
+            }
             this.builderLock.readLock().lock();
             try
             {
@@ -2497,6 +2697,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             {
                 for(final var entry : entries)
                 {
+                    if(entry.vector == null)
+                    {
+                        // Entity has no embedding — excluded from the graph.
+                        continue;
+                    }
                     final int ordinal = toOrdinal(entry.sourceEntityId);
                     final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(entry.vector);
                     this.builder.addGraphNode(ordinal, vf);
@@ -2515,8 +2720,25 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             try
             {
                 final int ordinal = toOrdinal(entry.sourceEntityId);
-                this.builder.markNodeDeleted(ordinal);
-                this.builder.removeDeletedNodes();
+                final boolean inGraph = this.index != null && this.index.containsNode(ordinal);
+
+                if(entry.vector == null)
+                {
+                    // vec→null / null→null: remove the node if present, otherwise nothing to do.
+                    if(inGraph)
+                    {
+                        this.builder.markNodeDeleted(ordinal);
+                    }
+                    return;
+                }
+
+                // vec→vec: delete the stale node then re-add. null→vec: the node is absent,
+                // so add it directly without the (invalid) delete.
+                if(inGraph)
+                {
+                    this.builder.markNodeDeleted(ordinal);
+                    this.builder.removeDeletedNodes();
+                }
                 final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(entry.vector);
                 this.builder.addGraphNode(ordinal, vf);
             }
@@ -2532,7 +2754,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             this.builderLock.readLock().lock();
             try
             {
-                this.builder.markNodeDeleted(ordinal);
+                // Guard against removing a never-indexed entity (e.g. one that never had an
+                // embedding): markNodeDeleted on an absent node would fail.
+                if(this.index != null && this.index.containsNode(ordinal))
+                {
+                    this.builder.markNodeDeleted(ordinal);
+                }
             }
             finally
             {

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -2653,9 +2653,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             // Always use the parent GigaMap's id space — that is the ordinal
             // space the HNSW graph is keyed on (via toOrdinal(entityId)) in
             // both embedded and computed-vector modes. The computed-mode
-            // vectorStore has its own monotonic id allocator that can drift
+            // vectorStore has its own monotonic id allocator that diverges
             // from the parent map's (e.g. when an index is registered against
-            // a parent with deletion holes), so it is unsafe as a stand-in.
+            // a parent with deletion holes, or when some entities have no
+            // embedding and so get no vectorStore entry at all), so it is
+            // unsafe as a stand-in. Note this is only about the highest-id
+            // bound: per-entity vector lookups no longer assume alignment —
+            // they resolve by VectorEntry.sourceEntityId (see lookupComputedVector).
             return this.parentMap().highestUsedId();
         }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -818,6 +818,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         private transient volatile boolean                cleanupInProgress;
         private transient ConcurrentLinkedQueue<Runnable> deferredBuilderOps;
 
+        // Test-only seam: run once at the start of persist Phase 2 (parentMap monitor released,
+        // builder about to be swapped by reenterIncrementalMode). Lets a test deterministically inject
+        // a mutation into the exact window where a deferred builder op is drained after the swap.
+        // Null (and a no-op) in production. See VectorIndex(persist-window deletion) regression test.
+        transient volatile Runnable persistPhase2TestHook;
+
 
         ///////////////////////////////////////////////////////////////////////////
         // constructors //
@@ -1363,7 +1369,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          * <p>
          * Marks BOTH the instance and children dirty: {@code structuralModCount} is a field of this
          * instance, so it is only re-serialized when the instance itself is flagged
-         * ({@link AbstractStateChangeFlagged#isInstanceNewOrChanged()} gates {@code internalStore}) —
+         * AbstractStateChangeFlagged#isInstanceNewOrChanged() gates {@code internalStore}) —
          * {@code markStateChangeChildren()} alone would persist only children (e.g. the computed-mode
          * {@code vectorStore}) and silently drop the counter.
          */
@@ -1580,9 +1586,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // No removeDeletedNodes() — unnecessary (markNodeDeleted already excludes it
                     // from liveNodes), and its ForkJoinPool would deadlock with the GigaMap
                     // monitor we hold for embedded vectorizers.
+                    // Route through internalMarkOrdinalDeleted so a deferral drained after a persist
+                    // builder swap still records the deletion (via diskDeletedOrdinals) instead of
+                    // no-op'ing against the new empty builder.
                     if(inGraph)
                     {
-                        this.executeOrDeferBuilderOp(() -> this.builder.markNodeDeleted(ordinal));
+                        this.executeOrDeferBuilderOp(() -> this.internalMarkOrdinalDeleted(ordinal));
                         changed = true;
                     }
                 }
@@ -1816,10 +1825,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
                 // Mark deleted in the in-memory builder if the node exists there
                 // (e.g., added after disk reload). Disk-only nodes are excluded
-                // via diskDeletedOrdinals and won't be in the builder.
+                // via diskDeletedOrdinals and won't be in the builder. Route through
+                // internalMarkOrdinalDeleted so a deferral drained after a persist builder swap
+                // still records the deletion instead of no-op'ing against the new empty builder.
                 if(this.index != null && this.index.containsNode(ordinal))
                 {
-                    this.executeOrDeferBuilderOp(() -> this.builder.markNodeDeleted(ordinal));
+                    this.executeOrDeferBuilderOp(() -> this.internalMarkOrdinalDeleted(ordinal));
                 }
 
                 // Mark dirty for background managers
@@ -2435,6 +2446,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // background worker mutations, removeAll, and close.
                     // parentMap monitor is released, so ForkJoinPool workers and
                     // disk writer threads can call parentMap.get() for embedded vectors.
+
+                    // Test-only injection point: exercises the window where a sync mutation defers a
+                    // builder op that is drained only after the builder is swapped below. No-op in prod.
+                    final Runnable hook = this.persistPhase2TestHook;
+                    if(hook != null)
+                    {
+                        hook.run();
+                    }
+
                     capturedBuilder.cleanup();
                     capturedDiskMgr.writeIndex(capturedIndex, capturedRavv, capturedPqMgr);
 
@@ -2957,6 +2977,29 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // ================================================================
         // Builder operation deferral helpers
         // ================================================================
+
+        /**
+         * Marks a graph ordinal deleted, re-deriving the target from CURRENT state at execution time
+         * rather than from a captured builder reference. This matters when the op is deferred
+         * (via {@link #executeOrDeferBuilderOp}) during a persist and drained afterwards: {@code
+         * doPersistToDisk} swaps the in-memory builder (exit/reenter incremental mode) between deferral
+         * and drain, so a captured {@code builder.markNodeDeleted(ordinal)} would land on the new, empty
+         * builder and be lost — leaving the entity live on the reloaded disk graph until the next
+         * persist. Recording the deletion in {@link #diskDeletedOrdinals} (when incremental) makes it
+         * survive the swap; the in-builder {@code markNodeDeleted} is applied only when the node is
+         * actually present in the current builder.
+         */
+        private void internalMarkOrdinalDeleted(final int ordinal)
+        {
+            if(this.incrementalMode && this.diskDeletedOrdinals != null)
+            {
+                this.diskDeletedOrdinals.add(ordinal);
+            }
+            if(this.index != null && this.index.containsNode(ordinal))
+            {
+                this.builder.markNodeDeleted(ordinal);
+            }
+        }
 
         /**
          * Executes a builder operation immediately, or defers it if cleanup is in progress.

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -1941,6 +1941,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             {
                 throw new IllegalArgumentException("Query vector must not be null");
             }
+            // Enforce the documented k > 0 precondition here, the single funnel for every search
+            // overload (float[] and entity-based, with and without an explicit beam width), rather
+            // than letting a non-positive topK reach jvector's searcher.
+            if(k <= 0)
+            {
+                throw new IllegalArgumentException("k must be positive: " + k);
+            }
             this.validateDimension(queryVector);
 
             // Acquire read lock — blocks during cleanup/persistence/removeAll/close,

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -1446,10 +1446,18 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
             if(this.isEventualIndexing())
             {
-                // Defer graph update to background thread. applyGraphUpdate derives the actual
-                // transition (add / delete / delete+re-add) from the entry's vector nullness.
-                this.backgroundTaskManager.enqueueUpdate(new VectorEntry(entityId, vector));
-                this.markStateChangeChildren();
+                // Computed-mode null→null (no store entry existed, vector still null) is a
+                // complete no-op — don't generate background work for it. The store and
+                // computedIdIndex are updated synchronously, so !changed is a reliable witness.
+                // Embedded mode has no synchronous witness for the old state (graph mutations
+                // are queued, so containsNode is racy against pending ops) and must always
+                // defer to applyGraphUpdate, which derives the actual transition
+                // (add / delete / delete+re-add) from the entry's vector nullness.
+                if(embedded || changed)
+                {
+                    this.backgroundTaskManager.enqueueUpdate(new VectorEntry(entityId, vector));
+                    this.markStateChangeChildren();
+                }
             }
             else
             {
@@ -1744,7 +1752,20 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 return this.vectorizer.vectorize(entity);
             }
 
-            final VectorEntry entry = VectorEntry.lookup(this.vectorStore, entityId);
+            // Resolve via the fast source-id index when available (O(1), no query allocation,
+            // no dependency on the vector store's own indices being wired); fall back to the
+            // identity-index query only if this instance's transients are not initialized yet.
+            final Map<Long, Long> idIndex = this.computedIdIndex;
+            final VectorEntry entry;
+            if(idIndex != null)
+            {
+                final Long storeId = idIndex.get(entityId);
+                entry = storeId == null ? null : this.vectorStore.get(storeId);
+            }
+            else
+            {
+                entry = VectorEntry.lookup(this.vectorStore, entityId);
+            }
             if(entry == null)
             {
                 return null;

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -2254,7 +2254,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 )
                 : new GigaMapBackedVectorValues.Caching(
                     this::lookupComputedVector,
-                    () -> (int)this.vectorStore.size(),
+                    // RAVV size() is the dense ordinal upper bound (getVector must be valid for
+                    // [0, size())), NOT the vector count. Graph ordinals are source entity ids, so with
+                    // null embeddings / deletion holes the highest ordinal exceeds vectorStore.size().
+                    // PQ encodeAll() builds a dense PQVectors of this length and FusedPQ / PQ search then
+                    // index it by graph ordinal — an under-reported count skips/overflows high ordinals
+                    // (IndexOutOfBoundsException). Match the graph's ordinal space (see getHighestEntityId()).
+                    () -> (int)(this.parentMap().highestUsedId() + 1),
                     this.configuration.dimension(),
                     this.vectorTypeSupport
                 );
@@ -2768,7 +2774,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 )
                 : new GigaMapBackedVectorValues(
                     this::lookupComputedVector,
-                    () -> (int)this.vectorStore.size(),
+                    // RAVV size() is the dense ordinal upper bound (getVector must be valid for
+                    // [0, size())), NOT the vector count. Graph ordinals are source entity ids, so with
+                    // null embeddings / deletion holes the highest ordinal exceeds vectorStore.size().
+                    // PQ encodeAll() builds a dense PQVectors of this length and FusedPQ / PQ search then
+                    // index it by graph ordinal — an under-reported count skips/overflows high ordinals
+                    // (IndexOutOfBoundsException). Match the graph's ordinal space (see getHighestEntityId()).
+                    () -> (int)(this.parentMap().highestUsedId() + 1),
                     this.configuration.dimension(),
                     this.vectorTypeSupport
                 );

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -1488,18 +1488,37 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 }
                 else if(embedded)
                 {
-                    // vec→vec: leave the graph as-is — removeDeletedNodes() uses a ForkJoinPool
-                    // whose workers call parentMap.get(), deadlocking with the GigaMap monitor we
-                    // hold. The updated entity is already in the GigaMap, so
-                    // EntityBackedVectorValues returns the new vector during search, and the next
-                    // optimize/persist cycle rebuilds the graph connections.
-                    // null→vec: the node was never added — add it now. addGraphNode alone is
-                    // monitor-safe (no removeDeletedNodes), the same call internalAdd makes.
+                    // Three distinct embedded, non-null transitions, distinguished by graph state.
+                    // Note containsNode() alone is NOT enough: jvector's markNodeDeleted() only sets
+                    // a deleted bit and leaves the node in layer 0, so containsNode() stays true for
+                    // a marked-deleted node. A prior vec→null in this same session (without an
+                    // intervening optimize) leaves the node present-but-deleted, which is a third
+                    // case the plain !inGraph guard would silently mis-handle.
                     if(!inGraph)
                     {
+                        // null→vec: the node was never added (or a prior optimize physically removed
+                        // it) — add it now. addGraphNode alone is monitor-safe (no removeDeletedNodes),
+                        // the same call internalAdd makes.
                         final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
                         this.executeOrDeferBuilderOp(() -> this.builder.addGraphNode(ordinal, vf));
                     }
+                    else if(this.index.getDeletedNodes().get(ordinal))
+                    {
+                        // vec→null→vec on the SAME entity: the node is still present but marked
+                        // deleted. Resurrect it by clearing the deleted bit — monitor-safe (no
+                        // ForkJoinPool), unlike removeDeletedNodes()+addGraphNode, whose workers
+                        // call parentMap.get() and would deadlock with the GigaMap monitor we hold.
+                        // The node keeps its (now stale) neighbor links and search re-scores it live
+                        // from the entity via EntityBackedVectorValues — identical to the vec→vec
+                        // "leave as-is" contract below; the next optimize/persist rebuilds connections.
+                        // Without this, the entity would stay excluded from liveNodes() forever.
+                        this.executeOrDeferBuilderOp(() -> this.index.getDeletedNodes().clear(ordinal));
+                    }
+                    // else vec→vec: leave the graph as-is — removeDeletedNodes() uses a ForkJoinPool
+                    // whose workers call parentMap.get(), deadlocking with the GigaMap monitor we
+                    // hold. The updated entity is already in the GigaMap, so EntityBackedVectorValues
+                    // returns the new vector during search, and the next optimize/persist cycle
+                    // rebuilds the graph connections.
                     changed = true;
                 }
                 else

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -764,12 +763,16 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // GraphSearcher pool for thread-local reuse
         private transient ExplicitThreadLocal<GraphSearcher> inMemorySearcherPool;
 
-        // Non-null only for the duration of a graph rebuild from the computed-mode vector store.
-        // Maps ordinal (source entity id) -> raw vector for the entries being rebuilt. The
-        // rebuild runs during deserialization (complete()), when the vector store's own indices
-        // may not be wired yet, so scoring must not query the store — it reads this overlay
-        // instead. Cleared once the rebuild finishes, after which live lookups query the store.
-        private transient Map<Integer, float[]> rebuildOverlay;
+        // Computed-mode fast index: source entity id (graph ordinal) -> vector store's own
+        // internal entity id. Lets vector lookups use a direct, lazy vectorStore.get(internalId)
+        // instead of an index query per call (which is far too costly on the hot scoring path),
+        // while still resolving by source entity id so it stays correct when the store's id
+        // allocator drifts from the parent's (deletion holes, or entities without an embedding
+        // that get no store entry). Rebuilt from the store by positional iteration — no index
+        // dependency — so it is safe to populate during deserialization (complete()). Null in
+        // embedded mode. Concurrent map: read by search threads, written by mutations (which are
+        // serialized by the parent GigaMap monitor).
+        private transient Map<Long, Long> computedIdIndex;
 
         // Incremental on-disk mode: after disk reload, use disk index for search
         // and in-memory builder only for new mutations. Full rebuild deferred to persistToDisk().
@@ -877,39 +880,39 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 return;
             }
 
-            // Serve scoring from an in-memory overlay for the duration of the rebuild: this runs
-            // during deserialization, when the computed-mode vector store's indices may not yet be
-            // wired, so lookupComputedVector() must not query the store. (Embedded mode ignores the
-            // overlay — it scores via EntityBackedVectorValues over the parent map.)
-            final Map<Integer, float[]> overlay = new HashMap<>(entries.size());
-            for(final VectorEntry entry : entries)
-            {
-                overlay.put(toOrdinal(entry.sourceEntityId), entry.vector);
-            }
-            this.rebuildOverlay = overlay;
-            try
-            {
-                this.addGraphNodesSequential(entries);
-            }
-            finally
-            {
-                this.rebuildOverlay = null;
-            }
+            this.addGraphNodesSequential(entries);
         }
 
         /**
-         * Resolves the raw vector for a graph ordinal (source entity id) in computed mode.
-         * During a rebuild the in-memory overlay is authoritative (the store's indices may not be
-         * ready); otherwise the entry is looked up by source entity id via the identity index.
+         * (Re)builds the computed-mode {@link #computedIdIndex} from the vector store by positional
+         * iteration (no index query, so it is safe during deserialization). No-op for embedded mode.
+         */
+        private void rebuildComputedIdIndex()
+        {
+            if(this.isEmbedded() || this.vectorStore == null)
+            {
+                this.computedIdIndex = null;
+                return;
+            }
+            final Map<Long, Long> index = new ConcurrentHashMap<>();
+            this.vectorStore.iterateIndexed((storeId, entry) -> index.put(entry.sourceEntityId, storeId));
+            this.computedIdIndex = index;
+        }
+
+        /**
+         * Resolves the raw vector for a graph ordinal (source entity id) in computed mode via the
+         * {@link #computedIdIndex} and a direct, lazy {@code vectorStore.get(internalId)} — no index
+         * query on the hot scoring path. Returns {@code null} if the entity has no stored vector.
          */
         private float[] lookupComputedVector(final int ordinal)
         {
-            final Map<Integer, float[]> overlay = this.rebuildOverlay;
-            if(overlay != null)
+            final Map<Long, Long> index = this.computedIdIndex;
+            final Long storeId = index == null ? null : index.get((long)ordinal);
+            if(storeId == null)
             {
-                return overlay.get(ordinal);
+                return null;
             }
-            final VectorEntry entry = VectorEntry.lookup(this.vectorStore, ordinal);
+            final VectorEntry entry = this.vectorStore.get(storeId);
             return entry == null ? null : entry.vector;
         }
 
@@ -961,6 +964,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             {
                 this.deferredBuilderOps = new ConcurrentLinkedQueue<>();
             }
+
+            // Build the computed-mode fast lookup index before the in-memory builder, whose
+            // rebuild scores nodes via lookupComputedVector().
+            this.rebuildComputedIdIndex();
 
             // Initialize PQ manager if compression enabled
             if(this.configuration.enablePqCompression())
@@ -1333,7 +1340,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             // Store based on vectorizer type
             if(!this.isEmbedded())
             {
-                this.vectorStore.add(vectorEntry);
+                final long storeId = this.vectorStore.add(vectorEntry);
+                this.computedIdIndex.put(entityId, storeId);
             }
 
             this.markStateChangeChildren();
@@ -1394,30 +1402,31 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             boolean changed = false;
             if(!embedded)
             {
-                // Resolve the store-internal id by source entity id, then mutate via id-based
-                // ops (set / removeById). These avoid the like(...) key round-trip, which would
-                // reject a source entity id of 0 (encoded to the Long.MAX_VALUE sentinel).
-                final long storeId = VectorEntry.lookupId(this.vectorStore, entityId);
+                // Resolve the store-internal id by source entity id via the fast index, then
+                // mutate via id-based ops (set / removeById / add), keeping the index in sync.
+                final Long storeId = this.computedIdIndex.get(entityId);
                 if(vector == null)
                 {
                     // vec→null: drop the stored entry so the entity is no longer indexed.
                     // null→null: nothing stored, nothing to do.
-                    if(storeId >= 0)
+                    if(storeId != null)
                     {
                         this.vectorStore.removeById(storeId);
+                        this.computedIdIndex.remove(entityId);
                         changed = true;
                     }
                 }
-                else if(storeId >= 0)
+                else if(storeId != null)
                 {
-                    // vec→vec
+                    // vec→vec (store-internal id unchanged)
                     this.vectorStore.set(storeId, new VectorEntry(entityId, vector));
                     changed = true;
                 }
                 else
                 {
                     // null→vec: the entity gains an embedding.
-                    this.vectorStore.add(new VectorEntry(entityId, vector));
+                    final long newStoreId = this.vectorStore.add(new VectorEntry(entityId, vector));
+                    this.computedIdIndex.put(entityId, newStoreId);
                     changed = true;
                 }
             }
@@ -1553,7 +1562,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
             if(!this.isEmbedded())
             {
-                this.vectorStore.addAll(entries);
+                // Add individually to capture each store-internal id for the fast index; robust
+                // against hole reuse (a batch addAll only reports the last assigned id).
+                for(final VectorEntry entry : entries)
+                {
+                    final long storeId = this.vectorStore.add(entry);
+                    this.computedIdIndex.put(entry.sourceEntityId, storeId);
+                }
             }
 
             this.markStateChangeChildren();
@@ -1621,12 +1636,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             final int ordinal = toOrdinal(entityId);
             if(!this.isEmbedded())
             {
-                // Look up by source entity id rather than positionally; a never-indexed
-                // entity (null embedding) simply has no entry and nothing is removed.
-                final long storeId = VectorEntry.lookupId(this.vectorStore, entityId);
-                if(storeId >= 0)
+                // Resolve by source entity id via the fast index; a never-indexed entity
+                // (null embedding) simply has no entry and nothing is removed.
+                final Long storeId = this.computedIdIndex.get(entityId);
+                if(storeId != null)
                 {
                     this.vectorStore.removeById(storeId);
+                    this.computedIdIndex.remove(entityId);
                 }
             }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -758,6 +758,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // Key: entity ID (used as ordinal), Value: vector
         final GigaMap<VectorEntry> vectorStore;
 
+        // Persisted, monotonically increasing count of graph-affecting mutations (add / remove /
+        // vec↔null transition). It is the witness used to detect, on reload, whether the persisted
+        // GigaMap state has advanced past the on-disk graph: the value is stamped into the disk
+        // .meta at persist time and compared against the store-recovered value in
+        // DiskIndexManager.verifyMetadata. Unlike parentMap().size()/highestUsedId(), it changes on
+        // a vec↔null transition, so it catches the crash-restart window those proxies are blind to.
+        // Not transient — it must survive (de)serialization.
+        long structuralModCount;
+
         // HNSW graph components (transient - rebuilt on load)
         private transient VectorTypeSupport vectorTypeSupport;
         private transient GraphIndexBuilder builder          ;
@@ -1291,6 +1300,26 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             return this.parent.parentMap();
         }
 
+        /**
+         * Records a graph-affecting content change: bumps the persisted {@link #structuralModCount}
+         * (the crash-restart witness stamped into the disk {@code .meta}) and marks the index dirty
+         * for the next persist. Use in place of {@link #markStateChangeChildren()} at content
+         * mutation sites (add / remove / vec↔null transition); do NOT use it for {@code optimize()},
+         * which reshapes the graph without changing logical content and must not force a rebuild.
+         * <p>
+         * Marks BOTH the instance and children dirty: {@code structuralModCount} is a field of this
+         * instance, so it is only re-serialized when the instance itself is flagged
+         * ({@link AbstractStateChangeFlagged#isInstanceNewOrChanged()} gates {@code internalStore}) —
+         * {@code markStateChangeChildren()} alone would persist only children (e.g. the computed-mode
+         * {@code vectorStore}) and silently drop the counter.
+         */
+        private void markContentChanged()
+        {
+            this.structuralModCount++;
+            this.markStateChangeInstance();
+            this.markStateChangeChildren();
+        }
+
         @Override
         public VectorIndices<E> parent()
         {
@@ -1352,7 +1381,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 this.computedIdIndex.put(entityId, storeId);
             }
 
-            this.markStateChangeChildren();
+            this.markContentChanged();
 
             if(this.isEventualIndexing())
             {
@@ -1439,6 +1468,23 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 }
             }
 
+            // Persisted structural-change witness: driven by the logical (id→vector) transition,
+            // NOT the in-memory graph op below. In incremental mode an embedded vec→null removes a
+            // disk-resident node the in-memory builder never held, so the graph-op flag would miss
+            // it (and the crash-restart rebuild would not trigger); classify embedded transitions
+            // from the old vector instead. Computed mode's store block above already set `changed`
+            // precisely (the four transitions map onto add / set / remove / no-op).
+            final boolean contentChanged;
+            if(embedded)
+            {
+                final float[] oldVector = replacedEntity == null ? null : this.vectorize(replacedEntity);
+                contentChanged = !(oldVector == null && vector == null); // null→null is the only no-op
+            }
+            else
+            {
+                contentChanged = changed;
+            }
+
             // In incremental mode, mark the ordinal as deleted from disk graph
             // so disk search excludes the stale version immediately,
             // regardless of whether indexing is synchronous or eventual.
@@ -1459,7 +1505,6 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 if(embedded || changed)
                 {
                     this.backgroundTaskManager.enqueueUpdate(new VectorEntry(entityId, vector));
-                    this.markStateChangeChildren();
                 }
             }
             else
@@ -1540,9 +1585,17 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
                 if(changed)
                 {
-                    this.markStateChangeChildren();
                     this.markDirtyForBackgroundManagers(1);
                 }
+            }
+
+            // Bump the persisted structural-change counter + mark the index dirty whenever the
+            // logical mapping changed — independent of whether an in-memory graph op ran, so an
+            // incremental-mode disk-node deletion (embedded vec→null) is still recorded and forces
+            // a crash-restart rebuild. null→null is the only case that skips this.
+            if(contentChanged)
+            {
+                this.markContentChanged();
             }
         }
 
@@ -1606,7 +1659,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 }
             }
 
-            this.markStateChangeChildren();
+            this.markContentChanged();
 
             if(this.isEventualIndexing())
             {
@@ -1681,7 +1734,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 }
             }
 
-            this.markStateChangeChildren();
+            this.markContentChanged();
 
             // In incremental mode, mark the ordinal as deleted from disk graph
             // so disk search excludes it immediately, even before background
@@ -1750,7 +1803,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
                 // Reinitialize the index (this will also restart background managers if configured)
                 this.initializeIndex();
-                this.markStateChangeChildren();
+                this.markContentChanged();
 
                 // Mark dirty for background managers
                 this.markDirtyForBackgroundManagers(1);
@@ -2725,6 +2778,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             // bound: per-entity vector lookups no longer assume alignment —
             // they resolve by VectorEntry.sourceEntityId (see lookupComputedVector).
             return this.parentMap().highestUsedId();
+        }
+
+        @Override
+        public long getStructuralModCount()
+        {
+            // The persisted witness stamped into the disk .meta at write time and compared on
+            // reload. Unlike count/highestId it changes on vec↔null transitions, closing the
+            // crash-restart window where a stale on-disk graph would otherwise be accepted.
+            return this.structuralModCount;
         }
 
         // ================================================================

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -28,6 +28,7 @@ import org.eclipse.serializer.exceptions.IORuntimeException;
 import org.eclipse.serializer.persistence.binary.types.BinaryTypeHandler;
 import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.store.gigamap.types.AbstractStateChangeFlagged;
+import org.eclipse.store.gigamap.types.BitmapIndex;
 import org.eclipse.store.gigamap.types.GigaIndex;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.ScoredSearchResult;
@@ -785,11 +786,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // instead of an index query per call (which is far too costly on the hot scoring path),
         // while still resolving by source entity id so it stays correct when the store's id
         // allocator drifts from the parent's (deletion holes, or entities without an embedding
-        // that get no store entry). Rebuilt from the store by positional iteration — no index
-        // dependency — so it is safe to populate during deserialization (complete()). Null in
-        // embedded mode. Concurrent map: read by search threads, written by mutations (which are
-        // serialized by the parent GigaMap monitor).
-        private transient Map<Long, Long> computedIdIndex;
+        // that get no store entry). Null in embedded mode.
+        //
+        // Built lazily on first access via computedIdIndex(): from the vector store's identity index
+        // bitmaps (cheap, loads no VectorEntry / no vectors) once the store is queryable, falling back
+        // to a positional store scan during the deserialization window when the index registry is not
+        // yet wired. Deferring the build off the load path is what keeps incremental on-disk startup
+        // O(1) in the vector payload. Volatile: read lock-free by search threads (fast path), written
+        // under the vector store's own monitor (a leaf lock — see computedIdIndex()).
+        private transient volatile Map<Long, Long> computedIdIndex;
 
         // Incremental on-disk mode: after disk reload, use disk index for search
         // and in-memory builder only for new mutations. Full rebuild deferred to persistToDisk().
@@ -901,19 +906,66 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         }
 
         /**
-         * (Re)builds the computed-mode {@link #computedIdIndex} from the vector store by positional
-         * iteration (no index query, so it is safe during deserialization). No-op for embedded mode.
+         * Returns the computed-mode {@link #computedIdIndex}, building it lazily on first access.
+         * {@code null} in embedded mode (or before the vector store exists).
+         * <p>
+         * The build is deferred out of {@code complete()}: at deserialization time the vector store's
+         * index registry is not yet queryable, and — more importantly — building eagerly there would
+         * reintroduce the O(n) I/O + heap spike that incremental on-disk mode exists to avoid. On first
+         * access the map is reconstructed cheaply from the identity index bitmaps (no {@link VectorEntry},
+         * no vectors); see {@link #buildComputedIdIndex()}.
+         * <p>
+         * Thread-safety: double-checked with {@link #computedIdIndex} volatile. The build holds the
+         * vector store's own monitor — a leaf lock independent of the parent GigaMap monitor and
+         * {@code builderLock}, so triggering it from a search (under {@code builderLock.readLock}) or a
+         * mutation (under the parent monitor) cannot deadlock. Mutations route their store lookups
+         * through this accessor too, so the map is present before any {@code put}/{@code get}.
          */
-        private void rebuildComputedIdIndex()
+        private Map<Long, Long> computedIdIndex()
         {
             if(this.isEmbedded() || this.vectorStore == null)
             {
-                this.computedIdIndex = null;
-                return;
+                return null;
             }
+            Map<Long, Long> idx = this.computedIdIndex;
+            if(idx == null)
+            {
+                synchronized(this.vectorStore)
+                {
+                    idx = this.computedIdIndex;
+                    if(idx == null)
+                    {
+                        this.computedIdIndex = idx = this.buildComputedIdIndex();
+                    }
+                }
+            }
+            return idx;
+        }
+
+        /**
+         * Builds the {@code sourceEntityId -> storeId} map. Preferred path: reconstruct it from the
+         * vector store's {@code sourceEntityId} identity index bitmaps via
+         * {@link org.eclipse.store.gigamap.types.BitmapIndex#iterateKeyEntityPairs}, loading no
+         * {@code VectorEntry} and therefore no stored vectors. Fallback (index registry not yet
+         * queryable, i.e. the {@code complete()} deserialization window): a positional store scan.
+         * The fallback is only reached by a non-incremental graph rebuild, which loads every vector
+         * anyway, so its value pass is not an added cost.
+         */
+        private Map<Long, Long> buildComputedIdIndex()
+        {
             final Map<Long, Long> index = new ConcurrentHashMap<>();
-            this.vectorStore.iterateIndexed((storeId, entry) -> index.put(entry.sourceEntityId, storeId));
-            this.computedIdIndex = index;
+            final BitmapIndex<VectorEntry, Long> idIndex = this.vectorStore.index().bitmap()
+                .get(Long.class, VectorEntry.SOURCE_ENTITY_ID_INDEXER.name());
+            if(idIndex != null)
+            {
+                // (key = sourceEntityId, entityId = storeId) — no value loaded.
+                idIndex.iterateKeyEntityPairs((sourceEntityId, storeId) -> index.put(sourceEntityId, storeId));
+            }
+            else
+            {
+                this.vectorStore.iterateIndexed((storeId, entry) -> index.put(entry.sourceEntityId, storeId));
+            }
+            return index;
         }
 
         /**
@@ -923,7 +975,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          */
         private float[] lookupComputedVector(final int ordinal)
         {
-            final Map<Long, Long> index = this.computedIdIndex;
+            final Map<Long, Long> index = this.computedIdIndex();
             final Long storeId = index == null ? null : index.get((long)ordinal);
             if(storeId == null)
             {
@@ -982,9 +1034,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 this.deferredBuilderOps = new ConcurrentLinkedQueue<>();
             }
 
-            // Build the computed-mode fast lookup index before the in-memory builder, whose
-            // rebuild scores nodes via lookupComputedVector().
-            this.rebuildComputedIdIndex();
+            // Reset the computed-mode fast lookup index; it is (re)built lazily on first access
+            // (see computedIdIndex()). Clearing here covers reinitialization after internalRemoveAll,
+            // where a stale map would otherwise survive. A non-incremental graph rebuild that follows
+            // triggers the lazy build itself via lookupComputedVector() during node scoring.
+            this.computedIdIndex = null;
 
             // Initialize PQ manager if compression enabled
             if(this.configuration.enablePqCompression())
@@ -1378,7 +1432,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             if(!this.isEmbedded())
             {
                 final long storeId = this.vectorStore.add(vectorEntry);
-                this.computedIdIndex.put(entityId, storeId);
+                this.computedIdIndex().put(entityId, storeId);
             }
 
             this.markContentChanged();
@@ -1441,7 +1495,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             {
                 // Resolve the store-internal id by source entity id via the fast index, then
                 // mutate via id-based ops (set / removeById / add), keeping the index in sync.
-                final Long storeId = this.computedIdIndex.get(entityId);
+                final Map<Long, Long> computedIdIndex = this.computedIdIndex();
+                final Long storeId = computedIdIndex.get(entityId);
                 if(vector == null)
                 {
                     // vec→null: drop the stored entry so the entity is no longer indexed.
@@ -1449,7 +1504,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     if(storeId != null)
                     {
                         this.vectorStore.removeById(storeId);
-                        this.computedIdIndex.remove(entityId);
+                        computedIdIndex.remove(entityId);
                         changed = true;
                     }
                 }
@@ -1463,7 +1518,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 {
                     // null→vec: the entity gains an embedding.
                     final long newStoreId = this.vectorStore.add(new VectorEntry(entityId, vector));
-                    this.computedIdIndex.put(entityId, newStoreId);
+                    computedIdIndex.put(entityId, newStoreId);
                     changed = true;
                 }
             }
@@ -1652,10 +1707,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             {
                 // Add individually to capture each store-internal id for the fast index; robust
                 // against hole reuse (a batch addAll only reports the last assigned id).
+                final Map<Long, Long> computedIdIndex = this.computedIdIndex();
                 for(final VectorEntry entry : entries)
                 {
                     final long storeId = this.vectorStore.add(entry);
-                    this.computedIdIndex.put(entry.sourceEntityId, storeId);
+                    computedIdIndex.put(entry.sourceEntityId, storeId);
                 }
             }
 
@@ -1726,11 +1782,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             {
                 // Resolve by source entity id via the fast index; a never-indexed entity
                 // (null embedding) simply has no entry and nothing is removed.
-                final Long storeId = this.computedIdIndex.get(entityId);
+                final Map<Long, Long> computedIdIndex = this.computedIdIndex();
+                final Long storeId = computedIdIndex.get(entityId);
                 if(storeId != null)
                 {
                     this.vectorStore.removeById(storeId);
-                    this.computedIdIndex.remove(entityId);
+                    computedIdIndex.remove(entityId);
                 }
             }
 
@@ -1827,10 +1884,9 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 return this.vectorizer.vectorize(entity);
             }
 
-            // Resolve via the fast source-id index when available (O(1), no query allocation,
-            // no dependency on the vector store's own indices being wired); fall back to the
-            // identity-index query only if this instance's transients are not initialized yet.
-            final Map<Long, Long> idIndex = this.computedIdIndex;
+            // Resolve via the fast source-id index (built lazily on first access); fall back to a
+            // direct identity-index query only in the defensive case where it is unavailable.
+            final Map<Long, Long> idIndex = this.computedIdIndex();
             final VectorEntry entry;
             if(idIndex != null)
             {

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -452,15 +452,20 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
     }
 
     /**
-     * Extracts the query vector from the given entity, rejecting a null result: an entity
-     * without an embedding has no meaningful similarity and cannot be used as a query.
+     * Extracts the query vector from the given entity, rejecting both a null entity and a null
+     * result: an entity without an embedding has no meaningful similarity and cannot be used as
+     * a query.
      *
-     * @param queryEntity the query entity
+     * @param queryEntity the query entity; must not be null
      * @return the non-null query vector
-     * @throws IllegalArgumentException if the vectorizer returns null for the entity
+     * @throws IllegalArgumentException if the entity is null, or the vectorizer returns null for it
      */
     private float[] requireQueryVector(final E queryEntity)
     {
+        if(queryEntity == null)
+        {
+            throw new IllegalArgumentException("Query entity must not be null");
+        }
         final float[] queryVector = this.vectorizer().vectorize(queryEntity);
         if(queryVector == null)
         {

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/Vectorizer.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/Vectorizer.java
@@ -57,6 +57,11 @@ public abstract class Vectorizer<E>
      * This default implementation just delegates to {@link #vectorize(Object)} for each entity.
      * <p>
      * If you want to implement an optimized custom batch vectorization logic, override this method.
+     * <p>
+     * The returned list must have exactly the same size as {@code entities}, with positional
+     * correspondence (element <i>i</i> is the vector of entity <i>i</i>). When
+     * {@link #allowsNullVectors()} returns {@code true}, individual elements may be {@code null}
+     * (meaning the corresponding entity has no embedding); otherwise every element must be non-null.
      *
      * @param entities a list of entities of type E to be vectorized
      * @return a list of float arrays, where each array represents the numerical vector of the corresponding entity
@@ -82,6 +87,39 @@ public abstract class Vectorizer<E>
      * @return true if vectors are embedded in entities, false if computed
      */
     public boolean isEmbedded()
+    {
+        return false;
+    }
+
+    /**
+     * Returns whether this vectorizer is permitted to return {@code null} from
+     * {@link #vectorize(Object)} (and, correspondingly, to include {@code null} elements in the
+     * list returned by {@link #vectorizeAll(List)}).
+     * <p>
+     * When {@code false} (default), a {@code null} vector is treated as an error: an
+     * {@link IllegalStateException} is thrown when the entity is added, updated, or re-indexed.
+     * This fail-fast behavior catches accidental bugs in vectorizer implementations.
+     * <p>
+     * When {@code true}, a {@code null} vector means "this entity has no embedding". Such an
+     * entity remains in the {@code GigaMap} and all of its other indices, but is excluded from
+     * the vector index's HNSW graph and never appears in vector search results. In computed
+     * mode no vector store entry is kept for it, and {@link VectorIndex#getVector(long)} returns
+     * {@code null} for it. Vector transitions on update behave as follows:
+     * <ul>
+     *   <li>non-null &rarr; null: the entity is removed from the vector index</li>
+     *   <li>null &rarr; non-null: the entity is added to the vector index</li>
+     *   <li>null &rarr; null: no-op</li>
+     * </ul>
+     * An entity whose vector is {@code null} cannot be used as a similarity query
+     * (see {@link VectorIndex#search(Object, int)}); doing so throws {@link IllegalArgumentException}.
+     * <p>
+     * The return value must be constant for the lifetime of the vectorizer / index — it is
+     * consulted on every mutation, on reload/rebuild, and during PQ training; changing it at
+     * runtime yields undefined behavior.
+     *
+     * @return true to permit {@code null} vectors (excluded from the index), false to fail fast
+     */
+    public boolean allowsNullVectors()
     {
         return false;
     }

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/annotations/Vector.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/annotations/Vector.java
@@ -69,4 +69,15 @@ public @interface Vector
 	 * @return true to store the index on disk
 	 */
 	public boolean onDisk() default false;
+
+	/**
+	 * Whether the annotated member may produce a {@code null} vector for some entities. When
+	 * {@code true}, an entity whose vector is {@code null} has no embedding: it remains in the
+	 * {@code GigaMap} but is excluded from the vector index and never appears in search results.
+	 * When {@code false} (default), a {@code null} vector throws an {@link IllegalStateException}.
+	 *
+	 * @return true to permit entities without an embedding
+	 * @see org.eclipse.store.gigamap.jvector.Vectorizer#allowsNullVectors()
+	 */
+	public boolean allowNull() default false;
 }

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorAnnotationTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorAnnotationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class VectorAnnotationTest
@@ -40,6 +41,17 @@ class VectorAnnotationTest
 	{
 		@Vector(dimension = 4)
 		String notAVector;
+	}
+
+	static class Nullable
+	{
+		@Vector(dimension = 4, similarity = VectorSimilarityFunction.COSINE, allowNull = true)
+		float[] vector;
+
+		Nullable(final float[] vector)
+		{
+			this.vector = vector;
+		}
 	}
 
 	static class Conflict
@@ -158,6 +170,37 @@ class VectorAnnotationTest
 				.register(VectorAnnotationHandler.New())
 				.generateIndices(map)
 		);
+	}
+
+	@Test
+	void vectorAnnotationAllowNullExcludesEntitiesWithoutEmbedding()
+	{
+		final GigaMap<Nullable> map = GigaMap.New();
+		IndexerGenerator.AnnotationBased(Nullable.class)
+			.register(VectorAnnotationHandler.New())
+			.generateIndices(map);
+
+		final long idA = map.add(new Nullable(new float[]{1, 0, 0, 0}));
+		final long idNull = map.add(new Nullable(null));
+		map.add(new Nullable(new float[]{0, 1, 0, 0}));
+
+		final VectorIndex<Nullable> index = map.index().get(VectorIndices.class).get("vector");
+		assertEquals(2, index.search(new float[]{1, 0, 0, 0}, 10).size(),
+			"the entity without an embedding must be excluded from search");
+		assertEquals(idA, index.search(new float[]{1, 0, 0, 0}, 1).stream().findFirst().orElseThrow().entityId());
+		assertNull(index.getVector(idNull));
+	}
+
+	@Test
+	void vectorAnnotationDefaultRejectsNull()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		IndexerGenerator.AnnotationBased(Item.class)
+			.register(VectorAnnotationHandler.New())
+			.generateIndices(map);
+
+		// Item's @Vector does not set allowNull, so a null embedding must fail fast.
+		assertThrows(IllegalStateException.class, () -> map.add(new Item(null)));
 	}
 
 	@Test

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -337,6 +337,25 @@ class VectorIndexNullVectorTest
         map.set(b, new Doc("b", basis(3)));
         assertEquals(b, index.search(basis(3), 1).stream().findFirst().orElseThrow().entityId());
         assertNotNull(index.getVector(b));
+
+        // vec -> null -> vec on the SAME entity that WAS in the graph. Regression guard: jvector's
+        // markNodeDeleted only sets a deleted bit and leaves the node in layer 0, so containsNode
+        // stays true; a naive re-add guard would skip resurrection and b would vanish permanently.
+        // Searchable before the cycle: {c=basis(2), b=basis(3)} (a is null).
+        map.set(b, new Doc("b", null)); // vec -> null: b disappears
+        assertNull(index.getVector(b));
+        final VectorSearchResult<Doc> afterNullB = index.search(basis(0), 10);
+        assertEquals(1, afterNullB.size());
+        assertTrue(afterNullB.stream().noneMatch(e -> e.entityId() == b),
+            "entity whose vector became null must not appear");
+
+        map.set(b, new Doc("b", basis(3))); // null -> vec: b must REAPPEAR without reload
+        assertNotNull(index.getVector(b));
+        final VectorSearchResult<Doc> afterReaddB = index.search(basis(0), 10);
+        assertEquals(2, afterReaddB.size(), "entity must reappear after a vec->null->vec cycle");
+        assertTrue(afterReaddB.stream().anyMatch(e -> e.entityId() == b),
+            "resurrected entity must be searchable again");
+        assertEquals(b, index.search(basis(3), 1).stream().findFirst().orElseThrow().entityId());
     }
 
     // ==================== 7. Update transitions (eventual indexing) ====================
@@ -362,7 +381,7 @@ class VectorIndexNullVectorTest
         try(final VectorIndex<Doc> index = indices.add("embeddings", eventualConfig(), vectorizer))
         {
             final long a = map.add(new Doc("a", basis(0)));
-            map.add(new Doc("b", basis(1)));
+            final long b = map.add(new Doc("b", basis(1)));
             final long c = map.add(new Doc("c", null));
             drain(index);
             assertEquals(2, index.search(basis(0), 10).size());
@@ -378,6 +397,18 @@ class VectorIndexNullVectorTest
             assertEquals(2, result.size());
             assertTrue(result.stream().noneMatch(e -> e.entityId() == a));
             assertEquals(c, index.search(basis(2), 1).stream().findFirst().orElseThrow().entityId());
+
+            // vec -> null -> vec on the SAME entity that WAS in the graph. The eventual path
+            // already re-adds correctly (markNodeDeleted + removeDeletedNodes + addGraphNode);
+            // lock that in alongside the sync-mode regression guard. Searchable: {b, c}.
+            map.set(b, new Doc("b", null));    // vec -> null
+            map.set(b, new Doc("b", basis(1))); // null -> vec: b must reappear
+            drain(index);
+            final VectorSearchResult<Doc> afterCycle = index.search(basis(0), 10);
+            assertEquals(2, afterCycle.size(), "entity must reappear after a vec->null->vec cycle");
+            assertTrue(afterCycle.stream().anyMatch(e -> e.entityId() == b),
+                "resurrected entity must be searchable again");
+            assertEquals(b, index.search(basis(1), 1).stream().findFirst().orElseThrow().entityId());
         }
     }
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -683,6 +683,82 @@ class VectorIndexNullVectorTest
         }
     }
 
+    // ==================== 10c-crash. Persist-window crash restart: stale .meta must be rejected ====================
+
+    /**
+     * The persist-window variant of the crash-restart hole: {@code writeMetadata} used to read the
+     * witness values ({@code structuralModCount}, {@code expectedVectorCount}, {@code highestEntityId})
+     * LIVE during persist Phase 2, while the graph content was captured in Phase 1. A {@code
+     * vec→null} landing during the disk write (parentMap monitor released) bumps the counter
+     * BEFORE the {@code .meta} is written, so the {@code .meta} carries the post-mutation counter
+     * while the graph on disk still contains the nulled entity. After the store commit and a crash
+     * before the next persist, restart compares store counter == {@code .meta} counter → the stale
+     * graph is ACCEPTED and the nulled entity reappears in search. In-session the transient
+     * {@code diskDeletedOrdinals} masks this — only the restart exposes it.
+     * <p>
+     * Fix: the witness values are captured in Phase 1 alongside {@code capturedIndex} and stamped
+     * into the {@code .meta}, so a Phase-2 mutation yields a mismatch and forces the rebuild.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("unchecked")
+    void crashRestartAfterPersistWindowVecToNull_rejectsStaleMeta(@TempDir final Path dir)
+    {
+        final Path storageDir = dir.resolve("storage");
+        final Path indexDir   = dir.resolve("index");
+
+        final VectorIndexConfiguration diskConfig = VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .persistOnShutdown(false) // simulate a crash: close() must not overwrite the stale .meta
+            .build();
+
+        final long v0;
+        final long v1;
+
+        // Phase A: two vectors; inject the vec→null into persist Phase 2 via the test hook, so the
+        // .meta is stamped with the post-mutation counter while the written graph still holds v0.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = GigaMap.New();
+            storage.setRoot(map);
+            final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+                .add("embeddings", diskConfig, new NullableEmbeddedVectorizer());
+
+            v0 = map.add(new Doc("v0", basis(0)));
+            v1 = map.add(new Doc("v1", basis(1)));
+
+            final VectorIndex.Default<Doc> def = (VectorIndex.Default<Doc>)index;
+            def.persistPhase2TestHook = () ->
+            {
+                def.persistPhase2TestHook = null;
+                map.set(v0, new Doc("v0", null)); // bumps structuralModCount before writeMetadata runs
+            };
+
+            index.persistToDisk(); // graph contains v0; .meta must reflect the Phase-1 counter
+            storage.storeRoot();   // commit the store, carrying the bumped counter
+            index.close();         // persistOnShutdown(false) → "crash", no corrective persist
+        }
+
+        // Phase B: restart. Store counter == live-read .meta counter (both post-mutation) would accept
+        // the stale graph; the Phase-1 capture makes the .meta lag the store, forcing a rebuild.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = storage.root();
+            final VectorIndex<Doc> index = map.index().get(VectorIndices.Category()).get("embeddings");
+
+            assertNull(index.getVector(v0), "v0 lost its embedding");
+            final VectorSearchResult<Doc> result = index.search(basis(0), 10);
+            assertTrue(result.stream().noneMatch(e -> e.entityId() == v0),
+                "entity nulled during persist Phase 2 must not survive a crash restart");
+            assertEquals(1, result.size(), "only v1 must remain searchable");
+            assertEquals(v1, index.search(basis(1), 1).stream().findFirst().orElseThrow().entityId());
+            index.close();
+        }
+    }
+
     // ==================== 10d. Finding #5 repro: on-disk delete + persist + reload ====================
 
     @Test

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -683,6 +683,53 @@ class VectorIndexNullVectorTest
         }
     }
 
+    // ==================== 10d. Finding #5 repro: on-disk delete + persist + reload ====================
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void onDiskComputedDeleteThenReloadKeepsSurvivors(@TempDir final Path dir)
+    {
+        final Path storageDir = dir.resolve("storage");
+        final Path indexDir   = dir.resolve("index");
+        final VectorIndexConfiguration diskConfig = VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .build();
+
+        long v0;
+        long v2;
+        long v3;
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = GigaMap.New();
+            storage.setRoot(map);
+            final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+                .add("embeddings", diskConfig, new NullableComputedVectorizer());
+
+            v0 = map.add(new Doc("v0", basis(0)));
+            final long v1 = map.add(new Doc("v1", basis(1)));
+            v2 = map.add(new Doc("v2", basis(2)));
+            v3 = map.add(new Doc("v3", basis(3)));
+            map.removeById(v1);
+            index.persistToDisk();
+            storage.storeRoot();
+        }
+
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = storage.root();
+            final VectorIndex<Doc> index = map.index().get(VectorIndices.Category()).get("embeddings");
+
+            assertEquals(3, index.search(basis(0), 10).size(),
+                "all three survivors must remain searchable after delete+persist+reload");
+            assertEquals(v0, index.search(basis(0), 1).stream().findFirst().orElseThrow().entityId());
+            assertEquals(v2, index.search(basis(2), 1).stream().findFirst().orElseThrow().entityId());
+            assertEquals(v3, index.search(basis(3), 1).stream().findFirst().orElseThrow().entityId());
+        }
+    }
+
     // ==================== 11. Query by null-vector entity / null query ====================
 
     @Test
@@ -845,6 +892,68 @@ class VectorIndexNullVectorTest
             final VectorIndex<Doc> index = map.index().get(VectorIndices.Category()).get("embeddings");
             assertNotNull(index.getVector(knownId));
             assertFalse(index.search(map.get(knownId), 5).isEmpty());
+        }
+    }
+
+    /**
+     * Regression for the RAVV {@code size()} contract: in computed mode the graph ordinal is the
+     * source entity id, so with null embeddings (sparse ordinals) the highest ordinal exceeds the
+     * non-null vector count. When PQ compression is actually trained, {@code ProductQuantization
+     * .encodeAll(ravv)} builds a dense {@code PQVectors} of length {@code ravv.size()}; if
+     * {@code size()} is the count rather than the ordinal upper bound, the FusedPQ write / PQ search
+     * index that dense array by graph ordinal and blow past its end. Unlike
+     * {@link #pqCompressionExcludesNulls}, this test explicitly triggers training so the FusedPQ path
+     * is exercised.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("unchecked")
+    void pqCompressionWithSparseOrdinals_trainedAndSearched(@TempDir final Path dir)
+    {
+        final int dim = 16;
+        final Path indexDir = dir.resolve("index");
+        final Random random = new Random(11);
+
+        final VectorIndexConfiguration pqConfig = VectorIndexConfiguration.builder()
+            .dimension(dim)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .enablePqCompression(true)
+            .pqSubspaces(dim / 4)
+            .build();
+
+        final GigaMap<Doc> map = GigaMap.New();
+        try(final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+            .add("embeddings", pqConfig, new NullableComputedVectorizer()))
+        {
+            // >256 vectored entities so PQ training triggers, with null embeddings interspersed so the
+            // highest graph ordinal (a real node) exceeds the non-null vector count.
+            for(int i = 0; i < 300; i++)
+            {
+                map.add(new Doc("v" + i, randomUnit(random, dim)));
+                if(i % 20 == 0)
+                {
+                    map.add(new Doc("none" + i, null)); // sparse ordinal gaps
+                }
+            }
+            final float[] known = randomUnit(random, dim);
+            final long knownId = map.add(new Doc("known", known)); // highest ordinal, a real node
+
+            // Force PQ training so persist writes FusedPQ (the path that indexes the dense PQ array by
+            // ordinal). Before the size() fix this threw IndexOutOfBoundsException while encoding /
+            // writing the highest-ordinal node (ordinal > non-null count); it must now complete,
+            // proving every graph ordinal up to highestUsedId is PQ-encoded and written.
+            ((VectorIndex.Internal<Doc>)index).trainCompressionIfNeeded();
+            index.persistToDisk();
+
+            // Approximate PQ search: assert it runs and yields only real (non-null) entities. (Exact
+            // top-1 identity isn't guaranteed under lossy PQ, so we don't assert the query is #1.)
+            final VectorSearchResult<Doc> result = index.search(known, 5);
+            assertFalse(result.isEmpty(), "PQ search over sparse ordinals must return results");
+            assertTrue(result.stream().allMatch(e -> index.getVector(e.entityId()) != null),
+                "no null-embedding entity may appear in PQ search results");
+            assertNotNull(index.getVector(knownId), "the highest-ordinal node remains stored and resolvable");
         }
     }
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -844,6 +844,22 @@ class VectorIndexNullVectorTest
         assertThrows(IllegalArgumentException.class, () -> index.search((float[])null, 5));
     }
 
+    @Test
+    void nonPositiveK_throws()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, new NullableComputedVectorizer());
+        map.add(new Doc("v", basis(0)));
+
+        // k <= 0 must surface as IllegalArgumentException per the API contract, not flow into
+        // jvector's searcher as an invalid topK, across every search overload.
+        assertThrows(IllegalArgumentException.class, () -> index.search(basis(0), 0));
+        assertThrows(IllegalArgumentException.class, () -> index.search(basis(0), -1));
+        assertThrows(IllegalArgumentException.class, () -> index.search(basis(0), 0, 50));
+        assertThrows(IllegalArgumentException.class, () -> index.search(new Doc("v", basis(0)), -3));
+        assertThrows(IllegalArgumentException.class, () -> index.search(new Doc("v", basis(0)), 0, 50));
+    }
+
     // ==================== 12. Custom vectorizeAll with positional nulls ====================
 
     static class BatchNullableVectorizer extends Vectorizer<Doc>

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -557,6 +557,78 @@ class VectorIndexNullVectorTest
         }
     }
 
+    // ==================== 10b. Crash restart: vec→null must not survive a stale disk graph ====================
+
+    /**
+     * Regression guard for the disk-metadata blindness: a {@code vec→null} transition changes
+     * neither {@code parentMap().size()} nor {@code highestUsedId()}, so before the persisted
+     * structural-change counter the on-disk graph passed metadata validation after a crash between
+     * the transition (committed via {@code storeRoot()}) and the next {@code persistToDisk()} — the
+     * nulled entity kept appearing in search. {@code persistOnShutdown(false)} simulates the crash:
+     * {@code close()} must not persist the graph, leaving the {@code .meta} stale.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void crashRestartAfterVecToNull_rebuildsAndExcludesNulled(@TempDir final Path dir)
+    {
+        final Path storageDir = dir.resolve("storage");
+        final Path indexDir   = dir.resolve("index");
+
+        final VectorIndexConfiguration diskConfig = VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .persistOnShutdown(false) // simulate a crash: close() must not flush the graph to disk
+            .build();
+
+        final long v0;
+        final long v1;
+
+        // Phase A: two embedded vectors; persist graph + metadata, then commit the store.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = GigaMap.New();
+            storage.setRoot(map);
+            final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+                .add("embeddings", diskConfig, new NullableEmbeddedVectorizer());
+
+            v0 = map.add(new Doc("v0", basis(0)));
+            v1 = map.add(new Doc("v1", basis(1)));
+
+            index.persistToDisk(); // writes .graph + .meta (structuralModCount = 2)
+            storage.storeRoot();   // store also carries structuralModCount = 2
+            index.close();
+        }
+
+        // Phase B: null out v0 and commit the store WITHOUT persisting the graph, then "crash".
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = storage.root();
+            final VectorIndex<Doc> index = map.index().get(VectorIndices.Category()).get("embeddings");
+
+            map.set(v0, new Doc("v0", null)); // vec→null: bumps structuralModCount to 3
+            map.store();                      // persist the mutation (+ counter 3); .meta still carries 2
+            index.close();                    // persistOnShutdown(false) → .meta stays stale
+        }
+
+        // Phase C: restart. The structuralModCount mismatch (store 3 vs .meta 2) must reject the
+        // stale disk graph and rebuild from the store, so v0 is gone from search.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = storage.root();
+            final VectorIndex<Doc> index = map.index().get(VectorIndices.Category()).get("embeddings");
+
+            assertNull(index.getVector(v0), "v0 lost its embedding");
+            final VectorSearchResult<Doc> result = index.search(basis(0), 10);
+            assertEquals(1, result.size(), "nulled entity must not survive a crash restart");
+            assertTrue(result.stream().noneMatch(e -> e.entityId() == v0),
+                "stale on-disk node must not reappear after a vec→null crash restart");
+            assertEquals(v1, index.search(basis(1), 1).stream().findFirst().orElseThrow().entityId());
+            index.close();
+        }
+    }
+
     // ==================== 11. Query by null-vector entity / null query ====================
 
     @Test

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -518,6 +518,19 @@ class VectorIndexNullVectorTest
     }
 
     @Test
+    void searchByNullEntity_throws()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, new NullableComputedVectorizer());
+        map.add(new Doc("v", basis(0)));
+
+        // A null query entity must surface as IllegalArgumentException per the API contract,
+        // not a NullPointerException from the vectorizer.
+        assertThrows(IllegalArgumentException.class, () -> index.search((Doc)null, 5));
+        assertThrows(IllegalArgumentException.class, () -> index.search((Doc)null, 5, 50));
+    }
+
+    @Test
     void nullQueryVector_throws()
     {
         final GigaMap<Doc> map = GigaMap.New();

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -1,0 +1,686 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for opted-in null-embedding support: {@link Vectorizer#allowsNullVectors()}.
+ * A {@code null} vector means "this entity has no embedding" — it stays in the GigaMap but is
+ * excluded from the HNSW graph and never appears in vector search results.
+ */
+class VectorIndexNullVectorTest
+{
+    static final int DIM = 4;
+
+    // Orthogonal unit basis vectors so nearest-neighbor maps deterministically to one entity.
+    static float[] basis(final int i)
+    {
+        final float[] v = new float[DIM];
+        v[i] = 1.0f;
+        return v;
+    }
+
+    /**
+     * An entity that may or may not carry an embedding.
+     */
+    static final class Doc
+    {
+        final String  content;
+        final float[] embedding; // may be null
+
+        Doc(final String content, final float[] embedding)
+        {
+            this.content   = content;
+            this.embedding = embedding;
+        }
+    }
+
+    /** Embedded vectorizer that permits null embeddings. */
+    static class NullableEmbeddedVectorizer extends Vectorizer<Doc>
+    {
+        @Override
+        public float[] vectorize(final Doc entity)
+        {
+            return entity.embedding;
+        }
+
+        @Override
+        public boolean isEmbedded()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean allowsNullVectors()
+        {
+            return true;
+        }
+    }
+
+    /** Computed vectorizer (separate store) that permits null embeddings. */
+    static class NullableComputedVectorizer extends Vectorizer<Doc>
+    {
+        @Override
+        public float[] vectorize(final Doc entity)
+        {
+            return entity.embedding;
+        }
+
+        @Override
+        public boolean allowsNullVectors()
+        {
+            return true;
+        }
+    }
+
+    /** Strict computed vectorizer (default: null forbidden). */
+    static class StrictComputedVectorizer extends Vectorizer<Doc>
+    {
+        @Override
+        public float[] vectorize(final Doc entity)
+        {
+            return entity.embedding;
+        }
+    }
+
+    /** Strict embedded vectorizer (default: null forbidden). */
+    static class StrictEmbeddedVectorizer extends Vectorizer<Doc>
+    {
+        @Override
+        public float[] vectorize(final Doc entity)
+        {
+            return entity.embedding;
+        }
+
+        @Override
+        public boolean isEmbedded()
+        {
+            return true;
+        }
+    }
+
+    private static VectorIndexConfiguration config()
+    {
+        return VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .build();
+    }
+
+    private static VectorIndexConfiguration eventualConfig()
+    {
+        return VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .eventualIndexing(true)
+            .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void drain(final VectorIndex<Doc> index)
+    {
+        final VectorIndex.Default<Doc> def = (VectorIndex.Default<Doc>)index;
+        if(def.backgroundTaskManager != null)
+        {
+            def.backgroundTaskManager.drainQueue();
+        }
+    }
+
+    private static VectorIndex<Doc> newIndex(final GigaMap<Doc> map, final Vectorizer<Doc> vectorizer)
+    {
+        final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+        return indices.add("embeddings", config(), vectorizer);
+    }
+
+    // ==================== 1. Opt-out regression ====================
+
+    @Test
+    void nullVectorRejectedByDefault_computedAdd()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        newIndex(map, new StrictComputedVectorizer());
+        assertThrows(IllegalStateException.class, () -> map.add(new Doc("no-vec", null)));
+    }
+
+    @Test
+    void nullVectorRejectedByDefault_embeddedAdd()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        newIndex(map, new StrictEmbeddedVectorizer());
+        assertThrows(IllegalStateException.class, () -> map.add(new Doc("no-vec", null)));
+    }
+
+    @Test
+    void nullVectorRejectedByDefault_update()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        newIndex(map, new StrictComputedVectorizer());
+        final long id = map.add(new Doc("has-vec", basis(0)));
+        assertThrows(IllegalStateException.class, () -> map.set(id, new Doc("now-null", null)));
+    }
+
+    @Test
+    void nullVectorRejectedByDefault_addAll()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        newIndex(map, new StrictComputedVectorizer());
+        final List<Doc> docs = List.of(
+            new Doc("a", basis(0)),
+            new Doc("b", null),
+            new Doc("c", basis(1))
+        );
+        assertThrows(IllegalStateException.class, () -> map.addAll(docs));
+    }
+
+    // ==================== 2/3. Mixed add + search (both modes) ====================
+
+    @Test
+    void mixedAdd_computed()
+    {
+        assertMixedAddExcludesNulls(new NullableComputedVectorizer());
+    }
+
+    @Test
+    void mixedAdd_embedded()
+    {
+        assertMixedAddExcludesNulls(new NullableEmbeddedVectorizer());
+    }
+
+    private void assertMixedAddExcludesNulls(final Vectorizer<Doc> vectorizer)
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, vectorizer);
+
+        final long id0 = map.add(new Doc("e0", basis(0)));
+        final long idN = map.add(new Doc("none", null));
+        final long id1 = map.add(new Doc("e1", basis(1)));
+        final long id2 = map.add(new Doc("e2", basis(2)));
+
+        // Only the three vectored entities are searchable.
+        final VectorSearchResult<Doc> all = index.search(basis(0), 10);
+        assertEquals(3, all.size(), "null-embedding entity must be excluded from search");
+
+        // Nearest-neighbor identity is correct per query.
+        assertEquals(id0, index.search(basis(0), 1).stream().findFirst().orElseThrow().entityId());
+        assertEquals(id1, index.search(basis(1), 1).stream().findFirst().orElseThrow().entityId());
+        assertEquals(id2, index.search(basis(2), 1).stream().findFirst().orElseThrow().entityId());
+
+        // getVector reflects presence/absence.
+        assertNotNull(index.getVector(id0));
+        assertNull(index.getVector(idN), "entity without embedding has no vector");
+
+        // A later remove/update still resolves the right entries.
+        map.removeById(id2);
+        assertEquals(2, index.search(basis(0), 10).size());
+        assertNull(index.getVector(id2));
+    }
+
+    // ==================== 4. addAll alignment with interspersed nulls ====================
+
+    @Test
+    void addAll_withNulls_computed()
+    {
+        assertAddAllAlignment(new NullableComputedVectorizer());
+    }
+
+    @Test
+    void addAll_withNulls_embedded()
+    {
+        assertAddAllAlignment(new NullableEmbeddedVectorizer());
+    }
+
+    private void assertAddAllAlignment(final Vectorizer<Doc> vectorizer)
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, vectorizer);
+
+        // nulls at head, middle, tail
+        final List<Doc> docs = new ArrayList<>();
+        docs.add(new Doc("headNull", null));
+        docs.add(new Doc("v0", basis(0)));
+        docs.add(new Doc("midNull", null));
+        docs.add(new Doc("v1", basis(1)));
+        docs.add(new Doc("v2", basis(2)));
+        docs.add(new Doc("tailNull", null));
+
+        map.addAll(docs);
+
+        assertEquals(3, index.search(basis(0), 10).size());
+
+        // Each vectored entity resolves to the correct content via its own id.
+        for(int dim = 0; dim < 3; dim++)
+        {
+            final long id = index.search(basis(dim), 1).stream().findFirst().orElseThrow().entityId();
+            assertEquals("v" + dim, map.get(id).content, "id must map to the aligned entity");
+            assertNotNull(index.getVector(id));
+        }
+    }
+
+    // ==================== 5/6. Update transitions (sync, both modes) ====================
+
+    @Test
+    void updateTransitions_computedSync()
+    {
+        assertUpdateTransitions(new NullableComputedVectorizer());
+    }
+
+    @Test
+    void updateTransitions_embeddedSync()
+    {
+        assertUpdateTransitions(new NullableEmbeddedVectorizer());
+    }
+
+    private void assertUpdateTransitions(final Vectorizer<Doc> vectorizer)
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, vectorizer);
+
+        final long a = map.add(new Doc("a", basis(0)));
+        final long b = map.add(new Doc("b", basis(1)));
+        final long c = map.add(new Doc("c", null)); // starts without embedding
+
+        assertEquals(2, index.search(basis(0), 10).size());
+        assertNull(index.getVector(c));
+
+        // null -> vec: c gains an embedding and must appear WITHOUT reload.
+        map.set(c, new Doc("c", basis(2)));
+        assertEquals(3, index.search(basis(0), 10).size());
+        assertEquals(c, index.search(basis(2), 1).stream().findFirst().orElseThrow().entityId());
+        assertNotNull(index.getVector(c));
+
+        // vec -> null: a loses its embedding and disappears from search.
+        map.set(a, new Doc("a", null));
+        assertNull(index.getVector(a));
+        final VectorSearchResult<Doc> afterRemoveA = index.search(basis(0), 10);
+        assertEquals(2, afterRemoveA.size());
+        assertTrue(afterRemoveA.stream().noneMatch(e -> e.entityId() == a),
+            "entity whose vector became null must not appear");
+
+        // null -> null: no-op, no exception, still absent.
+        map.set(a, new Doc("a", null));
+        assertNull(index.getVector(a));
+        assertEquals(2, index.search(basis(0), 10).size());
+
+        // vec -> vec: b changes embedding; still present and now nearest to its new vector.
+        map.set(b, new Doc("b", basis(3)));
+        assertEquals(b, index.search(basis(3), 1).stream().findFirst().orElseThrow().entityId());
+        assertNotNull(index.getVector(b));
+    }
+
+    // ==================== 7. Update transitions (eventual indexing) ====================
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void updateTransitions_eventual_computed()
+    {
+        assertUpdateTransitionsEventual(new NullableComputedVectorizer());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void updateTransitions_eventual_embedded()
+    {
+        assertUpdateTransitionsEventual(new NullableEmbeddedVectorizer());
+    }
+
+    private void assertUpdateTransitionsEventual(final Vectorizer<Doc> vectorizer)
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+        try(final VectorIndex<Doc> index = indices.add("embeddings", eventualConfig(), vectorizer))
+        {
+            final long a = map.add(new Doc("a", basis(0)));
+            map.add(new Doc("b", basis(1)));
+            final long c = map.add(new Doc("c", null));
+            drain(index);
+            assertEquals(2, index.search(basis(0), 10).size());
+
+            // null -> vec
+            map.set(c, new Doc("c", basis(2)));
+            // vec -> null
+            map.set(a, new Doc("a", null));
+            // remove of a never-indexed entity must not blow up the worker
+            drain(index);
+
+            final VectorSearchResult<Doc> result = index.search(basis(0), 10);
+            assertEquals(2, result.size());
+            assertTrue(result.stream().noneMatch(e -> e.entityId() == a));
+            assertEquals(c, index.search(basis(2), 1).stream().findFirst().orElseThrow().entityId());
+        }
+    }
+
+    // ==================== 8. Remove of a never-indexed entity ====================
+
+    @Test
+    void removeNeverIndexedEntity_sync()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, new NullableComputedVectorizer());
+        map.add(new Doc("v", basis(0)));
+        final long idNone = map.add(new Doc("none", null));
+
+        // Must be a safe no-op — the entity was never added to the graph or the store.
+        map.removeById(idNone);
+        assertEquals(1, index.search(basis(0), 10).size());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void removeNeverIndexedEntity_eventual()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+        try(final VectorIndex<Doc> index = indices.add(
+            "embeddings", eventualConfig(), new NullableComputedVectorizer()))
+        {
+            map.add(new Doc("v", basis(0)));
+            final long idNone = map.add(new Doc("none", null));
+            map.removeById(idNone);
+            drain(index);
+            assertEquals(1, index.search(basis(0), 10).size());
+        }
+    }
+
+    // ==================== 9. Persistence round-trip ====================
+
+    @Test
+    void persistenceRoundTrip_computed(@TempDir final Path dir)
+    {
+        assertPersistenceRoundTrip(dir, false);
+    }
+
+    @Test
+    void persistenceRoundTrip_embedded(@TempDir final Path dir)
+    {
+        assertPersistenceRoundTrip(dir, true);
+    }
+
+    private void assertPersistenceRoundTrip(final Path dir, final boolean embedded)
+    {
+        // Phase 1: store entities, some without embeddings.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+        {
+            final GigaMap<Doc> map = GigaMap.New();
+            storage.setRoot(map);
+            final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+            indices.add("embeddings", config(),
+                embedded ? new NullableEmbeddedVectorizer() : new NullableComputedVectorizer());
+
+            map.add(new Doc("v0", basis(0)));
+            map.add(new Doc("none", null));
+            map.add(new Doc("v1", basis(1)));
+            storage.storeRoot();
+        }
+
+        // Phase 2: reload — rebuild must skip null entities and stay consistent.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+        {
+            final GigaMap<Doc> map = storage.root();
+            final VectorIndices<Doc> indices = map.index().get(VectorIndices.Category());
+            final VectorIndex<Doc> index = indices.get("embeddings");
+
+            assertEquals(3, map.size(), "all entities survive, including the vector-less one");
+            assertEquals(2, index.search(basis(0), 10).size(), "only vectored entities are searchable");
+            assertEquals("v0", map.get(index.search(basis(0), 1).stream().findFirst().orElseThrow().entityId()).content);
+            assertEquals("v1", map.get(index.search(basis(1), 1).stream().findFirst().orElseThrow().entityId()).content);
+        }
+    }
+
+    // ==================== 10. On-disk index with nulls ====================
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void onDiskWithNulls(@TempDir final Path dir) throws Exception
+    {
+        final Path storageDir = dir.resolve("storage");
+        final Path indexDir   = dir.resolve("index");
+
+        final VectorIndexConfiguration diskConfig = VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .build();
+
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = GigaMap.New();
+            storage.setRoot(map);
+            final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+            final VectorIndex<Doc> index = indices.add(
+                "embeddings", diskConfig, new NullableComputedVectorizer());
+
+            map.add(new Doc("v0", basis(0)));
+            map.add(new Doc("none", null));
+            map.add(new Doc("v1", basis(1)));
+            map.add(new Doc("v2", basis(2)));
+
+            index.persistToDisk();
+            storage.storeRoot();
+        }
+
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = storage.root();
+            final VectorIndex<Doc> index = map.index().get(VectorIndices.Category()).get("embeddings");
+
+            assertEquals(4, map.size());
+            assertEquals(3, index.search(basis(0), 10).size());
+            assertEquals("v1", map.get(index.search(basis(1), 1).stream().findFirst().orElseThrow().entityId()).content);
+        }
+    }
+
+    // ==================== 11. Query by null-vector entity / null query ====================
+
+    @Test
+    void searchByEntityWithoutVector_throws()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, new NullableComputedVectorizer());
+        map.add(new Doc("v", basis(0)));
+        final Doc none = new Doc("none", null);
+        map.add(none);
+
+        assertThrows(IllegalArgumentException.class, () -> index.search(none, 5));
+        assertThrows(IllegalArgumentException.class, () -> index.search(none, 5, 50));
+    }
+
+    @Test
+    void nullQueryVector_throws()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndex<Doc> index = newIndex(map, new NullableComputedVectorizer());
+        map.add(new Doc("v", basis(0)));
+
+        assertThrows(IllegalArgumentException.class, () -> index.search((float[])null, 5));
+    }
+
+    // ==================== 12. Custom vectorizeAll with positional nulls ====================
+
+    static class BatchNullableVectorizer extends Vectorizer<Doc>
+    {
+        @Override
+        public float[] vectorize(final Doc entity)
+        {
+            return entity.embedding;
+        }
+
+        @Override
+        public List<float[]> vectorizeAll(final List<? extends Doc> entities)
+        {
+            // positional, may include nulls
+            final List<float[]> out = new ArrayList<>(entities.size());
+            for(final Doc d : entities)
+            {
+                out.add(d.embedding);
+            }
+            return out;
+        }
+
+        @Override
+        public boolean allowsNullVectors()
+        {
+            return true;
+        }
+    }
+
+    static class BatchStrictVectorizer extends BatchNullableVectorizer
+    {
+        @Override
+        public boolean allowsNullVectors()
+        {
+            return false;
+        }
+    }
+
+    @Test
+    void vectorizeAll_positionalNulls_allowed()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+        final VectorIndex<Doc> index = indices.add("embeddings", config(), new BatchNullableVectorizer());
+
+        map.addAll(List.of(
+            new Doc("v0", basis(0)),
+            new Doc("none", null),
+            new Doc("v1", basis(1))
+        ));
+
+        assertEquals(2, index.search(basis(0), 10).size());
+    }
+
+    @Test
+    void vectorizeAll_positionalNulls_rejectedWhenOptedOut()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+        indices.add("embeddings", config(), new BatchStrictVectorizer());
+
+        assertThrows(IllegalStateException.class, () -> map.addAll(List.of(
+            new Doc("v0", basis(0)),
+            new Doc("none", null)
+        )));
+    }
+
+    // ==================== 13. PQ compression with nulls ====================
+
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void pqCompressionExcludesNulls(@TempDir final Path dir)
+    {
+        final int dim = 16;
+        final Path storageDir = dir.resolve("storage");
+        final Path indexDir   = dir.resolve("index");
+        final Random random   = new Random(7);
+
+        final VectorIndexConfiguration pqConfig = VectorIndexConfiguration.builder()
+            .dimension(dim)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .enablePqCompression(true)
+            .pqSubspaces(dim / 4)
+            .build();
+
+        long knownId;
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = GigaMap.New();
+            storage.setRoot(map);
+            final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+            final VectorIndex<Doc> index = indices.add(
+                "embeddings", pqConfig, new NullableComputedVectorizer());
+
+            // > 256 vectored entities so PQ training triggers, plus some null ones.
+            for(int i = 0; i < 300; i++)
+            {
+                map.add(new Doc("v" + i, randomUnit(random, dim)));
+                if(i % 20 == 0)
+                {
+                    map.add(new Doc("none" + i, null));
+                }
+            }
+            final float[] known = randomUnit(random, dim);
+            knownId = map.add(new Doc("known", known));
+
+            index.persistToDisk();
+            storage.storeRoot();
+
+            final VectorSearchResult<Doc> result = index.search(known, 5);
+            assertFalse(result.isEmpty());
+            assertTrue(result.stream().allMatch(e -> index.getVector(e.entityId()) != null),
+                "no null-embedding entity may appear in PQ search results");
+        }
+
+        // Reload: PQ-compressed on-disk index round-trips with nulls present.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+        {
+            final GigaMap<Doc> map = storage.root();
+            final VectorIndex<Doc> index = map.index().get(VectorIndices.Category()).get("embeddings");
+            assertNotNull(index.getVector(knownId));
+            assertFalse(index.search(map.get(knownId), 5).isEmpty());
+        }
+    }
+
+    private static float[] randomUnit(final Random random, final int dim)
+    {
+        final float[] v = new float[dim];
+        float norm = 0;
+        for(int i = 0; i < dim; i++)
+        {
+            v[i] = random.nextFloat() * 2 - 1;
+            norm += v[i] * v[i];
+        }
+        norm = (float)Math.sqrt(norm);
+        for(int i = 0; i < dim; i++)
+        {
+            v[i] /= norm;
+        }
+        return v;
+    }
+
+    // sanity: equals/hashCode of stored entries tolerate null vectors (defensive)
+    @Test
+    void vectorEntryToleratesNull()
+    {
+        final VectorEntry a = new VectorEntry(1L, null);
+        final VectorEntry b = new VectorEntry(1L, null);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertTrue(a.toString().contains("sourceEntityId=1"));
+        assertNull(a.vector);
+        assertFalse(Arrays.equals(new float[]{1f}, a.vector));
+    }
+}

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -381,6 +381,30 @@ class VectorIndexNullVectorTest
         }
     }
 
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void nullToNullUpdate_eventual_computed_enqueuesNothing()
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+        try(final VectorIndex<Doc> index = indices.add(
+            "embeddings", eventualConfig(), new NullableComputedVectorizer()))
+        {
+            map.add(new Doc("v", basis(0)));
+            final long c = map.add(new Doc("c", null));
+            drain(index);
+
+            // null→null is a documented no-op: it must not generate background work.
+            final VectorIndex.Default<Doc> def = (VectorIndex.Default<Doc>)index;
+            map.set(c, new Doc("c", null));
+            assertEquals(0, def.backgroundTaskManager.getPendingIndexingCount(),
+                "computed-mode null→null update must not enqueue a graph operation");
+
+            assertEquals(1, index.search(basis(0), 10).size());
+            assertNull(index.getVector(c));
+        }
+    }
+
     // ==================== 8. Remove of a never-indexed entity ====================
 
     @Test

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNullVectorTest.java
@@ -629,6 +629,60 @@ class VectorIndexNullVectorTest
         }
     }
 
+    // ==================== 10c. Deletion during persist Phase 2 (Finding #4) ====================
+
+    /**
+     * A sync-mode {@code vec→null} that lands in persist Phase 2 defers its graph-deletion op, which is
+     * drained only after {@code doPersistToDisk} swaps the in-memory builder (exit/reenter incremental).
+     * Before the fix the deferred {@code markNodeDeleted} hit the new empty builder and was lost, leaving
+     * the entity live on the reloaded disk graph until the next persist. The {@code persistPhase2TestHook}
+     * injects the delete deterministically into that exact window, on the persist thread — the same
+     * monitor / {@code cleanupInProgress} state a concurrent sync mutation would observe.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("unchecked")
+    void deletionDuringPersistPhase2NotLost(@TempDir final Path indexDir)
+    {
+        final VectorIndexConfiguration diskConfig = VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .build();
+
+        final GigaMap<Doc> map = GigaMap.New();
+        try(final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+            .add("embeddings", diskConfig, new NullableComputedVectorizer()))
+        {
+            final long a = map.add(new Doc("a", basis(0)));
+            map.add(new Doc("b", basis(1)));
+            map.add(new Doc("c", basis(2)));
+            assertEquals(3, index.search(basis(0), 10).size());
+
+            // One-shot: null out 'a' during persist Phase 2 — after the parentMap monitor is released,
+            // before the builder is swapped (reenterIncrementalMode) and the deferred op is drained.
+            // Runs on the persist thread: the same cleanupInProgress / monitor state a concurrent sync
+            // mutation would observe, so it defers exactly as the bug requires.
+            final VectorIndex.Default<Doc> def = (VectorIndex.Default<Doc>)index;
+            def.persistPhase2TestHook = () ->
+            {
+                def.persistPhase2TestHook = null;
+                map.set(a, new Doc("a", null));
+            };
+
+            // This persist writes a,b,c to disk (captured before the hook), the hook defers a's delete,
+            // then the builder is swapped and the deferred op drained.
+            index.persistToDisk();
+
+            final VectorSearchResult<Doc> result = index.search(basis(0), 10);
+            assertEquals(2, result.size(), "nulled entity must not survive a persist-window deletion");
+            assertTrue(result.stream().noneMatch(e -> e.entityId() == a),
+                "deferred deletion drained after the builder swap must still exclude the entity");
+            assertNull(index.getVector(a));
+        }
+    }
+
     // ==================== 11. Query by null-vector entity / null query ====================
 
     @Test

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorValuesTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorValuesTest.java
@@ -174,7 +174,9 @@ class VectorValuesTest
         @Test
         void testSize()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
             vectorStore.add(new VectorEntry(1L, new float[]{4.0f, 5.0f, 6.0f}));
             vectorStore.add(new VectorEntry(2L, new float[]{7.0f, 8.0f, 9.0f}));
@@ -189,7 +191,9 @@ class VectorValuesTest
         @Test
         void testSizeEmptyStore()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
 
             final GigaMapBackedVectorValues values = new GigaMapBackedVectorValues(
                 vectorStore, 3, vectorTypeSupport
@@ -201,7 +205,9 @@ class VectorValuesTest
         @Test
         void testDimension()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
 
             final GigaMapBackedVectorValues values = new GigaMapBackedVectorValues(
                 vectorStore, 128, vectorTypeSupport
@@ -213,7 +219,9 @@ class VectorValuesTest
         @Test
         void testGetVectorValidOrdinal()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
             vectorStore.add(new VectorEntry(1L, new float[]{4.0f, 5.0f, 6.0f}));
 
@@ -234,7 +242,9 @@ class VectorValuesTest
         @Test
         void testGetVectorNonExistentOrdinalReturnsNull()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues values = new GigaMapBackedVectorValues(
@@ -249,7 +259,9 @@ class VectorValuesTest
         void testGetVectorConvertsToVectorFloat()
         {
             final VectorEntry originalVector = new VectorEntry(0L, new float[]{1.5f, 2.5f, 3.5f});
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(originalVector);
 
             final GigaMapBackedVectorValues values = new GigaMapBackedVectorValues(
@@ -268,7 +280,9 @@ class VectorValuesTest
         @Test
         void testIsValueSharedReturnsFalse()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
 
             final GigaMapBackedVectorValues values = new GigaMapBackedVectorValues(
                 vectorStore, 3, vectorTypeSupport
@@ -280,7 +294,9 @@ class VectorValuesTest
         @Test
         void testCopyReturnsNewInstance()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues values = new GigaMapBackedVectorValues(
@@ -297,7 +313,9 @@ class VectorValuesTest
         @Test
         void testCopySharesUnderlyingStore()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues values = new GigaMapBackedVectorValues(
@@ -305,8 +323,9 @@ class VectorValuesTest
             );
             final GigaMapBackedVectorValues copy = (GigaMapBackedVectorValues) values.copy();
 
-            // Both should access the same underlying GigaMap
-            assertSame(values.vectorStore, copy.vectorStore);
+            // The copy shares the same underlying lookup, so it resolves the same vectors.
+            assertNotSame(values, copy);
+            assertEquals(values.getVector(0).get(0), copy.getVector(0).get(0), 0.001f);
         }
     }
 
@@ -318,7 +337,9 @@ class VectorValuesTest
         @Test
         void testCachingInheritsBaseProperties()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
             vectorStore.add(new VectorEntry(1L, new float[]{4.0f, 5.0f, 6.0f}));
 
@@ -334,7 +355,9 @@ class VectorValuesTest
         @Test
         void testGetVectorCachesResult()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues.Caching values = new GigaMapBackedVectorValues.Caching(
@@ -352,7 +375,9 @@ class VectorValuesTest
         @Test
         void testGetVectorCachesMultipleOrdinals()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
             vectorStore.add(new VectorEntry(1L, new float[]{4.0f, 5.0f, 6.0f}));
             vectorStore.add(new VectorEntry(2L, new float[]{7.0f, 8.0f, 9.0f}));
@@ -379,7 +404,9 @@ class VectorValuesTest
         @Test
         void testGetVectorNonExistentReturnsNull()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues.Caching values = new GigaMapBackedVectorValues.Caching(
@@ -392,7 +419,9 @@ class VectorValuesTest
         @Test
         void testCopyReturnsNewCachingInstance()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues.Caching values = new GigaMapBackedVectorValues.Caching(
@@ -409,7 +438,9 @@ class VectorValuesTest
         @Test
         void testCopyHasIndependentCache()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues.Caching values = new GigaMapBackedVectorValues.Caching(
@@ -435,7 +466,9 @@ class VectorValuesTest
         @Test
         void testCachingSharesUnderlyingStore()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues.Caching values = new GigaMapBackedVectorValues.Caching(
@@ -444,14 +477,17 @@ class VectorValuesTest
             final GigaMapBackedVectorValues.Caching copy =
                 (GigaMapBackedVectorValues.Caching) values.copy();
 
-            // Both should access the same underlying GigaMap
-            assertSame(values.vectorStore, copy.vectorStore);
+            // The copy shares the same underlying lookup, so it resolves the same vectors.
+            assertNotSame(values, copy);
+            assertEquals(values.getVector(0).get(0), copy.getVector(0).get(0), 0.001f);
         }
 
         @Test
         void testCachingExtendsGigaMapBackedVectorValues()
         {
-            final GigaMap<VectorEntry> vectorStore = GigaMap.New();
+            final GigaMap<VectorEntry> vectorStore = GigaMap.<VectorEntry>Builder()
+                .withBitmapIdentityIndex(VectorEntry.SOURCE_ENTITY_ID_INDEXER)
+                .build();
             vectorStore.add(new VectorEntry(0L, new float[]{1.0f, 2.0f, 3.0f}));
 
             final GigaMapBackedVectorValues.Caching values = new GigaMapBackedVectorValues.Caching(

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorValuesTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorValuesTest.java
@@ -326,6 +326,14 @@ class VectorValuesTest
             // The copy shares the same underlying lookup, so it resolves the same vectors.
             assertNotSame(values, copy);
             assertEquals(values.getVector(0).get(0), copy.getVector(0).get(0), 0.001f);
+
+            // Mutate the backing store AFTER copying: both instances must observe the new
+            // entry, proving the copy shares the live store rather than a snapshot.
+            vectorStore.add(new VectorEntry(1L, new float[]{4.0f, 5.0f, 6.0f}));
+            assertNotNull(values.getVector(1));
+            assertNotNull(copy.getVector(1));
+            assertEquals(4.0f, values.getVector(1).get(0), 0.001f);
+            assertEquals(4.0f, copy.getVector(1).get(0), 0.001f);
         }
     }
 
@@ -480,6 +488,16 @@ class VectorValuesTest
             // The copy shares the same underlying lookup, so it resolves the same vectors.
             assertNotSame(values, copy);
             assertEquals(values.getVector(0).get(0), copy.getVector(0).get(0), 0.001f);
+
+            // Mutate the backing store AFTER copying: both instances must observe the new
+            // entry, proving the copy shares the live store rather than a snapshot. Use an
+            // ordinal neither instance has resolved yet, so per-instance caches don't mask
+            // the lookup.
+            vectorStore.add(new VectorEntry(1L, new float[]{4.0f, 5.0f, 6.0f}));
+            assertNotNull(values.getVector(1));
+            assertNotNull(copy.getVector(1));
+            assertEquals(4.0f, values.getVector(1).get(0), 0.001f);
+            assertEquals(4.0f, copy.getVector(1).get(0), 0.001f);
         }
 
         @Test


### PR DESCRIPTION
## Summary

`VectorIndex` previously rejected a `null` return from `Vectorizer.vectorize()` with an `IllegalStateException`, so entities without an embedding could not live in a `GigaMap` carrying a vector index. This PR adds opt-in support for entities that legitimately have no embedding: a `null` vector now means the entity stays in the `GigaMap` and all of its other indices but is excluded from the HNSW graph and never appears in vector search results.

The behavior is opt-in via the new `Vectorizer.allowsNullVectors()` (default `false`). Existing vectorizers are unaffected and keep their fail-fast behavior, which continues to catch accidental bugs in vectorizer implementations.

## Semantics

- Add of a null-vector entity: the entity is stored/kept but not indexed for vector search.
- Update transitions: non-null to null removes the entity from the index; null to non-null adds it; null to null is a no-op; non-null to non-null is unchanged.
- `getVector(entityId)` returns `null` for a vector-less entity.
- `search(entity, k)` throws `IllegalArgumentException` when the query entity has no vector (an entity without an embedding has no meaningful similarity).
- Under eventual indexing there is a brief window where a just-nulled entity may still appear in results until the background worker applies the mutation, the same consistency window that already applies to removals.

## Notable implementation details

Computed-mode vector-store access no longer assumes the store's internal id equals the source entity id (positional `get`/`set`/`removeById`). This is required for null support: a computed-mode entity without a vector gets no store entry, so positional access would misalign every later entity's vector. Instead a small transient index maps source entity id to the store's internal id:

- Lookups resolve by source entity id, which is correct even when the store's id allocator drifts from the parent map's (deletion holes, or vector-less entities), the latent drift the `getHighestEntityId` comment warns about.
- Vector access stays a direct, lazy `vectorStore.get(internalId)` rather than an index query per call. This is important on the hot graph-scoring and persistence paths; an earlier query-per-lookup form was roughly an order of magnitude slower and allocation-heavy on the on-disk build/write path.
- The index is rebuilt from the store by positional iteration, so it is safe to populate during deserialization (`complete()`), before the store's own indices are wired, and is kept in sync on add/update/remove.
- Mutations use id-based `set`/`removeById` via this index, which also sidesteps the `like(...)` key round-trip that would otherwise reject a source entity id of `0` (encoded to the reserved `Long.MAX_VALUE` sentinel).

Annotation support: `@Vector(allowNull = true)` opts an annotated embedded member into the same behavior.

## Testing

- Full `gigamap-jvector` suite green on JDK 17 (the CI JVM): 216 default tests plus 107 slow-profile tests (disk, main, concurrency, lifecycle), 0 failures and 0 errors, run in a single fork to mirror CI. The slow-profile `VectorIndexDiskTest` also dropped from roughly 140s to under 20s once vector access stopped querying per lookup.
- New `VectorIndexNullVectorTest` (23 tests) covers both embedded and computed modes across synchronous and eventual indexing and across in-memory, on-disk, and PQ-compressed storage, plus reload round-trips, all four update transitions, `addAll` alignment with interspersed nulls, opt-out fail-fast, and query-by-vectorless-entity.
- Two new `@Vector(allowNull = true)` annotation tests.

## Docs

Updated `advanced.adoc`, `defining.adoc`, and `index.adoc` under the GigaMap jvector docs to describe the opt-in, the transition semantics, the batch (`vectorizeAll`) implications, and the `@Vector(allowNull)` attribute.
