### PR TITLE
Transactions file compaction reworked 91

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/various/TransactionFileSizeTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/various/TransactionFileSizeTest.java
@@ -69,6 +69,13 @@ public class TransactionFileSizeTest
 
         Customer customer = new Customer("first");
         try (EmbeddedStorageManager storageManager = EmbeddedStorage.start(customer, location)) {
+            // ensure the log exceeds the compacted minimum (creation + two store anchors)
+            // before the first cleanup, so every cleanup strictly shrinks it
+            customer.setName(faker
+                    .name()
+                    .lastName());
+            storageManager.store(customer);
+
             for (int i = 0; i < 10; i++) {
                 customer.setName(faker
                         .name()

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionIncompleteTransactionsEntry.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionIncompleteTransactionsEntry.java
@@ -1,0 +1,49 @@
+package org.eclipse.store.storage.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * A transactions file ends inside an entry (torn tail), typically caused by a crash during an
+ * append. {@link #position()} is the offset of the incomplete trailing entry: the content before
+ * it is intact, so truncating to that position heals the file.
+ */
+public class StorageExceptionIncompleteTransactionsEntry extends StorageExceptionConsistency
+{
+	///////////////////////////////////////////////////////////////////////////
+	// instance fields //
+	////////////////////
+
+	private final long position;
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public StorageExceptionIncompleteTransactionsEntry(final long position, final String message)
+	{
+		super(message);
+		this.position = position;
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+	// declared methods //
+	/////////////////////
+
+	public final long position()
+	{
+		return this.position;
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionTransactionsFileCompaction.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/exceptions/StorageExceptionTransactionsFileCompaction.java
@@ -1,0 +1,59 @@
+package org.eclipse.store.storage.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * A transaction-log compaction failed and could not be reconciled: the live transactions file is
+ * in an undefined state and the retained swap file is its only heal source. The channel must not
+ * process further writes - any appended entry would be silently discarded by the swap restore on
+ * the next initialization.
+ */
+public class StorageExceptionTransactionsFileCompaction extends StorageException
+{
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	public StorageExceptionTransactionsFileCompaction()
+	{
+		super();
+	}
+
+	public StorageExceptionTransactionsFileCompaction(final String message)
+	{
+		super(message);
+	}
+
+	public StorageExceptionTransactionsFileCompaction(final Throwable cause)
+	{
+		super(cause);
+	}
+
+	public StorageExceptionTransactionsFileCompaction(final String message, final Throwable cause)
+	{
+		super(message, cause);
+	}
+
+	public StorageExceptionTransactionsFileCompaction(
+		final String    message           ,
+		final Throwable cause             ,
+		final boolean   enableSuppression ,
+		final boolean   writableStackTrace
+	)
+	{
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupHandler.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupHandler.java
@@ -238,7 +238,7 @@ public interface StorageBackupHandler extends Runnable, StorageActivePart
 		public void synchronize(final StorageInventory storageInventory)
 		{
 			logger.debug("Synchronizing backup with storage");
-			
+
 			try
 			{
 				this.trySynchronize(storageInventory);
@@ -514,7 +514,7 @@ public interface StorageBackupHandler extends Runnable, StorageActivePart
 
 			final long storageFileLength      = liveTransactionsFile.size();
 			final long backupTargetFileLength = backupTransactionFile.size();
-			
+
 			if(backupTargetFileLength != storageFileLength)
 			{
 				// on any mismatch, the backup transaction file is deleted (potentially moved&renamed) and rebuilt.
@@ -523,7 +523,7 @@ public interface StorageBackupHandler extends Runnable, StorageActivePart
 				this.copyFile(liveTransactionsFile, backupTransactionFileNew);
 			}
 		}
-				
+
 		private void copyFile(
 			final StorageFile       storageFile     ,
 			final StorageBackupFile backupTargetFile

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -40,6 +40,7 @@ import org.eclipse.serializer.util.BufferSizeProviderIncremental;
 import org.eclipse.serializer.util.X;
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.exceptions.StorageExceptionTransactionsFileCompaction;
 import org.eclipse.store.storage.monitoring.StorageChannelHousekeepingMonitor;
 import org.eclipse.store.storage.types.StorageAdjacencyDataExporter.AdjacencyFiles;
 import org.slf4j.Logger;
@@ -725,7 +726,21 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		@Override
 		public boolean issuedTransactionsLogCleanup()
 		{
-			return this.housekeepingBroker.performTransactionFileCheck(this, false);
+			try
+			{
+				return this.housekeepingBroker.performTransactionFileCheck(this, false);
+			}
+			catch(final StorageExceptionTransactionsFileCompaction e)
+			{
+				/*
+				 * The live transaction log is broken and only the retained swap file can heal it
+				 * on the next initialization; any further append would be discarded by that heal.
+				 * Unlike ordinary task problems, this failure must therefore stop the channel.
+				 */
+				this.operationController.registerDisruption(e);
+				this.operationController.setChannelProcessingEnabled(false);
+				throw e;
+			}
 		}
 		
 		private long calculateSpecificHousekeepingTimeBudget(final long nanoTimeBudget)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
@@ -275,12 +275,12 @@ public interface StorageConnection extends UsageMarkable, Persister
 	);
 
 	/**
-	 * Issue a cleanup of the transaction log to reduce size regardless of its current size.
-	 * 
-	 * To shrink the file size all store, transfer, and truncation entries are combined into one single store entry
-	 * for each storage files. FileCreation entries are kept, FileDeletion entries are kept
-	 * if the storage data file still exists on the file system. Otherwise, all entries related
-	 * to deleted files are removed if the storage data file does no more exist.
+	 * Issue a cleanup of the transaction log regardless of its current size.
+	 *
+	 * Each storage file is reduced to a single FileCreation entry carrying its latest length;
+	 * only the head file keeps its latest store timestamps. FileDeletion entries are kept if the
+	 * storage data file still exists on the file system; otherwise, all entries of the deleted
+	 * file are removed.
 	 */
 	public void issueTransactionsLogCleanup();
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -40,6 +40,7 @@ import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageException;
 import org.eclipse.store.storage.exceptions.StorageExceptionCommitSizeExceeded;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+import org.eclipse.store.storage.exceptions.StorageExceptionIncompleteTransactionsEntry;
 import org.eclipse.store.storage.exceptions.StorageExceptionIoReading;
 import org.eclipse.store.storage.exceptions.StorageExceptionIoWriting;
 import org.eclipse.store.storage.exceptions.StorageExceptionIoWritingChunk;
@@ -273,6 +274,10 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 
 		private StorageTransactionsFileCleaner transactionFileCleaner;
+
+		// initialization rewrote the transactions file past the backup queue: the backup copy
+		// can then be stale at equal length, so its synchronization must rebuild unconditionally
+		private boolean transactionsFileRestored;
 
 
 		///////////////////////////////////////////////////////////////////////////
@@ -1094,6 +1099,13 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		{
 			final StorageLiveTransactionsFile file = this.createTransactionsFile();
 
+			// heal an interrupted transaction-log compaction
+			this.transactionsFileRestored = StorageTransactionsFileCleaner.recoverInterruptedCompaction(
+				file.file()         ,
+				this.channelIndex() ,
+				this.writeController
+			);
+
 			if(!file.exists())
 			{
 				/* (11.09.2014 TM)TODO: missing transactions file handler function
@@ -1105,15 +1117,48 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 			try
 			{
-				final StorageTransactionsAnalysis.EntryAggregator
-					aggregator = file.processBy(new StorageTransactionsAnalysis.EntryAggregator(this.channelIndex()));
-				return aggregator.yield(file);
+				try
+				{
+					final StorageTransactionsAnalysis.EntryAggregator
+						aggregator = file.processBy(new StorageTransactionsAnalysis.EntryAggregator(this.channelIndex()));
+					return aggregator.yield(file);
+				}
+				catch(final StorageExceptionIncompleteTransactionsEntry e)
+				{
+					this.truncateTornTransactionsFileTail(file, e);
+					final StorageTransactionsAnalysis.EntryAggregator
+						aggregator = file.processBy(new StorageTransactionsAnalysis.EntryAggregator(this.channelIndex()));
+					return aggregator.yield(file);
+				}
 			}
 			catch(final Exception e)
 			{
 				StorageClosableFile.close(file, e);
 				throw new StorageException(e);
 			}
+		}
+
+		/**
+		 * A torn trailing entry is the expected artifact of a crash during an append: the content
+		 * before it is intact and the torn entry's transaction never completed. Truncate it away,
+		 * like a torn data file tail.
+		 */
+		private void truncateTornTransactionsFileTail(
+			final StorageLiveTransactionsFile                 file ,
+			final StorageExceptionIncompleteTransactionsEntry cause
+		)
+		{
+			if(!this.writeController.isWritable())
+			{
+				throw cause;
+			}
+			logger.warn(
+				"Channel {}: truncating torn transactions file tail at position {}",
+				this.channelIndex(),
+				cause.position(),
+				cause
+			);
+			this.writer.truncate(file, cause.position(), this.fileProvider);
 		}
 
 		private long validateStorageDataFilesLength(
@@ -1346,12 +1391,50 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		
 		private void initializeBackupHandler(final StorageInventory inventory)
 		{
-			if(!this.initializeBackupHandler())
+			if(this.backupHandler == null)
 			{
 				return;
 			}
-			
+
+			if(this.transactionsFileRestored)
+			{
+				// invalidate the backup transactions file at the source, BEFORE the handler
+				// registers its file inventory: the synchronization below then rebuilds it
+				// regardless of the handler implementation
+				this.deleteBackupTransactionsFile();
+			}
+
+			this.initializeBackupHandler();
 			this.backupHandler.synchronize(inventory);
+		}
+
+		private void deleteBackupTransactionsFile()
+		{
+			final StorageBackupFileProvider backupFileProvider =
+				this.backupHandler.setup().backupFileProvider();
+			final StorageBackupTransactionsFile backupTransactionsFile =
+				backupFileProvider.provideBackupTransactionsFile(this.channelIndex());
+			final AFile backupFile = backupTransactionsFile.file();
+			if(!backupFile.exists())
+			{
+				return;
+			}
+
+			// mirror the backup handler's own deletion semantics: rescue-move when configured.
+			// Raw, released AFS accesses: a retained lease would collide with the handler's
+			// own file wrapper during the subsequent synchronization.
+			final AFile deletionTargetFile = backupFileProvider.provideDeletionTargetFile(backupTransactionsFile);
+			AFS.executeWriting(backupFile, wf ->
+			{
+				if(deletionTargetFile == null)
+				{
+					wf.delete();
+				}
+				else
+				{
+					AFS.executeWriting(deletionTargetFile, targetWf -> wf.moveTo(targetWf));
+				}
+			});
 		}
 
 		private StorageIdAnalysis initializeForExistingFiles(

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -1428,7 +1428,14 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			{
 				if(deletionTargetFile == null)
 				{
-					wf.delete();
+					if(wf.exists() && !wf.delete())
+					{
+						// a silently retained file would defeat the invalidation: at equal
+						// length, the synchronization would keep the stale backup content
+						throw new StorageException(
+							"Could not delete backup transactions file " + backupFile.toPathString()
+						);
+					}
 				}
 				else
 				{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsAnalysis.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsAnalysis.java
@@ -339,7 +339,7 @@ public interface StorageTransactionsAnalysis
 					// loop is guaranteed to terminate as it depends on the buffer capacity and the file length
 					file.readBytes(buffer, currentFilePosition);
 
-					// buffer is guaranteed to be filled exactely to its limit in any case
+					// buffer is guaranteed to be filled exactly to its limit in any case
 					final long progress = processBufferedEntities(address, buffer.limit(), entryProcessor);
 					if(progress == 0)
 					{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsAnalysis.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsAnalysis.java
@@ -33,6 +33,7 @@ import org.eclipse.serializer.exceptions.IndexBoundsException;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.store.storage.exceptions.StorageException;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
+import org.eclipse.store.storage.exceptions.StorageExceptionIncompleteTransactionsEntry;
 import org.eclipse.store.storage.exceptions.StorageExceptionIoReading;
 
 
@@ -321,27 +322,89 @@ public interface StorageTransactionsAnalysis
 			final ByteBuffer buffer  = XMemory.allocateDirectNativeDefault();
 			final long       address = XMemory.getDirectByteBufferAddress(buffer);
 
-			// process whole file part by part
-			while(currentFilePosition < boundPosition)
+			try
 			{
-				buffer.clear();
-
-				// end of file special case: adjust buffer limit if buffer would exceed the bounds
-				if(currentFilePosition + buffer.limit() >= boundPosition)
+				// process whole file part by part
+				while(currentFilePosition < boundPosition)
 				{
-					// cast (value range) safety is guaranteed by if above
-					buffer.limit((int)(boundPosition - currentFilePosition));
+					buffer.clear();
+
+					// end of file special case: adjust buffer limit if buffer would exceed the bounds
+					if(currentFilePosition + buffer.limit() >= boundPosition)
+					{
+						// cast (value range) safety is guaranteed by if above
+						buffer.limit((int)(boundPosition - currentFilePosition));
+					}
+
+					// loop is guaranteed to terminate as it depends on the buffer capacity and the file length
+					file.readBytes(buffer, currentFilePosition);
+
+					// buffer is guaranteed to be filled exactely to its limit in any case
+					final long progress = processBufferedEntities(address, buffer.limit(), entryProcessor);
+					if(progress == 0)
+					{
+						/*
+						 * The leading entry cannot be interpreted (incomplete, zero length or a
+						 * sub-header remainder); re-reading would yield the identical window and
+						 * loop forever. A remainder no larger than the largest entry, or one that
+						 * is completely zero-filled, is the expected artifact of a crash during an
+						 * append and healable by truncating it. Anything else is corruption amid
+						 * the content and must fail loudly: healing would silently discard the
+						 * unreachable remainder.
+						 */
+						if(boundPosition - currentFilePosition <= LENGTH_COMMON_MAXIMUM
+							|| isZeroFilled(file, currentFilePosition, boundPosition, buffer, address)
+						)
+						{
+							throw new StorageExceptionIncompleteTransactionsEntry(
+								currentFilePosition,
+								"Incomplete trailing transactions entry at position " + currentFilePosition
+								+ " of " + boundPosition + " in file " + file.toPathString()
+							);
+						}
+						throw new StorageExceptionConsistency(
+							"Unreadable transactions entry at position " + currentFilePosition
+							+ " of " + boundPosition + " in file " + file.toPathString()
+						);
+					}
+					currentFilePosition += progress;
 				}
 
-				// loop is guaranteed to terminate as it depends on the buffer capacity and the file length
-				file.readBytes(buffer, currentFilePosition);
-
-				// buffer is guaranteed to be filled exactely to its limit in any case
-				final long progress = processBufferedEntities(address, buffer.limit(), entryProcessor);
-				currentFilePosition += progress;
+				return entryProcessor;
 			}
+			finally
+			{
+				XMemory.deallocateDirectByteBuffer(buffer);
+			}
+		}
 
-			return entryProcessor;
+		private static boolean isZeroFilled(
+			final AReadableFile file    ,
+			final long          position,
+			final long          bound   ,
+			final ByteBuffer    buffer  ,
+			final long          address
+		)
+		{
+			long currentPosition = position;
+			while(currentPosition < bound)
+			{
+				buffer.clear();
+				if(currentPosition + buffer.limit() >= bound)
+				{
+					buffer.limit((int)(bound - currentPosition));
+				}
+				file.readBytes(buffer, currentPosition);
+				for(int i = 0; i < buffer.limit(); i++)
+				{
+					if(XMemory.get_byte(address + i) != 0)
+					{
+						return false;
+					}
+				}
+				currentPosition += buffer.limit();
+			}
+			return true;
 		}
 
 		private static long processBufferedEntities(
@@ -365,13 +428,20 @@ public interface StorageTransactionsAnalysis
 			// iterate over and process every complete entity record, skip all gaps, revert trailing complete entity
 			while(true) // loop gets terminated by end-of-data recognition logic specific to the found case
 			{
+				// an entry needs at least its length and type byte; a smaller remainder is either
+				// a window boundary (the caller re-reads) or a torn tail (the caller decides)
+				if(bufferBound - address < LENGTH_ENTRY_LENGTH + LENGTH_ENTRY_TYPE)
+				{
+					return address - startAddress;
+				}
+
 				// read length of current entry (actual or gap)
 				entryLength = getEntryLength(address); // implicit cast!
 
 				if(entryLength == 0)
 				{
-					// entity length may never be 0 or the iteration will hang forever
-					throw new StorageException("Zero length transactions entry.");
+					// cannot be advanced over; tail-or-corruption policy is decided by the caller
+					return address - startAddress;
 				}
 
 				// depending on the processor logic, incomplete entity data can still be enough (e.g. only needs header)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsFileCleaner.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsFileCleaner.java
@@ -16,11 +16,16 @@ package org.eclipse.store.storage.types;
 
 import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
+import java.util.zip.CRC32;
 
+import org.eclipse.serializer.afs.types.AFS;
+import org.eclipse.serializer.afs.types.AFile;
+import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.util.X;
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageException;
+import org.eclipse.store.storage.exceptions.StorageExceptionTransactionsFileCompaction;
 import org.eclipse.store.storage.types.StorageTransactionsAnalysis.EntryIterator;
 import org.eclipse.store.storage.types.StorageTransactionsAnalysis.Logic;
 import org.slf4j.Logger;
@@ -30,232 +35,405 @@ public interface StorageTransactionsFileCleaner
 	/**
 	 * Reduces the size of the storage transactions log file if it exceeds the configured limit.
 	 * <br>
-	 * To shrink the file size all store, transfer, and truncation entries are combined into one single store entry
-	 * for each storage files. FileCreation entries are kept, FileDeletion entries are kept
-	 * if the storage data file still exists on the file system. Otherwise, all entries related
-	 * to deleted files are removed if the storage data file does no more exist.
-	 * 
+	 * Each storage file is reduced to a single FileCreation entry carrying its latest length;
+	 * only the head file keeps its latest store timestamps. FileDeletion entries are kept if the
+	 * storage data file still exists on the file system; otherwise, all entries of the deleted
+	 * file are removed.
+	 *
 	 * @param checkSize if false the file is compacted regardless of its current size.
 	 */
 	public void compactTransactionsFile(boolean checkSize);
-	
+
+	/**
+	 * Heals a compaction that was interrupted by a crash. A complete swap file (length and
+	 * checksum match its header) is the authoritative state of an interrupted rewrite and is
+	 * restored into the transactions file; an incomplete one means the live file was never
+	 * touched and the fragment is discarded. Must be called during initialization, before the
+	 * transactions file is read.
+	 *
+	 * @param transactionsFile the channel's transactions file.
+	 * @param channelIndex the channel index, for logging.
+	 * @param writeController controller gating the repair writes.
+	 * @return whether the transactions file content may not be reflected in the backup (an
+	 *         interrupted rewrite bypassed or lost the backup queue), so the caller must have
+	 *         the backup transactions file rebuilt.
+	 */
+	public static boolean recoverInterruptedCompaction(
+		final AFile                  transactionsFile,
+		final int                    channelIndex    ,
+		final StorageWriteController writeController
+	)
+	{
+		return Default.recoverInterruptedCompaction(transactionsFile, channelIndex, writeController);
+	}
+
 	public final class Default implements StorageTransactionsFileCleaner
 	{
-		private static class FileTransactionInfo
+		///////////////////////////////////////////////////////////////////////////
+		// nested types //
+		/////////////////
+
+		/**
+		 * Captures the per-file values the {@link StorageTransactionsAnalysis.EntryAggregator}
+		 * validates but does not retain: creation and deletion timestamps and lengths.
+		 */
+		private static final class EntrySupplements
 		{
-			///////////////////////////////////////////////////////////////////////////
-			// instance fields //
-			////////////////////
-			
-			private long creationFileLength;
-			private long creationTimeStamp;
-			private long storeFileLength;
-			private long storeTimeStamp;
-			private long deletionFileLength;
-			private long deletionTimeStamp;
-	
-			///////////////////////////////////////////////////////////////////////////
-			// constructors //
-			/////////////////
-			
-			public FileTransactionInfo()
+			static final class FileSupplement
 			{
-				super();
+				long creationTimeStamp ;
+				long creationFileLength;
+				long deletionTimeStamp ;
+				long deletionFileLength;
 			}
-			
-			///////////////////////////////////////////////////////////////////////////
-			// methods //
-			////////////
-			
-			public void setCreation(final long fileLength, final long timestamp)
+
+			final LinkedHashMap<Long, FileSupplement> files = new LinkedHashMap<>();
+
+			void accept(final long address)
 			{
-				this.creationFileLength = fileLength;
-				this.creationTimeStamp  = timestamp;
-			}
-			
-			public void setStore(final long fileLength, final long timestamp)
-			{
-				this.storeFileLength = fileLength;
-				this.storeTimeStamp  = timestamp;
-			}
-			
-			public void setDeletion(final long fileLength, final long timestamp)
-			{
-				this.deletionFileLength = fileLength;
-				this.deletionTimeStamp  = timestamp;
-			}
-				
-		}
-		
-		private static class Collector implements EntryIterator
-		{
-			///////////////////////////////////////////////////////////////////////////
-			// instance fields //
-			////////////////////
-			
-			private final LinkedHashMap<Long, FileTransactionInfo> transactions;
-			private FileTransactionInfo currentTransactionInfo;
-						
-			private long currentFileNumber;
-			private long currentCreationTimeStamp;
-			
-			
-			///////////////////////////////////////////////////////////////////////////
-			// constructors //
-			/////////////////
-			
-			public Collector()
-			{
-				super();
-				this.transactions = new LinkedHashMap<>();
-			}
-			
-			
-			///////////////////////////////////////////////////////////////////////////
-			// methods //
-			////////////
-			
-			public LinkedHashMap<Long, FileTransactionInfo> transactions()
-			{
-				return this.transactions;
-			}
-			
-			@Override
-			public boolean accept(final long address, final long availableEntryLength)
-			{
-				// check for and skip gaps / comments
-				if(availableEntryLength < 0)
-				{
-					return true;
-				}
-				
 				switch(Logic.getEntryType(address))
 				{
-					case Logic.TYPE_FILE_CREATION  : return this.handleEntryFileCreation  (address, availableEntryLength);
-					case Logic.TYPE_STORE          : return this.handleEntryStore         (address, availableEntryLength);
-					case Logic.TYPE_TRANSFER       : return this.handleEntryTransfer      (address, availableEntryLength);
-					case Logic.TYPE_FILE_TRUNCATION: return this.handleEntryFileTruncation(address, availableEntryLength);
-					case Logic.TYPE_FILE_DELETION  : return this.handleEntryFileDeletion  (address, availableEntryLength);
+					case Logic.TYPE_FILE_CREATION:
+					{
+						final FileSupplement supplement = new FileSupplement();
+						supplement.creationTimeStamp  = Logic.getEntryTimestamp(address);
+						supplement.creationFileLength = Logic.getFileLength(address);
+						this.files.put(Logic.getFileNumber(address), supplement);
+						break;
+					}
+					case Logic.TYPE_FILE_DELETION:
+					{
+						final FileSupplement supplement = this.files.get(Logic.getFileNumber(address));
+						if(supplement != null)
+						{
+							supplement.deletionTimeStamp  = Logic.getEntryTimestamp(address);
+							supplement.deletionFileLength = Logic.getFileLength(address);
+						}
+						break;
+					}
 					default:
 					{
-						throw new StorageException("Unknown transactions entry type: " + Logic.getEntryType(address));
+						// stores, transfers and truncations are fully covered by the aggregator
+						break;
 					}
 				}
 			}
-	
-			private boolean handleEntryFileDeletion(final long address, final long availableEntryLength)
-			{
-				if(availableEntryLength < Logic.LENGTH_FILE_DELETION)
-				{
-					return false;
-				}
-				
-				final long fileNumber = Logic.getFileNumber(address);
-				final long fileLength = Logic.getFileLength(address);
-				final long timestamp  = Logic.getEntryTimestamp(address);
-				
-				final FileTransactionInfo info = this.transactions.get(fileNumber);
-				if(info == null)
-				{
-					throw new RuntimeException("no FileTransactionInfo for file found, file number: " + fileNumber);
-				}
-				
-				info.setDeletion(fileLength, timestamp);
-				
-				return true;
-			}
-	
-			private boolean handleEntryFileTruncation(final long address, final long availableEntryLength)
-			{
-				if(availableEntryLength < Logic.LENGTH_FILE_TRUNCATION)
-				{
-					return false;
-				}
-				
-				final long fileLength = Logic.getFileLength(address);
-				
-				this.currentTransactionInfo.setStore(fileLength, this.currentTransactionInfo.storeTimeStamp);
 
-				return true;
-			}
-	
-			private boolean handleEntryTransfer(final long address, final long availableEntryLength)
+			FileSupplement get(final long fileNumber)
 			{
-				if(availableEntryLength < Logic.LENGTH_TRANSFER)
-				{
-					return false;
-				}
-				
-				final long fileLength = Logic.getFileLength(address);
-				final long timestamp  = Logic.getEntryTimestamp(address);
-				
-				if(timestamp < this.currentCreationTimeStamp)
-				{
-					logger.debug("Store belongs to other file!");
-					FileTransactionInfo prev = this.transactions.get(this.currentFileNumber);
-					prev.setStore(fileLength, timestamp);
-				}
-				else
-				{
-					this.currentTransactionInfo.setStore(fileLength, timestamp);
-				}
-				
-				return true;
+				return this.files.get(fileNumber);
 			}
-	
-			private boolean handleEntryStore(final long address, final long availableEntryLength)
-			{
-				if(availableEntryLength < Logic.LENGTH_STORE)
-				{
-					return false;
-				}
-				
-				final long fileLength = Logic.getFileLength(address);
-				final long timestamp  = Logic.getEntryTimestamp(address);
-				
-				if(timestamp < this.currentCreationTimeStamp)
-				{
-					logger.debug("Store belongs to other file!");
-					FileTransactionInfo prev = this.transactions.get(this.currentFileNumber);
-					prev.setStore(fileLength, timestamp);
-				}
-				else
-				{
-					this.currentTransactionInfo.setStore(fileLength, timestamp);
-				}
 
-				return true;
-			}
-	
-			private boolean handleEntryFileCreation(final long address, final long availableEntryLength)
-			{
-				if(availableEntryLength < Logic.LENGTH_FILE_CREATION)
-				{
-					return false;
-				}
-				
-				final long fileNumber = Logic.getFileNumber(address);
-				final long fileLength = Logic.getFileLength(address);
-				final long timestamp  = Logic.getEntryTimestamp(address);
-				
-				this.currentFileNumber         = fileNumber;
-				this.currentCreationTimeStamp  = timestamp;
-				
-				this.currentTransactionInfo = new FileTransactionInfo();
-				this.currentTransactionInfo.setCreation(fileLength, timestamp);
-				
-				if(null != this.transactions.putIfAbsent(fileNumber, this.currentTransactionInfo))
-				{
-					throw new RuntimeException("duplicated creation entry!");
-				}
-						
-				return true;
-			}
-			
 		}
-	
+
+		/**
+		 * The assembled compacted log plus the section boundaries the writer needs: creation
+		 * entries in {@code [0, storesOffset)}, store entries in {@code [storesOffset,
+		 * deletionsOffset)}, deletion entries in {@code [deletionsOffset, buffer limit)}.
+		 */
+		private static final class CompactedContent
+		{
+			final ByteBuffer buffer          ;
+			final int        storesOffset    ;
+			final int        deletionsOffset ;
+			final long       headLatestLength;
+
+			CompactedContent(
+				final ByteBuffer buffer          ,
+				final int        storesOffset    ,
+				final int        deletionsOffset ,
+				final long       headLatestLength
+			)
+			{
+				super();
+				this.buffer           = buffer          ;
+				this.storesOffset     = storesOffset    ;
+				this.deletionsOffset  = deletionsOffset ;
+				this.headLatestLength = headLatestLength;
+			}
+		}
+
+		///////////////////////////////////////////////////////////////////////////
+		// constants //
+		//////////////
+
+		/*
+		 * Sibling of the transactions file holding the complete compacted content while the
+		 * live file is rewritten. Layout: [8B content length][8B CRC-32 of content][content]
+		 */
+		private static final String SWAP_FILE_NAME_SUFFIX = "_compaction";
+		private static final String SWAP_FILE_TYPE        = "swp";
+		private static final int    SWAP_HEADER_LENGTH    = 2 * XMemory.byteSize_long();
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// static fields //
+		//////////////////
+
 		private final static Logger logger = Logging.getLogger(StorageTransactionsFileCleaner.class);
-		
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// static methods //
+		///////////////////
+
+		static AFile compactionSwapFile(final AFile transactionsFile)
+		{
+			return transactionsFile.parent().ensureFile(
+				transactionsFile.name() + SWAP_FILE_NAME_SUFFIX,
+				SWAP_FILE_TYPE
+			);
+		}
+
+		private static long crc32(final ByteBuffer content)
+		{
+			final CRC32 crc = new CRC32();
+			crc.update(content.duplicate());
+			return crc.getValue();
+		}
+
+		private static void writeSwapFile(final AFile swapFile, final ByteBuffer content)
+		{
+			final ByteBuffer header = XMemory.allocateDirectNative(SWAP_HEADER_LENGTH);
+			try
+			{
+				final long headerAddress = XMemory.getDirectByteBufferAddress(header);
+				XMemory.set_long(headerAddress                           , content.remaining());
+				XMemory.set_long(headerAddress + XMemory.byteSize_long() , crc32(content)     );
+
+				swapFile.ensureExists();
+				AFS.executeWriting(swapFile, wf ->
+				{
+					// discard a stale fragment from an older interruption
+					wf.truncate(0);
+					wf.writeBytes(X.ArrayView(header, content));
+					// the swap must be durably complete before the live file is touched, or a
+					// power loss could invalidate it after the truncate persisted. Residual: the
+					// file's directory entry cannot be synced (no such primitive), so some file
+					// systems may still lose the whole swap file on power loss.
+					wf.synchronize();
+				});
+			}
+			finally
+			{
+				XMemory.deallocateDirectByteBuffer(header);
+			}
+		}
+
+		private static void deleteSwapFile(final AFile swapFile)
+		{
+			// a leftover complete swap file would be restored by a later initialization,
+			// discarding every entry written after this point - fail loudly
+			AFS.executeWriting(swapFile, wf ->
+			{
+				if(wf.exists() && !wf.delete())
+				{
+					throw new StorageException(
+						"Could not delete compaction swap file " + swapFile.toPathString()
+					);
+				}
+			});
+		}
+
+		private static void deleteSwapFileOrEscalate(final AFile swapFile, final Throwable cause)
+		{
+			try
+			{
+				deleteSwapFile(swapFile);
+			}
+			catch(final Throwable deleteFailure)
+			{
+				// a possibly complete swap file could not be removed: same trap as a failed rewrite
+				cause.addSuppressed(deleteFailure);
+				throw new StorageExceptionTransactionsFileCompaction(
+					"Could not remove the compaction swap file after a failed swap write: "
+					+ swapFile.toPathString(),
+					cause
+				);
+			}
+		}
+
+		/**
+		 * Returns the swap file's content if its length and CRC-32 match the header,
+		 * {@code null} otherwise.
+		 */
+		private static ByteBuffer readCompleteSwapContent(final AFile swapFile)
+		{
+			final long swapSize = swapFile.size();
+			if(swapSize < SWAP_HEADER_LENGTH)
+			{
+				return null;
+			}
+
+			return AFS.apply(swapFile, rf ->
+			{
+				final ByteBuffer header = XMemory.allocateDirectNative(SWAP_HEADER_LENGTH);
+				try
+				{
+					rf.readBytes(header, 0, SWAP_HEADER_LENGTH);
+					final long headerAddress = XMemory.getDirectByteBufferAddress(header);
+					final long contentLength = XMemory.get_long(headerAddress);
+					final long contentCrc    = XMemory.get_long(headerAddress + XMemory.byteSize_long());
+					if(contentLength < 0 || contentLength != swapSize - SWAP_HEADER_LENGTH)
+					{
+						return null;
+					}
+
+					final ByteBuffer content = XMemory.allocateDirectNative(X.checkArrayRange(contentLength));
+					boolean valid = false;
+					try
+					{
+						rf.readBytes(content, SWAP_HEADER_LENGTH, contentLength);
+						content.flip();
+						valid = crc32(content) == contentCrc;
+						return valid ? content : null;
+					}
+					finally
+					{
+						if(!valid)
+						{
+							XMemory.deallocateDirectByteBuffer(content);
+						}
+					}
+				}
+				finally
+				{
+					XMemory.deallocateDirectByteBuffer(header);
+				}
+			});
+		}
+
+		private static boolean transactionsFileEquals(final AFile transactionsFile, final ByteBuffer content)
+		{
+			if(!transactionsFile.exists() || transactionsFile.size() != content.remaining())
+			{
+				return false;
+			}
+			if(content.remaining() == 0)
+			{
+				return true;
+			}
+
+			return AFS.apply(transactionsFile, rf ->
+			{
+				final ByteBuffer live = XMemory.allocateDirectNative(content.remaining());
+				try
+				{
+					rf.readBytes(live, 0, live.capacity());
+					live.flip();
+					return live.equals(content.duplicate());
+				}
+				finally
+				{
+					XMemory.deallocateDirectByteBuffer(live);
+				}
+			});
+		}
+
+		private static Iterable<? extends ByteBuffer> sectionView(
+			final ByteBuffer buffer,
+			final int        start ,
+			final int        end
+		)
+		{
+			final ByteBuffer view = buffer.duplicate();
+			view.limit(end).position(start);
+			return X.ArrayView(view);
+		}
+
+		static boolean recoverInterruptedCompaction(
+			final AFile                  transactionsFile,
+			final int                    channelIndex    ,
+			final StorageWriteController writeController
+		)
+		{
+			final AFile swapFile = compactionSwapFile(transactionsFile);
+			if(!swapFile.exists())
+			{
+				return false;
+			}
+
+			final ByteBuffer content = readCompleteSwapContent(swapFile);
+			if(content == null)
+			{
+				// crash while the swap file was still being written: the live file was never touched
+				logger.warn(
+					"Channel {}: discarding incomplete compaction swap file {}",
+					channelIndex,
+					swapFile.toPathString()
+				);
+				if(writeController.isWritable())
+				{
+					try
+					{
+						deleteSwapFile(swapFile);
+					}
+					catch(final RuntimeException e)
+					{
+						// the fragment is inert (fails the header check) and gets replaced by the
+						// next compaction, so a failed delete must not block the start
+						logger.warn(
+							"Channel {}: could not delete incomplete compaction swap file {}",
+							channelIndex,
+							swapFile.toPathString(),
+							e
+						);
+					}
+				}
+				return false;
+			}
+
+			try
+			{
+				if(transactionsFileEquals(transactionsFile, content))
+				{
+					// the interrupted rewrite had completed; only the swap deletion is outstanding,
+					// so even a read-only start may proceed (leaving the swap for a writable start)
+					if(writeController.isWritable())
+					{
+						deleteSwapFile(swapFile);
+						// the completed rewrite may not be reflected in the backup (its queued
+						// mirror items died with the process) - report it for a backup rebuild
+						return true;
+					}
+					logger.warn(
+						"Channel {}: transaction file already matches compaction swap file {}; leaving it for the next writable start",
+						channelIndex,
+						swapFile.toPathString()
+					);
+					return false;
+				}
+
+				// the live file may be empty, partial or stale; the swap content is the
+				// authoritative compacted state (nothing was appended after its creation)
+				logger.warn(
+					"Channel {}: restoring transaction file {} from interrupted compaction swap file {}",
+					channelIndex,
+					transactionsFile.toPathString(),
+					swapFile.toPathString()
+				);
+				writeController.validateIsWritable();
+
+				transactionsFile.ensureExists();
+				AFS.executeWriting(transactionsFile, wf ->
+				{
+					wf.truncate(0);
+					wf.writeBytes(content);
+					// force the restored log before discarding its only heal source
+					wf.synchronize();
+				});
+
+				deleteSwapFile(swapFile);
+
+				return true;
+			}
+			finally
+			{
+				XMemory.deallocateDirectByteBuffer(content);
+			}
+		}
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
@@ -266,13 +444,7 @@ public interface StorageTransactionsFileCleaner
 		private final StorageFileWriter storageFileWriter;
 		private final StorageLiveFileProvider fileProvider;
 
-		/**
-		 * The most actual store time stamp in all processed files.
-		 * Required if a file has only transfers but no stores.
-		 */
-		private long lastStoreTimestamp;
-		
-		
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
@@ -294,9 +466,276 @@ public interface StorageTransactionsFileCleaner
 		
 		
 		///////////////////////////////////////////////////////////////////////////
-		// methods //
-		////////////
-		
+		// declared methods //
+		/////////////////////
+
+		private void compactTransactionsFileInternal()
+		{
+			logger.info("Compacting transaction file {}", this.storageLiveTransactionsFile.identifier());
+
+			/*
+			 * One pass: the aggregator (the reload validator itself) is the single source of truth
+			 * for per-file lengths, deleted flags and the head file's store anchors; the supplements
+			 * keep only the creation/deletion values it discards. Read through the file's managed
+			 * access: releasing a separate lease retires the channel's shared handle and races a
+			 * concurrently copying backup thread.
+			 */
+			final StorageTransactionsAnalysis.EntryAggregator aggregator =
+				new StorageTransactionsAnalysis.EntryAggregator(this.channelIndex);
+			final EntrySupplements supplements = new EntrySupplements();
+			this.storageLiveTransactionsFile.processBy((EntryIterator)(address, availableEntryLength) ->
+			{
+				if(!aggregator.accept(address, availableEntryLength))
+				{
+					return false;
+				}
+				if(availableEntryLength >= 0)
+				{
+					supplements.accept(address);
+				}
+				return true;
+			});
+			final StorageTransactionsAnalysis analysis = aggregator.yield(this.storageLiveTransactionsFile);
+
+			final CompactedContent compacted = this.assembleCompactedContent(analysis, supplements);
+			try
+			{
+				if(this.liveFileEquals(compacted.buffer))
+				{
+					// already compacted: rewriting byte-identical content would only churn the
+					// swap file, two fsyncs and the backup queue on every housekeeping cycle
+					return;
+				}
+
+				// the content becomes durable in the swap file BEFORE the live file is touched,
+				// so an interrupted rewrite is healed by #recoverInterruptedCompaction
+				final AFile swapFile = compactionSwapFile(this.storageLiveTransactionsFile.file());
+				try
+				{
+					writeSwapFile(swapFile, compacted.buffer);
+				}
+				catch(final Throwable e)
+				{
+					// live file untouched; the swap may be a fragment or even complete (a failed
+					// synchronize after a complete write) - remove it so no stale restore can occur
+					deleteSwapFileOrEscalate(swapFile, e);
+					throw e;
+				}
+
+				try
+				{
+					this.rewriteTransactionsFile(compacted, swapFile);
+				}
+				catch(final Throwable e)
+				{
+					// the live file's state is unknown, but the in-memory content is still
+					// authoritative: retry the idempotent rewrite once
+					try
+					{
+						this.rewriteTransactionsFile(compacted, swapFile);
+						logger.warn("Transaction file compaction failed transiently and was healed by retry", e);
+					}
+					catch(final Throwable retryFailure)
+					{
+						/*
+						 * The live file stays broken and the retained swap file is its only heal
+						 * source; any further append would be discarded by the swap restore on the
+						 * next initialization. The dedicated type makes the channel stop processing
+						 * (see StorageChannel#issuedTransactionsLogCleanup).
+						 */
+						e.addSuppressed(retryFailure);
+						throw new StorageExceptionTransactionsFileCompaction(
+							"Transaction file rewrite failed and could not be reconciled, swap file retained: "
+							+ swapFile.toPathString(),
+							e
+						);
+					}
+				}
+			}
+			finally
+			{
+				XMemory.deallocateDirectByteBuffer(compacted.buffer);
+			}
+		}
+
+		private boolean liveFileEquals(final ByteBuffer content)
+		{
+			// managed access only: a separate lease+release would retire the channel's shared handle
+			final long length = content.remaining();
+			if(this.storageLiveTransactionsFile.size() != length)
+			{
+				return false;
+			}
+			if(length == 0)
+			{
+				return true;
+			}
+
+			final ByteBuffer live = XMemory.allocateDirectNative((int)length);
+			try
+			{
+				this.storageLiveTransactionsFile.readBytes(live, 0, length);
+				live.flip();
+				return live.equals(content.duplicate());
+			}
+			finally
+			{
+				XMemory.deallocateDirectByteBuffer(live);
+			}
+		}
+
+		private void rewriteTransactionsFile(final CompactedContent compacted, final AFile swapFile)
+		{
+			this.storageFileWriter.truncate(this.storageLiveTransactionsFile, 0, this.fileProvider);
+			this.writeCompactedContent(compacted);
+
+			// force the rewritten log before discarding its only heal source
+			this.storageLiveTransactionsFile.synchronize();
+			deleteSwapFile(swapFile);
+		}
+
+		/**
+		 * Assembles the compacted log into one buffer (content length = buffer limit): one
+		 * FileCreation entry per still existing file, carrying the file's latest length - the
+		 * pattern the initialization's derive fallback boots from. Only the head file keeps
+		 * store entries: its two anchors, reproduced verbatim, so cross-channel crash
+		 * reconciliation behaves exactly as with the uncompacted log.
+		 * <p>
+		 * Deletion entries come after all per-file groups: on reload, a file is registered only
+		 * once the next file's creation entry is reached, so an inline deletion entry would not
+		 * find its file yet.
+		 */
+		private CompactedContent assembleCompactedContent(
+			final StorageTransactionsAnalysis analysis   ,
+			final EntrySupplements            supplements
+		)
+		{
+			// the head file (highest number, registered last) is exempt from the existence probe:
+			// lazily materializing backends report a still-empty head file as non-existing, and
+			// dropping it would re-attribute its anchors to the previous file
+			final StorageTransactionEntry headFile = analysis.transactionsFileEntries().values().peek();
+
+			final BulkList<StorageTransactionEntry> files = BulkList.New();
+			for(final StorageTransactionEntry file : analysis.transactionsFileEntries().values())
+			{
+				if(file == headFile || this.fileProvider.provideDataFile(this.channelIndex, file.fileNumber()).exists())
+				{
+					files.add(file);
+				}
+				else
+				{
+					logger.debug("channel {} file {} no more existing, removing all entries from transactions log ", this.channelIndex, file.fileNumber());
+				}
+			}
+
+			// upper bound; the actual content length is set as the buffer's limit after assembly
+			final long maximumLength = files.size() * (long)(
+				Logic.entryLengthFileCreation() + Logic.entryLengthFileDeletion()
+			) + 2L * Logic.entryLengthStore();
+
+			final ByteBuffer content = XMemory.allocateDirectNative(X.checkArrayRange(maximumLength));
+			final long       address = XMemory.getDirectByteBufferAddress(content);
+
+			int offset = 0;
+			for(final StorageTransactionEntry file : files)
+			{
+				if(file != headFile)
+				{
+					final EntrySupplements.FileSupplement supplement = supplements.get(file.fileNumber());
+					Logic.initializeEntryFileCreation(address + offset);
+					Logic.setEntryFileCreation(address + offset, file.length(), supplement.creationTimeStamp, file.fileNumber());
+					offset += Logic.entryLengthFileCreation();
+				}
+			}
+
+			final long latestTs = analysis.headFileLatestTimestamp();
+			final long lcTs     = analysis.headFileLastConsistentStoreTimestamp();
+
+			/*
+			 * The head's creation entry carries the last consistent store length: it seeds the
+			 * reloaded rollback anchor when both anchors collapse onto one timestamp
+			 * (store-less head - equal-timestamp store entries cannot be written), so a
+			 * reconciliation degenerating to timestamp 0 truncates to the correct length.
+			 * With two anchors, the first store entry overwrites it anyway.
+			 */
+			Logic.initializeEntryFileCreation(address + offset);
+			Logic.setEntryFileCreation(
+				address + offset,
+				analysis.headFileLastConsistentStoreLength(),
+				supplements.get(headFile.fileNumber()).creationTimeStamp,
+				headFile.fileNumber()
+			);
+			offset += Logic.entryLengthFileCreation();
+
+			final int storesOffset = offset;
+			if(latestTs > 0)
+			{
+				if(lcTs > 0 && lcTs < latestTs)
+				{
+					Logic.initializeEntryStore(address + offset);
+					Logic.setEntryStore(address + offset, analysis.headFileLastConsistentStoreLength(), lcTs);
+					offset += Logic.entryLengthStore();
+				}
+				Logic.initializeEntryStore(address + offset);
+				Logic.setEntryStore(address + offset, analysis.headFileLatestLength(), latestTs);
+				offset += Logic.entryLengthStore();
+			}
+
+			final int deletionsOffset = offset;
+			for(final StorageTransactionEntry file : files)
+			{
+				if(file.isDeleted())
+				{
+					final EntrySupplements.FileSupplement supplement = supplements.get(file.fileNumber());
+					Logic.initializeEntryFileDeletion(address + offset);
+					Logic.setEntryFileDeletion(address + offset, supplement.deletionFileLength, supplement.deletionTimeStamp, file.fileNumber());
+					offset += Logic.entryLengthFileDeletion();
+				}
+			}
+			content.limit(offset);
+
+			return new CompactedContent(content, storesOffset, deletionsOffset, analysis.headFileLatestLength());
+		}
+
+		/**
+		 * Writes the assembled content into the truncated live file: three contiguous,
+		 * type-homogeneous sections, one mirrored writer call each, preserving writer semantics
+		 * such as backup mirroring.
+		 */
+		private void writeCompactedContent(final CompactedContent compacted)
+		{
+			if(compacted.storesOffset > 0)
+			{
+				this.storageFileWriter.writeTransactionEntryCreate(
+					this.storageLiveTransactionsFile,
+					sectionView(compacted.buffer, 0, compacted.storesOffset),
+					null
+				);
+			}
+			if(compacted.deletionsOffset > compacted.storesOffset)
+			{
+				this.storageFileWriter.writeTransactionEntryStore(
+					this.storageLiveTransactionsFile,
+					sectionView(compacted.buffer, compacted.storesOffset, compacted.deletionsOffset),
+					null,
+					0,
+					compacted.headLatestLength
+				);
+			}
+			if(compacted.buffer.limit() > compacted.deletionsOffset)
+			{
+				this.storageFileWriter.writeTransactionEntryDelete(
+					this.storageLiveTransactionsFile,
+					sectionView(compacted.buffer, compacted.deletionsOffset, compacted.buffer.limit()),
+					null
+				);
+			}
+		}
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
 		@Override
 		public void compactTransactionsFile(final boolean checkSize)
 		{
@@ -310,128 +749,9 @@ public interface StorageTransactionsFileCleaner
 				this.compactTransactionsFileInternal();
 			}
 		}
-		
-		private void compactTransactionsFileInternal()
-		{
-			logger.info("Compacting transaction file {}", this.storageLiveTransactionsFile.identifier());
-			
-			final LinkedHashMap<Long, FileTransactionInfo> transactions = this.collectEntries();
-			this.lastStoreTimestamp = this.getLastStoreTimestamp(transactions);
-			
-			this.removeDeletedEntries(transactions);
-			
-			this.storageFileWriter.truncate(this.storageLiveTransactionsFile, 0, this.fileProvider);
-			this.writeTransactionLog(transactions);
-		}
-		
-		private LinkedHashMap<Long, FileTransactionInfo> collectEntries()
-		{
-			final Collector collector = new Collector();
-			StorageTransactionsAnalysis.Logic.processInputFile(this.storageLiveTransactionsFile.file().tryUseReading(), collector);
-			return collector.transactions();
-		}
-		
-		private long getLastStoreTimestamp(final LinkedHashMap<Long, FileTransactionInfo> transactions)
-		{
-			return transactions.values().stream().mapToLong((x)->x.storeTimeStamp).max().orElse(0);
-		}
-			
-		private void removeDeletedEntries(final LinkedHashMap<Long, FileTransactionInfo> transactions)
-		{
-			transactions.entrySet().removeIf( e -> {
-				logger.debug("channel {} file {} no more existing, removing all entries from transactions log ", this.channelIndex, e.getKey());
-				return !this.fileProvider.provideDataFile(this.channelIndex, e.getKey()).exists();
-			});
-		}
-		
-		private void writeTransactionLog(final LinkedHashMap<Long, FileTransactionInfo> transactions)
-		{
-			final ByteBuffer
-			entryBufferFileCreation   = XMemory.allocateDirectNative(StorageTransactionsAnalysis.Logic.entryLengthFileCreation()),
-			entryBufferStore          = XMemory.allocateDirectNative(StorageTransactionsAnalysis.Logic.entryLengthStore())       ,
-			entryBufferFileDeletion   = XMemory.allocateDirectNative(StorageTransactionsAnalysis.Logic.entryLengthFileDeletion());
-			
-			final Iterable<? extends ByteBuffer>
-			entryBufferWrapFileCreation   = X.ArrayView(entryBufferFileCreation  ),
-			entryBufferWrapStore          = X.ArrayView(entryBufferStore         ),
-			entryBufferWrapFileDeletion   = X.ArrayView(entryBufferFileDeletion  );
-			
-			final long
-			entryBufferFileCreationAddress   = XMemory.getDirectByteBufferAddress(entryBufferFileCreation)  ,
-			entryBufferStoreAddress          = XMemory.getDirectByteBufferAddress(entryBufferStore)         ,
-			entryBufferFileDeletionAddress   = XMemory.getDirectByteBufferAddress(entryBufferFileDeletion)  ;
-			
-			StorageTransactionsAnalysis.Logic.initializeEntryFileCreation  (entryBufferFileCreationAddress  );
-			StorageTransactionsAnalysis.Logic.initializeEntryStore         (entryBufferStoreAddress         );
-			StorageTransactionsAnalysis.Logic.initializeEntryFileDeletion  (entryBufferFileDeletionAddress  );
-			
-			transactions.forEach( (k,v) -> {
-				
-				entryBufferFileCreation.clear();
-				StorageTransactionsAnalysis.Logic.setEntryFileCreation(
-					entryBufferFileCreationAddress,
-					v.creationFileLength,
-					v.creationTimeStamp,
-					k
-				);
-				this.storageFileWriter.writeTransactionEntryCreate(this.storageLiveTransactionsFile, entryBufferWrapFileCreation, null);
-									
-								
-				if(v.storeTimeStamp > 0) {
-			
-					entryBufferStore.clear();
-					StorageTransactionsAnalysis.Logic.setEntryStore(
-						entryBufferStoreAddress,
-						v.storeFileLength,
-						v.storeTimeStamp
-					);
-					
-					this.storageFileWriter.writeTransactionEntryStore(
-						this.storageLiveTransactionsFile,
-						entryBufferWrapStore,
-						null,
-						0,
-						v.storeFileLength);
-				}
-				else
-				{
-					//special case: there is no real store entry that sets a correct time stamp and file length.
-					//This may happen if older data file are deleted and the current one has only transfers.
-					
-					entryBufferStore.clear();
-					StorageTransactionsAnalysis.Logic.setEntryStore(
-						entryBufferStoreAddress,
-						v.storeFileLength,
-						this.lastStoreTimestamp
-					);
-					
-					this.storageFileWriter.writeTransactionEntryStore(
-						this.storageLiveTransactionsFile,
-						entryBufferWrapStore,
-						null,
-						0,
-						v.storeFileLength);
-				}
-							
-				if(v.deletionTimeStamp > 0) {
-					entryBufferFileDeletion.clear();
-					StorageTransactionsAnalysis.Logic.setEntryFileDeletion(
-						entryBufferFileDeletionAddress,
-						v.deletionFileLength,
-						v.deletionTimeStamp,
-						k
-					);
-					this.storageFileWriter.writeTransactionEntryDelete(this.storageLiveTransactionsFile, entryBufferWrapFileDeletion, null);
-				}
-			});
-			
-			XMemory.deallocateDirectByteBuffer(entryBufferFileCreation);
-			XMemory.deallocateDirectByteBuffer(entryBufferStore);
-			XMemory.deallocateDirectByteBuffer(entryBufferFileDeletion);
-		}
-		
+
 	}
-	
+
 	/**
 	 * Defines a creator for StorageTransactionsFileCleaner instances.
 	 */


### PR DESCRIPTION
The old compactor fabricated and promoted store timestamps while rewriting the log, producing duplicate or inverted STORE entries that failed the strictly-monotonic reload validation on the next start ("Inconsistent timestamp of file N"). It also truncated the live log before rewriting it, so a crash mid-rewrite destroyed the transaction history.

Compacted format: one FileCreation entry per surviving file carrying its latest length; only the head file keeps store entries (its two reload anchors, reproduced verbatim, the creation entry carrying the last consistent store length); deletion entries last. The compactor reuses the reload validator (EntryAggregator) as its single source of truth instead of a second parser.

  Crash safety and robustness:
  - the complete compacted content is made durable in a checksummed sibling swap file before the live log is touched; an interrupted rewrite is healed from it at startup (read-only starts refuse if a repair write would be needed)
  - rewrites are batched into three type-homogeneous writer calls and skipped entirely when the log is already compacted
  - an unreconcilable rewrite failure stops the channel loudly instead of letting further appends be discarded by the next swap restore
  - torn transaction-log tails (crash during append, including zero-filled and sub-header remainders) are truncated at startup; corruption amid the content still fails loudly
  - after a startup restore, the backup transactions file is invalidated at the source so any backup handler rebuilds it; live rewrites keep mirroring through the backup queue