### PR TITLE
Harden GigaMap consistency against exceptions from user code (indexers, update logic)

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -15,7 +15,6 @@ package org.eclipse.store.gigamap.types;
  */
 
 import org.eclipse.store.gigamap.exceptions.BitmapIndicesException;
-import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
 import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationExceptionBitmap;
 import org.eclipse.serializer.chars.VarString;
 import org.eclipse.serializer.collections.BulkList;
@@ -805,41 +804,92 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public final void internalAdd(final long entityId, final E entity)
 		{
-			for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+			// mark in any case: a mid-loop throw from an indexer leaves already updated indices behind.
+			try
 			{
-				index.internalAdd(entityId, entity);
+				for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+				{
+					index.internalAdd(entityId, entity);
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
 		}
-		
+
 		@Override
 		public final void internalAddAll(final long firstEntityId, final Iterable<? extends E> entities)
 		{
-			for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+			try
 			{
-				index.internalAddAll(firstEntityId, entities);
+				for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+				{
+					index.internalAddAll(firstEntityId, entities);
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
 		}
-		
+
 		@Override
 		public final void internalAddAll(final long firstEntityId, final E[] entities)
 		{
-			for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+			try
 			{
-				index.internalAddAll(firstEntityId, entities);
+				for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+				{
+					index.internalAddAll(firstEntityId, entities);
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
 		}
-		
+
 		@Override
 		public final void internalRemove(final long entityId, final E entity)
 		{
-			for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+			/*
+			 * Best-effort removal: a throwing indexer must not prevent the remaining indices from
+			 * being cleaned up, otherwise the entity (already removed from the map's storage by the
+			 * calling context) would leave orphaned entries in perfectly healthy indices. The first
+			 * exception is rethrown after all indices had their chance, subsequent failures are
+			 * attached as suppressed exceptions.
+			 */
+			RuntimeException first = null;
+			try
 			{
-				index.internalRemove(entityId, entity);
+				for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
+				{
+					try
+					{
+						index.internalRemove(entityId, entity);
+					}
+					catch(final RuntimeException e)
+					{
+						if(first == null)
+						{
+							first = e;
+						}
+						else
+						{
+							first.addSuppressed(e);
+						}
+					}
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
+			if(first != null)
+			{
+				throw first;
+			}
 		}
 		
 		@Override
@@ -1155,33 +1205,39 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			final CustomConstraints<? super E> customConstraints
 		)
 		{
+			this.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints, false);
+		}
+
+		@Override
+		public final void internalUpdateIndices(
+			final long                         entityId         ,
+			final E                            replacedEntity   ,
+			final E                            entity           ,
+			final CustomConstraints<? super E> customConstraints,
+			final boolean                      removeOnFailure
+		)
+		{
 			if(this.bitmapIndices.isEmpty())
 			{
 				// no-op
 				return;
 			}
 
+			/*
+			 * Phase 1: derive the new change handlers and run all checks. This is where all user code
+			 * (indexers, key equality, constraints) runs; no index state has been mutated, yet, since
+			 * handler derivation defers entry creation to changeInIndex (see NewKeyChangeChandler).
+			 */
 			try
 			{
 				// Derive state handlers for the new, potentially changed state
 				this.createChangeHandlers(this.cachedNewChangeHandlers, entity);
-				
+
 				if(customConstraints != null)
 				{
-					try
-					{
-						customConstraints.check(entityId, replacedEntity, entity);
-					}
-					catch(final ConstraintViolationException e)
-					{
-						for(final ChangeHandler cachedPrevChangeHandler : this.cachedPrevChangeHandlers)
-						{
-							cachedPrevChangeHandler.removeFromIndex(entityId);
-						}
-						throw e;
-					}
+					customConstraints.check(entityId, replacedEntity, entity);
 				}
-				
+
 				// Evaluate changes for each index
 				for(int i = 0; i < this.cachedPrevChangeHandlers.length; i++)
 				{
@@ -1191,27 +1247,47 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 						this.cachedNewChangeHandlers[i] = null;
 						continue;
 					}
-					try
+					if(this.cachedIsUniqueIndex[i])
 					{
-						if(this.cachedIsUniqueIndex[i])
+						if(this.cachedIndices[i].internalContains(entity))
 						{
-							if(this.cachedIndices[i].internalContains(entity))
-							{
-								throw new UniqueConstraintViolationExceptionBitmap(entityId, replacedEntity, entity, this.cachedIndices[i]);
-							}
+							throw new UniqueConstraintViolationExceptionBitmap(entityId, replacedEntity, entity, this.cachedIndices[i]);
 						}
 					}
-					catch(final ConstraintViolationException e)
+				}
+			}
+			catch(final RuntimeException e)
+			{
+				if(removeOnFailure)
+				{
+					/*
+					 * The calling context removes the in-place mutated entity from the map on failure,
+					 * so this entity's previous state must be de-indexed as well. The cached prev
+					 * handlers accomplish that without re-running any user code.
+					 */
+					try
 					{
 						for(final ChangeHandler cachedPrevChangeHandler : this.cachedPrevChangeHandlers)
 						{
 							cachedPrevChangeHandler.removeFromIndex(entityId);
 						}
-						throw e;
+					}
+					catch(final RuntimeException suppressed)
+					{
+						e.addSuppressed(suppressed);
+					}
+					finally
+					{
+						this.markStateChangeChildren();
 					}
 				}
-				
-				// Update Indices for all actual changes
+				// without removeOnFailure nothing was mutated, so no state change marking, either.
+				throw e;
+			}
+
+			// Phase 2: update indices for all actual changes. Runs no more user code apart from key hashing.
+			try
+			{
 				for(int i = 0; i < this.cachedNewChangeHandlers.length; i++)
 				{
 					// Skip index positions for unchanged values

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -415,20 +415,22 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 					 * The logic threw: the entity's state is unreliable and the calling context will
 					 * remove the entity. The indices are still updated from the entity's current state
 					 * so that the subsequent removal, which re-derives the keys from that same state,
-					 * can locate all entries. A group whose update fails de-indexes its previous
-					 * entries via the prepared change handlers instead (removeOnFailure). Custom
-					 * constraints are not checked; the entity is doomed either way.
+					 * can locate all entries. This runs best-effort per group so every group gets its
+					 * chance to align; a group whose own update fails de-indexes its previous entries
+					 * via the prepared change handlers instead (removeOnFailure) and the failure is
+					 * attached as a suppressed exception. Custom constraints are not checked; the
+					 * entity is doomed either way.
 					 */
-					try
+					for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
 					{
-						for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+						try
 						{
 							indexGroup.internalUpdateIndices(entityId, entity, entity, null, true);
 						}
-					}
-					catch(final RuntimeException suppressed)
-					{
-						e.addSuppressed(suppressed);
+						catch(final RuntimeException suppressed)
+						{
+							e.addSuppressed(suppressed);
+						}
 					}
 					throw e;
 				}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -212,38 +212,88 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 		protected final void internalAdd(final long entityId, final E entity)
 		{
 			notNull(entity);
-			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			// mark in any case: a mid-loop throw from an indexer leaves already updated groups behind.
+			try
 			{
-				indexGroup.internalAdd(entityId, entity);
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					indexGroup.internalAdd(entityId, entity);
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
 		}
-		
+
 		protected final void internalAddAll(final long firstEntityId, final Iterable<? extends E> entities)
 		{
-			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			try
 			{
-				indexGroup.internalAddAll(firstEntityId, entities);
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					indexGroup.internalAddAll(firstEntityId, entities);
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
 		}
-		
+
 		protected final void internalAddAll(final long firstEntityId, final E[] entities)
 		{
-			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			try
 			{
-				indexGroup.internalAddAll(firstEntityId, entities);
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					indexGroup.internalAddAll(firstEntityId, entities);
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
 		}
-		
+
 		protected final void internalRemove(final long entityId, final E entity)
 		{
-			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			/*
+			 * Best-effort removal across all index groups, mirroring BitmapIndices#internalRemove:
+			 * a throwing indexer in one group must not prevent the other groups from being cleaned
+			 * up. The first exception is rethrown at the end, subsequent failures are attached as
+			 * suppressed exceptions.
+			 */
+			RuntimeException first = null;
+			try
 			{
-				indexGroup.internalRemove(entityId, entity);
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					try
+					{
+						indexGroup.internalRemove(entityId, entity);
+					}
+					catch(final RuntimeException e)
+					{
+						if(first == null)
+						{
+							first = e;
+						}
+						else
+						{
+							first.addSuppressed(e);
+						}
+					}
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
+			if(first != null)
+			{
+				throw first;
+			}
 		}
 		
 		protected void internalRemoveAll()
@@ -282,7 +332,12 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 					indexGroup.internalPrepareIndicesUpdate(replacedEntity);
 					try
 					{
-						indexGroup.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints);
+						/*
+						 * removeOnFailure == false: the calling context (set/replace) keeps the replaced
+						 * entity in place when the update fails, so the previous index entries must
+						 * remain untouched.
+						 */
+						indexGroup.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints, false);
 					}
 					finally
 					{
@@ -295,38 +350,138 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 				this.markStateChangeChildren();
 			}
 		}
-		
-		<R> R internalUpdateIndices(
+
+		/**
+		 * First phase of an in-place entity update: derives the change handlers for the entity's
+		 * current (pre-mutation) state in all index groups. This runs all indexers, i.e. user code,
+		 * but does not mutate any index state: a throw here leaves the map completely unchanged,
+		 * already prepared groups are released again and nothing gets state-change marked.
+		 */
+		void internalPrepareUpdate(final E entity)
+		{
+			int prepared = 0;
+			try
+			{
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					indexGroup.internalPrepareIndicesUpdate(entity);
+					prepared++;
+				}
+			}
+			catch(final RuntimeException e)
+			{
+				int i = 0;
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					if(i++ >= prepared)
+					{
+						break;
+					}
+					try
+					{
+						indexGroup.internalFinishIndicesUpdate();
+					}
+					catch(final RuntimeException suppressed)
+					{
+						e.addSuppressed(suppressed);
+					}
+				}
+				throw e;
+			}
+		}
+
+		/**
+		 * Second phase of an in-place entity update: executes the mutating logic and updates all
+		 * index groups from the entity's resulting state. Must be preceded by a successful
+		 * {@link #internalPrepareUpdate(Object)}.
+		 */
+		<R> R internalApplyUpdate(
 			final long                         entityId         ,
 			final E                            entity           ,
 			final Function<? super E, R>       logic            ,
 			final CustomConstraints<? super E> customConstraints
 		)
 		{
-			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
-			{
-				indexGroup.internalPrepareIndicesUpdate(entity);
-			}
-			
 			try
 			{
-				final R result = logic.apply(entity);
-				
+				R result;
+				try
+				{
+					result = logic.apply(entity);
+				}
+				catch(final RuntimeException e)
+				{
+					/*
+					 * The logic threw: the entity's state is unreliable and the calling context will
+					 * remove the entity. The indices are still updated from the entity's current state
+					 * so that the subsequent removal, which re-derives the keys from that same state,
+					 * can locate all entries. A group whose update fails de-indexes its previous
+					 * entries via the prepared change handlers instead (removeOnFailure). Custom
+					 * constraints are not checked; the entity is doomed either way.
+					 */
+					try
+					{
+						for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+						{
+							indexGroup.internalUpdateIndices(entityId, entity, entity, null, true);
+						}
+					}
+					catch(final RuntimeException suppressed)
+					{
+						e.addSuppressed(suppressed);
+					}
+					throw e;
+				}
+
 				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
 				{
-					indexGroup.internalUpdateIndices(entityId, entity, entity, customConstraints);
+					/*
+					 * removeOnFailure == true: the calling context removes the in-place mutated entity
+					 * from the map when the update fails, so on failure a group must de-index the
+					 * entity's previous state via its prepared change handlers.
+					 */
+					indexGroup.internalUpdateIndices(entityId, entity, entity, customConstraints, true);
 				}
-				
+
+				this.internalFinishUpdate(null);
+
 				return result;
+			}
+			catch(final RuntimeException e)
+			{
+				this.internalFinishUpdate(e);
+				throw e;
 			}
 			finally
 			{
-				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				this.markStateChangeChildren();
+			}
+		}
+
+		private void internalFinishUpdate(final RuntimeException primary)
+		{
+			RuntimeException first = primary;
+			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			{
+				try
 				{
 					indexGroup.internalFinishIndicesUpdate();
 				}
-				
-				this.markStateChangeChildren();
+				catch(final RuntimeException e)
+				{
+					if(first == null)
+					{
+						first = e;
+					}
+					else
+					{
+						first.addSuppressed(e);
+					}
+				}
+			}
+			if(primary == null && first != null)
+			{
+				throw first;
 			}
 		}
 					

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -116,18 +116,32 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Adds the specified element to this collection.
 	 * <p>
 	 * Null values are not allowed.
-	 * 
+	 * <p>
+	 * <b>Behavior on failure:</b> if a constraint is violated or an {@link Indexer} throws an
+	 * exception while the element is being indexed, the addition is rolled back and the exception
+	 * is rethrown: the element is not contained, {@link #size()} is unchanged and no index refers
+	 * to it. If the rollback itself encounters secondary failures (e.g. the broken indexer throws
+	 * again during cleanup), those are attached as suppressed exceptions and the affected id is
+	 * "burned", i.e. skipped for future additions, so that possibly remaining stale index entries
+	 * can never refer to another entity. Such remainders are cleaned up by {@link #reindex()}.
+	 *
 	 * @param element the element to add, not <code>null</code>
 	 * @return the assigned id
 	 * @throws IllegalArgumentException if element is <code>null</code>
 	 */
 	public long add(E element);
-	
+
 	/**
 	 * Adds all elements to this collection.
 	 * <p>
 	 * Null values are not allowed
-	 * 
+	 * <p>
+	 * <b>Behavior on failure:</b> the operation is atomic in the same way as {@link #add(Object)}:
+	 * if a constraint is violated or an {@link Indexer} throws an exception for any of the
+	 * elements, all elements added so far by this call are rolled back and the exception is
+	 * rethrown; secondary cleanup failures are attached as suppressed exceptions and the affected
+	 * ids are skipped for future additions.
+	 *
 	 * @param elements the elements to add
 	 * @return the last assigned id
 	 * @throws IllegalArgumentException if an element is <code>null</code>
@@ -159,7 +173,15 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	
 	/**
 	 * Removes the entitiy mapped to the specified id.
-	 * 
+	 * <p>
+	 * <b>Behavior on failure:</b> if an {@link Indexer} throws an exception while the entity's
+	 * index entries are being located for cleanup, the removal nevertheless completes: the entity
+	 * is removed from the map and {@link #size()} is decremented, the remaining indices are cleaned
+	 * best-effort, and the exception is rethrown afterwards (further failures attached as
+	 * suppressed exceptions). Entries left behind in the index whose indexer failed refer to a now
+	 * empty id and are invisible to queries; they are cleaned up by {@link #reindex()}. Aborting
+	 * instead would make an entity with a broken indexer permanently unremovable.
+	 *
 	 * @param entityId the id of the element to be deleted
 	 * @return the deleted element, or <code>null</code> if none was deleted
 	 */
@@ -175,7 +197,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * <p>
 	 * To get the best performance for this operation is the use of an identity index.
 	 * See {@link BitmapIndices#setIdentityIndices(IndexIdentifier...)}.
-	 *
+	 * <p>
+	 * <b>Behavior on failure:</b> identical to {@link #removeById(long)}: once the entity has been
+	 * resolved to its id, the removal completes even if an {@link Indexer} throws during index
+	 * cleanup, and the exception is rethrown afterwards. (A throw during the id resolution itself
+	 * happens before any mutation and leaves the map unchanged.)
 	 *
 	 * @param entity the entity to be removed
 	 * @return the previously mapped id of the entity, or -1 if none was removed
@@ -269,7 +295,15 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	/**
 	 * Replaces an entity if present in this collection, updates the indices accordingly,
 	 * and returns the old entity mapped to the specified id.
-	 * 
+	 * <p>
+	 * <b>Behavior on failure:</b> constraints are checked and the bitmap indices are updated
+	 * <em>before</em> the entity is replaced in the map's storage. If a constraint is violated or
+	 * an {@link Indexer} throws an exception while deriving the new entity's keys, the map is left
+	 * unchanged: the old entity stays in place and remains indexed. (On maps with additional,
+	 * non-bitmap index groups such as Lucene or vector indices, a failure in a group that is
+	 * processed after another group already updated can leave the groups diverged; such states are
+	 * repaired by {@link #reindex()}.)
+	 *
 	 * @param entityId the entity id to replace
 	 * @param entity the new entity
 	 * @return the old entity
@@ -290,6 +324,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * See {@link BitmapIndices#setIdentityIndices(IndexIdentifier...)}.
 	 * 
 	 * 
+	 * <p>
+	 * <b>Behavior on failure:</b> identical to {@link #set(long, Object)}: the map is left
+	 * unchanged if a constraint is violated or an {@link Indexer} throws while the indices are
+	 * being updated.
+	 *
 	 * @param current the entity to be removed
 	 * @param replacement the new entity instance
 	 * @return the mapped id of the entity
@@ -326,6 +365,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * (via {@code violatingEntity} and {@code entityId}); callers that need to recover can re-add the
 	 * entity after correcting the violation, or use {@code set} / {@code replace} instead when
 	 * non-destructive semantics are required.
+	 * <p>
+	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
+	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
+	 * may have (partially) mutated the entity: the entity is removed from the map and the original
+	 * exception is rethrown, with cleanup failures attached as suppressed exceptions. Only exceptions
+	 * thrown while the entity's <em>pre-update</em> state is being indexed (i.e. before {@code logic}
+	 * runs) abort cleanly and leave the map and the entity unchanged.
 	 *
 	 * @param current the entity to be updated
 	 * @param logic the update logic to be executed
@@ -364,7 +410,10 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * <b>Behavior on constraint violation (potential data loss):</b> identical to
 	 * {@link #apply(long, Function)}: if the post-update state violates a registered constraint, a
 	 * {@link ConstraintViolationException ConstraintViolationException} is thrown <em>and the entity is
-	 * removed from this GigaMap</em>, because the in-place mutation cannot be rolled back.
+	 * removed from this GigaMap</em>, because the in-place mutation cannot be rolled back. The same
+	 * destructive-removal contract applies to any other {@link RuntimeException} thrown by {@code logic}
+	 * or by an {@link Indexer} once {@code logic} may have mutated the entity; exceptions thrown while
+	 * the <em>pre-update</em> state is being indexed abort cleanly and leave the map unchanged.
 	 *
 	 * @param entityId the id of the entity to be updated
 	 * @param logic the update logic to be executed
@@ -413,6 +462,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * (via {@code violatingEntity} and {@code entityId}); callers that need to recover can re-add the
 	 * entity after correcting the violation, or use {@code set} / {@code replace} instead when
 	 * non-destructive semantics are required.
+	 * <p>
+	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
+	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
+	 * may have (partially) mutated the entity: the entity is removed from the map and the original
+	 * exception is rethrown, with cleanup failures attached as suppressed exceptions. Only exceptions
+	 * thrown while the entity's <em>pre-application</em> state is being indexed (i.e. before {@code logic}
+	 * runs) abort cleanly and leave the map and the entity unchanged.
 	 *
 	 * @param current the entity to be updated
 	 * @param logic the logic to be executed
@@ -448,6 +504,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * and its id (via {@code violatingEntity} and {@code entityId}); callers that need to recover can
 	 * re-add the entity after correcting the violation, or use {@link #set(long, Object) set} when
 	 * non-destructive semantics are required.
+	 * <p>
+	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
+	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
+	 * may have (partially) mutated the entity: the entity is removed from the map and the original
+	 * exception is rethrown, with cleanup failures attached as suppressed exceptions. Only exceptions
+	 * thrown while the entity's <em>pre-application</em> state is being indexed (i.e. before {@code logic}
+	 * runs) abort cleanly and leave the map and the entity unchanged.
 	 *
 	 * @param entityId the id of the entity the logic is applied to
 	 * @param logic the logic to be executed
@@ -1993,11 +2056,18 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			if(!this.equalator.equal(replacedEntity, entity))
 			{
 				this.constraints.check(entityId, replacedEntity, entity);
+
+				/*
+				 * The indices are updated BEFORE the storage slot is overwritten: the index update is
+				 * the last operation that runs user code (indexers deriving the new entity's keys), so
+				 * a throw from it must leave the map observably unchanged instead of storing an entity
+				 * whose keys the indices do not reflect.
+				 */
+				this.indices.internalUpdateIndices(entityId, replacedEntity, entity, this.constraints.custom());
+
 				level1.entities[level1Index] = entity;
 				level3.markChanged(level3Index);
 				level2.markChanged(level2Index);
-
-				this.indices.internalUpdateIndices(entityId, replacedEntity, entity, this.constraints.custom());
 			}
 			
 			return replacedEntity;
@@ -2046,9 +2116,16 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 		private <R> R internalApply(final long entityId, final E current, final Function<? super E, R> logic)
 		{
+			/*
+			 * Phase 1 runs all indexers on the entity's pre-mutation state. A throw here (e.g. from
+			 * a broken indexer) aborts cleanly: the entity has not been touched and the map is
+			 * observably unchanged.
+			 */
+			this.indices.internalPrepareUpdate(current);
+
 			try
 			{
-				final R result = this.indices.internalUpdateIndices(entityId, current, logic, this.constraints.custom());
+				final R result = this.indices.internalApplyUpdate(entityId, current, logic, this.constraints.custom());
 
 				// The entity was mutated in-place. Track it so that store() can explicitly
 				// re-persist the entity object (the storer won't re-persist it automatically
@@ -2061,16 +2138,26 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 				return result;
 			}
-			catch(final ConstraintViolationException e)
+			catch(final RuntimeException e)
 			{
 				this.ensureClearedAddingState();
 
 				/*
 				 * Since a state change done by a custom logic cannot be rolled back, there is no other choice
 				 * but to remove the entity from the map and report the entity and entityId to the calling
-				 * context in the exception.
+				 * context in the exception. This applies not only to constraint violations but to any
+				 * exception thrown by the update logic or an indexer once the logic may have run: in all
+				 * those cases the entity's state is unreliable. The removal completes best-effort;
+				 * cleanup failures are attached as suppressed exceptions.
 				 */
-				this.internalRemove(entityId);
+				try
+				{
+					this.internalRemove(entityId);
+				}
+				catch(final RuntimeException suppressed)
+				{
+					e.addSuppressed(suppressed);
+				}
 				throw e;
 			}
 		}
@@ -2119,12 +2206,23 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		{
 			this.validateForCRUD(element);
 			this.ensureMutability();
-			this.internalAdd(element);
-			
-			// all indices in all index groups have too be updated. Indices do NOT store by themselves!
-			this.indices.internalAdd(this.nextFreeId(), element);
-			
-			return this.baseAddingId + this.addingLevel1Index++;
+
+			final long entityId = this.nextFreeId();
+			try
+			{
+				this.internalAdd(element);
+				this.addingLevel1Index++;
+
+				// all indices in all index groups have too be updated. Indices do NOT store by themselves!
+				this.indices.internalAdd(entityId, element);
+
+				return entityId;
+			}
+			catch(final Exception e)
+			{
+				this.rollbackToEntityId(entityId, e);
+				throw e;
+			}
 		}
 		
 		final void checkConstraints(final long entityId, final E replacedEntity, final E entity)
@@ -2225,18 +2323,44 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			}
 			catch(final Exception e)
 			{
-				this.rollbackToEntityId(currentId);
+				this.rollbackToEntityId(currentId, e);
 				throw e;
 			}
 		}
-		
-		private void rollbackToEntityId(final long requiredCurrentId)
+
+		private void rollbackToEntityId(final long requiredCurrentId, final Exception cause)
 		{
 			this.clearAddingState();
-			while(this.highestUsedId() >= requiredCurrentId)
+
+			/*
+			 * The rollback must be exception-tolerant: internalRemove re-runs the indexers to locate
+			 * the entries to clean up, and the very indexer whose exception triggered this rollback
+			 * may throw again. Such secondary failures are attached to the causing exception as
+			 * suppressed exceptions instead of abandoning the rollback midway.
+			 */
+			boolean reclaimIds = true;
+			for(long id = this.highestUsedId(); id >= requiredCurrentId; id--)
 			{
-				this.internalRemove(this.highestUsedId());
-				this.baseAddingId--;
+				try
+				{
+					this.internalRemove(id);
+				}
+				catch(final RuntimeException e)
+				{
+					cause.addSuppressed(e);
+
+					/*
+					 * The failed cleanup may have left stale index entries for this id. Not reclaiming
+					 * it (and consequently all lower ids, since ids are assigned from a single counter)
+					 * guarantees that the stale entries can never alias a future entity: they keep
+					 * pointing at a permanently null slot and get repaired by reindex().
+					 */
+					reclaimIds = false;
+				}
+				if(reclaimIds)
+				{
+					this.baseAddingId--;
+				}
 			}
 		}
 					

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -172,7 +172,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public E peek(long entityId);
 	
 	/**
-	 * Removes the entitiy mapped to the specified id.
+	 * Removes the entity mapped to the specified id.
 	 * <p>
 	 * <b>Behavior on failure:</b> if an {@link Indexer} throws an exception while the entity's
 	 * index entries are being located for cleanup, the removal nevertheless completes: the entity

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
@@ -63,7 +63,38 @@ public interface IndexGroup<E> extends GigaMap.Component<E>
 		 * @param entity new entity from which the key will be extracted
 		 */
 		public void internalUpdateIndices(long entityId, E replacedEntity, E entity, CustomConstraints<? super E> customConstraints);
-		
+
+		/**
+		 * Variant of {@link #internalUpdateIndices(long, Object, Object, CustomConstraints)} that
+		 * additionally states how a failure is to be handled.
+		 * <p>
+		 * With {@code removeOnFailure == true} the calling context signals that the entity was mutated
+		 * in place and will be removed from the map if the update fails, so on a failure this group
+		 * should de-index the entity's previous state (using the state prepared via
+		 * {@link #internalPrepareIndicesUpdate(Object)}) before propagating the exception. With
+		 * {@code false} the calling context guarantees that the entity's previous state stays in place
+		 * on failure, so the group must leave its previous entries untouched.
+		 * <p>
+		 * The default implementation ignores the flag and delegates to the 4-arg variant, which is
+		 * correct for groups without such cleanup capability.
+		 *
+		 * @param entityId the entity's id
+		 * @param replacedEntity old entity
+		 * @param entity new entity from which the key will be extracted
+		 * @param customConstraints the custom constraints to check, may be {@code null}
+		 * @param removeOnFailure whether a failed update is followed by the entity's removal
+		 */
+		public default void internalUpdateIndices(
+			final long                         entityId         ,
+			final E                            replacedEntity   ,
+			final E                            entity           ,
+			final CustomConstraints<? super E> customConstraints,
+			final boolean                      removeOnFailure
+		)
+		{
+			this.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints);
+		}
+
 		public void internalFinishIndicesUpdate();
 		
 		/**

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ThrowingIndexerConsistencyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ThrowingIndexerConsistencyTest.java
@@ -1,0 +1,542 @@
+package org.eclipse.store.gigamap.indexer.edge;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.CustomConstraint;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerMultiValue;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the GigaMap consistency guarantees when user code (indexers, update logic,
+ * constraints) throws exceptions in the middle of a mutation:
+ * <ul>
+ *   <li>{@code add}/{@code addAll} roll back completely; ids whose cleanup also failed are burned
+ *       instead of being reused.</li>
+ *   <li>{@code removeById}/{@code remove} always complete the removal, cleaning the remaining
+ *       indices best-effort and rethrowing afterwards.</li>
+ *   <li>{@code set}/{@code replace} leave the map observably unchanged.</li>
+ *   <li>{@code update}/{@code apply} abort cleanly while the pre-mutation state is being indexed
+ *       and extend the documented destructive-removal contract (previously limited to
+ *       {@link ConstraintViolationException}) to all exceptions once the logic may have mutated
+ *       the entity.</li>
+ * </ul>
+ */
+public class ThrowingIndexerConsistencyTest
+{
+	// ---------------------------------------------------------------
+	// Shared domain and indexers
+	// ---------------------------------------------------------------
+
+	static final class IndexerBoomException extends RuntimeException
+	{
+		IndexerBoomException(final String message)
+		{
+			super(message);
+		}
+	}
+
+	static final class Item
+	{
+		String name;
+		String category;
+
+		Item(final String name, final String category)
+		{
+			this.name     = name;
+			this.category = category;
+		}
+	}
+
+	/** Always healthy, indexes the name. */
+	static final IndexerString<Item> NAME = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.name;
+		}
+	};
+
+	/** Always healthy, indexes the category. */
+	static final IndexerString<Item> CATEGORY = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.category;
+		}
+	};
+
+	/** Throws whenever {@link #toggleArmed} is set, regardless of the entity's value. */
+	static volatile boolean toggleArmed = false;
+
+	static final IndexerString<Item> TOGGLE = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if(toggleArmed)
+			{
+				throw new IndexerBoomException("toggle boom");
+			}
+			return entity.name;
+		}
+	};
+
+	/** Throws for entities named "poison", healthy for all others. */
+	static final IndexerString<Item> POISON = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if("poison".equals(entity.name))
+			{
+				throw new IndexerBoomException("poison name");
+			}
+			return entity.name;
+		}
+	};
+
+	/** Throws exactly once (on the first invocation after arming), then behaves normally. */
+	static final AtomicBoolean throwOnceArmed = new AtomicBoolean(false);
+
+	static final IndexerString<Item> THROW_ONCE = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if(throwOnceArmed.compareAndSet(true, false))
+			{
+				throw new IndexerBoomException("throw once");
+			}
+			return entity.name;
+		}
+	};
+
+	/** Multi-value indexer whose key iterable yields "first" and then throws, for "multiPoison" entities. */
+	static final IndexerMultiValue<Item, String> MULTI = new IndexerMultiValue.Abstract<>()
+	{
+		@Override
+		public Class<String> keyType()
+		{
+			return String.class;
+		}
+
+		@Override
+		public Iterable<? extends String> indexEntityMultiValue(final Item entity)
+		{
+			if(!"multiPoison".equals(entity.name))
+			{
+				return List.of(entity.name);
+			}
+			return () -> new Iterator<String>()
+			{
+				int i = 0;
+
+				@Override
+				public boolean hasNext()
+				{
+					return true;
+				}
+
+				@Override
+				public String next()
+				{
+					if(this.i++ == 0)
+					{
+						return "first";
+					}
+					throw new IndexerBoomException("multi boom");
+				}
+			};
+		}
+	};
+
+	static final class NoBadCategory extends CustomConstraint.AbstractSimple<Item>
+	{
+		@Override
+		public boolean isViolated(final Item item)
+		{
+			return "bad".equals(item.category);
+		}
+	}
+
+	@BeforeEach
+	@AfterEach
+	void disarm()
+	{
+		toggleArmed = false;
+		throwOnceArmed.set(false);
+	}
+
+	// ---------------------------------------------------------------
+	// add
+	// ---------------------------------------------------------------
+
+	@Test
+	void add_throwingIndexer_rollsBackAndBurnsId()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(TOGGLE);
+
+		toggleArmed = true;
+		final IndexerBoomException e = assertThrows(
+			IndexerBoomException.class,
+			() -> map.add(new Item("a", "c1"))
+		);
+
+		// the cleanup re-ran the still-throwing indexer, so the secondary failure must be suppressed
+		assertEquals(1, e.getSuppressed().length);
+
+		assertEquals(0, map.size());
+		assertNull(map.get(0L));
+		assertEquals(0, map.query(NAME.is("a")).count());
+
+		// the failed cleanup burned id 0, so the next add must not alias it
+		toggleArmed = false;
+		final long nextId = map.add(new Item("b", "c1"));
+		assertEquals(1L, nextId);
+		assertEquals(1, map.query(NAME.is("b")).count());
+		assertEquals(0, map.query(NAME.is("a")).count());
+	}
+
+	@Test
+	void add_throwingIndexer_reclaimsIdWhenCleanupSucceeds()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(THROW_ONCE);
+
+		throwOnceArmed.set(true);
+		final IndexerBoomException e = assertThrows(
+			IndexerBoomException.class,
+			() -> map.add(new Item("a", "c1"))
+		);
+
+		// the indexer recovered during the rollback, so cleanup fully succeeded
+		assertEquals(0, e.getSuppressed().length);
+		assertEquals(0, map.size());
+
+		// full cleanup allows the id to be reclaimed
+		final long nextId = map.add(new Item("b", "c1"));
+		assertEquals(0L, nextId);
+		assertEquals(1, map.query(NAME.is("b")).count());
+	}
+
+	@Test
+	void add_multiValueIndexerThrowsMidIteration_partialKeysCleanedUp()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(MULTI);
+
+		assertThrows(IndexerBoomException.class, () -> map.add(new Item("multiPoison", "c1")));
+
+		assertEquals(0, map.size());
+		// the first key had already been indexed before the iterable threw; it must be cleaned up
+		assertEquals(0, map.query(MULTI.is("first")).count());
+		assertEquals(0, map.query(NAME.is("multiPoison")).count());
+	}
+
+	@Test
+	void add_middleIndexThrows_healthyIndicesHoldNoEntries()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(POISON);
+		map.index().bitmap().add(CATEGORY);
+
+		assertThrows(IndexerBoomException.class, () -> map.add(new Item("poison", "c1")));
+
+		assertEquals(0, map.size());
+		assertEquals(0, map.query(NAME.is("poison")).count());
+		assertEquals(0, map.query(CATEGORY.is("c1")).count());
+	}
+
+	// ---------------------------------------------------------------
+	// addAll
+	// ---------------------------------------------------------------
+
+	@Test
+	void addAll_midFailure_rollsBackAllAndRetrySucceeds()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(POISON);
+
+		assertThrows(IndexerBoomException.class, () -> map.addAll(
+			new Item("a", "c1"),
+			new Item("b", "c1"),
+			new Item("poison", "c1"),
+			new Item("d", "c1"),
+			new Item("e", "c1")
+		));
+
+		assertEquals(0, map.size());
+		assertEquals(0, map.query(NAME.is("a")).count());
+		assertEquals(0, map.query(NAME.is("e")).count());
+
+		final long lastId = map.addAll(
+			new Item("f", "c1"),
+			new Item("g", "c1"),
+			new Item("h", "c1"),
+			new Item("i", "c1"),
+			new Item("j", "c1")
+		);
+		assertEquals(5, map.size());
+		// the poison entity's cleanup failed, burning ids 0-2; the retry starts at id 3
+		assertEquals(7L, lastId);
+		assertEquals(1, map.query(NAME.is("f")).count());
+		assertEquals(1, map.query(NAME.is("j")).count());
+	}
+
+	// ---------------------------------------------------------------
+	// removeById
+	// ---------------------------------------------------------------
+
+	@Test
+	void removeById_throwingIndexer_completesRemoval()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(TOGGLE);
+
+		final Item item = new Item("a", "c1");
+		final long id   = map.add(item);
+
+		toggleArmed = true;
+		assertThrows(IndexerBoomException.class, () -> map.removeById(id));
+
+		// the removal must have completed despite the exception
+		assertNull(map.get(id));
+		assertEquals(0, map.size());
+		assertEquals(0, map.query(NAME.is("a")).count());
+		// residue in the broken index is invisible to queries
+		assertEquals(0, map.query(TOGGLE.is("a")).count());
+
+		// reindex() repairs the residue once the indexer works again
+		toggleArmed = false;
+		map.reindex();
+		final long newId = map.add(new Item("a", "c1"));
+		assertEquals(1, map.query(NAME.is("a")).count());
+		assertEquals(1, map.query(TOGGLE.is("a")).count());
+		assertSame(map.get(newId), map.query(TOGGLE.is("a")).findFirst().orElse(null));
+	}
+
+	// ---------------------------------------------------------------
+	// set / replace
+	// ---------------------------------------------------------------
+
+	@Test
+	void set_throwingIndexer_leavesMapUnchanged()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(TOGGLE);
+
+		final Item original = new Item("a", "c1");
+		final long id       = map.add(original);
+
+		toggleArmed = true;
+		assertThrows(IndexerBoomException.class, () -> map.set(id, new Item("b", "c1")));
+
+		assertSame(original, map.get(id));
+		assertEquals(1, map.size());
+		assertEquals(1, map.query(NAME.is("a")).count());
+		assertEquals(0, map.query(NAME.is("b")).count());
+
+		// the map is fully functional afterwards
+		toggleArmed = false;
+		final Item replacement = new Item("b", "c1");
+		assertSame(original, map.set(id, replacement));
+		assertSame(replacement, map.get(id));
+		assertEquals(1, map.query(NAME.is("b")).count());
+		assertEquals(0, map.query(NAME.is("a")).count());
+	}
+
+	@Test
+	void replace_throwingIndexer_leavesMapUnchanged()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(TOGGLE);
+
+		final Item original = new Item("a", "c1");
+		map.add(original);
+
+		toggleArmed = true;
+		assertThrows(IndexerBoomException.class, () -> map.replace(original, new Item("b", "c1")));
+
+		toggleArmed = false;
+		assertEquals(1, map.size());
+		assertEquals(1, map.query(NAME.is("a")).count());
+		assertEquals(0, map.query(NAME.is("b")).count());
+	}
+
+	@Test
+	void set_customConstraintViolation_oldEntityStaysIndexed()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(CATEGORY);
+		map.constraints().custom().addConstraint(new NoBadCategory());
+
+		final Item original = new Item("a", "good");
+		final long id       = map.add(original);
+
+		assertThrows(ConstraintViolationException.class, () -> map.set(id, new Item("b", "bad")));
+
+		assertSame(original, map.get(id));
+		assertEquals(1, map.size());
+		assertEquals(1, map.query(NAME.is("a")).count());
+		assertEquals(1, map.query(CATEGORY.is("good")).count());
+		assertEquals(0, map.query(CATEGORY.is("bad")).count());
+	}
+
+	// ---------------------------------------------------------------
+	// update / apply
+	// ---------------------------------------------------------------
+
+	@Test
+	void apply_logicThrows_entityRemovedAndIndicesClean()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+
+		final long id = map.add(new Item("a", "c1"));
+
+		final IndexerBoomException boom = new IndexerBoomException("logic boom");
+		final IndexerBoomException thrown = assertThrows(IndexerBoomException.class, () ->
+			map.apply(id, item ->
+			{
+				item.name = "changed";
+				throw boom;
+			})
+		);
+		assertSame(boom, thrown);
+
+		// destructive removal: the half-mutated entity must be gone entirely
+		assertNull(map.get(id));
+		assertEquals(0, map.size());
+		assertEquals(0, map.query(NAME.is("a")).count());
+		assertEquals(0, map.query(NAME.is("changed")).count());
+	}
+
+	@Test
+	void apply_indexerThrowsDuringPrepare_abortsCleanly()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(TOGGLE);
+
+		final Item item = new Item("a", "c1");
+		final long id   = map.add(item);
+
+		toggleArmed = true;
+		final AtomicBoolean logicRan = new AtomicBoolean(false);
+		assertThrows(IndexerBoomException.class, () ->
+			map.apply(id, e ->
+			{
+				logicRan.set(true);
+				e.name = "changed";
+				return null;
+			})
+		);
+
+		// the throw happened while the pre-mutation state was being indexed: nothing may have changed
+		assertFalse(logicRan.get());
+		assertSame(item, map.get(id));
+		assertEquals("a", item.name);
+		assertEquals(1, map.size());
+
+		toggleArmed = false;
+		assertEquals(1, map.query(NAME.is("a")).count());
+	}
+
+	@Test
+	void apply_indexerThrowsOnMutatedValue_entityRemovedWithSuppressedCleanupFailure()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(POISON);
+
+		final long id = map.add(new Item("a", "c1"));
+
+		final IndexerBoomException thrown = assertThrows(IndexerBoomException.class, () ->
+			map.apply(id, item ->
+			{
+				item.name = "poison";
+				return null;
+			})
+		);
+
+		// destructive removal, original exception raw, cleanup failure attached
+		assertNull(map.get(id));
+		assertEquals(0, map.size());
+		assertEquals(0, map.query(NAME.is("a")).count());
+		assertTrue(thrown.getSuppressed().length > 0);
+	}
+
+	// ---------------------------------------------------------------
+	// lock state
+	// ---------------------------------------------------------------
+
+	@Test
+	void mutationsRemainPossibleAfterThrowingMutations()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(NAME);
+		map.index().bitmap().add(TOGGLE);
+
+		final long keptId = map.add(new Item("kept", "c1"));
+
+		toggleArmed = true;
+		assertThrows(IndexerBoomException.class, () -> map.add(new Item("a", "c1")));
+		assertThrows(IndexerBoomException.class, () -> map.set(keptId, new Item("b", "c1")));
+		assertThrows(IndexerBoomException.class, () -> map.apply(keptId, item ->
+		{
+			item.name = "c";
+			return null;
+		}));
+		toggleArmed = false;
+
+		// none of the failed mutations may leave the map blocked or read-locked
+		assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+		{
+			final long id = map.add(new Item("after", "c1"));
+			assertEquals(1, map.query(NAME.is("after")).count());
+			map.removeById(id);
+		});
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/AddIndexerExceptionIdReuseReproTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/AddIndexerExceptionIdReuseReproTest.java
@@ -1,0 +1,99 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproducer for internal issue #94: add() had no index rollback on indexer exceptions
+ * (unlike addAll()). A first index is updated, a second (user) indexer throws, the entity
+ * id is not consumed — and the next add() reused the same entityId, binding the first
+ * index's already-written entries to a DIFFERENT entity. The corruption was persisted by
+ * the next store() because the partially-updated index was already state-change marked.
+ * <p>
+ * Adopted from the reproducer by zdenek-jonas posted on the issue; kept verbatim so the
+ * fix (rollback in {@code GigaMap.add} plus id-burning when the cleanup itself fails) is
+ * verified against the reporter's exact scenario.
+ */
+public class AddIndexerExceptionIdReuseReproTest
+{
+	@Test
+	@Timeout(60)
+	void failedAddMustNotLeakIndexEntriesToNextEntity()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		final ValueIndexer valueIndexer = new ValueIndexer();
+		map.index().bitmap().add(valueIndexer);          // updated first
+		map.index().bitmap().add(new ThrowingIndexer()); // throws for "bad" afterwards
+
+		assertThrows(RuntimeException.class, () -> map.add(new Item("bad")),
+			"the poisoned entity must be rejected");
+
+		final long idGood = map.add(new Item("good"));
+
+		// The failed add must leave no trace: querying the FIRST index for the failed
+		// entity's key must return nothing. On the bug, the stale entry for "bad"
+		// (written before the second indexer threw) now resolves to the reused id of "good".
+		final List<Item> hits = new ArrayList<>();
+		map.query(valueIndexer.is("bad")).forEach(hits::add);
+
+		assertTrue(hits.isEmpty(),
+			"failed add leaked an index entry: query for the rejected key returned " + hits.size()
+			+ " entity/ies (the reused entityId " + idGood + " now answers under the wrong key)");
+		assertEquals("good", map.get(idGood).value);
+	}
+
+	static final class Item
+	{
+		final String value;
+
+		Item(final String value)
+		{
+			this.value = value;
+		}
+	}
+
+	static final class ValueIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.value;
+		}
+	}
+
+	static final class ThrowingIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if("bad".equals(entity.value))
+			{
+				throw new RuntimeException("user indexer failure for: " + entity.value);
+			}
+			return entity.value;
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/ThrowingIndexerRestartTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/ThrowingIndexerRestartTest.java
@@ -1,0 +1,199 @@
+package org.eclipse.store.gigamap.restart;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Restart round-trips for the GigaMap failure semantics when an indexer throws mid-mutation:
+ * the state persisted by a {@code store()} after a failed mutation must be internally consistent
+ * (dirty-flag correctness), i.e. entity segments, indices and size must agree after a reload.
+ */
+public class ThrowingIndexerRestartTest
+{
+	static final class Item
+	{
+		final String name;
+
+		Item(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	static final IndexerString<Item> NAME = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.name;
+		}
+	};
+
+	/** Throws for entities named "poison", healthy for all others. */
+	static final IndexerString<Item> POISON = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if("poison".equals(entity.name))
+			{
+				throw new RuntimeException("poison name");
+			}
+			return entity.name;
+		}
+	};
+
+	/** Throws whenever {@link #toggleArmed} is set, regardless of the entity's value. */
+	static volatile boolean toggleArmed = false;
+
+	static final IndexerString<Item> TOGGLE = new IndexerString.Abstract<>()
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if(toggleArmed)
+			{
+				throw new RuntimeException("toggle boom");
+			}
+			return entity.name;
+		}
+	};
+
+	@BeforeEach
+	@AfterEach
+	void disarm()
+	{
+		toggleArmed = false;
+	}
+
+	@Test
+	void failedAddSurvivesRestartConsistently(@TempDir final Path dir)
+	{
+		// ---- Session 1: store a valid entity, fail an add, store again ----
+		{
+			final GigaMap<Item> map = GigaMap.New();
+			map.index().bitmap().add(NAME);
+			map.index().bitmap().add(POISON);
+
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+			{
+				map.add(new Item("alice"));
+				storage.storeRoot();
+
+				assertThrows(RuntimeException.class, () -> map.add(new Item("poison")));
+				map.store();
+			}
+		}
+
+		// ---- Session 2: everything the failed add touched must have been rolled back ----
+		{
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+			{
+				@SuppressWarnings("unchecked")
+				final GigaMap<Item> loaded = (GigaMap<Item>)storage.root();
+
+				assertEquals(1, loaded.size());
+				assertNull(loaded.get(1L));
+				assertEquals(1, loaded.query(NAME.is("alice")).count());
+				assertEquals(0, loaded.query(NAME.is("poison")).count());
+
+				// the poison entity's failed cleanup burned its id; it must not be reused after reload
+				final long bobId = loaded.add(new Item("bob"));
+				assertEquals(2L, bobId);
+				assertEquals(2, loaded.size());
+				assertEquals(1, loaded.query(NAME.is("bob")).count());
+			}
+		}
+	}
+
+	@Test
+	void failedRemoveSurvivesRestartConsistently(@TempDir final Path dir)
+	{
+		final long aliceId;
+
+		// ---- Session 1: store two entities, fail a remove, store again ----
+		{
+			final GigaMap<Item> map = GigaMap.New();
+			map.index().bitmap().add(NAME);
+			map.index().bitmap().add(TOGGLE);
+
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+			{
+				aliceId = map.add(new Item("alice"));
+				map.add(new Item("bob"));
+				storage.storeRoot();
+
+				toggleArmed = true;
+				assertThrows(RuntimeException.class, () -> map.removeById(aliceId));
+				toggleArmed = false;
+
+				map.store();
+			}
+		}
+
+		// ---- Session 2: the removal must be durable and consistent ----
+		{
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+			{
+				@SuppressWarnings("unchecked")
+				final GigaMap<Item> loaded = (GigaMap<Item>)storage.root();
+
+				assertNull(loaded.get(aliceId));
+				assertEquals(1, loaded.size());
+				assertEquals(0, loaded.query(NAME.is("alice")).count());
+				assertEquals(1, loaded.query(NAME.is("bob")).count());
+				// residue in the broken index refers to an empty id and is query-invisible
+				assertEquals(0, loaded.query(TOGGLE.is("alice")).count());
+
+				// reindex() repairs the residue; the map is fully usable afterwards
+				loaded.reindex();
+				loaded.add(new Item("carol"));
+				assertEquals(2, loaded.size());
+				assertEquals(1, loaded.query(TOGGLE.is("carol")).count());
+				assertEquals(1, loaded.query(NAME.is("carol")).count());
+
+				loaded.store();
+			}
+		}
+
+		// ---- Session 3: the reindexed state must also be durable ----
+		{
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+			{
+				@SuppressWarnings("unchecked")
+				final GigaMap<Item> loaded = (GigaMap<Item>)storage.root();
+
+				assertEquals(2, loaded.size());
+				assertEquals(1, loaded.query(NAME.is("bob")).count());
+				assertEquals(1, loaded.query(NAME.is("carol")).count());
+				assertEquals(0, loaded.query(TOGGLE.is("alice")).count());
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

GigaMap runs user code (`Indexer.index`, key equality, `update`/`apply` logic, custom constraints) in the middle of mutations. On several paths the internal state (storage slots, size counters, dirty flags, sibling indices) was already mutated when that user code ran, so a thrown `RuntimeException` left the map inconsistent — and the next `store()` persisted that state. Fixes an issue, which reports the `add()`/`set()` part of this class: a failed `add()` leaked index entries and the not-consumed entityId was reused by the next `add()`, binding the leaked entries to a different entity (persisted wrong query results).

## Failure semantics now enforced (documented on the `GigaMap` interface)

**add / addAll:** `add()` now rolls back like `addAll()`, whose rollback additionally became exception-tolerant: the cleanup re-runs the indexers, and if the broken indexer throws again, the secondary failure is attached as a suppressed exception and the affected ids are "burned" (never reused), so stale index entries can never alias a future entity. Remainders are repaired by `reindex()`.

**removeById / remove:** the removal always completes (entity gone, size correct); the remaining indices and index groups are cleaned best-effort per index/per group and the first exception is rethrown afterwards. Residue in a broken index points at an empty id, is invisible to queries, and is repaired by `reindex()`. Aborting instead would make an entity with a broken indexer permanently unremovable.

**set / replace:** the index update — the last step that runs user code — now happens before the storage slot is overwritten, so a throw leaves the map observably unchanged. As a side effect, set-path failures no longer destructively de-index the previous entity state (new `removeOnFailure` flag, threaded through a binary-compatible default method on `IndexGroup.Internal`; the lucene/jvector modules compile unchanged).

**update / apply:** split into a prepare phase (indexers run on the pre-mutation state; a throw aborts cleanly with the map unchanged) and an apply phase. Once the logic may have mutated the entity, the documented destructive-removal contract — previously limited to `ConstraintViolationException` — applies to every `RuntimeException`: the unreliable entity is removed, the original exception is rethrown raw, and cleanup failures are suppressed. On a logic throw the indices are first brought in line with the entity's current state so the removal's key re-derivation finds all entries; a group whose update fails de-indexes via its prepared change handlers instead.

**Dirty-marking:** index add/remove loops now mark state-changed even when an indexer throws mid-loop (previously a mid-loop throw could mutate children without marking, so `store()` silently skipped them — the same lost-update class as review finding GM-B); conversely, clean-abort paths no longer mark when provably nothing was mutated.

## Accepted limitation

On maps with multiple index groups (bitmap + Lucene/vector), a failure in a later group can still leave the groups diverged: a cross-group prepare/apply restructure would break the `IndexGroup.Internal` API implemented by external modules. This is documented on the affected methods; `reindex()` repairs such states.

## Tests

- `indexer/edge/ThrowingIndexerConsistencyTest` — 13 scenarios: throwing single- and multi-value indexers on every CRUD path, id burning vs. reclaiming, constraint interplay, suppressed cleanup failures, and lock-state health after failed mutations.
- `restart/ThrowingIndexerRestartTest` — restart round-trips asserting the state persisted after a failed `add`/`remove` is consistent and repairable.
- `issues/AddIndexerExceptionIdReuseReproTest` — the reporter's reproducer from internal#94, adopted verbatim (red on main, green here).
- Full gigamap suite passes: 1059 tests, 0 failures.

