### PR TITLE
Defer VectorIndex graph rebuild out of complete() to first access

### DIFF
--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BinaryHandlerVectorIndexDefault.java
@@ -160,8 +160,11 @@ extends AbstractBinaryHandlerStateChangeFlagged<VectorIndex.Default<?>>
         final PersistenceLoadHandler handler
     )
     {
-        // Reinitialize transient components after all fields are loaded
-        instance.ensureIndexInitialized();
+        // Reinitialize transient components after all fields are loaded. Only the nested-load-free
+        // setup runs here; the graph rebuild (which iterates the store and would perform a nested
+        // object-graph load inside this enclosing load's completeInstances phase — internal #87) is
+        // deferred to the first search/mutation via VectorIndex.ensureIndexInitialized().
+        instance.initializeAfterLoad();
     }
 
     // Provided only for PersistenceTypeHandler contract conformity. The standard store path

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -929,12 +929,21 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          * Rebuilds the in-memory graph from the store exactly once, lazily, on first access after a
          * load — the step deferred out of {@code complete()} (internal #87). Runs under the parent
          * GigaMap monitor: mutation / optimize / persist callers already hold it (reentrant), and the
-         * search path calls this before taking {@code builderLock.readLock()} (so it takes no read
-         * lock here and cannot deadlock a concurrent {@code internalRemoveAll}/{@code persistToDisk},
-         * which acquire the monitor then the write lock). Because every builder-swapping path
-         * (optimize / persistToDisk) also calls {@code ensureIndexInitialized()} before its swap, the
-         * first caller wins the rebuild under the monitor and publishes {@code graphRebuilt}; all
-         * others see the flag and skip. Skipped in incremental on-disk mode (the disk index serves
+         * search path calls this before taking {@code builderLock.readLock()}, so it never holds the
+         * read lock and the monitor at the same time.
+         * <p>
+         * Deadlock-free despite the builder-swapping paths using opposite lock orders
+         * ({@code internalRemoveAll}: monitor then {@code builderLock.writeLock()};
+         * {@code doPersistToDisk}: write lock then monitor): the rebuild acquires NO
+         * {@code builderLock} while it holds the monitor — {@code addGraphNodesSequential} adds nodes
+         * to the builder directly, and {@code collectStoredVectors} only re-enters this monitor (and,
+         * in computed mode, the vector store's own leaf monitor). A thread rebuilding here therefore
+         * holds only the monitor and waits for no lock a write-lock holder needs, so it cannot sit in
+         * a monitor↔builderLock cycle.
+         * <p>
+         * Because every builder-swapping path also calls {@code ensureIndexInitialized()} before its
+         * swap, the first caller wins the rebuild under the monitor and publishes {@code graphRebuilt};
+         * all others see the flag and skip. Skipped in incremental on-disk mode (the disk index serves
          * search; the in-memory graph is rebuilt later by {@code exitIncrementalMode}).
          */
         private void ensureGraphRebuilt()

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -801,6 +801,17 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // against each other by the parent GigaMap monitor the mutation already holds.
         private transient volatile Map<Long, Long> computedIdIndex;
 
+        // One-shot guard for the deferred graph rebuild. The HNSW graph is transient and must be
+        // rebuilt from the store after deserialization, but that rebuild iterates the parent GigaMap
+        // / vector store (a nested object-graph load) and therefore may NOT run inside the enclosing
+        // deserialization's complete() phase (internal #87). So complete() only does the nested-load-
+        // free transient setup (initializeAfterLoad -> initializeIndex); the graph rebuild is deferred
+        // to the first search/mutation/optimize via ensureGraphRebuilt(), which runs it exactly once
+        // under the parent GigaMap monitor (see there). Volatile: fast-path read lock-free; the actual
+        // rebuild + set happens under synchronized(parentMap()). Also set true by the runtime rebuild
+        // in exitIncrementalMode() so it is not repeated.
+        private transient volatile boolean                   graphRebuilt       ;
+
         // Incremental on-disk mode: after disk reload, use disk index for search
         // and in-memory builder only for new mutations. Full rebuild deferred to persistToDisk().
         // Volatile: written under writeLock (reenterIncrementalMode, exitIncrementalMode)
@@ -881,8 +892,27 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         }
 
         /**
-         * Ensures the transient HNSW index is initialized.
-         * Called after deserialization to rebuild the graph.
+         * Nested-load-free transient setup run from the binary handler's {@code complete()} during
+         * deserialization: (re)creates the transient managers, locks and (empty) in-memory builder,
+         * and, for on-disk indices, loads the disk graph. It deliberately does NOT rebuild the
+         * in-memory graph from the store, because that rebuild iterates the parent GigaMap / vector
+         * store (a nested object-graph load) which must not run inside the enclosing load's
+         * completeInstances phase (internal #87). The rebuild is deferred to first access via
+         * {@link #ensureGraphRebuilt()}.
+         */
+        void initializeAfterLoad()
+        {
+            final boolean diskLoaded = this.diskManager != null && this.diskManager.isLoaded();
+            if(this.builder == null && !diskLoaded)
+            {
+                this.initializeIndex();
+            }
+            // graph rebuild intentionally deferred to first access — see ensureGraphRebuilt()
+        }
+
+        /**
+         * Ensures the transient HNSW index is initialized and its graph rebuilt from the store.
+         * Called at the start of every search / mutation / optimize / persist entry point.
          */
         void ensureIndexInitialized()
         {
@@ -890,14 +920,37 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             if(this.builder == null && !diskLoaded)
             {
                 this.initializeIndex();
+            }
 
-                if(!this.incrementalMode)
+            this.ensureGraphRebuilt();
+        }
+
+        /**
+         * Rebuilds the in-memory graph from the store exactly once, lazily, on first access after a
+         * load — the step deferred out of {@code complete()} (internal #87). Runs under the parent
+         * GigaMap monitor: mutation / optimize / persist callers already hold it (reentrant), and the
+         * search path calls this before taking {@code builderLock.readLock()} (so it takes no read
+         * lock here and cannot deadlock a concurrent {@code internalRemoveAll}/{@code persistToDisk},
+         * which acquire the monitor then the write lock). Because every builder-swapping path
+         * (optimize / persistToDisk) also calls {@code ensureIndexInitialized()} before its swap, the
+         * first caller wins the rebuild under the monitor and publishes {@code graphRebuilt}; all
+         * others see the flag and skip. Skipped in incremental on-disk mode (the disk index serves
+         * search; the in-memory graph is rebuilt later by {@code exitIncrementalMode}).
+         */
+        private void ensureGraphRebuilt()
+        {
+            if(this.graphRebuilt || this.incrementalMode)
+            {
+                return;
+            }
+            synchronized(this.parentMap())
+            {
+                if(this.graphRebuilt || this.incrementalMode)
                 {
-                    // Rebuild graph from stored data (after deserialization).
-                    // Skipped in incremental mode — disk index serves search,
-                    // in-memory builder only handles new mutations.
-                    this.rebuildGraphFromStore();
+                    return;
                 }
+                this.rebuildGraphFromStore();
+                this.graphRebuilt = true;
             }
         }
 
@@ -1950,6 +2003,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             }
             this.validateDimension(queryVector);
 
+            // Ensure the (deferred) graph rebuild has run BEFORE acquiring the read lock: the
+            // rebuild gate takes the parent GigaMap monitor, and holding readLock while acquiring
+            // that monitor would risk the exact lock-ordering deadlock the read-lock note below
+            // warns about. Once rebuilt this is a lock-free volatile check.
+            this.ensureIndexInitialized();
+
             // Acquire read lock — blocks during cleanup/persistence/removeAll/close,
             // allows concurrent searches and GigaMap mutations.
             // No synchronized(parentMap) — avoids lock-ordering deadlock with
@@ -1957,8 +2016,6 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             this.builderLock.readLock().lock();
             try
             {
-                this.ensureIndexInitialized();
-
                 final VectorFloat<?> query = this.vectorTypeSupport.createFloatVector(queryVector);
 
                 // Choose search strategy based on index mode
@@ -2571,6 +2628,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             this.initializeInMemoryBuilder();
             this.rebuildGraphFromStore();
             this.initializeSearcherPool();
+
+            // The full in-memory graph now exists: mark the (deferred) rebuild done so a later
+            // first-access ensureGraphRebuilt() does not rebuild a second time on top of this one.
+            this.graphRebuilt = true;
         }
 
         /**

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNestedLoadReproTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNestedLoadReproTest.java
@@ -192,7 +192,12 @@ public class VectorIndexNestedLoadReproTest
 					try
 					{
 						ready.countDown();
-						go.await();
+						// bounded wait so a worker never blocks indefinitely if the start signal
+						// is missed (e.g. the ready barrier below failed before countDown)
+						if(!go.await(30, TimeUnit.SECONDS))
+						{
+							return;
+						}
 						final VectorSearchResult<Doc> r = index.search(new float[]{1.0f, 0.0f, 0.0f}, 2);
 						assertEquals(2, r.size());
 					}
@@ -201,6 +206,8 @@ public class VectorIndexNestedLoadReproTest
 						failure.compareAndSet(null, t);
 					}
 				}, "first-search-" + i);
+				// daemon so a stuck worker can never keep the JVM (and the test suite) alive
+				pool[i].setDaemon(true);
 				pool[i].start();
 			}
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNestedLoadReproTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexNestedLoadReproTest.java
@@ -1,0 +1,220 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression test for internal issue #87 (a regression from serializer#299).
+ * <p>
+ * A vector index rebuilds its transient HNSW graph inside its deserialization {@code complete()}
+ * ({@code BinaryHandlerVectorIndexDefault.complete} -> {@code VectorIndex.ensureIndexInitialized}
+ * -> {@code rebuildGraphFromStore} -> {@code collectStoredVectors} -> {@code parentMap().iterateIndexed}
+ * -> {@code Lazy.get()}). That iteration performs a <b>nested object-graph load on the same thread</b>
+ * while the enclosing roots load is still inside its own {@code completeInstances} phase.
+ * <p>
+ * Since serializer#299 deferred the loader's object-registry publication to a post-{@code complete}
+ * phase, the outer loader's freshly built (but not yet published) instance of a shared entity is
+ * invisible to that nested loader. The nested loader builds and publishes its own second instance
+ * for the same object id; the outer loader's {@code registerBuiltInstances} then finds a foreign
+ * instance under that id and throws {@code PersistenceExceptionConsistencyObject} — so the storage
+ * fails to start.
+ * <p>
+ * The scenario needs a shared entity that is <b>both</b> built eagerly by the outer roots load and
+ * re-loaded by the vector index's iteration: {@link Root} holds a direct reference to a
+ * {@link Tag} (eager -> outer build) and a {@link GigaMap} of {@link Doc}s each also referencing the
+ * same {@code Tag} (loaded by the vector index's embedded-mode iteration during {@code complete} ->
+ * nested build). Against the unpatched jvector this fails at the second {@code start()}; once the
+ * graph rebuild is deferred out of {@code complete()}, startup succeeds and search works.
+ */
+public class VectorIndexNestedLoadReproTest
+{
+	static final class Tag
+	{
+		String label;
+
+		Tag(final String label)
+		{
+			this.label = label;
+		}
+	}
+
+	static final class Doc
+	{
+		Tag     tag;
+		float[] embedding;
+
+		Doc(final Tag tag, final float[] embedding)
+		{
+			this.tag       = tag;
+			this.embedding = embedding;
+		}
+	}
+
+	static final class Root
+	{
+		Tag             sharedTag;
+		GigaMap<Doc>    docs;
+	}
+
+	static final class DocVectorizer extends Vectorizer<Doc>
+	{
+		@Override
+		public float[] vectorize(final Doc entity)
+		{
+			return entity.embedding;
+		}
+
+		@Override
+		public boolean isEmbedded()
+		{
+			return true;
+		}
+	}
+
+	private static VectorIndexConfiguration config()
+	{
+		return VectorIndexConfiguration.builder()
+			.dimension(3)
+			.similarityFunction(VectorSimilarityFunction.COSINE)
+			.build();
+	}
+
+	private static Root newSeededRoot()
+	{
+		final Tag shared = new Tag("shared");
+
+		final GigaMap<Doc> docs = GigaMap.New();
+		final VectorIndices<Doc> vectorIndices = docs.index().register(VectorIndices.Category());
+		vectorIndices.add("emb", config(), new DocVectorizer());
+
+		docs.add(new Doc(shared, new float[]{1.0f, 0.0f, 0.0f}));
+		docs.add(new Doc(shared, new float[]{0.0f, 1.0f, 0.0f}));
+		docs.add(new Doc(shared, new float[]{0.0f, 0.0f, 1.0f}));
+
+		final Root root = new Root();
+		root.sharedTag = shared;   // eager reference from the root -> built by the outer roots load
+		root.docs      = docs;     // each Doc also references `shared` -> re-loaded by the vector index
+		return root;
+	}
+
+	@Test
+	@Timeout(120)
+	void restartWithSharedEntityAndVectorIndexMustStart(@TempDir final Path dir)
+	{
+		// ---- session 1: seed + store ----------------------------------------
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			storage.setRoot(newSeededRoot());
+			storage.storeRoot();
+		}
+
+		// ---- session 2: restart (the failing path pre-fix) ------------------
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final Root root = (Root)storage.root();
+			assertNotNull(root, "root must reload");
+			assertNotNull(root.docs, "GigaMap must reload");
+			assertEquals(3, root.docs.size(), "all docs must be present");
+
+			// the shared entity must be a single instance across the root and the docs
+			final VectorIndex<Doc> index = root.docs.index().get(VectorIndices.Category()).get("emb");
+			assertNotNull(index, "vector index must reload");
+
+			final VectorSearchResult<Doc> result = index.search(new float[]{1.0f, 0.0f, 0.0f}, 2);
+			assertNotNull(result);
+			assertEquals(2, result.size(), "search must work after restart");
+
+			final Doc top = result.iterator().next().entity();
+			assertNotNull(top);
+			assertSame(root.sharedTag, top.tag, "the shared entity must resolve to a single instance");
+		}
+	}
+
+	/**
+	 * Same scenario, but two threads issue the very first {@code search()} concurrently right after
+	 * restart — exercising the deferred, thread-safe first-access rebuild introduced by the fix.
+	 */
+	@Test
+	@Timeout(120)
+	void concurrentFirstSearchAfterRestart(@TempDir final Path dir) throws Exception
+	{
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			storage.setRoot(newSeededRoot());
+			storage.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final Root root = (Root)storage.root();
+			final VectorIndex<Doc> index = root.docs.index().get(VectorIndices.Category()).get("emb");
+
+			final int threads = 4;
+			final CountDownLatch ready = new CountDownLatch(threads);
+			final CountDownLatch go    = new CountDownLatch(1);
+			final AtomicReference<Throwable> failure = new AtomicReference<>();
+			final Thread[] pool = new Thread[threads];
+			for(int i = 0; i < threads; i++)
+			{
+				pool[i] = new Thread(() ->
+				{
+					try
+					{
+						ready.countDown();
+						go.await();
+						final VectorSearchResult<Doc> r = index.search(new float[]{1.0f, 0.0f, 0.0f}, 2);
+						assertEquals(2, r.size());
+					}
+					catch(final Throwable t)
+					{
+						failure.compareAndSet(null, t);
+					}
+				}, "first-search-" + i);
+				pool[i].start();
+			}
+
+			assertTrue(ready.await(30, TimeUnit.SECONDS), "threads must be ready");
+			go.countDown();
+			for(final Thread t : pool)
+			{
+				t.join(TimeUnit.SECONDS.toMillis(30));
+				assertFalse(t.isAlive(), "search thread must finish");
+			}
+			if(failure.get() != null)
+			{
+				fail("concurrent first search failed", failure.get());
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes an availability regression from serializer#299.

## Problem

Starting a storage that contains a GigaMap with a JVector index fails with `PersistenceExceptionConsistencyObject`, thrown from the loader while the storage is starting — the storage does not come up. It surfaced in `vmt_smoke` via the GigaMap + Lucene + JVector travel scenario.

The cause is a nested, same-thread object-graph load during deserialization. `BinaryHandlerVectorIndexDefault.complete()` rebuilds the transient HNSW graph inline: `ensureIndexInitialized()` → `rebuildGraphFromStore()` → `collectStoredVectors()` → `parentMap().iterateIndexed()` / `vectorStore.iterate()` → `Lazy.get()`. That iteration triggers a nested load on the same thread while the enclosing roots load is still inside its own `completeInstances` phase. Since serializer#299 stopped publishing a loader's freshly built (but not yet completed) instances until after `complete`, the outer loader's instance of a shared entity is invisible to the nested loader; the nested loader builds and publishes its own second instance for the same object id, and the outer loader's `registerBuiltInstances` then finds a foreign instance under that id and throws. JVector is the only GigaMap index whose `complete()` re-enters the loader — bitmap indices complete purely in memory — so it is the only one that hits this.

Before serializer#299 the outer loader published eagerly, so the nested loader adopted the outer instance and there was only ever one. This PR restores correct startup without reverting that change, by making sure no nested load happens during `complete()`.

## Fix

Defer the graph rebuild out of `complete()` to the first access (search / mutation / optimize / persist), after the enclosing load has finished. This mirrors the treatment #748 already gave the computed-id index, which was deferred out of `complete()` for the same "store not yet queryable / O(n) load spike" reasons.

- `BinaryHandlerVectorIndexDefault.complete()` now calls the new `VectorIndex.initializeAfterLoad()`, which performs only the nested-load-free transient setup (`initializeIndex`: builder, locks, PQ / disk managers, searcher pool, background managers). It does not rebuild the graph.
- `ensureIndexInitialized()` — already called at the start of every search / mutation / optimize / persist entry point — now runs the one-shot rebuild via `ensureGraphRebuilt()`: a lock-free volatile `graphRebuilt` fast path, otherwise the rebuild under `synchronized(parentMap())`. Mutation / optimize / persist callers already hold that monitor (reentrant); the search path calls it before taking `builderLock.readLock()`, so the gate takes no read lock and serializes with `internalRemoveAll` / `persistToDisk` on the monitor rather than deadlocking. Because every builder-swapping path also calls `ensureIndexInitialized()` before its swap, the first caller performs the rebuild and publishes the flag; the rest skip.
- Incremental on-disk mode is unchanged (the rebuild stays skipped and the disk index serves search); `exitIncrementalMode()` sets `graphRebuilt` so its own runtime rebuild is not repeated.

The only observable change is that, for embedded-mode indices, the graph-build cost moves from startup to the first query or mutation. Search still works immediately after load. Disk, incremental and PQ paths are untouched.

## Tests

`VectorIndexNestedLoadReproTest` (new) reproduces the scenario end to end through real embedded storage: a root holds a direct reference to a shared entity (built eagerly by the outer roots load) plus a GigaMap of documents that also reference it (re-loaded by the vector index's embedded-mode iteration during `complete`). Against the unpatched code both a plain restart and a concurrent first-search after restart throw `PersistenceExceptionConsistencyObject` at the second `start()` (3/3 runs); with this fix both pass, and the shared entity resolves to a single instance. The concurrent-first-search case also exercises the new thread-safe deferred init.

Full JVector suite is green (333 tests: search, mutation, disk, incremental, lifecycle, batch, interleaving, null-vector), as is the store integration suite. The microstream-test `TravelAgencyServiceTest` remains the end-to-end regression guard for the original vmt_smoke trigger.

## Note

The serializer needs no change for this fix; the earlier serializer-side attempt (PR eclipse-serializer#303, "Adopt canonical constant…") was based on an incorrect diagnosis (roots/constants registration) and is being closed. serializer#299's publication guard stays in place as a fail-safe — with JVector no longer performing a nested load during `complete()`, nothing legitimately hits it.