### PR TITLE
Remove private issue-tracker references from comments and docs

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/backup/ShortCopyValidationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/backup/ShortCopyValidationTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 /**
- * Empirical verification of the internal#71 fix (store#744): short copies must fail loudly at
+ * Empirical verification of the fix (store#744): short copies must fail loudly at
  * every backup-relevant site, and the backupping writer must never enqueue a backup item for a
  * short copy (a wrong-length item would permanently diverge the backup).
  */

--- a/integration-tests/src/test/java/test/eclipse/store/entitycache/TypeInFileRebuildDuplicateReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/entitycache/TypeInFileRebuildDuplicateReproTest.java
@@ -50,8 +50,8 @@ import org.junit.jupiter.api.io.TempDir;
  * (there is no removal), the inflated count triggers further — again wrongly
  * keyed — rebuilds, and the hot {@code typeInFile()} lookup path degrades.
  *
- * <p>Unlike the sibling defect in {@code StorageEntityCache.putEntity}
- * (internal#77), this one is contained: {@code TypeInFile} is a pure
+ * <p>Unlike the sibling defect in {@code StorageEntityCache.putEntity},
+ * this one is contained: {@code TypeInFile} is a pure
  * (type, file) flyweight, lookups verify {@code t.type == type}, and nothing
  * iterates the table — so the impact is memory/CPU degradation, not data
  * corruption. The fix is to re-hash by {@code entries.type}.

--- a/integration-tests/src/test/java/test/eclipse/store/gc/MultiChannelResidualWindowReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/gc/MultiChannelResidualWindowReproTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 
 /**
- * Reproducer for the MULTI-CHANNEL residual window of the storage GC (internal#85; GC.md §10.4):
+ * Reproducer for the MULTI-CHANNEL residual window of the storage GC (GC.md §10.4):
  * with channelCount >= 2, a load can straddle a sweep wave — one channel has already swept when
  * the load's collect runs on another channel. The handed-out entity X is black-marked shallowly
  * (no reference walk: the wave's mark queues must stay empty), its unloaded-Lazy target Y on the
@@ -216,7 +216,7 @@ public class MultiChannelResidualWindowReproTest
 	 * {@link MultiChannelSweepEntryRaceReproTest}. The control run below (whole orphan graph collected
 	 * consistently, no partial survival) stays enabled.
 	 */
-	@Disabled("internal#85 GC.md §10.4: child's channel sweeps before the reheating registration -"
+	@Disabled("GC.md §10.4: child's channel sweeps before the reheating registration -"
 		+ " fundamentally not closeable post-hoc (the child is already physically deleted); the"
 		+ " rescuable subset is covered by MultiChannelSweepEntryRaceReproTest")
 	@Test

--- a/integration-tests/src/test/java/test/eclipse/store/gc/MultiChannelSweepEntryRaceReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/gc/MultiChannelSweepEntryRaceReproTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 
 /**
- * Regression test for the <b>sweep-entry registration race</b> (internal#85 "Window B", the
+ * Regression test for the <b>sweep-entry registration race</b> ("Window B", the
  * residual documented in GC.md §10.4). This is the multi-channel continuation of
  * {@link MidCycleRegistrationRaceTest}: there the mid-cycle registration lands <i>before</i> the
  * sweep is initiated (caught by the pre-sweep re-seed of store#736); here it lands <i>after</i>

--- a/integration-tests/src/test/java/test/eclipse/store/gc/PartialSweepRetryReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/gc/PartialSweepRetryReproTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
 
 /**
- * Reproducer for the <b>partial-sweep re-execution hazard</b> (internal#83): the sweep whitens
+ * Reproducer for the <b>partial-sweep re-execution hazard</b>: the sweep whitens
  * surviving (marked) entities AS IT GOES ({@code StorageEntityCache.Default.sweep}, whiten-as-you-go)
  * and clears the channel's sweep flag only at the very end. A TRANSIENT exception thrown partway
  * through the sweep (e.g. by a custom {@code LiveObjectIdsHandler} selector, or an OOM) leaves the

--- a/integration-tests/src/test/java/test/eclipse/store/various/ReadOnlyConcurrentIssue25ExperimentTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/various/ReadOnlyConcurrentIssue25ExperimentTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Experimental verification of microstream-one/internal#25:
+ * Experimental verification of the read-only concurrent-access behavior:
  * a second, read-only EmbeddedStorageManager on the same storage directory
  * within the same JVM while the first (writing) manager is still running.
  */

--- a/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/zombie/SkipPinningTest.java
@@ -133,7 +133,7 @@ public class SkipPinningTest
 		assertNotNull(pinned,
 			"the storer must pin the skipped instance until commit - it was collected");
 
-		// the t1..t4 window of internal#73: reap attempt + full storage GC. With the pin alive,
+		// the t1..t4 window: reap attempt + full storage GC. With the pin alive,
 		// the registry entry stays and the safety net keeps X's entity on disk.
 		registry.cleanUp();
 		this.storage.issueFullGarbageCollection();

--- a/storage/storage/GC.md
+++ b/storage/storage/GC.md
@@ -445,7 +445,7 @@ The former §10.3 justification for this window ("the entity's binary was just l
 
 **Layer 1 — load-side marking + pending-load gate** (primary for loads): `StorageChannel.collectLoadByOids/Tids` signal a *pending load* on the mark monitor for the duration of the collection (`pendingLoadCount` participates in `isMarkingComplete()`, so no sweep can be *initiated* mid-load), and every entity handed out by a load is marked like changed data via `StorageEntityCache#markEntityForLoadedData` — gray-marked and enqueued (references walked transitively) during an active mark phase, black-marked if a sweep was already initiated. This protects the loaded graph **at hand-out time**, i.e. even before the application-side `BinaryLoader` registration happens — a gap the registry-based layer below cannot see.
 
-> **Multi-channel visibility gap ("variant 2", internal#85 "Window A") and its fix.** The per-channel
+> **Multi-channel visibility gap ("variant 2", "Window A") and its fix.** The per-channel
 > `pendingLoad` above is signaled only *around that channel's own collect*, and skipped entirely for a
 > channel whose oid subset of the load is empty (`if(!loadOids.isEmpty())`). At `channelCount ≥ 2` a
 > load already in flight is therefore **invisible** to a sibling channel's sweep-initiation check: the
@@ -473,7 +473,7 @@ Trade-offs and boundaries:
   registration landing after `initiateSweep()` but before/between the per-channel sweeps used to be
   covered only by the shallow predicate (Layer 1's `hasLoadPendingSweep` branch black-marks the
   handed-out entity but cannot rescue its not-yet-loaded children in that already-initiated sweep).
-  **Layer 3 — registrationVersion check at sweep entry (internal#85)** closes the rescuable part of
+  **Layer 3 — registrationVersion check at sweep entry** closes the rescuable part of
   this window: at the very start of each channel's `sweep(_longPredicate)` — which runs *inside* the
   registry mutex, so a registration cannot interleave with that channel's sweep —
   `StorageEntityMarkMonitor#isSeedRegistrationStale(currentRegistrationVersion)` compares the

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -151,7 +151,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 
 		/**
 		 * Set when a sweep attempt failed with an exception before the sweep flag was cleared
-		 * (internal#83) - whether mid-iteration or in the completion bookkeeping afterwards. The
+		 * - whether mid-iteration or in the completion bookkeeping afterwards. The
 		 * attempt may have already reset an unknown prefix of the surviving (marked) entities back
 		 * to white, so re-executing the still-flagged sweep with normal delete semantics could
 		 * delete reachable entities. The next execution runs as a keep-all rescue sweep instead.
@@ -1313,7 +1313,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			try
 			{
 				/*
-				 * internal#85 (GC.md §10.4, "Window B"): if the application registry gained an entry
+				 * GC.md §10.4, "Window B": if the application registry gained an entry
 				 * since this wave took its seed snapshot, the seed is stale for this channel. A
 				 * just-loaded orphan graph (e.g. a reheated parent whose unloaded Lazy target is
 				 * neither loaded nor marked, and lives on another channel) could be partially swept.
@@ -1386,8 +1386,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		}
 
 		/**
-		 * Keep-all re-execution of a sweep whose previous attempt failed before completing
-		 * (internal#83).
+		 * Keep-all re-execution of a sweep whose previous attempt failed before completing.
 		 * The aborted attempt already whitened an unknown prefix of the surviving entities, so mark
 		 * state can no longer distinguish garbage from reachable data. This pass therefore deletes
 		 * nothing and consults no application predicate: the sweep pass itself is straight-line
@@ -1415,8 +1414,8 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		/**
 		 * Keep-all sweep pass: reset every entity of this channel to white and delete nothing,
 		 * consulting no application predicate. Used both by {@link #rescueSweep()} (a previous attempt
-		 * failed mid-run, internal#83) and by the stale-seed deferral in {@link #sweep(_longPredicate)}
-		 * (internal#85). The pass itself is straight-line pointer operations that cannot throw; the
+		 * failed mid-run) and by the stale-seed deferral in {@link #sweep(_longPredicate)}.
+		 * The pass itself is straight-line pointer operations that cannot throw; the
 		 * completion bookkeeping afterwards may still throw (mark monitor / registry interaction),
 		 * which the callers handle. Garbage collection is merely deferred: the following mark cycle
 		 * re-establishes marks from the roots and the registry seed.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityMarkMonitor.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityMarkMonitor.java
@@ -79,7 +79,7 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 	 * This is the task-scoped counterpart to the per-channel
 	 * {@link #signalPendingLoad(StorageEntityCache)}: the latter is signaled inside each channel's
 	 * own collect and is skipped entirely for a channel whose oid subset of the load is empty, so
-	 * an in-flight load is invisible to a sibling channel's sweep-initiation check (internal#85).
+	 * an in-flight load is invisible to a sibling channel's sweep-initiation check.
 	 * Signaling this task-scoped gate once at load-task enqueue (before any channel is notified)
 	 * and clearing it once when the task has been processed on all channels closes that
 	 * cross-channel visibility gap: no wave can initiate while a load is in flight, so the loaded
@@ -126,8 +126,8 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 	/**
 	 * Reports whether the current sweep wave's live-OID seed has become stale relative to the passed
 	 * registration version, i.e. whether the application registry gained a new association after this
-	 * wave snapshotted its seed but before the calling channel executes its sweep (internal#85,
-	 * "Window B" / GC.md §10.4).
+	 * wave snapshotted its seed but before the calling channel executes its sweep
+	 * ("Window B" / GC.md §10.4).
 	 * <p>
 	 * A channel calls this at the very start of its sweep, from inside the registry mutex (so the
 	 * version cannot change under it for the duration of that channel's sweep). If it returns
@@ -421,7 +421,7 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 		 * <p>
 		 * Volatile: written under the monitor lock (callToSweepRequired / completeSweep) but read
 		 * lock-free by a sweeping channel in {@link #isSeedRegistrationStale(long)} (that read cannot
-		 * take the monitor lock — it runs while the channel holds the registry mutex, internal#85).
+		 * take the monitor lock — it runs while the channel holds the registry mutex).
 		 */
 		private volatile long seedRegistrationVersion;
 
@@ -609,7 +609,7 @@ public interface StorageEntityMarkMonitor extends PersistenceObjectIdAcceptor
 			// pendingLoadCount > 0 defers sweep initiation while a channel is collecting entities for
 			// a load, and pendingLoadTaskCount > 0 defers it for the entire lifetime of any in-flight
 			// load task (from enqueue until processed on all channels, closing the cross-channel
-			// visibility gap of internal#85), so that entities handed out to the application are
+			// visibility gap), so that entities handed out to the application are
 			// gc-protected and their references are marked before any sweep (see #signalPendingLoad
 			// and #signalPendingLoadTask).
 			return this.pendingMarksCount == 0 && this.pendingStoreUpdateCount == 0

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskLoad.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskLoad.java
@@ -22,7 +22,7 @@ public interface StorageRequestTaskLoad extends StorageRequestTask
 	public ChunksBuffer result() throws StorageExceptionRequest;
 
 	/**
-	 * Arms the task-scoped pending-load gate (internal#85): the task keeps the passed mark monitor so
+	 * Arms the task-scoped pending-load gate: the task keeps the passed mark monitor so
 	 * that it can clear the gate when it has completed on all channels (or on the enqueue-failure
 	 * path). Called by the task broker at enqueue, before the task is signaled and made visible to any
 	 * channel. Returns whether the gate was armed; the broker only signals (and, on failure, clears)
@@ -104,7 +104,7 @@ public interface StorageRequestTaskLoad extends StorageRequestTask
 		@Override
 		protected void onLastCompletion()
 		{
-			// Release the task-scoped pending-load gate signaled at enqueue (internal#85). Runs
+			// Release the task-scoped pending-load gate signaled at enqueue. Runs
 			// exactly once, when the task has completed on all channels - by then every channel has
 			// finished its collect and enqueued its gray marks, so pendingMarksCount keeps
 			// isMarkingComplete() false until those are drained; the gate can be released safely.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
@@ -810,8 +810,8 @@ public interface StorageSystem extends StorageController
 		{
 			// The mark monitor is a singleton shared by all channels; read it from any channel. Only
 			// valid once startup has created the channels; guard with a deterministic exception rather
-			// than risking an NPE on channelKeepers[0] if called before startup or after teardown
-			// (internal#85 review). Loads - the only caller - occur only while running, so this never
+			// than risking an NPE on channelKeepers[0] if called before startup or after teardown.
+			// Loads - the only caller - occur only while running, so this never
 			// rejects a legitimate call.
 			final ChannelKeeper[] keepers = this.channelKeepers;
 			if(keepers.length == 0 || keepers[0] == null || !this.isRunning())

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
@@ -122,7 +122,7 @@ public interface StorageTaskBroker
 		// StorageSystem (NOT StorageManager) is safe to hold: it is a distinct object that does not
 		// reference the manager, so it does not affect the manager's auto-shutdown weak reachability.
 		// Used only to lazily reach the shared mark monitor at load-task enqueue time (the monitor
-		// does not yet exist when this broker is constructed - internal#85).
+		// does not yet exist when this broker is constructed).
 		private final StorageSystem                 storageSystem         ;
 
 		private volatile StorageTask currentHead;
@@ -469,7 +469,7 @@ public interface StorageTaskBroker
 		 * Arm the task-scoped pending-load gate for a load task and enqueue it. The task is given the
 		 * shared mark monitor (so it can clear the gate when it completes on all channels, via
 		 * {@link StorageRequestTaskLoad.Abstract#onLastCompletion()}), then the gate is signaled BEFORE
-		 * the task becomes visible to any channel (internal#85): a channel mid-housekeeping when the load
+		 * the task becomes visible to any channel: a channel mid-housekeeping when the load
 		 * is enqueued then observes the gate at its next sweep-initiation check and cannot initiate a
 		 * sweep in the enqueue -> pickup gap. If the task does not arm the gate (a custom load task that
 		 * would not clear it - see {@link StorageRequestTaskLoad#registerPendingLoadTaskGate}), the gate


### PR DESCRIPTION
## Summary

Removes references to the private issue tracker (`internal#NN` / `microstream-one/internal#NN`) from Javadoc, inline comments, the storage `GC.md` notes and one `@Disabled` reason string. These had accumulated across recent storage GC / entity-cache work and shouldn't ship in the public repository.

## Scope

- Comments, documentation and one annotation string only — **no code changes** (verified: the only non-comment edit is a `@Disabled` reason string).
- Public references are kept intact so the explanations stay useful: `store#NNN`, `GC.md` section numbers (`§10.4`), the `"Window A/B"` and `t1..t4` labels.

## Files

13 files: 5 storage main-source files, `storage/storage/GC.md`, and 7 integration-test files.
