### PR TITLE
fix-power-loss-durability-fsync_74

### DIFF
--- a/afs/nio/src/main/java/org/eclipse/store/afs/nio/types/NioIoHandler.java
+++ b/afs/nio/src/main/java/org/eclipse/store/afs/nio/types/NioIoHandler.java
@@ -666,6 +666,23 @@ public interface NioIoHandler extends AIoHandler
 		}
 
 		@Override
+		protected void specificSynchronize(final NioWritableFile file)
+		{
+			// idempotent: the file is already open on every call path that reaches here
+			this.openWriting(file);
+			try
+			{
+				// force(true): appends grow the file, so the new length (metadata) must reach
+				// physical storage too, not only the content bytes.
+				file.fileChannel().force(true);
+			}
+			catch(final IOException e)
+			{
+				throw new IORuntimeException(e);
+			}
+		}
+
+		@Override
 		protected void specificMoveFile(
 			final NioWritableFile sourceFile,
 			final AWritableFile   targetFile

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFile.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFile.java
@@ -151,6 +151,13 @@ public interface StorageFile
 	public long writeBytes(Iterable<? extends ByteBuffer> buffers);
 
 
+	/**
+	 * Forces previously written bytes of this file to physical storage (fsync). No-op on backends
+	 * that are already durable on write.
+	 */
+	public void synchronize();
+
+
 //	public void pull(AWritableFile fileToMove);
 
 
@@ -440,7 +447,20 @@ public interface StorageFile
 				throw new StorageExceptionIoWriting(e);
 			}
 		}
-		
+
+		@Override
+		public final synchronized void synchronize()
+		{
+			try
+			{
+				this.ensureWritable().synchronize();
+			}
+			catch(final Exception e)
+			{
+				throw new StorageExceptionIoWriting(e);
+			}
+		}
+
 		@Override
 		public final synchronized long copyTo(
 			final StorageFile target

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFile.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFile.java
@@ -154,8 +154,14 @@ public interface StorageFile
 	/**
 	 * Forces previously written bytes of this file to physical storage (fsync). No-op on backends
 	 * that are already durable on write.
+	 * <p>
+	 * Default no-op for source/binary backward compatibility; {@link StorageFile.Abstract} overrides
+	 * this to force through the underlying writable file.
 	 */
-	public void synchronize();
+	public default void synchronize()
+	{
+		// no-op; see StorageFile.Abstract for the effective implementation
+	}
 
 
 //	public void pull(AWritableFile fileToMove);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -824,6 +824,11 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 		final void createNextStorageFile()
 		{
+			// Durability floor: the outgoing head is now complete and will not be appended again.
+			// Forcing it here means a power loss can strand at most the current head's tail, never a
+			// sealed (long-committed) file. Also covers a head that received transferred bytes and
+			// then rolled over mid-dissolution.
+			this.headFile.synchronize();
 			this.createNewStorageFile(this.headFile.number() + 1);
 		}
 		
@@ -2115,7 +2120,16 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			this.writeTransactionsEntryFileDeletion(file, this.timestampProvider.currentNanoTimestamp());
 
 			// (12.08.2020 TM)FIXME: priv#351: where and how to check whether files may be deleted? Here? Weird!
-			
+
+			// Durability barrier (power-loss safety): before the source file is physically unlinked,
+			// (a) the current head file must hold the relocated bytes durably - sealed heads were
+			// already forced at their rollover, this covers the not-yet-rolled current head - and
+			// (b) the transactions file must hold the transfer + deletion entries durably, so a crash
+			// can never leave the source unlinked while the records that relocated its data, or the
+			// record explaining its absence, are still in page cache.
+			this.headFile.synchronize();
+			this.fileTransactions.synchronize();
+
 			// physically delete file after the transactions entry is ensured
 			this.writer.delete(file, this.writeController, this.fileProvider);
 		}


### PR DESCRIPTION
Establish two invariants via the new AFS synchronize() primitive:                                                                                                                                                                                
                                                                                                                                                                                                                                                   
  1. Sealed data files are durable: fsync the outgoing head on every rollover                                                                                                                                                                      
     (createNextStorageFile). Power loss can now strand at most the current                                                                                                                                                                        
     head's tail, never a sealed file. Benefits the store and import paths too.                                                                                                                                                                    
                                                                                                                                                                                                                                                   
  2. No source file is unlinked before its relocated bytes and validating tx                                                                                                                                                                       
     entries are durable: in deleteFile, fsync the current head and the                                                                                                                                                                            
     transactions file before the physical unlink.                                                                                                                                                                                                 
                                                                                                                                                                                                                                                   
  NIO backend forces via FileChannel.force(true) (appends grow the file, so                                                                                                                                                                        
  the length metadata must be durable too); object-store backends are no-ops.                                                                                                                                                                      
                                                                                                                                                                                                                                                   
  The load path is untouched. The store path is unchanged per commit, except                                                                                                                                                                       
  that a commit which triggers a head rollover now incurs one fsync of the                                                                                                                                                                         
  outgoing sealed file (~once per fileMaximumSize, 8 MB by default); this is                                                                                                                                                                       
  invariant 1 above. Object-store backends see only no-ops.                                                                                                                                                                                        
                                                                                                                                                                                                                                                   
  StorageFile.synchronize() is a default no-op on the public interface for                                                                                                                                                                         
  source/binary backward compatibility; StorageFile.Abstract overrides it with                                                                                                                                                                     
  the real fsync, so all built-in files (head, transactions) force as intended.                                                                                                                                                                    
                                                                                                                                                                                                                                                   
  Requires the paired serializer change (AWritableFile.synchronize()).