### PR TITLE
Fix use-after-free + double-free in bitmap index decompress of a partially-decompressed level2 segment

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -934,20 +934,26 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 			{
 				// either null pointer or already decompressed/standalone level1 segment, keep as is.
 				setLevel1SegmentAddress(newLevel2Address, i, oldLevel1Address);
-
-				if(oldLevel1Address > 0L)
-				{
-					// Ownership of this standalone segment is TRANSFERRED to the new block (pointer copy,
-					// not a copy of the pointed-to native memory). Clear it in the old block so the
-					// subsequent deallocate(oldLevel2Address) in ensureDecompressed() does not free memory
-					// now owned by, and still referenced from, the new block (use-after-free + double free).
-					setLevel1SegmentAddress(level2Address, i, 0L);
-				}
 			}
 		}
-		
+
 		// totalLength and level3Index have already been set by allocation method above
-		
+
+		// The new block is now fully built, so ownership of the standalone (positive-pointer) level1
+		// segments can be transferred: they were copied into the new block above by pointer, not by
+		// value, so the caller's deallocate(level2Address) must NOT free them (that would be a
+		// use-after-free plus, on a later release, a double free via the new block). Clear them from the
+		// old block here. This runs only after the build loop has completed successfully: if an
+		// allocation above throws mid-build, the old block is left fully intact (only the partially
+		// built new block leaks), preserving the exception safety of the original transform.
+		for(int i = 0; i < level2IndexBound; i++)
+		{
+			if(getLevel1SegmentAddress(level2Address, i) > 0L)
+			{
+				setLevel1SegmentAddress(level2Address, i, 0L);
+			}
+		}
+
 		return newLevel2Address;
 	}
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -934,6 +934,15 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 			{
 				// either null pointer or already decompressed/standalone level1 segment, keep as is.
 				setLevel1SegmentAddress(newLevel2Address, i, oldLevel1Address);
+
+				if(oldLevel1Address > 0L)
+				{
+					// Ownership of this standalone segment is TRANSFERRED to the new block (pointer copy,
+					// not a copy of the pointed-to native memory). Clear it in the old block so the
+					// subsequent deallocate(oldLevel2Address) in ensureDecompressed() does not free memory
+					// now owned by, and still referenced from, the new block (use-after-free + double free).
+					setLevel1SegmentAddress(level2Address, i, 0L);
+				}
 			}
 		}
 		

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexTest.java
@@ -138,26 +138,34 @@ public class BitmapIndexTest
         {
             final EntityValueIndexer indexer = new EntityValueIndexer();
             final GigaMap<Entity>    map     = GigaMap.New();
-            map.index().bitmap().add(indexer);
-
-            for(int i = 0; i < 20_000; i++)
+            // release the off-heap memory each round so a failure mid-loop cannot pile up native pressure
+            try
             {
-                map.add(new Entity("e" + i, i % 7));
+                map.index().bitmap().add(indexer);
+
+                for(int i = 0; i < 20_000; i++)
+                {
+                    map.add(new Entity("e" + i, i % 7));
+                }
+                final BitmapIndex<Entity, Integer> bitmap = map.index().bitmap(indexer);
+
+                bitmap.ensureOptimizedSize();                 // compress everything (standaloneCount == 0)
+
+                for(int i = 0; i < 5_000; i++)                // mutate -> partially-decompressed mixed state
+                {
+                    map.add(new Entity("m" + i, i % 7));
+                }
+
+                final long expected = map.query(indexer.is(3)).count();
+                bitmap.ensureOptimizedPerformance();          // decompress (the previously buggy transfer path)
+                assertEquals(expected, map.query(indexer.is(3)).count());
+                bitmap.ensureOptimizedSize();                 // recompress (previously double-freed -> crash)
+                assertEquals(expected, map.query(indexer.is(3)).count());
             }
-            final BitmapIndex<Entity, Integer> bitmap = map.index().bitmap(indexer);
-
-            bitmap.ensureOptimizedSize();                 // compress everything (standaloneCount == 0)
-
-            for(int i = 0; i < 5_000; i++)                // mutate -> partially-decompressed mixed state
+            finally
             {
-                map.add(new Entity("m" + i, i % 7));
+                map.release();
             }
-
-            final long expected = map.query(indexer.is(3)).count();
-            bitmap.ensureOptimizedPerformance();          // decompress (the previously buggy transfer path)
-            assertEquals(expected, map.query(indexer.is(3)).count());
-            bitmap.ensureOptimizedSize();                 // recompress (previously double-freed -> crash)
-            assertEquals(expected, map.query(indexer.is(3)).count());
         }
     }
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexTest.java
@@ -121,6 +121,46 @@ public class BitmapIndexTest
 
     }
 
+    /**
+     * Regression test for a use-after-free + double-free in the bitmap index off-heap memory
+     * (microstream-one/internal#102). Decompressing a partially-decompressed level2 segment used to
+     * transfer standalone level1 pointers into the new block while the old block still freed them,
+     * producing silent, nondeterministic wrong query counts and, on a subsequent recompression, a
+     * hard JVM crash (native heap corruption / double free). The lifecycle below reproduces the mixed
+     * compressed+mutated state that the previous coverage never hit. Several rounds are run because
+     * the corruption is nondeterministic; a stable query count across the optimize calls proves the
+     * transferred pointers are no longer freed prematurely.
+     */
+    @Test
+    void ensureOptimizedPerformance_afterCompressAndMutate_keepsQueryCountsStable()
+    {
+        for(int round = 0; round < 10; round++)
+        {
+            final EntityValueIndexer indexer = new EntityValueIndexer();
+            final GigaMap<Entity>    map     = GigaMap.New();
+            map.index().bitmap().add(indexer);
+
+            for(int i = 0; i < 20_000; i++)
+            {
+                map.add(new Entity("e" + i, i % 7));
+            }
+            final BitmapIndex<Entity, Integer> bitmap = map.index().bitmap(indexer);
+
+            bitmap.ensureOptimizedSize();                 // compress everything (standaloneCount == 0)
+
+            for(int i = 0; i < 5_000; i++)                // mutate -> partially-decompressed mixed state
+            {
+                map.add(new Entity("m" + i, i % 7));
+            }
+
+            final long expected = map.query(indexer.is(3)).count();
+            bitmap.ensureOptimizedPerformance();          // decompress (the previously buggy transfer path)
+            assertEquals(expected, map.query(indexer.is(3)).count());
+            bitmap.ensureOptimizedSize();                 // recompress (previously double-freed -> crash)
+            assertEquals(expected, map.query(indexer.is(3)).count());
+        }
+    }
+
     private static class EntityValueIndexer extends IndexerInteger.Abstract<Entity> {
     	
         @Override

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/BitmapIndexTest.java
@@ -122,8 +122,8 @@ public class BitmapIndexTest
     }
 
     /**
-     * Regression test for a use-after-free + double-free in the bitmap index off-heap memory
-     * (microstream-one/internal#102). Decompressing a partially-decompressed level2 segment used to
+     * Regression test for a use-after-free + double-free in the bitmap index off-heap memory.
+     * Decompressing a partially-decompressed level2 segment used to
      * transfer standalone level1 pointers into the new block while the old block still freed them,
      * producing silent, nondeterministic wrong query counts and, on a subsequent recompression, a
      * hard JVM crash (native heap corruption / double free). The lifecycle below reproduces the mixed


### PR DESCRIPTION
## Problem

`BitmapLevel2.decompress()` transferred standalone level1 segment pointers (`> 0L`) into the newly allocated level2 block by copying the pointer, not the pointed-to off-heap memory, leaving the same pointer in both the old and the new index array. `ensureDecompressed()` then called `deallocate()` on the old block, which frees every positive pointer it holds — including the ones just transferred to the new block. The new block therefore read freed native memory (silent, nondeterministic wrong query results) and a subsequent recompression freed the same pointers again (double free → native heap corruption → JVM crash). The whole sequence is reachable through public API: `ensureOptimizedSize()` → mutate → `ensureOptimizedPerformance()`.

## Fix

Clear the transferred pointer in the old block right after handing it to the new block, so the old block relinquishes ownership and its `deallocate()` no longer frees memory still referenced from the new block. The transfer stays a pointer move — no extra allocation or copy. `compress()` was never affected because it copies segment data rather than transferring pointers.

## Test

Added a regression test exercising the compress → mutate → decompress → recompress lifecycle that produces the mixed compressed+mutated state the previous coverage never reached. On the unfixed code it reproduces both symptoms: a query-count mismatch and a native heap-corruption crash. The full gigamap suite (1076 tests) passes with the fix.
