### PR TITLE
Fix notNull()/null-check condition methods on GigaMap composite indexers

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryCompositeIndexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryCompositeIndexer.java
@@ -113,19 +113,40 @@ public interface BinaryCompositeIndexer<E> extends CompositeIndexer<E, long[]>
 		}
 		
 		@Override
+		public <S extends E> Condition<S> is(final long[] key)
+		{
+			// generic/raw callers may pass literal null for the composite key; route it to the
+			// sentinel-based null query instead of building a null-sample predicate (which NPEs).
+			return key == null ? this.isNull() : super.is(key);
+		}
+
+		@Override
+		public <S extends E> Condition<S> not(final long[] key)
+		{
+			return new Condition.Not<>(this.is(key));
+		}
+
+		@Override
 		public <S extends E> Condition<S> isNull()
 		{
 			return this.is(NULL());
 		}
-		
+
+		@Override
+		public <S extends E> Condition<S> notNull()
+		{
+			// null is encoded as the NULL() sentinel, so "not null" is exactly its negation.
+			return new Condition.Not<>(this.isNull());
+		}
+
 		protected <S extends E> Condition<S> isValue(final V other)
 		{
 			return this.is(this.indexValue(other, null));
 		}
-		
+
 	}
-	
-	
+
+
 	public abstract class AbstractSingleValueVariableSize<E, V> extends Abstract<E>
 	{
 		protected AbstractSingleValueVariableSize()
@@ -165,16 +186,37 @@ public interface BinaryCompositeIndexer<E> extends CompositeIndexer<E, long[]>
 		}
 		
 		@Override
+		public <S extends E> Condition<S> is(final long[] key)
+		{
+			// generic/raw callers may pass literal null for the composite key; route it to the
+			// sentinel-based null query instead of building a null-sample predicate (which NPEs).
+			return key == null ? this.isNull() : super.is(key);
+		}
+
+		@Override
+		public <S extends E> Condition<S> not(final long[] key)
+		{
+			return new Condition.Not<>(this.is(key));
+		}
+
+		@Override
 		public <S extends E> Condition<S> isNull()
 		{
 			return super.is(NULL());
 		}
-		
+
+		@Override
+		public <S extends E> Condition<S> notNull()
+		{
+			// null is encoded as the NULL() sentinel, so "not null" is exactly its negation.
+			return new Condition.Not<>(this.isNull());
+		}
+
 		protected <S extends E> Condition<S> isValue(final V other)
 		{
 			return super.is(this.indexValue(other, null));
 		}
-		
+
 	}
-	
+
 }

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/HashingCompositeIndexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/HashingCompositeIndexer.java
@@ -115,19 +115,40 @@ public interface HashingCompositeIndexer<E> extends CompositeIndexer<E, Object[]
 		}
 		
 		@Override
+		public <S extends E> Condition<S> is(final Object[] key)
+		{
+			// generic/raw callers may pass literal null for the composite key; route it to the
+			// sentinel-based null query instead of building a null-sample predicate (which NPEs).
+			return key == null ? this.isNull() : super.is(key);
+		}
+
+		@Override
+		public <S extends E> Condition<S> not(final Object[] key)
+		{
+			return new Condition.Not<>(this.is(key));
+		}
+
+		@Override
 		public <S extends E> Condition<S> isNull()
 		{
 			return this.is(NULL());
 		}
-		
+
+		@Override
+		public <S extends E> Condition<S> notNull()
+		{
+			// null is encoded as the NULL() sentinel, so "not null" is exactly its negation.
+			return new Condition.Not<>(this.isNull());
+		}
+
 		protected <S extends E> Condition<S> isValue(final V other)
 		{
 			return super.is(this.indexValue(other, null));
 		}
-		
+
 	}
-	
-	
+
+
 	public abstract class AbstractSingleValueVariableSize<E, V> extends Abstract<E>
 	{
 		protected AbstractSingleValueVariableSize()
@@ -167,16 +188,37 @@ public interface HashingCompositeIndexer<E> extends CompositeIndexer<E, Object[]
 		}
 		
 		@Override
+		public <S extends E> Condition<S> is(final Object[] key)
+		{
+			// generic/raw callers may pass literal null for the composite key; route it to the
+			// sentinel-based null query instead of building a null-sample predicate (which NPEs).
+			return key == null ? this.isNull() : super.is(key);
+		}
+
+		@Override
+		public <S extends E> Condition<S> not(final Object[] key)
+		{
+			return new Condition.Not<>(this.is(key));
+		}
+
+		@Override
 		public <S extends E> Condition<S> isNull()
 		{
 			return super.is(NULL());
 		}
-		
+
+		@Override
+		public <S extends E> Condition<S> notNull()
+		{
+			// null is encoded as the NULL() sentinel, so "not null" is exactly its negation.
+			return new Condition.Not<>(this.isNull());
+		}
+
 		protected <S extends E> Condition<S> isValue(final V other)
 		{
 			return super.is(this.indexValue(other, null));
 		}
-		
+
 	}
-	
+
 }

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerTemporal.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerTemporal.java
@@ -31,11 +31,65 @@ public interface IndexerTemporal<E, K, T extends Temporal> extends Indexer<E, K>
 	/**
 	 * Creates a condition which checks if the key is equal to a given point in time.
 	 *
-	 * @param other the value to check against, not null
+	 * @param other the value to check against, may be null to match entities with a null key
 	 * @return a new condition
+	 *
+	 * @implNote Temporal indexers are composite indexers whose key type is {@code Object[]}. Invoking
+	 * the generic {@link IndexIdentifier#is(Object)} through a raw or {@code Object}-typed
+	 * {@link IndexIdentifier} reference passes the logical value where an {@code Object[]} composite
+	 * key is expected and throws {@link ClassCastException} in the synthetic bridge method. Always use
+	 * this typed {@code is(T)} overload (and the typed {@link #not(Temporal)} / {@link #in(Temporal...)}
+	 * / {@link #notIn(Temporal...)} / {@link IndexIdentifier#isNull()} / {@link IndexIdentifier#notNull()}
+	 * methods) rather than the generic {@code Object[]}-keyed API.
 	 */
 	public <S extends E> Condition<S> is(T other);
-	
+
+	/**
+	 * Creates a condition which checks if the key is not equal to a given point in time.
+	 * Entities with a null key are included (a null key is "not equal" to any concrete value).
+	 *
+	 * @param other the value to check against, may be null (equivalent to {@link IndexIdentifier#notNull()})
+	 * @return a new negated condition
+	 */
+	public default <S extends E> Condition<S> not(final T other)
+	{
+		return new Condition.Not<>(this.is(other));
+	}
+
+	/**
+	 * Creates a condition which checks if the key is equal to any of the given points in time.
+	 *
+	 * @param others the values to check against, not null and not empty
+	 * @return a new condition representing the containment check
+	 */
+	@SuppressWarnings("unchecked")
+	public default <S extends E> Condition<S> in(final T... others)
+	{
+		if(others == null || others.length == 0)
+		{
+			throw new IllegalArgumentException("others must not be null or empty");
+		}
+		Condition<S> result = this.is(others[0]);
+		for(int i = 1; i < others.length; i++)
+		{
+			result = result.or(this.is(others[i]));
+		}
+		return others.length > 1 ? result.complete() : result;
+	}
+
+	/**
+	 * Creates a condition which checks if the key is not equal to any of the given points in time.
+	 * Entities with a null key are included unless {@code null} is among the given values.
+	 *
+	 * @param others the values to check against, not null and not empty
+	 * @return a new negated condition representing the containment check
+	 */
+	@SuppressWarnings("unchecked")
+	public default <S extends E> Condition<S> notIn(final T... others)
+	{
+		return new Condition.Not<>(this.in(others));
+	}
+
 	/**
 	 * Creates a condition which checks if the key is before a given point in time.
 	 *

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerTemporal.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexerTemporal.java
@@ -46,9 +46,13 @@ public interface IndexerTemporal<E, K, T extends Temporal> extends Indexer<E, K>
 
 	/**
 	 * Creates a condition which checks if the key is not equal to a given point in time.
-	 * Entities with a null key are included (a null key is "not equal" to any concrete value).
+	 * <p>
+	 * For a non-null {@code other}, entities with a null key <b>are</b> included (a null key is "not
+	 * equal" to any concrete value). When {@code other} is null this is instead equivalent to
+	 * {@link IndexIdentifier#notNull()}, i.e. it matches all non-null keys and <b>excludes</b>
+	 * null-key entities.
 	 *
-	 * @param other the value to check against, may be null (equivalent to {@link IndexIdentifier#notNull()})
+	 * @param other the value to check against; may be null (then equivalent to {@link IndexIdentifier#notNull()})
 	 * @return a new negated condition
 	 */
 	public default <S extends E> Condition<S> not(final T other)
@@ -58,8 +62,12 @@ public interface IndexerTemporal<E, K, T extends Temporal> extends Indexer<E, K>
 
 	/**
 	 * Creates a condition which checks if the key is equal to any of the given points in time.
+	 * <p>
+	 * A null element is permitted and matches entities with a null key (it delegates to
+	 * {@link #is(Temporal)}, which treats null as {@link IndexIdentifier#isNull()}).
 	 *
-	 * @param others the values to check against, not null and not empty
+	 * @param others the values to check against; the array itself must not be null or empty, but
+	 *               individual elements may be null (to also match entities with a null key)
 	 * @return a new condition representing the containment check
 	 */
 	@SuppressWarnings("unchecked")
@@ -79,9 +87,14 @@ public interface IndexerTemporal<E, K, T extends Temporal> extends Indexer<E, K>
 
 	/**
 	 * Creates a condition which checks if the key is not equal to any of the given points in time.
-	 * Entities with a null key are included unless {@code null} is among the given values.
+	 * <p>
+	 * Entities with a null key are included <b>unless</b> {@code null} is among the given values:
+	 * a null element makes {@link #in(Temporal...)} match null keys, so negating it then excludes
+	 * them.
 	 *
-	 * @param others the values to check against, not null and not empty
+	 * @param others the values to check against; the array itself must not be null or empty, but
+	 *               individual elements may be null (a null element excludes null-key entities from
+	 *               the result)
 	 * @return a new negated condition representing the containment check
 	 */
 	@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/NumberQueryable.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/NumberQueryable.java
@@ -60,6 +60,13 @@ public interface NumberQueryable<E, K extends Number>
 	 * @param <S> the type of entity this condition applies to
 	 * @param keys the array of keys to compare to
 	 * @return a new condition representing the containment check
+	 *
+	 * @implNote When an explicitly built array is passed (rather than individual varargs
+	 * elements), its runtime component type must match the numeric key type {@code K}, e.g.
+	 * {@code new Integer[]{2016, 2018}} — <b>not</b> {@code new Object[]{2016, 2018}}. This typed
+	 * override generates a {@code checkcast} bridge method that casts the whole array to {@code K[]};
+	 * an {@code Object[]} (even one holding only well-typed elements) throws
+	 * {@link ClassCastException} in that bridge before any library code runs.
 	 */
 	@SuppressWarnings("unchecked")
 	public <S extends E> Condition<S> in(K... keys);
@@ -70,6 +77,10 @@ public interface NumberQueryable<E, K extends Number>
 	 * @param <S> the type of entity this condition applies to
 	 * @param keys the array of keys to compare to
 	 * @return a new condition representing the negated containment check
+	 *
+	 * @implNote See {@link #in(Number...)} — an explicitly built {@code keys} array must have runtime
+	 * component type {@code K} ({@code new Integer[]{...}}, not {@code new Object[]{...}}), otherwise
+	 * the {@code checkcast} bridge throws {@link ClassCastException}.
 	 */
 	@SuppressWarnings("unchecked")
 	public <S extends E> Condition<S> notIn(K... keys);

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeIndexerNullConditionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeIndexerNullConditionTest.java
@@ -1,0 +1,204 @@
+package org.eclipse.store.gigamap.indexer;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.BinaryIndexerUUID;
+import org.eclipse.store.gigamap.types.ByteIndexerLong;
+import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexIdentifier;
+import org.eclipse.store.gigamap.types.IndexerLocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression coverage for broken generic condition methods on GigaMap composite indexers.
+ * <p>
+ * Composite indexers encode a {@code null} logical value as a dedicated sentinel array, not literal
+ * {@code null}. Before the fix, {@code notNull()} (and the generic {@code is((K)null)} /
+ * {@code not((K)null)} paths) lowered to a predicate backed by a {@code null} sample array, which
+ * threw {@link NullPointerException} at query time - and only in some query shapes (e.g. inside
+ * {@code And}/{@code Or}). This test pins down that {@code isNull()}/{@code notNull()} work
+ * standalone <b>and</b> combined, that the generic {@code Object[]}/{@code long[]}-keyed
+ * {@code is}/{@code not} with {@code null} behave as the null query, and that the temporal typed
+ * {@code not}/{@code in}/{@code notIn} additions work.
+ * <p>
+ * Coverage spans one representative per composite family: hashing fixed-size numeric
+ * ({@link ByteIndexerLong}), hashing fixed-size temporal ({@link IndexerLocalDate}), binary
+ * variable-size ({@link BinaryIndexerString}), and binary fixed-size ({@link BinaryIndexerUUID}).
+ */
+public class CompositeIndexerNullConditionTest
+{
+	record Rec(long id, Long num, String str, LocalDate date, UUID uuid)
+	{
+	}
+
+	static final LocalDate D1 = LocalDate.of(2025, 3, 1);
+	static final LocalDate D2 = LocalDate.of(2025, 3, 2);
+	static final UUID      U1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+	static final UUID      U2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+	// hashing composite (byte-decomposed numeric)
+	static final ByteIndexerLong<Rec> NUM = new ByteIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Rec r)
+		{
+			return r.num();
+		}
+	};
+
+	// binary composite, variable size
+	static final BinaryIndexerString<Rec> STR = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Rec r)
+		{
+			return r.str();
+		}
+	};
+
+	// hashing composite, temporal
+	static final IndexerLocalDate<Rec> DATE = new IndexerLocalDate.Abstract<>()
+	{
+		@Override
+		protected LocalDate getLocalDate(final Rec r)
+		{
+			return r.date();
+		}
+	};
+
+	// binary composite, fixed size
+	static final BinaryIndexerUUID<Rec> UID = new BinaryIndexerUUID.Abstract<>()
+	{
+		@Override
+		protected UUID getUUID(final Rec r)
+		{
+			return r.uuid();
+		}
+	};
+
+	private GigaMap<Rec> map;
+
+	@BeforeEach
+	void setUp()
+	{
+		map = GigaMap.<Rec>Builder()
+			.withBitmapIndex(NUM)
+			.withBitmapIndex(STR)
+			.withBitmapIndex(DATE)
+			.withBitmapIndex(UID)
+			.build();
+
+		//              id  num    str    date  uuid
+		map.add(new Rec(0L, null,  null,  null, null));
+		map.add(new Rec(1L, null,  "x",   null, U1));
+		map.add(new Rec(2L, 10L,   "x",   D1,   U1));
+		map.add(new Rec(3L, 20L,   "y",   D2,   U2));
+		map.add(new Rec(4L, 20L,   null,  null, null));
+
+		assertEquals(5, map.size());
+	}
+
+	private int count(final Condition<Rec> condition)
+	{
+		return map.query(condition).toList().size();
+	}
+
+	// ---- hashing composite numeric (ByteIndexerLong) --------------------------------------------
+
+	@Test
+	void byteLong_nullChecks()
+	{
+		assertEquals(2, count(NUM.isNull()));   // e0, e1
+		assertEquals(3, count(NUM.notNull()));  // e2, e3, e4  (previously NPE'd)
+		assertEquals(2, count(NUM.is(20L)));    // e3, e4
+		assertEquals(3, count(NUM.not(20L)));   // e0, e1, e2  (null included)
+	}
+
+	@Test
+	void byteLong_nullChecksCombined()
+	{
+		// notNull()/isNull() nested inside And/Or previously NPE'd depending on shape
+		assertEquals(1, count(NUM.notNull().and(STR.is("x"))));   // e2
+		assertEquals(2, count(NUM.isNull().and(DATE.isNull())));  // e0, e1
+		assertEquals(4, count(NUM.notNull().or(STR.isNull())));   // e2,e3,e4 + e0,e4
+	}
+
+	@Test
+	void byteLong_genericNullPath()
+	{
+		// K == Object[] for hashing composites; generic is((K)null)/not((K)null) must behave as the null query
+		final IndexIdentifier<Rec, Object[]> generic = NUM;
+		assertEquals(2, count(generic.is((Object[])null)));   // == isNull()
+		assertEquals(3, count(generic.not((Object[])null)));  // == notNull()
+	}
+
+	// ---- binary composite variable-size (BinaryIndexerString) -----------------------------------
+
+	@Test
+	void binaryString_nullChecks()
+	{
+		assertEquals(2, count(STR.isNull()));   // e0, e4
+		assertEquals(3, count(STR.notNull()));  // e1, e2, e3
+		assertEquals(2, count(STR.is("x")));    // e1, e2
+		assertEquals(1, count(STR.notNull().and(NUM.isNull()))); // e1
+	}
+
+	// ---- binary composite fixed-size (BinaryIndexerUUID) ----------------------------------------
+
+	@Test
+	void binaryUuid_nullChecks()
+	{
+		assertEquals(2, count(UID.isNull()));   // e0, e4
+		assertEquals(3, count(UID.notNull()));  // e1, e2, e3  (previously NPE'd)
+		assertEquals(2, count(UID.is(U1)));     // e1, e2
+		assertEquals(1, count(UID.notNull().and(NUM.is(10L)))); // e2
+	}
+
+	@Test
+	void binaryUuid_genericNullPath()
+	{
+		final IndexIdentifier<Rec, long[]> generic = UID;
+		assertEquals(2, count(generic.is((long[])null)));
+		assertEquals(3, count(generic.not((long[])null)));
+	}
+
+	// ---- hashing composite temporal (IndexerLocalDate) ------------------------------------------
+
+	@Test
+	void localDate_nullChecks()
+	{
+		assertEquals(3, count(DATE.isNull()));   // e0, e1, e4
+		assertEquals(2, count(DATE.notNull()));  // e2, e3  (previously NPE'd)
+		assertEquals(2, count(DATE.notNull().and(NUM.notNull()))); // e2, e3
+	}
+
+	@Test
+	void localDate_typedNegationAndIn()
+	{
+		assertEquals(1, count(DATE.is(D1)));               // e2
+		assertEquals(4, count(DATE.not(D1)));              // Not(is) -> e0,e1,e3,e4 (nulls included)
+		assertEquals(2, count(DATE.in(D1, D2)));           // e2, e3
+		assertEquals(3, count(DATE.notIn(D1, D2)));        // e0, e1, e4
+		assertEquals(2, count(DATE.not((LocalDate)null))); // == notNull() -> e2, e3
+	}
+}


### PR DESCRIPTION
## Problem

The IndexIdentifier default condition methods (is(K), isNull(), notNull(), not(K), in(K...), notIn(K...)) assume the key type K is the logical value and that null is a valid key. That assumption is false for composite indexers, whose key type is Object[] (HashingCompositeIndexer) or long[] (BinaryCompositeIndexer) and which encode a null logical value as a dedicated sentinel array, not literal null. Because the interface accepts these calls without complaint, the failures only surface at query time.

Concretely, notNull() lowered to Not(is((K)null)), which built a sample-based CompositePredicate with a null sample array and threw NullPointerException during evaluation (AbstractCompositeBitmapIndex.search dereferencing the null sample). The context-dependence was the dangerous part: standalone isNull() happened to work, but notNull() - and null checks nested inside And/Or/Not - blew up. This affected the entire composite family: the ByteIndexer* numeric indexers, ByteIndexerInstant, BinaryIndexerString, BinaryIndexerUUID, and the temporal indexers (IndexerLocalDate/Time/DateTime, IndexerInstant, IndexerZonedDateTime, IndexerYearMonth).

A related gap: IndexerTemporal offered no typed not/in/notIn, so null-inclusive negation on temporal fields could not be expressed at all.

## Fix

Override notNull() as Not(isNull()) and make the generic is((K)null)/not((K)null) paths null-safe, placed in the four AbstractSingleValueFixedSize/AbstractSingleValueVariableSize base classes of HashingCompositeIndexer and BinaryCompositeIndexer - the same classes that already define the sentinel-based isNull() via NULL(). Non-null keys keep flowing through the existing sample-based super.is(...) path unchanged. This covers every concrete composite indexer through inheritance and deliberately leaves SpatialIndexer (which extends the Abstract base directly and relies on null-element skipping) untouched.

Add typed not(T)/in(T...)/notIn(T...) defaults to IndexerTemporal, implemented in terms of the existing typed is(T) (which already routes null to isNull()), so temporal negation and membership queries work and honor nulls.

## Known limitations (documented, not fixable from source)

Two ClassCastExceptions remain and are now called out in javadoc rather than silently surprising callers: invoking the generic Object-typed is(...) on a temporal indexer through a raw/Object-typed IndexIdentifier reference, and passing an Object[] to the type-narrowed in/notIn varargs (for example new Object[]{2016, 2018} where new Integer[]{2016, 2018} is required). Both are thrown by compiler-generated synthetic bridge checkcasts before any library code runs, so they cannot be intercepted from a method body. The javadoc steers callers to the typed API and to correctly-typed vararg arrays.

## Tests

Added CompositeIndexerNullConditionTest covering isNull()/notNull() standalone and combined (and/or), the generic is/not(null) path via an IndexIdentifier-typed reference, and the temporal typed not/in/notIn - one representative per composite family (ByteIndexerLong, BinaryIndexerString, BinaryIndexerUUID, IndexerLocalDate). The full gigamap module test suite passes (1055 tests, 0 failures), including the existing SpatialIndexerTest and all temporal, byte and binary indexer tests, confirming no regressions.
