### PR TITLE
Add missing regression guards for typeId-change, rebuild hashing and …

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/backup/ShortCopyValidationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/backup/ShortCopyValidationTest.java
@@ -1,0 +1,136 @@
+package test.eclipse.store.backup;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.store.storage.exceptions.StorageExceptionIoWriting;
+import org.eclipse.store.storage.types.StorageBackupItemEnqueuer;
+import org.eclipse.store.storage.types.StorageFileWriter;
+import org.eclipse.store.storage.types.StorageFileWriterBackupping;
+import org.eclipse.store.storage.types.StorageImportSource;
+import org.eclipse.store.storage.types.StorageLiveDataFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Empirical verification of the internal#71 fix (store#744): short copies must fail loudly at
+ * every backup-relevant site, and the backupping writer must never enqueue a backup item for a
+ * short copy (a wrong-length item would permanently diverge the backup).
+ */
+@Timeout(60)
+public class ShortCopyValidationTest
+{
+	private static <T> T proxy(final Class<T> type, final InvocationHandler handler)
+	{
+		return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler));
+	}
+
+	/** Answers size()=0 and copyTo(...)=shortCount; primitives default otherwise. */
+	private static InvocationHandler fileAnsweringShortCopy(final long shortCount)
+	{
+		return (proxyObj, method, args) ->
+		{
+			if("copyTo".equals(method.getName()))
+			{
+				return shortCount;
+			}
+			if(long.class.equals(method.getReturnType()))
+			{
+				return 0L;
+			}
+			if(int.class.equals(method.getReturnType()))
+			{
+				return 0;
+			}
+			if(boolean.class.equals(method.getReturnType()))
+			{
+				return false;
+			}
+			return null;
+		};
+	}
+
+	@Test
+	void defaultWriteTransferThrowsOnShortCopy()
+	{
+		final StorageFileWriter defaultWriter = new StorageFileWriter(){};
+		final StorageLiveDataFile source = proxy(StorageLiveDataFile.class, fileAnsweringShortCopy(5L));
+		final StorageLiveDataFile target = proxy(StorageLiveDataFile.class, fileAnsweringShortCopy(5L));
+
+		final StorageExceptionIoWriting e = assertThrows(StorageExceptionIoWriting.class,
+			() -> defaultWriter.writeTransfer(source, 0L, 100L, target),
+			"a short transfer copy (5 of 100 bytes) must fail loudly");
+		assertTrue(e.getMessage().contains("5") && e.getMessage().contains("100"),
+			"the exception must name both byte counts: " + e.getMessage());
+	}
+
+	@Test
+	void defaultWriteImportThrowsOnShortCopy()
+	{
+		final StorageFileWriter defaultWriter = new StorageFileWriter(){};
+		final StorageImportSource source = proxy(StorageImportSource.class, fileAnsweringShortCopy(7L));
+		final StorageLiveDataFile target = proxy(StorageLiveDataFile.class, fileAnsweringShortCopy(7L));
+
+		assertThrows(StorageExceptionIoWriting.class,
+			() -> defaultWriter.writeImport(source, 0L, 100L, target),
+			"a short import copy must fail loudly");
+	}
+
+	@Test
+	void backuppingWriterDoesNotEnqueueAnItemForAShortTransfer()
+	{
+		// delegate that reports a short transfer WITHOUT throwing (custom-writer threat model)
+		final StorageFileWriter shortDelegate = new StorageFileWriter()
+		{
+			@Override
+			public long writeTransfer(
+				final StorageLiveDataFile sourceFile  ,
+				final long                sourceOffset,
+				final long                copyLength  ,
+				final StorageLiveDataFile targetFile
+			)
+			{
+				return 5L; // short: only 5 of copyLength bytes "copied"
+			}
+		};
+
+		final List<String> enqueued = new ArrayList<>();
+		final StorageBackupItemEnqueuer recordingEnqueuer = proxy(
+			StorageBackupItemEnqueuer.class,
+			(proxyObj, method, args) -> { enqueued.add(method.getName()); return null; }
+		);
+
+		final StorageFileWriter backupping = StorageFileWriterBackupping
+			.Provider(recordingEnqueuer, () -> shortDelegate)
+			.provideWriter(0);
+
+		final StorageLiveDataFile source = proxy(StorageLiveDataFile.class, fileAnsweringShortCopy(5L));
+		final StorageLiveDataFile target = proxy(StorageLiveDataFile.class, fileAnsweringShortCopy(5L));
+
+		assertThrows(StorageExceptionIoWriting.class,
+			() -> backupping.writeTransfer(source, 0L, 100L, target),
+			"the backupping writer must reject the delegate's short count");
+		assertEquals(List.of(), enqueued,
+			"no backup item may be enqueued for a short copy - it would permanently diverge the backup");
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/entitycache/EntityV1.java
+++ b/integration-tests/src/test/java/test/eclipse/store/entitycache/EntityV1.java
@@ -1,0 +1,30 @@
+package test.eclipse.store.entitycache;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * "Old" version of the evolving entity type. Only used to seed the storage;
+ * the second session maps this type name to {@link EntityV2}.
+ */
+public class EntityV1
+{
+    public String value;
+
+    public EntityV1(final String value)
+    {
+        super();
+        this.value = value;
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/entitycache/EntityV2.java
+++ b/integration-tests/src/test/java/test/eclipse/store/entitycache/EntityV2.java
@@ -1,0 +1,35 @@
+package test.eclipse.store.entitycache;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * "New" version of the evolving entity type ({@link EntityV1} is mapped to
+ * this class via an explicit refactoring mapping). The matching {@code value}
+ * field is carried over by legacy mapping; the additional field changes the
+ * type structure, which is what forces a NEW typeId — with an identical
+ * structure the type handler manager just re-assigns the old typeId to the
+ * renamed class and no typeId change ever happens.
+ */
+public class EntityV2
+{
+    public String value;
+    public long   extra;
+
+    public EntityV2(final String value)
+    {
+        super();
+        this.value = value;
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/entitycache/TypeChangeDuplicateEntityReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/entitycache/TypeChangeDuplicateEntityReproTest.java
@@ -1,0 +1,374 @@
+package test.eclipse.store.entitycache;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import org.eclipse.serializer.afs.types.ADirectory;
+import org.eclipse.store.afs.nio.types.NioFileSystem;
+import org.eclipse.serializer.collections.EqHashTable;
+import org.eclipse.serializer.persistence.types.PersistenceRefactoringMappingProvider;
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.serializer.reference.Swizzling;
+import org.eclipse.serializer.typing.KeyValue;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageConnection;
+import org.eclipse.store.storage.types.StorageEntityCache;
+import org.eclipse.store.storage.types.StorageEntityTypeExportFileProvider;
+import org.eclipse.store.storage.types.StorageEntityTypeExportStatistics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Reproducer for the {@code StorageEntityCache.putEntity(long)} typeId-change
+ * defect: when a store updates an entity whose registered cache entry has a
+ * different typeId (the routine result of storing a legacy-mapped instance
+ * after type evolution), the branch at {@code StorageEntityCache.java:613-625}
+ * creates a <b>second</b> entry for the same OID and leaves the old entry
+ * registered — still in the OID hash chain, still in its type's entity list,
+ * still bound to its (stale) file record ({@code resetExistingEntityForUpdate}
+ * is never applied to it).
+ *
+ * <p>Two user-visible consequences are asserted here (both tests assert
+ * correct behavior and therefore FAIL while the defect exists):
+ *
+ * <ol>
+ * <li>{@link #reStoreAfterTypeChangeMustReplaceNotDuplicateEntity()} — the
+ *     stale entry survives a full GC because the sweep's application safety
+ *     net is id-only ({@code sweep: isGcMarked() ||
+ *     isReachableInApplication.test(item.objectId)}, StorageEntityCache.java:950)
+ *     and both entries carry the same OID: as long as the application holds
+ *     the instance, the old-type duplicate is rescued every cycle. A type
+ *     export then emits the same entity twice — once per type — which also
+ *     breaks re-import ({@code validateEntity} throws "Object Id already
+ *     assigned to an entity of another type").</li>
+ * <li>{@link #reloadMustNotServeStaleDataAfterHashTableRebuild()} — every OID
+ *     hash table rebuild reverses bucket chain order
+ *     ({@code rebuildOidHashSlots} prepends, StorageEntityCache.java:269-285),
+ *     so after a rebuild the STALE entry becomes the chain head and
+ *     {@code getEntry(oid)} — used by loads and by GC marking — resolves to
+ *     the old record: a reload returns pre-update data. (With JVM+storage GC
+ *     timing instead of the explicit clear/reload used here, the same flip
+ *     makes the mark phase mark only the stale entry, the sweep then deletes
+ *     the CURRENT record — permanent silent data regression.)</li>
+ * </ol>
+ *
+ * <p>Trigger is ordinary type evolution: class {@link EntityV1} is stored,
+ * the second session maps it to {@link EntityV2} (explicit refactoring
+ * mapping stands in for any legacy type mapping), the loaded instance is
+ * re-stored. The second test disables the storage GC via the
+ * {@code StorageEntityCache.Default.setGarbageCollectionEnabled} debug hook to
+ * keep the window deterministic; without it the same states are reachable,
+ * just timing-dependent.
+ */
+public class TypeChangeDuplicateEntityReproTest
+{
+    private static final String V1_VALUE = "v1-original";
+    private static final String V2_VALUE = "v2-updated";
+
+    @TempDir
+    Path tempDir;
+
+    EmbeddedStorageManager storage;
+
+    @AfterEach
+    public void afterTest()
+    {
+        StorageEntityCache.Default.setGarbageCollectionEnabled(true);
+        if (this.storage != null && this.storage.isRunning()) {
+            try {
+                this.storage.shutdown();
+            } catch (final Exception ignored) { /* best effort */ }
+        }
+    }
+
+    @Test
+    @Timeout(120)
+    void reStoreAfterTypeChangeMustReplaceNotDuplicateEntity() throws Exception
+    {
+        this.seedStorageWithV1Entity();
+        this.storage = this.startStorageWithV1toV2Mapping();
+
+        final DataRoot root = (DataRoot) this.storage.root();
+        final Object x = root.entity.get();
+        assertInstanceOf(EntityV2.class, x, "legacy mapping must load the entity as EntityV2");
+        assertEquals(V1_VALUE, ((EntityV2) x).value);
+
+        // The duplicating store: same OID, new typeId.
+        ((EntityV2) x).value = V2_VALUE;
+        this.storage.store(x);
+
+        // Full GC with the instance strongly held: the id-only sweep safety
+        // net rescues BOTH same-OID entries, so a correct implementation must
+        // have removed the old-type entry during the store itself.
+        this.storage.issueFullGarbageCollection();
+
+        // Detector: a type export walks the per-type entity lists. No record
+        // of the old type may exist for the re-stored entity.
+        final Path exportDir = this.tempDir.resolve("export");
+        Files.createDirectories(exportDir);
+        final NioFileSystem fs  = NioFileSystem.New();
+        final ADirectory    dir = fs.ensureDirectoryPath(exportDir.toAbsolutePath().toString());
+
+        final StorageConnection connection = this.storage.createConnection();
+        final StorageEntityTypeExportStatistics stats = connection.exportTypes(
+                new StorageEntityTypeExportFileProvider.Default(dir, "bin"),
+                typeHandler -> typeHandler.typeName().equals(EntityV1.class.getName())
+                        || typeHandler.typeName().equals(EntityV2.class.getName())
+        );
+
+        long v1Records = 0;
+        long v2Records = 0;
+        for (final StorageEntityTypeExportStatistics.TypeStatistic ts : stats.typeStatistics().values()) {
+            if (ts.typeName().equals(EntityV1.class.getName())) {
+                v1Records = ts.entityCount();
+            }
+            if (ts.typeName().equals(EntityV2.class.getName())) {
+                v2Records = ts.entityCount();
+            }
+        }
+
+        assertEquals(1, v2Records, "exactly one current-type record expected in the export");
+        assertEquals(0, v1Records,
+                "DUPLICATE ENTITY: the same OID is still registered under the old type "
+                        + EntityV1.class.getName() + " (" + v1Records + " record(s) exported)"
+                        + " — the stale entry survived the store and a full GC");
+    }
+
+    @Test
+    @Timeout(300)
+    void reloadMustNotServeStaleDataAfterHashTableRebuild() throws Exception
+    {
+        this.seedStorageWithV1Entity();
+
+        // Freeze the storage GC so the duplicate cannot be swept away between
+        // the checks below (with GC running, the same flip window exists but
+        // depends on housekeeping timing; see class javadoc).
+        StorageEntityCache.Default.setGarbageCollectionEnabled(false);
+        this.storage = this.startStorageWithV1toV2Mapping();
+
+        final DataRoot root = (DataRoot) this.storage.root();
+        Object x = root.entity.get();
+        assertInstanceOf(EntityV2.class, x);
+        assertEquals(V1_VALUE, ((EntityV2) x).value);
+
+        // The duplicating store: after it, the CURRENT entry is the bucket
+        // chain head, the STALE one sits behind it.
+        ((EntityV2) x).value = V2_VALUE;
+        this.storage.store(x);
+
+        // Grow the entity cache so the OID hash table rebuilds (each rebuild
+        // reverses bucket chain order). After an odd number of rebuilds the
+        // stale entry is the head and a fresh load resolves to the OLD record.
+        String staleObservation = null;
+        batches:
+        for (int batch = 1; batch <= 8 && staleObservation == null; batch++) {
+            final ArrayList<String> filler = new ArrayList<>(30_000);
+            for (int j = 0; j < 30_000; j++) {
+                filler.add("filler-" + batch + "-" + j);
+            }
+            this.storage.store(filler);
+
+            // Drop the held instance so the next Lazy.get() must load from disk.
+            final WeakReference<Object> probe = new WeakReference<>(x);
+            x = null;
+            root.entity.clear();
+            for (int i = 0; i < 20 && probe.get() != null; i++) {
+                System.gc();
+                Thread.sleep(50);
+            }
+            if (probe.get() != null) {
+                // could not force collection this round; re-load and try again
+                x = root.entity.get();
+                continue batches;
+            }
+            this.storage.persistenceManager().objectRegistry().cleanUp();
+
+            final Object reloaded = root.entity.get();
+            assertInstanceOf(EntityV2.class, reloaded);
+            final String value = ((EntityV2) reloaded).value;
+            if (!V2_VALUE.equals(value)) {
+                staleObservation = value + " (batch " + batch + ")";
+            }
+            x = reloaded;
+        }
+
+        assertNull(staleObservation,
+                "STALE DATA SERVED: after an OID hash table rebuild, reloading the entity returned "
+                        + "the pre-update record: " + staleObservation + " — getEntry(oid) resolves to the "
+                        + "leftover old-type entry; the same resolution is used by GC marking, where it leads "
+                        + "to the sweep deleting the current record");
+    }
+
+    /**
+     * The data-loss end of the chain: with the stale entry at the bucket-chain
+     * head (after a rebuild), the GC mark phase resolves the entity's OID to
+     * the STALE entry ({@code incrementalMark} → {@code getEntry},
+     * StorageEntityCache.java:882) and marks it; the CURRENT record's entry is
+     * never found by lookup, stays white and is deleted by the sweep. The file
+     * check then physically reclaims the current record (without it the
+     * startup scanner would resurrect the bytes), so after a restart the
+     * entity has permanently rolled back to its pre-update state.
+     */
+    @Test
+    @Timeout(600)
+    void gcMustNotDeleteCurrentRecordAfterHashTableRebuild() throws Exception
+    {
+        this.seedStorageWithV1Entity();
+
+        // Freeze the storage GC while staging (see class javadoc), but keep
+        // file housekeeping aggressive so the final file check can physically
+        // reclaim reclaimed regions.
+        StorageEntityCache.Default.setGarbageCollectionEnabled(false);
+        this.storage = this.startStorageWithV1toV2Mapping(true);
+
+        final DataRoot root = (DataRoot) this.storage.root();
+        Object x = root.entity.get();
+        assertInstanceOf(EntityV2.class, x);
+        ((EntityV2) x).value = V2_VALUE;
+        this.storage.store(x);
+
+        // Stage the flip: grow the cache and verify via a from-disk reload
+        // that the stale entry has become the chain head.
+        Object staleInstance = null;
+        for (int batch = 1; batch <= 8 && staleInstance == null; batch++) {
+            final ArrayList<String> filler = new ArrayList<>(30_000);
+            for (int j = 0; j < 30_000; j++) {
+                filler.add("filler-" + batch + "-" + j);
+            }
+            this.storage.store(filler);
+
+            final WeakReference<Object> probe = new WeakReference<>(x);
+            x = null;
+            root.entity.clear();
+            for (int i = 0; i < 20 && probe.get() != null; i++) {
+                System.gc();
+                Thread.sleep(50);
+            }
+            if (probe.get() != null) {
+                x = root.entity.get();
+                continue;
+            }
+            this.storage.persistenceManager().objectRegistry().cleanUp();
+
+            final Object reloaded = root.entity.get();
+            assertInstanceOf(EntityV2.class, reloaded);
+            if (V1_VALUE.equals(((EntityV2) reloaded).value)) {
+                staleInstance = reloaded;
+            } else {
+                x = reloaded;
+            }
+        }
+        assumeTrue(staleInstance != null,
+                "hash-rebuild flip not observed — cannot stage the sweep scenario deterministically");
+
+        // Nothing application-side may protect the OID during the GC (the
+        // id-only sweep rescue would otherwise keep BOTH entries alive).
+        final WeakReference<Object> staleProbe = new WeakReference<>(staleInstance);
+        staleInstance = null;
+        root.entity.clear();
+        for (int i = 0; i < 20 && staleProbe.get() != null; i++) {
+            System.gc();
+            Thread.sleep(50);
+        }
+        assumeTrue(staleProbe.get() == null, "JVM did not collect the reloaded instance");
+        this.storage.persistenceManager().objectRegistry().cleanUp();
+
+        // Resume the GC. Marking walks root -> Lazy -> entity OID and resolves
+        // it through the stale chain head; the current record's entry stays
+        // white (its store-time gray mark only survives the first sweep) and
+        // the second sweep deletes it. The file check reclaims it physically.
+        StorageEntityCache.Default.setGarbageCollectionEnabled(true);
+        this.storage.issueFullGarbageCollection();
+        this.storage.issueFullGarbageCollection();
+        this.storage.issueFullFileCheck();
+        this.storage.shutdown();
+
+        // Restart: only the stale record is left on disk.
+        this.storage = this.startStorageWithV1toV2Mapping(false);
+        final DataRoot reloadedRoot = (DataRoot) this.storage.root();
+        final Object survivor = reloadedRoot.entity.get();
+        assertInstanceOf(EntityV2.class, survivor);
+        assertEquals(V2_VALUE, ((EntityV2) survivor).value,
+                "DATA LOSS: the storage GC deleted the current record and kept the stale one — "
+                        + "after restart the entity permanently rolled back to its pre-update state");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // helpers //
+    /////////////
+
+    private void seedStorageWithV1Entity()
+    {
+        final EmbeddedStorageManager seed = EmbeddedStorage.Foundation(
+                        Storage.ConfigurationBuilder()
+                                .setChannelCountProvider(Storage.ChannelCountProvider(1))
+                                .setStorageFileProvider(Storage.FileProvider(this.tempDir))
+                                .createConfiguration()
+                )
+                .start();
+
+        final DataRoot root = new DataRoot();
+        root.entity = Lazy.Reference(new EntityV1(V1_VALUE));
+        seed.setRoot(root);
+        seed.storeRoot();
+
+        final long oid = seed.persistenceManager().objectRegistry().lookupObjectId(root.entity.peek());
+        assertNotEquals(Swizzling.notFoundId(), oid, "entity must be registered after seeding");
+
+        seed.shutdown();
+    }
+
+    private EmbeddedStorageManager startStorageWithV1toV2Mapping()
+    {
+        return this.startStorageWithV1toV2Mapping(false);
+    }
+
+    private EmbeddedStorageManager startStorageWithV1toV2Mapping(final boolean aggressiveFileCleanup)
+    {
+        final var configBuilder = Storage.ConfigurationBuilder()
+                .setChannelCountProvider(Storage.ChannelCountProvider(1))
+                .setStorageFileProvider(Storage.FileProvider(this.tempDir));
+        if (aggressiveFileCleanup) {
+            configBuilder
+                    .setHousekeepingController(Storage.HousekeepingController(100, 1_000_000_000))
+                    .setDataFileEvaluator(Storage.DataFileEvaluator(1024, 1024 * 1024, 1.0));
+        }
+        return EmbeddedStorage.Foundation(configBuilder.createConfiguration())
+                .setRefactoringMappingProvider(PersistenceRefactoringMappingProvider.New(
+                        EqHashTable.New(KeyValue.New(EntityV1.class.getName(), EntityV2.class.getName()))
+                ))
+                .start();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // data types //
+    ////////////////
+
+    public static class DataRoot
+    {
+        public Lazy<Object> entity;
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/entitycache/TypeInFileRebuildDuplicateReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/entitycache/TypeInFileRebuildDuplicateReproTest.java
@@ -1,0 +1,196 @@
+package test.eclipse.store.entitycache;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Reproducer for the {@code StorageLiveDataFile.rebuildTypeInFileTable} hash
+ * key mismatch: the per-file type-in-file registry is keyed by
+ * {@code System.identityHashCode(type)} on lookup and creation
+ * (StorageLiveDataFile.java:218, :234), but the rebuild re-hashes entries by
+ * {@code System.identityHashCode(entries)} — the identity of the
+ * {@code TypeInFile} entry itself, not of its type (StorageLiveDataFile.java:251-252).
+ *
+ * <p>After the first rebuild (triggered once a single data file holds more
+ * distinct types than the table range — initial length is 8) every existing
+ * entry sits in a wrong bucket: subsequent lookups of those types miss and
+ * {@code createTypeInFile} registers a <b>duplicate</b> {@code TypeInFile}
+ * for the same (type, file) pair. The stale entries are unreachable forever
+ * (there is no removal), the inflated count triggers further — again wrongly
+ * keyed — rebuilds, and the hot {@code typeInFile()} lookup path degrades.
+ *
+ * <p>Unlike the sibling defect in {@code StorageEntityCache.putEntity}
+ * (internal#77), this one is contained: {@code TypeInFile} is a pure
+ * (type, file) flyweight, lookups verify {@code t.type == type}, and nothing
+ * iterates the table — so the impact is memory/CPU degradation, not data
+ * corruption. The fix is to re-hash by {@code entries.type}.
+ *
+ * <p><b>This test asserts the registry invariant — at most one
+ * {@code TypeInFile} per type per file — and therefore FAILS while the defect
+ * exists.</b> It inspects the live channel structures via reflection
+ * (read-only, after a synchronous storage task has drained the channel).
+ */
+public class TypeInFileRebuildDuplicateReproTest
+{
+    @TempDir
+    Path tempDir;
+
+    EmbeddedStorageManager storage;
+
+    @AfterEach
+    public void afterTest()
+    {
+        if (this.storage != null && this.storage.isRunning()) {
+            try {
+                this.storage.shutdown();
+            } catch (final Exception ignored) { /* best effort */ }
+        }
+    }
+
+    @Test
+    @Timeout(120)
+    void typeInFileRegistryMustHoldOneEntryPerTypePerFile() throws Exception
+    {
+        this.storage = EmbeddedStorage.Foundation(
+                        Storage.ConfigurationBuilder()
+                                .setChannelCountProvider(Storage.ChannelCountProvider(1))
+                                .setStorageFileProvider(Storage.FileProvider(this.tempDir))
+                                .createConfiguration()
+                )
+                .start();
+
+        // Phase A: bring more than 8 distinct entity types into the head file —
+        // crossing the initial table range (8) triggers the wrongly-keyed rebuild.
+        final DataRoot root = new DataRoot();
+        root.items = new ArrayList<>(newInstanceOfEachType());
+        this.storage.setRoot(root);
+        this.storage.storeRoot();
+
+        // Phase B: store new instances of the SAME types. For every type whose
+        // entry was scattered by the rebuild, the lookup misses and a duplicate
+        // TypeInFile is created.
+        root.items.addAll(newInstanceOfEachType());
+        this.storage.store(root.items);
+
+        // Synchronous task as a barrier: all prior channel work is complete.
+        this.storage.issueFullGarbageCollection();
+
+        // Walk the live file structures and count TypeInFile entries per type.
+        final List<String> duplicates = new ArrayList<>();
+        int distinctTypesSeen = 0;
+
+        final Object storageSystem  = field(this.storage, "storageSystem");
+        final Object channelKeepers = field(storageSystem, "channelKeepers");
+        for (int k = 0; k < Array.getLength(channelKeepers); k++) {
+            final Object channel     = field(Array.get(channelKeepers, k), "channel");
+            final Object fileManager = field(channel, "fileManager");
+            final Object headFile    = field(fileManager, "headFile");
+            assertNotNull(headFile, "channel must have a head file");
+
+            Object file = headFile;
+            do {
+                final Map<Object, Integer> perType = new IdentityHashMap<>();
+                final Object slots = field(file, "typeInFileSlots");
+                for (int s = 0; s < Array.getLength(slots); s++) {
+                    for (Object e = Array.get(slots, s); e != null; e = field(e, "hashNext")) {
+                        perType.merge(field(e, "type"), 1, Integer::sum);
+                    }
+                }
+                distinctTypesSeen = Math.max(distinctTypesSeen, perType.size());
+                for (final Map.Entry<Object, Integer> t : perType.entrySet()) {
+                    if (t.getValue() > 1) {
+                        duplicates.add("file=" + file + " typeId=" + field(t.getKey(), "typeId")
+                                + " entries=" + t.getValue());
+                    }
+                }
+                file = field(file, "next");
+            }
+            while (file != headFile);
+        }
+
+        // Precondition: the rebuild threshold (initial table range 8) was crossed.
+        assumeTrue(distinctTypesSeen > 8,
+                "fewer than 9 distinct types in one file — rebuild not triggered, scenario not staged");
+
+        assertTrue(duplicates.isEmpty(),
+                "DUPLICATE TypeInFile registrations (same type registered more than once in one file's"
+                        + " type-in-file table — rebuild re-hashed by entry identity instead of type identity): "
+                        + duplicates);
+    }
+
+    private static List<Object> newInstanceOfEachType()
+    {
+        return List.of(
+                new T01(), new T02(), new T03(), new T04(), new T05(), new T06(),
+                new T07(), new T08(), new T09(), new T10(), new T11(), new T12()
+        );
+    }
+
+    private static Object field(final Object instance, final String name) throws ReflectiveOperationException
+    {
+        for (Class<?> c = instance.getClass(); c != null; c = c.getSuperclass()) {
+            try {
+                final Field f = c.getDeclaredField(name);
+                f.setAccessible(true);
+                return f.get(instance);
+            } catch (final NoSuchFieldException e) {
+                // try superclass
+            }
+        }
+        throw new NoSuchFieldException(instance.getClass().getName() + "." + name);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // data types //
+    ////////////////
+
+    public static class DataRoot
+    {
+        public ArrayList<Object> items;
+    }
+
+    // 12 distinct tiny entity types to cross the initial type-in-file table range (8)
+    public static class T01 { public int v; }
+    public static class T02 { public int v; }
+    public static class T03 { public int v; }
+    public static class T04 { public int v; }
+    public static class T05 { public int v; }
+    public static class T06 { public int v; }
+    public static class T07 { public int v; }
+    public static class T08 { public int v; }
+    public static class T09 { public int v; }
+    public static class T10 { public int v; }
+    public static class T11 { public int v; }
+    public static class T12 { public int v; }
+}


### PR DESCRIPTION
…backup byte counts

The fixes for these defects were merged without their reproducers; this adds them as permanent regression tests:

- TypeChangeDuplicateEntityReproTest (+ EntityV1/V2 fixtures): duplicate entity-cache entries on typeId change - duplicate survival, stale reads after a hash-table rebuild, GC deleting the current record (internal#77, fixed by #740).
- TypeInFileRebuildDuplicateReproTest: rebuildTypeInFileTable hashing by entry identity instead of type identity (internal#79, fixed by #741).
- ShortCopyValidationTest: short-copy byte counts must fail loudly and the backupping writer must never enqueue a backup item for a short copy (internal#71, fixed by #744).