### PR TITLE
Add BitmapIndices.addWithoutInitialization for lazy, no-back-fill index registration

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -65,7 +65,32 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * @see Indexer#name()
 	 */
 	public <K> BitmapIndex<E, K> add(final Indexer<? super E, K> indexer);
-	
+
+	/**
+	 * Adds an {@link Indexer} to this group <b>without initializing it from the entities that are
+	 * already present</b> in the parent {@link GigaMap}.
+	 * <p>
+	 * Unlike {@link #add(Indexer)}, the newly registered index is <b>not</b> back-filled by
+	 * iterating the existing entities: it starts empty and only receives entries for entities that
+	 * are added or updated <i>after</i> this call.
+	 * <p>
+	 * <b>Advanced use — the caller is responsible for correctness.</b> This is only safe when it is
+	 * guaranteed that no entity currently present in the map would be indexed under a non-trivial
+	 * key by {@code indexer} — i.e. the index data would be empty even if it were back-filled. The
+	 * canonical case is a freshly introduced key that, by construction, no existing entity can carry
+	 * yet (e.g. a per-value index created the first time that value appears). Using this for an
+	 * indexer that <i>would</i> match already-present entities leaves the index inconsistent and
+	 * produces wrong query results. When in doubt, use {@link #add(Indexer)}.
+	 *
+	 * @param <K> the key type
+	 * @param indexer the indexing logic
+	 * @return the resulting, initially empty index
+	 * @throws IllegalArgumentException if {@code indexer} or its name is {@code null}
+	 * @throws RuntimeException if an indexer with the same name is already registered
+	 * @see #add(Indexer)
+	 */
+	public <K> BitmapIndex<E, K> addWithoutInitialization(final Indexer<? super E, K> indexer);
+
 	/**
 	 * Adds all indexers to this group.
 	 * <p>
@@ -868,6 +893,22 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 		}
 
+		@Override
+		public <K> BitmapIndex<E, K> addWithoutInitialization(final Indexer<? super E, K> indexer)
+		{
+			synchronized(this.parentMap())
+			{
+				this.ensureMutable();
+				this.validateIndexToAdd(indexer);
+
+				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
+				this.internalAddBitmapIndex(index, false);
+				this.rebuildCache();
+
+				return index;
+			}
+		}
+
 		/**
 		 * Guards structural mutations against a read-only parent {@link GigaMap}. Must be called while
 		 * holding the parent-map lock.
@@ -1338,8 +1379,13 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		
 		private void internalAddBitmapIndex(final BitmapIndex.Internal<E, ?> index)
 		{
+			this.internalAddBitmapIndex(index, true);
+		}
+
+		private void internalAddBitmapIndex(final BitmapIndex.Internal<E, ?> index, final boolean initialize)
+		{
 			this.bitmapIndices.add(index.name(), index);
-			
+
 			// just to be safe and the performance cost is irrelevant for a structural element.
 			if(index.parent() != this)
 			{
@@ -1348,10 +1394,15 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					this
 				);
 			}
-			
+
 			this.markStateChangeInstance();
-			
-			this.parent.iterateIndexed(index::internalAdd);
+
+			// initialize==false: caller guarantees no existing entity would be indexed, so the
+			// back-fill over the already-present entities is skipped (see addWithoutInitialization).
+			if(initialize)
+			{
+				this.parent.iterateIndexed(index::internalAdd);
+			}
 			this.parent.internalReportIndexGroupStateChange(this);
 		}
 		

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
@@ -289,8 +289,8 @@ public class BooleanIndexTest
     @Test
     void addWithoutInitialization_skipsBackfill_butIsFalseInvertsOverIdRange()
     {
-        // Load-bearing test for lazy, no-back-fill per-value indexes (the mechanism CYROCK.DB's
-        // per-label boolean indexes rely on): a boolean index added AFTER entities already exist is
+        // Load-bearing test for lazy, no-back-fill per-value indexes: 
+		// a boolean index added AFTER entities already exist is
         // NOT back-filled - its TRUE set stays empty - yet isFalse() still returns every entity,
         // because it inverts the TRUE bitmap over the GigaMap's global id range, not over the set of
         // entities this particular index has seen.

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BooleanIndexTest.java
@@ -286,6 +286,47 @@ public class BooleanIndexTest
 
     }
 
+    @Test
+    void addWithoutInitialization_skipsBackfill_butIsFalseInvertsOverIdRange()
+    {
+        // Load-bearing test for lazy, no-back-fill per-value indexes (the mechanism CYROCK.DB's
+        // per-label boolean indexes rely on): a boolean index added AFTER entities already exist is
+        // NOT back-filled - its TRUE set stays empty - yet isFalse() still returns every entity,
+        // because it inverts the TRUE bitmap over the GigaMap's global id range, not over the set of
+        // entities this particular index has seen.
+        GigaMap<BooleanPerson> map = GigaMap.New();
+
+        // Populate BEFORE the index exists.
+        map.add(new BooleanPerson("Alice",   true));
+        map.add(new BooleanPerson("Bob",     false));
+        map.add(new BooleanPerson("Charlie", true));
+
+        // Register without back-fill. (For a real label index this is safe by construction: a brand
+        // new label has no pre-existing members. Here we deliberately violate that to prove the
+        // no-back-fill semantics - Alice/Charlie are true but were never indexed.)
+        map.index().bitmap().addWithoutInitialization(this.booleanPersonIndex);
+
+        // No back-fill: the pre-existing TRUE-valued entities are NOT in the TRUE set...
+        assertEquals(0, map.query(this.booleanPersonIndex.isTrue()).count());
+        // ...but isFalse() (inversion over the id range) still returns all three pre-existing entities.
+        assertEquals(3, map.query(this.booleanPersonIndex.isFalse()).count());
+
+        // Entities added AFTER the index are indexed normally.
+        map.add(new BooleanPerson("Dave", true));
+        assertEquals(1, map.query(this.booleanPersonIndex.isTrue()).count());   // only Dave
+        assertEquals(3, map.query(this.booleanPersonIndex.isFalse()).count());  // the three originals
+
+        // The semantics survive a persistence round-trip.
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(map, tempDir)) {
+            map.store();
+        }
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(tempDir)) {
+            GigaMap<BooleanPerson> newMap = manager.root();
+            assertEquals(1, newMap.query(this.booleanPersonIndex.isTrue()).count());
+            assertEquals(3, newMap.query(this.booleanPersonIndex.isFalse()).count());
+        }
+    }
+
     private GigaMap<BooleanPerson> prepageGigaMap()
     {
         GigaMap<BooleanPerson> map = GigaMap.New();


### PR DESCRIPTION
## Summary

Registering a bitmap index via `add(Indexer)` back-fills it by iterating every entity already present in the parent `GigaMap`. For lazy per-value index schemes — e.g. per-label boolean indexes where a new index is created the first time a value appears — that back-fill is pure overhead by construction: a brand-new key cannot have pre-existing members, yet index creation still costs a full scan of the map. On large maps this makes on-demand index creation prohibitively expensive.

## Change

New API method `BitmapIndices.addWithoutInitialization(Indexer)`: registers the index without the back-fill iteration. The index starts empty and only receives entries for entities that are added or updated after the call. `add(Indexer)` keeps its back-filling behavior unchanged; internally both share `internalAddBitmapIndex`, which gained an `initialize` flag.

This is an advanced-use API and the caller is responsible for correctness: it is only safe when no entity currently in the map would be indexed under a non-trivial key by the given indexer (i.e. the index data would be empty even if it were back-filled). Using it for an indexer that would match already-present entities leaves the index inconsistent and produces wrong query results. The method javadoc documents this contract explicitly and points to `add(Indexer)` as the safe default.

## Tests

New `BooleanIndexTest.addWithoutInitialization_skipsBackfill_butIsFalseInvertsOverIdRange` pins the semantics: entities present before registration are not indexed (`isTrue()` stays empty), `isFalse()` still returns them because it inverts the TRUE bitmap over the map's global id range rather than over the entities this index has seen, entities added after registration are indexed normally, and the behavior survives a persistence round-trip. Full `BooleanIndexTest` suite passes (11 tests).
