### PR TITLE
Document GigaMap index staleness on class evolution and fail loud on stale-key removal

### DIFF
--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -70,6 +70,30 @@ synchronized (gigaMap) {
 
 This is the same principle as the classic problem with synchronized JDK collections like `Vector`: synchronizing individual methods is not sufficient when multiple operations need to be atomic. In this case, the entire store traversal must be protected from concurrent modifications.
 
+== Class evolution and indexed fields
+
+GigaMap's indices (bitmap, Lucene, vector) are a *derived cache*: their keys are computed from your entities by the indexers and are then persisted alongside the entities. On load the index keys are restored *verbatim from storage* — they are **not** recomputed from, or revalidated against, the entities.
+
+This matters when an *indexed* field's class layout evolves between releases. {product-name}'s serializer maps an evolved class to the new layout on load (see xref:storage:legacy-type-mapping/index.adoc[Legacy Type Mapping]). If an indexed field is renamed or retyped *without a value-preserving refactoring mapping*, the loaded entities carry shifted or defaulted field values while the persisted index still carries the pre-evolution keys. The index is now stale, and nothing detects this automatically.
+
+[WARNING]
+====
+Evolving an *indexed* field without a value-preserving refactoring mapping leaves the indices stale — with the same consequences as a direct (untracked) mutation, and potentially worse:
+
+* Queries return pre-evolution results: `is(oldValue)` still matches, `is(actualValue)` returns nothing.
+* A subsequent `update` / `apply` / `set` that writes the entity's true value can raise a stale-index error, or — for a field under a unique constraint — trigger a *phantom* unique-constraint violation. Because `apply` mutates the entity in place and cannot roll back, such a violation causes the entity to be **removed from the map** (see the `apply` javadoc), and the next `store()` persists that loss.
+
+After evolving an indexed field, rebuild every index from the current entity state with `reindex()` **before** running any query or update, then `store()`:
+
+[source, java]
+----
+gigaMap.reindex();   // rebuild every index from current entity state
+gigaMap.store();     // persist the rebuilt indices
+----
+
+If in doubt, prefer a value-preserving refactoring mapping for indexed fields, or call `reindex()` on first load after a release that changed an indexed field's name or type.
+====
+
 == Concurrency
 
 TIP: See xref:intro:concurrent-access.adoc[Concurrent Access] for the full conceptual treatment.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexHashing.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexHashing.java
@@ -16,6 +16,8 @@ package org.eclipse.store.gigamap.types;
 
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.EqHashTable;
+import org.eclipse.store.gigamap.exceptions.BitmapIndexException;
+import org.eclipse.store.gigamap.exceptions.GigaIndexException;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -219,7 +221,29 @@ public abstract class AbstractBitmapIndexHashing<E, I, K> extends BitmapIndex.Ab
 		@Override
 		public void removeFromIndex(final long entityId)
 		{
-			throw new Error("Removing an entityId for a new key may never be required.");
+			/*
+			 * Reaching this point means an existing entity is being de-indexed under a key for which
+			 * the index holds no entry. For a genuine new key that is impossible by construction (a new
+			 * key has no prior members), so this indicates the index is stale relative to the current
+			 * entity state: its persisted keys no longer match the keys re-derived from the loaded
+			 * entities. The typical causes are a direct (untracked) mutation of an indexed field, or
+			 * entity class evolution (an indexed field renamed/retyped across releases without a
+			 * value-preserving refactoring mapping), which leaves the persisted bitmaps carrying the
+			 * pre-evolution keys. The remedy is to rebuild the indices from the current entity state via
+			 * GigaMap.reindex() before further queries or updates. Formerly this threw a raw
+			 * java.lang.Error; it now throws a descriptive, catchable exception.
+			 */
+			final String message =
+				"Cannot remove entityId " + entityId + " for key \"" + this.newKey + "\": the index holds no"
+				+ " entry for this key, which means the index is stale relative to the current entity state"
+				+ " (e.g. after a direct mutation of an indexed field or entity class evolution). Rebuild the"
+				+ " indices from the current entity state via GigaMap.reindex(), then store().";
+			if(this.index instanceof BitmapIndex<?, ?> bitmapIndex)
+			{
+				throw new BitmapIndexException(message, bitmapIndex);
+			}
+			// sub-indices of a composite index are a GigaIndex but not a BitmapIndex
+			throw new GigaIndexException(message, (GigaIndex<?>)this.index);
 		}
 		
 		@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -463,6 +463,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * entity after correcting the violation, or use {@code set} / {@code replace} instead when
 	 * non-destructive semantics are required.
 	 * <p>
+	 * Note that a <em>stale index</em> can make this destructive path fire on an otherwise legitimate update:
+	 * if an indexed field was mutated directly, or the entity class was evolved (an indexed field renamed or
+	 * retyped without a value-preserving refactoring mapping), the persisted index keys no longer match the
+	 * entities, and writing an entity's true value can trigger a <em>phantom</em> constraint violation whose
+	 * removal is a real data loss. Rebuild the indices with {@link #reindex()} before updating in that case.
+	 * <p>
 	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
 	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
 	 * may have (partially) mutated the entity: the entity is removed from the map and the original
@@ -505,6 +511,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * re-add the entity after correcting the violation, or use {@link #set(long, Object) set} when
 	 * non-destructive semantics are required.
 	 * <p>
+	 * Note that a <em>stale index</em> can make this destructive path fire on an otherwise legitimate update:
+	 * if an indexed field was mutated directly, or the entity class was evolved (an indexed field renamed or
+	 * retyped without a value-preserving refactoring mapping), the persisted index keys no longer match the
+	 * entities, and writing an entity's true value can trigger a <em>phantom</em> constraint violation whose
+	 * removal is a real data loss. Rebuild the indices with {@link #reindex()} before updating in that case.
+	 * <p>
 	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
 	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
 	 * may have (partially) mutated the entity: the entity is removed from the map and the original
@@ -545,6 +557,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * external-directory Lucene index is committed during the rebuild when its {@code LuceneContext.autoCommit}
 	 * is {@code true} (the default), otherwise at the next {@link #store()} boundary. On a very large map this
 	 * can be an expensive operation, as it iterates all entities once per index group.
+	 * <p>
+	 * <b>Class evolution:</b> the indices are a derived cache whose keys are restored verbatim from storage on
+	 * load and are <em>not</em> revalidated against the entities. Evolving an <em>indexed</em> field (renaming
+	 * or retyping it across releases without a value-preserving refactoring mapping) therefore leaves the
+	 * indices stale in exactly the same way a direct mutation does: the loaded entities carry shifted/defaulted
+	 * values while the persisted index keeps the pre-evolution keys. This method is the recovery path for that
+	 * case too; call it (then {@link #store()}) before any query or update after such an evolution.
 	 *
 	 * @see #update(long, Consumer)
 	 * @see #apply(long, Function)

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap88Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap88Test.java
@@ -1,0 +1,232 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.store.gigamap.exceptions.BitmapIndexException;
+import org.eclipse.store.gigamap.types.BinaryIndexerInteger;
+import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.Indexer;
+import org.eclipse.store.gigamap.types.IndexerInteger;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression coverage for internal issue #88: GigaMap's persisted bitmap indices are a derived
+ * cache whose keys are restored verbatim from storage on load and are never revalidated against
+ * the (possibly class-evolved) entities. When an indexed field is renamed/retyped across releases
+ * without a value-preserving refactoring mapping, the loaded entities carry defaulted values while
+ * the persisted bitmaps keep the pre-evolution keys.
+ * <p>
+ * Class evolution is simulated here by rewriting the persisted type dictionary: the indexed field
+ * is renamed to a dissimilar name AND retyped, so on reload the legacy member is unmatched (skipped)
+ * and the runtime field loads defaulted to 0 — byte-for-byte equivalent to "the data and dictionary
+ * were written by an older class version". A plain rename is not enough: with a single field on each
+ * side the automatic member matching still pairs dissimilar names, hence the field type is flipped
+ * from {@code int} to {@code float} (identical 4-byte layout) as well.
+ * <p>
+ * These tests pin the fixed behavior:
+ * <ul>
+ *   <li>{@link #reindexRecoversFromStaleUniqueIndexAfterEvolution(Path)} — {@code reindex()} is the
+ *       sanctioned recovery path: after it, queries reflect the actual entity state and a subsequent
+ *       {@code apply()} no longer triggers a phantom unique violation that would delete the entity.
+ *       Uses a binary index (unique constraints require a binary index).</li>
+ *   <li>{@link #staleHashingIndexRaisesDescriptiveExceptionInsteadOfRawError(Path)} — a write against
+ *       a stale hashing index now fails with a descriptive, catchable {@link BitmapIndexException}
+ *       pointing to {@code reindex()}, instead of the former raw {@code java.lang.Error}.</li>
+ * </ul>
+ */
+public class GigaMap88Test
+{
+	/**
+	 * Session 1: store a single {@code Person(code=5)} indexed on {@code code}, then simulate class
+	 * evolution by rewriting the persisted type dictionary. When {@code unique} is set, the index is
+	 * additionally registered as a unique constraint (requires a binary index). Returns the entity id.
+	 */
+	private static long seedAndEvolve(
+		final Path                         storageDir,
+		final Indexer<? super Person, ?>   indexer   ,
+		final boolean                      unique
+	)
+		throws IOException
+	{
+		final long            id;
+		final GigaMap<Person> map = GigaMap.New();
+		if(unique)
+		{
+			// the unique constraint registers the bitmap index for the indexer as well
+			map.index().bitmap().addUniqueConstraint("codeUnique", indexer);
+		}
+		else
+		{
+			map.index().bitmap().add(indexer);
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, storageDir))
+		{
+			id = map.add(new Person(5));
+			map.store();
+		}
+
+		// Simulate evolution: rewrite the indexed field's dictionary entry to a dissimilar name and a
+		// different (but same-width) type. The .ptd writes the field as "<type> <name>," (column padded,
+		// and only qualified with the declaring class when the simple name is ambiguous), so match it
+		// format-agnostically rather than assuming a fixed layout.
+		final Path   ptd     = storageDir.resolve("PersistenceTypeDictionary.ptd");
+		final String dict    = Files.readString(ptd, StandardCharsets.UTF_8);
+		final String evolved = dict.replaceAll("int(\\s+)((?:[\\w.$]+#)?)code(\\s*,)", "float$1$2qxz9$3");
+		assertTrue(!evolved.equals(dict), "sanity: the dictionary must contain the indexed field 'code'");
+		Files.writeString(ptd, evolved, StandardCharsets.UTF_8);
+
+		return id;
+	}
+
+	@Test
+	@Timeout(120)
+	void reindexRecoversFromStaleUniqueIndexAfterEvolution(@TempDir final Path dir) throws IOException
+	{
+		final long id = seedAndEvolve(dir, new BinaryCodeIndexer(), true);
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Person>     loaded  = (GigaMap<Person>)storage.root();
+			final BinaryCodeIndexer   indexer = new BinaryCodeIndexer();
+
+			// sanity: the evolution simulation worked — the loaded entity's field defaulted to 0.
+			assertNotNull(loaded.get(id));
+			assertEquals(0, loaded.get(id).code, "sanity: field must have been skipped/defaulted by evolution");
+
+			// Before recovery the index is stale: it still answers for the PRE-evolution key.
+			assertEquals(1, count(loaded, indexer.is(5)), "precondition: stale index still answers for the old key");
+			assertEquals(0, count(loaded, indexer.is(0)), "precondition: entity not yet reachable by its actual value");
+
+			// reindex() rebuilds every index from the current entity state — the sanctioned recovery.
+			loaded.reindex();
+
+			assertEquals(0, count(loaded, indexer.is(5)), "after reindex: stale key must be gone");
+			assertEquals(1, count(loaded, indexer.is(0)), "after reindex: entity reachable by its actual value");
+
+			// A legitimate business update writing the entity's true old value now succeeds: with the
+			// index rebuilt there is no phantom unique entry under key 5, so apply() does NOT delete it.
+			loaded.apply(id, p ->
+			{
+				p.code = 5;
+				return null;
+			});
+			assertNotNull(loaded.get(id), "the committed entity must survive a legitimate update after reindex");
+			assertEquals(5, loaded.get(id).code);
+
+			loaded.store();
+		}
+
+		// The recovery is persistent across a restart.
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+			assertNotNull(loaded.get(id), "the committed entity must survive the restart");
+			assertEquals(5, loaded.get(id).code);
+		}
+	}
+
+	@Test
+	@Timeout(120)
+	void staleHashingIndexRaisesDescriptiveExceptionInsteadOfRawError(@TempDir final Path dir) throws IOException
+	{
+		// Hashing index (not binary): the loaded entity defaults to code=0, but the persisted key→entry
+		// table only holds an entry under the pre-evolution key 5 (nothing for 0). A write that changes
+		// the value must de-index the re-derived old key 0, for which there is no entry — the case that
+		// formerly threw a raw java.lang.Error deep inside the index update.
+		final long id = seedAndEvolve(dir, new HashingCodeIndexer(), false);
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+			assertEquals(0, loaded.get(id).code, "sanity: field defaulted by evolution");
+
+			final BitmapIndexException ex = assertThrows(
+				BitmapIndexException.class,
+				() -> loaded.set(id, new Person(7)),
+				"a write against a stale index must fail with a descriptive BitmapIndexException, not a raw Error"
+			);
+			assertTrue(
+				ex.getMessage() != null && ex.getMessage().contains("reindex"),
+				"the exception should point the caller to reindex(); was: " + ex.getMessage()
+			);
+		}
+	}
+
+	private static long count(final GigaMap<Person> map, final Condition<Person> condition)
+	{
+		return map.query(condition).count();
+	}
+
+	static final class Person
+	{
+		int code;
+
+		Person(final int code)
+		{
+			this.code = code;
+		}
+	}
+
+	/** Binary integer index — required to back a unique constraint. */
+	static final class BinaryCodeIndexer extends BinaryIndexerInteger.Abstract<Person>
+	{
+		@Override
+		public String name()
+		{
+			return "code";
+		}
+
+		@Override
+		protected Integer getInteger(final Person entity)
+		{
+			return entity.code;
+		}
+	}
+
+	/** Hashing integer index — exercises the key→entry table (and the stale-key removal guard). */
+	static final class HashingCodeIndexer extends IndexerInteger.Abstract<Person>
+	{
+		@Override
+		public String name()
+		{
+			return "code";
+		}
+
+		@Override
+		protected Integer getInteger(final Person entity)
+		{
+			return entity.code;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

GigaMap's persisted bitmap indices are a derived cache whose keys are stored verbatim and restored on load without ever being re-derived from, or revalidated against, the entities. When an indexed field's class layout evolves between releases without a value-preserving refactoring mapping, the loaded entities carry shifted/defaulted values while the persisted index keeps the pre-evolution keys. Nothing detects this divergence: queries return stale results, and a subsequent `update`/`apply`/`set` can fail deep inside the index update or — for a unique-constrained field — trigger a phantom constraint violation whose destructive `apply()` fallback removes the committed entity, which the next `store()` then persists.

`GigaMap.reindex()` already fully repairs this, but it was documented only as recovery from direct in-place mutation, and class evolution was mentioned nowhere in the GigaMap docs. This PR keeps the intentional destructive `apply()` semantics unchanged and instead attacks the root cause of the issue (the failure was undocumented and, on one path, silent/uncatchable): it documents the caveat and turns the raw failure into a clear, actionable exception.

## Changes

- **Docs.** New "Class evolution and indexed fields" section in the GigaMap persistence guide describing the stale-index condition and the `reindex()`-then-`store()` recovery, cross-linked from the `reindex()` and both `apply(...)` javadocs.
- **Fail-loud guard.** `AbstractBitmapIndexHashing.NewKeyChangeChandler.removeFromIndex` no longer throws a raw, uncatchable `java.lang.Error` ("Removing an entityId for a new key may never be required."). It now throws a descriptive `BitmapIndexException` (or `GigaIndexException` for composite sub-indices, which are a `GigaIndex` but not a `BitmapIndex`) that names the likely stale-index / class-evolution cause and points the caller to `GigaMap.reindex()`. Reaching this branch means an existing entity is being de-indexed under a key that has no entry, which for a genuine new key is impossible by construction and therefore signals a stale index.
- **Regression test.** `GigaMap88Test` simulates class evolution by rewriting the persisted type dictionary (rename + retype of the indexed field to a dissimilar, same-width member, so automatic member matching skips it and the runtime field loads defaulted). One test pins `reindex()` as the sanctioned recovery for a stale unique (binary) index so a legitimate `apply()` no longer deletes the committed entity and the fix survives a restart; the other pins that a write against a stale hashing index now raises the descriptive `BitmapIndexException` instead of a raw `Error`.

## Deliberately out of scope

- The destructive `apply()` removal on constraint violation is intentional and documented; it is not changed here.
- Making the key-type-mismatch lookup (`BitmapIndices.internalGet`) throw was considered but rejected: `get(Class, String)` is a documented public API that returns `null` on a miss and `IndexIdentifier.resolveFor` relies on that `null`, so throwing there would break the public contract. That consequence is covered by documentation only.
- Automatic evolution detection / auto-reindex on load (a persisted index fingerprint, or hooking the serializer's legacy-type-mapping awareness) is a larger design and migration effort and cannot cheaply catch same-key-type value shifts; deferred as a possible follow-up.

## Testing

- `GigaMap88Test`: 2/2 pass.
- Full `gigamap` module suite: 1075 tests, 0 failures (1 pre-existing skip), BUILD SUCCESS.
