### PR TITLE
Pin apply()/update()-mutated GigaMap segment to close silent lost-update window

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2050,6 +2050,14 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			{
 				final R result = this.indices.internalUpdateIndices(entityId, current, logic, this.constraints.custom());
 
+				// Mark the owning level1 segment as changed (like internalSet/remove do). This pins the
+				// segment via its usage marker so neither release() nor the LazyReferenceManager can evict
+				// it before the mutation is stored, keeping the mutated entity strongly reachable. Without
+				// this the entity's only strong root is the segment; an eviction + GC would let the store
+				// below silently skip the (then-dead) WeakReference while the index deltas commit anyway,
+				// permanently diverging the persisted indices from the entity.
+				this.markEntitySegmentChanged(entityId);
+
 				// The entity was mutated in-place. Track it so that store() can explicitly
 				// re-persist the entity object (the storer won't re-persist it automatically
 				// since the object reference/identity hasn't changed).
@@ -2073,6 +2081,18 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				this.internalRemove(entityId);
 				throw e;
 			}
+		}
+
+		private void markEntitySegmentChanged(final long entityId)
+		{
+			final GigaLevel3<E>       level3      = this.level3();
+			final int                 level3Index = this.toLevel3Index(entityId);
+			final Lazy<GigaLevel2<E>> lvl2Lazy    = level3.segments[level3Index];
+			final GigaLevel2<E>       level2      = lvl2Lazy.get();
+			final int                 level2Index = this.toLevel2Index(entityId);
+
+			level3.markChanged(level3Index);
+			level2.markChanged(level2Index);
 		}
 
 		private void ensureMutability()
@@ -2343,6 +2363,10 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 			// Entities mutated in-place via apply()/update() need to be explicitly re-stored
 			// since the storer won't pick them up automatically (same object reference/identity).
+			// Do NOT clear pendingEntityStores here: this runs before commit success, and clearing it
+			// eagerly (unlike the state-change markers, which are cleared in onAfterCommit) would drop
+			// the mutated entities on a failed commit + retry store(), while the re-stored segments and
+			// index deltas commit anyway. The list is cleared in onAfterCommit once the commit succeeds.
 			if(this.pendingEntityStores != null && !this.pendingEntityStores.isEmpty())
 			{
 				for(final WeakReference<E> ref : this.pendingEntityStores)
@@ -2353,7 +2377,6 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 						storer.store(entity);
 					}
 				}
-				this.pendingEntityStores.clear();
 			}
 
 			// must clear state change markers as soon as there is at least one either "changed" or "new" marker. So almost always.

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/ApplyReleaseLostUpdateTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/ApplyReleaseLostUpdateTest.java
@@ -1,0 +1,158 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.ref.WeakReference;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for the {@code apply()}/{@code update()} lost-update (internal issue #90): a
+ * mutated-in-place entity was tracked for the next {@code store()} only via a {@code WeakReference}
+ * in {@code pendingEntityStores}, <b>without pinning the level1 segment that owns it</b>. If the
+ * segment was evicted ({@code release()} or {@code LazyReferenceManager} timeout) and the JVM GC
+ * collected the mutated entity, {@code store()} silently skipped the dead reference — while the
+ * (non-lazy) bitmap-index deltas committed anyway, leaving the persisted index and entity
+ * permanently divergent on disk, with no exception ever thrown.
+ * <p>
+ * Mechanism (before the fix):
+ * <ul>
+ *   <li>{@code internalApply} mutated the entity in place and set the index change flags, but never
+ *       called {@code markChanged} on the owning segment — so, unlike add/set/remove, the segment
+ *       was not usage-pinned.</li>
+ *   <li>{@code release()} (or LRM timeout) evicted the unpinned, already-stored segment; the entity's
+ *       only strong root was gone and GC collected it.</li>
+ *   <li>{@code internalRegisterChangeStores} then found {@code WeakReference.get() == null} and
+ *       silently skipped the entity store, while the index deltas committed.</li>
+ * </ul>
+ * The fix marks the owning segment changed in {@code internalApply} (pinning it via
+ * {@code Lazy.markUsedFor} exactly as the other mutation paths do), so the segment — and thus the
+ * mutated entity — survives eviction and GC until it is stored. Everything here uses only public
+ * GigaMap API.
+ *
+ * @see DirtySegmentEvictionLostUpdateTest the analogous remove-path regression (review finding GM-B)
+ */
+public class ApplyReleaseLostUpdateTest
+{
+	static final IndexerString<Item> VALUE_INDEXER = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.value;
+		}
+	};
+
+	@Test
+	void applyMutationSurvivesReleaseAndGcBeforeStore(@TempDir final Path dir)
+	{
+		final long id;
+
+		// ---- Session 1: create, store, apply-mutate, release, GC, store ----
+		{
+			final GigaMap<Item> map = GigaMap.New();
+			map.index().bitmap().add(VALUE_INDEXER);
+
+			id = map.add(new Item("OLD"));
+
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+			{
+				storage.storeRoot(); // entity + index persisted, change flags cleared
+
+				// In-place mutation via the public apply API.
+				map.apply(id, e ->
+				{
+					e.value = "NEW";
+					return null;
+				});
+
+				// Probe the mutated entity without keeping a strong reference to it, so the only thing
+				// that can keep it alive is the (post-fix) usage-pinned segment.
+				final WeakReference<Item> probe = new WeakReference<>(map.get(id));
+
+				// release() promises unstored changes are retained (GigaMap.java javadoc). Pre-fix it
+				// evicted the unpinned dirty segment.
+				map.release();
+
+				// Try hard to collect the mutated entity. Post-fix the pinned segment keeps it alive
+				// (probe stays non-null); pre-fix it becomes collectible. Either way the post-restart
+				// invariant below must hold, so a non-collecting GC does not make this test flaky.
+				forceGcUntilCollected(probe, 5_000);
+
+				map.store(); // pre-fix: silently skipped the dead WeakReference; index delta committed anyway
+			}
+		}
+
+		// ---- Session 2: restart and verify index and entity agree ----
+		{
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+			{
+				@SuppressWarnings("unchecked")
+				final GigaMap<Item> loaded = (GigaMap<Item>)storage.root();
+
+				final Item item = loaded.get(id);
+
+				// The committed index deltas say "NEW"; the entity must too (else: lost update + divergence).
+				assertEquals("NEW", item.value, "apply() mutation must be persisted by store()");
+				assertEquals(1, loaded.query(VALUE_INDEXER.is("NEW")).count(),
+					"index must find the entity under its NEW value");
+				assertEquals(0, loaded.query(VALUE_INDEXER.is("OLD")).count(),
+					"index must no longer find the entity under its OLD value");
+			}
+		}
+	}
+
+	private static void forceGcUntilCollected(final WeakReference<?> ref, final long timeoutMs)
+	{
+		final long deadline = System.currentTimeMillis() + timeoutMs;
+		while(ref.get() != null && System.currentTimeMillis() < deadline)
+		{
+			System.gc();
+			try
+			{
+				Thread.sleep(50);
+			}
+			catch(final InterruptedException e)
+			{
+				Thread.currentThread().interrupt();
+				return;
+			}
+		}
+	}
+
+	static final class Item
+	{
+		String value; // intentionally mutable: apply() mutates in place
+
+		Item(final String value)
+		{
+			this.value = value;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Item[" + this.value + "]";
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/ApplyReleaseLostUpdateTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/ApplyReleaseLostUpdateTest.java
@@ -94,10 +94,11 @@ public class ApplyReleaseLostUpdateTest
 				// evicted the unpinned dirty segment.
 				map.release();
 
-				// Try hard to collect the mutated entity. Post-fix the pinned segment keeps it alive
-				// (probe stays non-null); pre-fix it becomes collectible. Either way the post-restart
-				// invariant below must hold, so a non-collecting GC does not make this test flaky.
-				forceGcUntilCollected(probe, 5_000);
+				// Give the pre-fix path a chance to collect the now-unreferenced mutated entity. Post-fix
+				// the pinned segment keeps it alive, so this returns as soon as its short budget is spent
+				// (it must not busy-wait for the full timeout on the fixed code). Either way the
+				// post-restart invariant below must hold, so a non-collecting GC does not make this flaky.
+				forceGcUntilCollected(probe, 10, 10);
 
 				map.store(); // pre-fix: silently skipped the dead WeakReference; index delta committed anyway
 			}
@@ -122,15 +123,17 @@ public class ApplyReleaseLostUpdateTest
 		}
 	}
 
-	private static void forceGcUntilCollected(final WeakReference<?> ref, final long timeoutMs)
+	private static void forceGcUntilCollected(final WeakReference<?> ref, final int maxCycles, final long sleepMs)
 	{
-		final long deadline = System.currentTimeMillis() + timeoutMs;
-		while(ref.get() != null && System.currentTimeMillis() < deadline)
+		// A single unreferenced small object is collected within the first cycle or two; a small bounded
+		// budget therefore reproduces the pre-fix collection without penalizing the fixed (pinned) path,
+		// which can never collect and would otherwise busy-wait for the whole budget.
+		for(int i = 0; i < maxCycles && ref.get() != null; i++)
 		{
 			System.gc();
 			try
 			{
-				Thread.sleep(50);
+				Thread.sleep(sleepMs);
 			}
 			catch(final InterruptedException e)
 			{


### PR DESCRIPTION
## Problem

`GigaMap.apply()`/`update()` was the only mutation path that never pinned the level1 segment owning the mutated entity. It mutated the entity in place, set the (non-lazy) index change flags, and tracked the entity for the next `store()` only via a `WeakReference` in `pendingEntityStores`. Because the entity's sole strong root was that segment, once `release()` or the default `LazyReferenceManager` evicted the already-stored, unpinned segment and the JVM GC collected the entity, `store()` silently skipped the dead `WeakReference` while the bitmap-index deltas committed anyway. On restart the entity held its OLD field values while the index pointed at the NEW key: `query(is(NEW))` returned an entity whose field was OLD, and `query(is(OLD))` was empty. No exception was ever thrown. This is triggered by documented API usage — `release()` explicitly promises unstored changes are retained — or by the default-enabled `LazyReferenceManager`.

A second defect in the same mechanism: `pendingEntityStores` was cleared eagerly in `internalRegisterChangeStores`, before commit success, unlike the state-change markers cleared in `onAfterCommit`. A failed commit followed by a retry `store()` re-stored the segments and index deltas but silently dropped the apply-mutated entities.

## Fix

1. `internalApply` now marks the owning level1 segment changed via a new `markEntitySegmentChanged(entityId)` helper, mirroring `internalSet` and the remove path. This usage-pins the segment (`Lazy.markUsedFor`), so both `release()` (the `!isUsed()` guard) and the `LazyReferenceManager` (the `Lazy.Default.clear(ClearingEvaluator)` guard) retain it until it is stored, keeping the mutated entity reachable. The explicit entity store via `pendingEntityStores` is kept, since the storer will not re-persist an entity of unchanged identity on its own.
2. The eager `pendingEntityStores.clear()` in `internalRegisterChangeStores` is removed; the list is now cleared only in `onAfterCommit`, symmetric with the state-change markers, so a commit retry re-stores the entities instead of dropping them. Re-storing the same entity across a retry is idempotent (the storer dedups by OID).

This is the same class of bug already fixed for the `remove()` path (review finding GM-B, `DirtySegmentEvictionLostUpdateTest`); `apply()`/`update()` was the remaining unpinned mutation path.

## Testing

- Adds `ApplyReleaseLostUpdateTest` (public-API only): apply-mutate, `release()`, GC, `store()`, restart, then assert the entity and index agree. It fails deterministically on the unfixed source (`expected: <NEW> but was: <OLD>`) and passes with the fix.
- Related suites pass: `DirtySegmentEvictionLostUpdateTest`, `ApplyTest`, `ApplyByIdTest`, `AllTypesApplyTest`, `AllTypesUpdateTest`, `CrudTest`, `GigaMapStoreTests`, `GigaMapTests`.
- Full gigamap module suite green: 1048 tests, 0 failures.