### PR TITLE
Add crash evidence logging and upload for integration and slow tests

### DIFF
--- a/.github/workflows/maven_it_test.yml
+++ b/.github/workflows/maven_it_test.yml
@@ -35,6 +35,27 @@ jobs:
     - name: Run integration tests
       run: mvn -P IT -B test -pl integration-tests --no-transfer-progress --file pom.xml -Dgpg.skip=true -Dlicense.skip=true -Denforcer.skip=true
 
+    - name: Dump crash evidence to log
+      if: failure()
+      run: |
+        echo "===== surefire dumpstream / dump files ====="
+        find . -path '*/target/surefire-reports/*' \( -name '*.dumpstream' -o -name '*.dump' \) \
+          -print -exec cat {} \; || true
+        echo "===== JVM fatal error logs (hs_err) ====="
+        find . -name 'hs_err_pid*.log' -print -exec cat {} \; || true
+
+    - name: Upload crash evidence
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: crash-evidence-integration-tests
+        path: |
+          **/target/surefire-reports/*.dumpstream
+          **/target/surefire-reports/*.dump
+          **/hs_err_pid*.log
+        if-no-files-found: ignore
+        retention-days: 14
+
     - name: Report JUnit results (dorny - surefire)
       if: always()
       uses: dorny/test-reporter@v2

--- a/.github/workflows/maven_slow_test.yml
+++ b/.github/workflows/maven_slow_test.yml
@@ -33,6 +33,27 @@ jobs:
     - name: Run slow tests
       run: mvn  -T 1C -P examples -P slow-tests -B clean test --no-transfer-progress --file pom.xml -U -Dmaven.javadoc.skip=true -Dgpg.skip=true -Dlicense.skip=true -Denforcer.skip=true
 
+    - name: Dump crash evidence to log
+      if: failure()
+      run: |
+        echo "===== surefire dumpstream / dump files ====="
+        find . -path '*/target/surefire-reports/*' \( -name '*.dumpstream' -o -name '*.dump' \) \
+          -print -exec cat {} \; || true
+        echo "===== JVM fatal error logs (hs_err) ====="
+        find . -name 'hs_err_pid*.log' -print -exec cat {} \; || true
+
+    - name: Upload crash evidence
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: crash-evidence-slow-tests
+        path: |
+          **/target/surefire-reports/*.dumpstream
+          **/target/surefire-reports/*.dump
+          **/hs_err_pid*.log
+        if-no-files-found: ignore
+        retention-days: 14
+
     - name: Report JUnit results (dorny - surefire)
       if: always()
       uses: dorny/test-reporter@v2


### PR DESCRIPTION
This pull request enhances the CI workflows for integration and slow tests by improving how crash evidence is collected and made available after test failures. The key changes add steps to both the `maven_it_test.yml` and `maven_slow_test.yml` workflows to automatically dump and upload crash-related files when a failure occurs, making it easier to diagnose test failures.

Crash evidence collection and reporting improvements:

* Added a step to both `maven_it_test.yml` and `maven_slow_test.yml` to print the contents of `.dumpstream`, `.dump`, and `hs_err_pid*.log` files to the workflow log if a test failure occurs, aiding immediate visibility into crash evidence. [[1]](diffhunk://#diff-59bf556366c1740aa531045b9d308f7f4cb6eee5637ec9fb7f263cb2f3252dd0R38-R58) [[2]](diffhunk://#diff-77e0dfc1dd68b5122b990fdb8b9972bda0bacb60646105d9d9ab0186a5ba5ccbR36-R56)
* Added a step to both workflows to upload all `.dumpstream`, `.dump`, and `hs_err_pid*.log` files as artifacts when a failure occurs, ensuring that detailed crash evidence is preserved and available for download and analysis after the workflow completes. [[1]](diffhunk://#diff-59bf556366c1740aa531045b9d308f7f4cb6eee5637ec9fb7f263cb2f3252dd0R38-R58) [[2]](diffhunk://#diff-77e0dfc1dd68b5122b990fdb8b9972bda0bacb60646105d9d9ab0186a5ba5ccbR36-R56)