### PR TITLE
Hold the StorageSystem weakly in the task broker so auto-shutdown can fire

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/various/AbandonedStorageAutoShutdownTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/various/AbandonedStorageAutoShutdownTest.java
@@ -1,0 +1,111 @@
+package test.eclipse.store.various;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.StorageSystem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression test for internal#97: the storage's auto-shutdown-by-unreachability mechanism —
+ * when the application drops all references to its {@link EmbeddedStorageManager} WITHOUT calling
+ * {@code shutdown()}, the {@code StorageOperationController}'s {@code WeakReference<StorageSystem>}
+ * clears, the channel threads observe processing disabled and exit, and the whole engine (threads +
+ * off-heap entity cache) is released.
+ * <p>
+ * store#755 (commit 24e8ccc0) added a strong {@code StorageSystem} field to {@code StorageTaskBroker}
+ * (to reach the shared mark monitor for the task-scoped pending-load gate). Every channel holds the
+ * broker and the live channel threads are GC roots, so the chain Thread &rarr; channel &rarr; broker
+ * &rarr; StorageSystem keeps the system strongly reachable forever: the weak reference never clears,
+ * auto-shutdown never fires, the non-daemon channel threads run forever and pin the off-heap cache.
+ * <p>
+ * This test wraps the (reflectively obtained) StorageSystem in a WeakReference, drops the manager,
+ * and asserts the reference clears within a bounded GC budget. RED on the buggy engine (never
+ * clears). Safe for CI: on the buggy path the leaked-but-still-reachable system is shut down in the
+ * finally block via the WeakReference's own referent, so no non-daemon thread is left running.
+ */
+public class AbandonedStorageAutoShutdownTest
+{
+	@Test
+	@Timeout(value = 120, unit = TimeUnit.SECONDS)
+	void abandonedManagerWithoutShutdown_engineMustBecomeUnreachable(@TempDir final Path dir) throws Exception
+	{
+		WeakReference<StorageSystem> weakSystem = null;
+		try
+		{
+			weakSystem = startAndAbandon(dir);
+
+			// Force GC repeatedly; on a correct engine the weak StorageSystem clears within a cycle or
+			// two (channel threads then self-terminate). On the buggy engine the live channel threads
+			// pin the system through the broker's strong reference, so it never clears.
+			final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20);
+			while(weakSystem.get() != null && System.nanoTime() < deadline)
+			{
+				System.gc();
+				Thread.sleep(50);
+			}
+
+			assertNull(weakSystem.get(),
+				"internal#97: StorageSystem is still strongly reachable after the manager was abandoned "
+				+ "without shutdown() — auto-shutdown-by-unreachability cannot fire, channel threads leak");
+		}
+		finally
+		{
+			// If the system leaked (buggy engine), it is still reachable via the weak referent — shut it
+			// down so no non-daemon channel thread survives the test and wedges the surefire fork.
+			final StorageSystem leaked = weakSystem == null ? null : weakSystem.get();
+			if(leaked != null)
+			{
+				try
+				{
+					leaked.shutdown();
+				}
+				catch(final Throwable ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	/**
+	 * Starts a storage, reflectively wraps its StorageSystem in a WeakReference, and returns that
+	 * reference. The manager and all strong references to the system created here go out of scope on
+	 * return, so only the (buggy) internal retention can keep the system alive.
+	 */
+	private static WeakReference<StorageSystem> startAndAbandon(final Path dir) throws Exception
+	{
+		final EmbeddedStorageManager manager = EmbeddedStorage.start(new ArrayList<>(), dir);
+		manager.storeRoot();
+
+		final Field f = manager.getClass().getDeclaredField("storageSystem");
+		f.setAccessible(true);
+		final StorageSystem system = (StorageSystem)f.get(manager);
+
+		return new WeakReference<>(system);
+		// manager + system are local: eligible for GC on return unless internally retained.
+	}
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
@@ -490,7 +490,10 @@ public interface StorageTaskBroker
 			final StorageSystem system = this.storageSystemReference.get();
 			if(system == null)
 			{
-				throw new StorageExceptionNotRunning();
+				throw new StorageExceptionNotRunning(
+					"Storage is shut down: the StorageSystem has been garbage-collected"
+					+ " (the manager was abandoned without shutdown())."
+				);
 			}
 			// entityMarkMonitor() throws if the system is not running; do it before signaling anything.
 			final StorageEntityMarkMonitor markMonitor = system.entityMarkMonitor();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
@@ -16,6 +16,7 @@ package org.eclipse.store.storage.types;
 
 import static org.eclipse.serializer.util.X.notNull;
 
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.function.Predicate;
@@ -119,11 +120,15 @@ public interface StorageTaskBroker
 		private final StorageRequestTaskCreator     taskCreator           ;
 		private final int                           channelCount          ;
 
-		// StorageSystem (NOT StorageManager) is safe to hold: it is a distinct object that does not
-		// reference the manager, so it does not affect the manager's auto-shutdown weak reachability.
-		// Used only to lazily reach the shared mark monitor at load-task enqueue time (the monitor
-		// does not yet exist when this broker is constructed).
-		private final StorageSystem                 storageSystem         ;
+		// WEAK reference to the StorageSystem: the broker is reachable from the live,
+		// non-daemon channel threads (Thread -> StorageChannel -> taskBroker), so a strong reference
+		// here would keep the StorageSystem strongly reachable and defeat auto-shutdown-by-unreach-
+		// ability - the StorageOperationController's WeakReference<StorageSystem> could never clear,
+		// leaking the channel threads and the off-heap entity cache when an application drops its
+		// manager without shutdown(). Held only to lazily reach the shared mark monitor at load-task
+		// enqueue time (the monitor does not yet exist when this broker is constructed); during normal
+		// operation the application/manager keeps the system strongly reachable, so it resolves.
+		private final WeakReference<StorageSystem>  storageSystemReference;
 
 		private volatile StorageTask currentHead;
 
@@ -148,7 +153,7 @@ public interface StorageTaskBroker
 			this.fileEvaluator          = notNull(fileEvaluator);
 			this.objectIdRangeEvaluator = notNull(objectIdRangeEvaluator);
 			this.channelCount           =         channelCount;
-			this.storageSystem          = notNull(storageSystem);
+			this.storageSystemReference = new WeakReference<>(notNull(storageSystem));
 			this.currentHead            = new StorageTask.DummyTask();
 		}
 
@@ -479,8 +484,16 @@ public interface StorageTaskBroker
 		 */
 		private void enqueueLoadTaskAndNotifyAll(final StorageRequestTaskLoad task) throws InterruptedException
 		{
+			// resolve the system through the weak reference (internal#97): during normal operation the
+			// application/manager keeps it strongly reachable, so this returns non-null; a null means the
+			// storage was abandoned (GC'd) without shutdown(), where there is nothing to enqueue against.
+			final StorageSystem system = this.storageSystemReference.get();
+			if(system == null)
+			{
+				throw new StorageExceptionNotRunning();
+			}
 			// entityMarkMonitor() throws if the system is not running; do it before signaling anything.
-			final StorageEntityMarkMonitor markMonitor = this.storageSystem.entityMarkMonitor();
+			final StorageEntityMarkMonitor markMonitor = system.entityMarkMonitor();
 			final boolean armed = task.registerPendingLoadTaskGate(markMonitor);
 			if(armed)
 			{


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #755. The task broker held a strong `StorageSystem` reference, which defeated the storage's auto-shutdown-by-unreachability mechanism: an application that dropped its `EmbeddedStorageManager` without calling `shutdown()` leaked the whole engine — the non-daemon channel threads kept running (the JVM could not exit) and the raw-`Unsafe` entity cache stayed pinned.

## Root cause

#755 gave `StorageTaskBroker.Default` a strong `StorageSystem` field so the broker could reach the shared mark monitor at load-task enqueue time (for the task-scoped pending-load gate). But the broker is reachable from the live, non-daemon channel threads (`Thread → StorageChannel → taskBroker`), so that field kept the `StorageSystem` strongly reachable. Auto-shutdown relies on `StorageOperationController` holding a `WeakReference<StorageSystem>` that clears when the system becomes unreachable; with the broker pinning the system it could never clear, so the channel threads never observed processing-disabled and never exited (and never disposed the off-heap cache). The guard comment claiming the field was safe to hold was wrong: the operation controller's weak reference targets the `StorageSystem`, not the manager.

## Fix

Hold the system through a `WeakReference<StorageSystem>` in the broker (mirroring `StorageOperationController.Default.storageSystemReference`) and resolve it via `get()` at enqueue, throwing `StorageExceptionNotRunning` if it has already cleared. During normal operation the application/manager keeps the system strongly reachable, so the lookup always resolves; it only returns `null` once the system has actually been abandoned and collected, where there is nothing to enqueue against. The pending-load gate and the `StorageSystem#entityMarkMonitor()` accessor are otherwise unchanged, so the #755 behaviour is preserved.

## Testing

Adds `AbandonedStorageAutoShutdownTest` (the issue's reproducer): it wraps the running `StorageSystem` in a `WeakReference`, drops the manager without `shutdown()`, and asserts the reference clears within a bounded GC budget, shutting the referent down in a `finally` so a buggy run cannot wedge the surefire fork. It is red before this change (the system never clears within 20s) and green after (it clears on the first GC and the channel threads self-terminate). The GC test battery, including the #755 regression tests (`MultiChannelSweepEntryRaceReproTest` and the rest of `test.eclipse.store.gc`), stays green — loads still reach the mark monitor and the pending-load gate still works.
