### PR TITLE
Backup / store rollback hardenings 09072026

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemEnqueuer.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemEnqueuer.java
@@ -30,5 +30,30 @@ public interface StorageBackupItemEnqueuer
 	public void enqueueDeletionItem(
 		StorageLiveChannelFile<?> file
 	);
-	
+
+	/**
+	 * Removes every still-queued item referencing {@code file} and releases the usage each held,
+	 * without processing them. Used before a physical delete: once the file is gone, the backup
+	 * thread must not try to copy/truncate/delete a source that no longer exists.
+	 *
+	 * @param file the file whose pending items are no longer valid.
+	 */
+	public void cancelPendingItemsFor(
+		StorageLiveChannelFile<?> file
+	);
+
+	/**
+	 * Removes still-queued copy items for {@code file} whose source range starts at or beyond
+	 * {@code newLength} and releases the usage each held. Used before a physical truncate: a copy
+	 * item covering bytes the truncate is about to remove would otherwise be processed against a
+	 * source that no longer has them.
+	 *
+	 * @param file      the file being truncated.
+	 * @param newLength the file's new (shorter) length; copy items at or beyond it are invalid.
+	 */
+	public void trimPendingCopyItemsBeyond(
+		StorageLiveChannelFile<?> file     ,
+		long                      newLength
+	);
+
 }

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
@@ -91,12 +91,96 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 		)
 		{
 			item.sourceFile.registerUsage(this);
-			
+
 			// no try-catch with unregisterUsage required since the following code is too simple to fail.
 			synchronized(this.head)
 			{
 				this.tail = this.tail.next = item;
 				this.head.notifyAll();
+			}
+		}
+
+		@Override
+		public void cancelPendingItemsFor(final StorageLiveChannelFile<?> file)
+		{
+			this.removeMatching(item -> item.sourceFile == file);
+		}
+
+		@Override
+		public void trimPendingCopyItemsBeyond(final StorageLiveChannelFile<?> file, final long newLength)
+		{
+			this.removeMatching(item ->
+				item.sourceFile == file
+				&& item instanceof CopyItem
+				&& ((CopyItem)item).sourcePosition >= newLength
+			);
+		}
+
+		/**
+		 * Unlinks {@code current} (whose predecessor in the chain is {@code previous}) and fixes
+		 * {@code tail} if {@code current} was the last item. Callers must hold {@code this.head}'s
+		 * monitor. Shared by {@link #processNextItem}'s single-item pop and {@link #removeMatching}'s
+		 * arbitrary-position removal, so a future change to the tail-fixup invariant only has one
+		 * place to get right.
+		 */
+		private void unlink(final Item previous, final Item current)
+		{
+			previous.next = current.next;
+			if(current == this.tail)
+			{
+				this.tail = previous;
+			}
+		}
+
+		/**
+		 * Removes every still-queued item matching {@code predicate} and releases the usage each
+		 * held, without processing them. Only reaches items still sitting in the queue; one
+		 * already popped by the backup thread and mid-processing is outside this lock and not
+		 * covered (an accepted, narrow residual race window).
+		 * <p>
+		 * The queue lock is a leaf (see {@link #processNextItem}): file-monitor calls
+		 * (registerUsage/unregisterUsage) must never run while it is held, otherwise the queue
+		 * lock and a {@code StorageLiveFile} monitor can be acquired in opposite orders by the
+		 * housekeeping channel and the backup handler and deadlock. Removed items are therefore
+		 * collected into a separate chain (reusing their own {@code next} field, now free) and
+		 * their usage released only after the lock is released.
+		 */
+		private void removeMatching(final java.util.function.Predicate<? super Item> predicate)
+		{
+			Item removedHead = null;
+			Item removedTail = null;
+
+			synchronized(this.head)
+			{
+				Item previous = this.head;
+				Item current  = this.head.next;
+				while(current != null)
+				{
+					final Item next = current.next;
+					if(predicate.test(current))
+					{
+						this.unlink(previous, current);
+						current.next = null;
+						if(removedHead == null)
+						{
+							removedHead = removedTail = current;
+						}
+						else
+						{
+							removedTail = removedTail.next = current;
+						}
+					}
+					else
+					{
+						previous = current;
+					}
+					current = next;
+				}
+			}
+
+			for(Item item = removedHead; item != null; item = item.next)
+			{
+				item.sourceFile.unregisterUsage(this);
 			}
 		}
 
@@ -134,12 +218,7 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 				}
 
 				itemToBeProcessed = this.head.next;
-
-				if((this.head.next = itemToBeProcessed.next) == null)
-				{
-					// queue has been processed completely, reset to initial state of appending directly to the head.
-					this.tail = this.head;
-				}
+				this.unlink(this.head, itemToBeProcessed);
 			}
 
 			try

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
@@ -109,6 +109,10 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 		@Override
 		public void trimPendingCopyItemsBeyond(final StorageLiveChannelFile<?> file, final long newLength)
 		{
+			// A start-only check (>= newLength) suffices: copy items are enqueued at exact write
+			// boundaries (sourcePosition == the file length before that write), and the only truncation
+			// that reaches here is a rollback to the committed length - itself a write boundary. So an
+			// item either lies fully below newLength or starts at/after it; none can straddle newLength.
 			this.removeMatching(item ->
 				item.sourceFile == file
 				&& item instanceof CopyItem

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelSynchronizingTask.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelSynchronizingTask.java
@@ -133,6 +133,14 @@ public interface StorageChannelSynchronizingTask extends StorageChannelTask
 			}
 		}
 
+		@Override
+		protected final void completeExceptionally(final StorageChannel channel)
+		{
+			// own failure means fail() regardless of siblings, so unlike complete() this must NOT
+			// waitOnProcessing() first - see the contract for why waiting here would deadlock.
+			this.synchronizedComplete(channel, null);
+		}
+
 
 		public static final class Dummy extends AbstractCompletingTask<Void> implements StorageRequestTask
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelTask.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelTask.java
@@ -13,13 +13,13 @@ package org.eclipse.store.storage.types;
  * #L%
  */
 
+import static org.eclipse.serializer.util.X.notNull;
+
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageException;
-import org.slf4j.Logger;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.eclipse.serializer.util.X.notNull;
+import org.slf4j.Logger;
 
 public interface StorageChannelTask extends StorageTask
 {
@@ -117,6 +117,22 @@ public interface StorageChannelTask extends StorageTask
 		protected abstract R internalProcessBy(StorageChannel channel);
 
 		protected abstract void complete(StorageChannel channel,  R value) throws InterruptedException;
+
+		/**
+		 * Completion for a channel whose OWN {@link #internalProcessBy} just threw. Unlike
+		 * {@link #complete}, this outcome is already determined (the channel must fail) regardless
+		 * of what sibling channels do, so implementations must NOT wait on siblings here:
+		 * {@link StorageChannelSynchronizingTask.AbstractCompletingTask#complete} does exactly that
+		 * via {@code waitOnProcessing()}, and some subclasses' {@link #cleanUp} (run immediately
+		 * after this method returns) is what unblocks siblings still stuck inside their own
+		 * {@code internalProcessBy} (e.g. a garbage-collection mark-wait) — waiting here would
+		 * deadlock against that.
+		 * <p>
+		 * Declared abstract (no default delegating to {@link #complete}) so that every direct
+		 * subclass makes this call explicitly: a future {@code complete()} that itself waits on
+		 * siblings would silently reintroduce the same deadlock if this were inherited unnoticed.
+		 */
+		protected abstract void completeExceptionally(StorageChannel channel) throws InterruptedException;
 
 		protected void finishProcessing()
 		{
@@ -245,9 +261,13 @@ public interface StorageChannelTask extends StorageTask
 				}
 				catch(final Throwable e)
 				{
-					// a problem occurring while processing gets reported and the task gets cleanly aborted.
+					// the problem is reported, but this channel must still reach a completion hook:
+					// skipping it (as before) also skipped fail(), so a channel that threw AFTER a
+					// partial write (e.g. mid-store) never got its own rollback. completeExceptionally
+					// (not complete) is used deliberately - see its contract. The finally below still
+					// runs finishProcessing() on this path, after this call and before the return.
 					this.addProblem(storageChannel.channelIndex(), e);
-					this.incrementCompletionProgress();
+					this.completeExceptionally(storageChannel);
 					return;
 				}
 				finally

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriterBackupping.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriterBackupping.java
@@ -259,6 +259,11 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 			final StorageFileProvider       fileProvider
 		)
 		{
+			// trim queued copy items for the bytes about to be removed BEFORE the physical truncate:
+			// processed afterwards they would copy a source range that no longer exists, throw, and
+			// escalate to a storage-wide disruption over an already-handled rollback.
+			this.itemEnqueuer.trimPendingCopyItemsBeyond(file, newLength);
+
 			// no user increment since only the identifier is required and the actual file can well be deleted.
 			this.delegate.truncate(file, newLength, fileProvider);
 			this.itemEnqueuer.enqueueTruncatingItem(file, newLength);
@@ -271,6 +276,11 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 			final StorageFileProvider    fileProvider
 		)
 		{
+			// cancel any still-queued item for this file BEFORE it physically disappears: a stale
+			// copy/truncate item processed afterwards would try to act on a source that no longer
+			// exists, throw, and register a storage-wide disruption over an intended deletion.
+			this.itemEnqueuer.cancelPendingItemsFor(file);
+
 			// no user increment since only the identifier is required and the actual file can well be deleted.
 			this.delegate.delete(file, writeController, fileProvider);
 			this.itemEnqueuer.enqueueDeletionItem(file);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskLoad.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskLoad.java
@@ -61,7 +61,15 @@ public interface StorageRequestTaskLoad extends StorageRequestTask
 			this.result[channel.channelIndex()] = result;
 			this.incrementCompletionProgress();
 		}
-		
+
+		@Override
+		protected void completeExceptionally(final StorageChannel channel) throws InterruptedException
+		{
+			// complete() above never waits on siblings, so reaching it directly on this channel's
+			// own failure is safe: the null result slot is harmless (already the array's default).
+			this.complete(channel, null);
+		}
+
 		@Override
 		public final ChunksBuffer result() throws StorageExceptionRequest
 		{


### PR DESCRIPTION
Two related data-safety fixes in the storage engine's failure paths.    
                                                                                                                                                                                                                                                                                                                                                                                                                            Task completion:                                                                                                                                                                                                                                                                                                                                                                                                                             when a channel's own internalProcessBy throws, it now                                                                                                                                                                            reaches a completion hook instead of only marking completion progress.                                                                                                                                                                            Previously fail() was skipped, so a channel that threw after a partial                                                                                                                                                                            write (e.g. mid-store) never rolled that write back; the head file's                                                                                                                                                                              physical length diverged from its tracked length and every later store                                                                                                                                                                            on that channel failed until a full restart. A new completeExceptionally                                                                                                                                                                          hook routes the failure to fail() without first waiting on sibling                                                                                                                                                                                channels: the failing channel's own cleanUp is what releases siblings                                                                                                                                                                             stuck in their processing (e.g. a garbage-collection mark-wait), so                                                                                                                                                                               waiting here would deadlock. It is abstract so each task type opts in                                                                                                                                                                             explicitly - AbstractCompletingTask completes directly, and the load                                                                                                                                                                              task delegates to its own non-waiting complete().         
                                                                                                                                                                                                                                                                                                                                                                                                                                          Backup queue: 
still-queued items for a file are now cancelled or trimmed                                                                                                                                                                          before that file is physically truncated or deleted. A copy item                                                                                                                                                                                  processed after its source range was truncated away, or after the source                                                                                                                                                                          was deleted, reads bytes that no longer exist, throws, and escalates a                                                                                                                                                                            single already-handled rollback into a storage-wide disruption.                                                                                                                                                                                   cancelPendingItemsFor removes every item for a doomed file;                                                                                                                                                                                       trimPendingCopyItemsBeyond removes copy items at or beyond a truncation                                                                                                                                                                           boundary. Both collect matches under the queue lock and release each                                                                                                                                                                              item's file-usage pin only after the lock is released, preserving the                                                                                                                                                                             queue's leaf-lock ordering against the file monitors. A shared unlink                                                                                                                                                                             helper backs both the single-item pop and arbitrary-position removal.