### PR TITLE
GC unmarked-sweep countdown: safety net against transient GC concurrency races

### DIFF
--- a/docs/modules/storage/pages/configuration/housekeeping.adoc
+++ b/docs/modules/storage/pages/configuration/housekeeping.adoc
@@ -28,6 +28,9 @@ Available properties are:
 
 |housekeeping-maximum-time-budget
 |The upper limit of the housekeeping time budgets. Default is 0.5 seconds.
+
+|gc-sweep-threshold
+|Number of consecutive garbage-collection sweeps an entity must remain unmarked before it is deleted. A safety net against rare, transient GC concurrency races; higher values keep unreachable entities slightly longer. Valid range is 1 to 127, default is 3.
 |===
 
 == Enabling Adaptive Housekeeping for Write-Intensive Data Applications

--- a/docs/modules/storage/pages/configuration/properties.adoc
+++ b/docs/modules/storage/pages/configuration/properties.adoc
@@ -94,6 +94,10 @@ They can be found as constants in `EmbeddedStorageConfigurationPropertyNames`.
 |The upper limit of the housekeeping time budgets. Default is 0.5 seconds.
 |xref:#type-duration[Duration]
 
+|gc-sweep-threshold
+|Number of consecutive garbage-collection sweeps an entity must remain unmarked before it is deleted (a safety net against rare, transient GC concurrency races). Valid range is 1 to 127, default is 3.
+|xref:#type-integer[Integer]
+
 |entity-cache-threshold
 |Abstract threshold value for the lifetime of entities in the cache. Default is `1000000000`.
 |xref:#type-long[Long]

--- a/integration-tests/src/test/java/org/eclipse/store/storage/types/GcSweepCountdownTest.java
+++ b/integration-tests/src/test/java/org/eclipse/store/storage/types/GcSweepCountdownTest.java
@@ -1,0 +1,423 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * White-box tests for the garbage-collection <b>unmarked-sweep countdown</b> (internal#109): an
+ * unreachable entity is not deleted the first sweep it is found unmarked, but only after it has
+ * stayed unmarked for a configurable number of consecutive sweeps
+ * ({@link StorageHousekeepingController#garbageCollectionSweepThreshold()}, default {@code 3}).
+ * Every successful marking resets the countdown. This is a probabilistic safety net against rare,
+ * transient GC concurrency races (see {@link StorageEntity.Default#ageUnmarkedAndIsCondemned(int)}).
+ * <p>
+ * The countdown reuses the free negative range of {@link StorageEntity.Default}'s {@code gcState}
+ * byte, so it costs no additional per-entity memory.
+ * <p>
+ * <b>Why this package / module.</b> The asserted members ({@code sweep}, {@code getEntry},
+ * {@code ageUnmarkedAndIsCondemned}, the {@code mark*} helpers) are package-private in
+ * {@code org.eclipse.store.storage.types}, so this is a deliberate "friend test" declared in that
+ * package. It lives in {@code integration-tests} because building a real object graph needs
+ * {@code storage-embedded} (which depends on {@code storage}); the reverse test dependency would
+ * create a reactor cycle. {@code integration-tests} runs with {@code useModulePath=false}, so the
+ * split package resolves on the classpath. This mirrors {@code Layer1LoadMarkingRaceTest}.
+ * <p>
+ * {@code @Isolated} because {@link StorageEntityCache.Default#setGarbageCollectionEnabled(boolean)}
+ * is a static, JVM-global switch.
+ */
+@Isolated
+public class GcSweepCountdownTest
+{
+	///////////////////////////////////////////////////////////////////////////
+	// data types //
+	///////////////
+
+	public static class DataRoot
+	{
+		public List<Object> entries = new ArrayList<>();
+	}
+
+	public static class Entry
+	{
+		public final String data;
+
+		public Entry(final String data)
+		{
+			super();
+			this.data = data;
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// fixture //
+	////////////
+
+	@TempDir
+	Path tempDir;
+
+	EmbeddedStorageManager storage;
+
+	StorageSystem.Default  storageSystem;
+
+	@AfterEach
+	public void afterTest()
+	{
+		// the static, JVM-global GC switch must never leak into other tests.
+		StorageEntityCache.Default.setGarbageCollectionEnabled(true);
+
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final Exception ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// unit test of the countdown logic //
+	/////////////////////////////////////
+
+	@Test
+	void ageUnmarkedAndIsCondemned_thresholdOne_deletesOnFirstUnmarkedSweep()
+	{
+		final StorageEntity.Default entity = StorageEntity.Default.createDummy();
+		entity.markWhite();
+
+		// threshold 1 is the classic, countdown-less behavior: condemned on the very first unmarked sweep.
+		assertTrue(entity.ageUnmarkedAndIsCondemned(1), "threshold 1 must condemn on the first unmarked sweep");
+	}
+
+	@Test
+	void ageUnmarkedAndIsCondemned_thresholdThree_condemnsOnlyOnThirdConsecutiveUnmarkedSweep()
+	{
+		final StorageEntity.Default entity = StorageEntity.Default.createDummy();
+		entity.markWhite();
+
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3), "1st unmarked sweep must keep the entity");
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3), "2nd unmarked sweep must keep the entity");
+		assertTrue (entity.ageUnmarkedAndIsCondemned(3), "3rd consecutive unmarked sweep must condemn the entity");
+	}
+
+	@Test
+	void ageUnmarkedAndIsCondemned_markWhiteResetsTheCountdown()
+	{
+		final StorageEntity.Default entity = StorageEntity.Default.createDummy();
+		entity.markWhite();
+
+		// age it partway towards condemnation ...
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3));
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3));
+
+		// ... a keep-alive sweep resets the countdown ...
+		entity.markWhite();
+
+		// ... so it again takes the full threshold of consecutive unmarked sweeps.
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3), "countdown must restart after markWhite()");
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3));
+		assertTrue (entity.ageUnmarkedAndIsCondemned(3));
+	}
+
+	@Test
+	void ageUnmarkedAndIsCondemned_markBlackResetsTheCountdown()
+	{
+		final StorageEntity.Default entity = StorageEntity.Default.createDummy();
+		entity.markWhite();
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3));
+
+		// a successful marking makes the entity gc-marked again; the next keep-alive sweep resets it to white.
+		entity.markBlack();
+		assertTrue(entity.isGcMarked(), "markBlack must make the entity gc-marked");
+		entity.markWhite();
+
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3), "countdown must restart after a successful marking");
+		assertFalse(entity.ageUnmarkedAndIsCondemned(3));
+		assertTrue (entity.ageUnmarkedAndIsCondemned(3));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// configuration wiring / validation //
+	//////////////////////////////////////
+
+	@Test
+	void housekeepingController_defaultSweepThreshold_isThree()
+	{
+		assertEquals(3, StorageHousekeepingController.New().garbageCollectionSweepThreshold());
+		assertEquals(3, StorageHousekeepingController.Defaults.defaultGarbageCollectionSweepThreshold());
+	}
+
+	@Test
+	void housekeepingController_explicitSweepThreshold_isReturned()
+	{
+		assertEquals(5, Storage.HousekeepingController(1_000, 10_000_000, 5).garbageCollectionSweepThreshold());
+	}
+
+	@Test
+	void housekeepingController_sweepThresholdOutOfRange_throws()
+	{
+		assertThrows(IllegalArgumentException.class,
+			() -> Storage.HousekeepingController(1_000, 10_000_000, 0),
+			"a sweep threshold below the minimum (1) must be rejected");
+		assertThrows(IllegalArgumentException.class,
+			() -> Storage.HousekeepingController(1_000, 10_000_000, 128),
+			"a sweep threshold above the maximum (127) must be rejected");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// white-box sweep progression //
+	////////////////////////////////
+
+	@Test
+	@Timeout(value = 120, unit = TimeUnit.SECONDS)
+	void sweep_withThresholdThree_deletesAnUnmarkedEntityOnlyOnTheThirdConsecutiveSweep() throws Exception
+	{
+		// halt background GC so the channel thread cannot mutate gcState during the synchronous white-box driving.
+		StorageEntityCache.Default.setGarbageCollectionEnabled(false);
+		final long targetOid = this.startWithGarbageCandidate(3);
+
+		final StorageEntityCache.Default entityCache = this.entityCache();
+
+		// simulate an in-progress cycle whose marking missed the target: force it white (start of countdown).
+		final StorageEntity.Default target = entityCache.getEntry(targetOid);
+		assertNotNull(target, "target entry must exist before sweeping");
+		target.markWhite();
+
+		// predicate: everything is application-reachable EXCEPT the target, so only the target ages down.
+		// 1st and 2nd sweep must keep it (countdown not yet exhausted) ...
+		this.directSweep(entityCache, targetOid);
+		assertNotNull(entityCache.getEntry(targetOid), "target must survive the 1st unmarked sweep (threshold 3)");
+
+		this.directSweep(entityCache, targetOid);
+		assertNotNull(entityCache.getEntry(targetOid), "target must survive the 2nd unmarked sweep (threshold 3)");
+
+		// ... the 3rd consecutive unmarked sweep condemns it.
+		this.directSweep(entityCache, targetOid);
+		assertNull(entityCache.getEntry(targetOid), "target must be deleted on the 3rd consecutive unmarked sweep");
+	}
+
+	@Test
+	@Timeout(value = 120, unit = TimeUnit.SECONDS)
+	void sweep_reMarkingBetweenSweeps_resetsTheCountdownAndSparesTheEntity() throws Exception
+	{
+		// halt background GC so the channel thread cannot mutate gcState during the synchronous white-box driving.
+		StorageEntityCache.Default.setGarbageCollectionEnabled(false);
+		final long targetOid = this.startWithGarbageCandidate(3);
+
+		final StorageEntityCache.Default entityCache = this.entityCache();
+		final StorageEntity.Default      target      = entityCache.getEntry(targetOid);
+		assertNotNull(target);
+		target.markWhite();
+
+		// two unmarked sweeps bring it close to condemnation ...
+		this.directSweep(entityCache, targetOid);
+		this.directSweep(entityCache, targetOid);
+		assertNotNull(entityCache.getEntry(targetOid), "target must still survive after 2 sweeps");
+
+		// ... a successful marking (as a correct mark cycle would do) resets the countdown ...
+		target.markBlack();
+
+		// ... so two more unmarked sweeps still do not delete it (a threshold-3 countdown restarted from scratch).
+		this.directSweep(entityCache, targetOid);
+		this.directSweep(entityCache, targetOid);
+		assertNotNull(entityCache.getEntry(targetOid),
+			"re-marking must reset the countdown, so the entity survives further sweeps");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// full garbage collection contract //
+	/////////////////////////////////////
+
+	@Test
+	@Timeout(value = 120, unit = TimeUnit.SECONDS)
+	void issueFullGarbageCollection_withThresholdThree_reclaimsGarbageInASingleCall() throws Exception
+	{
+		this.startStorage(3);
+
+		final PersistenceObjectRegistry  registry    = this.storage.persistenceManager().objectRegistry();
+		final StorageEntityCache.Default entityCache = this.entityCache();
+
+		final DataRoot root  = new DataRoot();
+		Entry          entry = new Entry("garbage-candidate");
+		root.entries.add(entry);
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+
+		final long targetOid = registry.lookupObjectId(entry);
+		assertTrue(targetOid > 0, "could not resolve the target entry's object id");
+		assertNotNull(entityCache.getEntry(targetOid), "target must exist before it becomes garbage");
+
+		// make the target actual garbage: drop it from the persistent graph, store, then release all Java refs.
+		root.entries.clear();
+		this.storage.store(root.entries);
+
+		final WeakReference<Entry> probe = new WeakReference<>(entry);
+		entry = null; // drop the last strong reference so the object registry can reap its (weak) entry
+
+		for(int i = 0; i < 10 && probe.get() != null; i++)
+		{
+			System.gc();
+			Thread.sleep(50);
+		}
+		assumeTrue(probe.get() == null,
+			"JVM did not garbage-collect the target entry - test cannot proceed deterministically");
+
+		// reap the cleared weak reference from the registry so the sweep's application-reachability
+		// safety net no longer reports the target as live (same code path a store triggers; see GC.md §8).
+		registry.cleanUp();
+
+		// a single explicit full GC must reclaim it despite the sweep threshold of 3: the full GC runs
+		// enough complete mark+sweep cycles internally to drive the countdown all the way to deletion.
+		this.storage.issueFullGarbageCollection();
+
+		assertNull(entityCache.getEntry(targetOid),
+			"issueFullGarbageCollection must reclaim actual garbage in a single call even with threshold 3");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// helpers //
+	////////////
+
+	/**
+	 * Starts a single-channel storage (background GC effectively disabled via a very long housekeeping
+	 * interval), stores a root holding one {@link Entry}, and returns that entry's object id.
+	 */
+	private void startStorage(final int sweepThreshold) throws Exception
+	{
+		final EmbeddedStorageFoundation<?> foundation = EmbeddedStorage.Foundation(
+			Storage.ConfigurationBuilder()
+				.setChannelCountProvider(Storage.ChannelCountProvider(1))
+				.setHousekeepingController(Storage.HousekeepingController(3_600_000, 1_000_000, sweepThreshold))
+				.setStorageFileProvider(Storage.FileProvider(this.tempDir.resolve("db")))
+				.createConfiguration()
+		);
+		this.storage       = foundation.start();
+		this.storageSystem = (StorageSystem.Default)foundation.getConnectionFoundation().getStorageSystem();
+
+		assertEquals(sweepThreshold,
+			gcSweepThresholdOf(this.entityCache()),
+			"the configured sweep threshold must be threaded into the entity cache");
+	}
+
+	private long startWithGarbageCandidate(final int sweepThreshold) throws Exception
+	{
+		this.startStorage(sweepThreshold);
+
+		final DataRoot root  = new DataRoot();
+		final Entry    entry = new Entry("garbage-candidate");
+		root.entries.add(entry);
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+
+		final long targetOid = this.storage.persistenceManager().objectRegistry().lookupObjectId(entry);
+		assertTrue(targetOid > 0, "could not resolve the target entry's object id");
+
+		return targetOid;
+	}
+
+	/**
+	 * Executes one direct sweep in which every object id is treated as application-reachable except
+	 * {@code targetOid}. Only the target can therefore age towards condemnation; every other entity is
+	 * kept and reset to white. The mark-monitor seed version is aligned first so the sweep does not take
+	 * the stale-seed keep-all shortcut.
+	 */
+	private void directSweep(final StorageEntityCache.Default entityCache, final long targetOid) throws Exception
+	{
+		alignSeedRegistrationVersion(entityCache);
+		entityCache.sweep(oid -> oid != targetOid);
+	}
+
+	private StorageEntityCache.Default entityCache() throws Exception
+	{
+		return entityCacheOf(channelZero(this.storageSystem));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// white-box reflection helpers (mirrors Layer1LoadMarkingRaceTest) //
+	////////////////////////////////////////////////////////////////////
+
+	private static StorageChannel.Default channelZero(final StorageSystem.Default system) throws Exception
+	{
+		final Field keepersField = StorageSystem.Default.class.getDeclaredField("channelKeepers");
+		keepersField.setAccessible(true);
+		final Object[] keepers = (Object[])keepersField.get(system);
+
+		final Object keeper       = keepers[0];
+		final Field  channelField = keeper.getClass().getDeclaredField("channel");
+		channelField.setAccessible(true);
+		return (StorageChannel.Default)channelField.get(keeper);
+	}
+
+	private static StorageEntityCache.Default entityCacheOf(final StorageChannel.Default channel) throws Exception
+	{
+		final Field cacheField = StorageChannel.Default.class.getDeclaredField("entityCache");
+		cacheField.setAccessible(true);
+		return (StorageEntityCache.Default)cacheField.get(channel);
+	}
+
+	private static int gcSweepThresholdOf(final StorageEntityCache.Default entityCache) throws Exception
+	{
+		final Field field = StorageEntityCache.Default.class.getDeclaredField("gcSweepThreshold");
+		field.setAccessible(true);
+		return field.getInt(entityCache);
+	}
+
+	private static void alignSeedRegistrationVersion(final StorageEntityCache.Default entityCache) throws Exception
+	{
+		final StorageEntityMarkMonitor markMonitor = entityCache.markMonitor();
+
+		final Field handlerField = StorageEntityCache.Default.class.getDeclaredField("liveObjectIdsHandler");
+		handlerField.setAccessible(true);
+		final LiveObjectIdsHandler handler = (LiveObjectIdsHandler)handlerField.get(entityCache);
+
+		final Field versionField = markMonitor.getClass().getDeclaredField("seedRegistrationVersion");
+		versionField.setAccessible(true);
+		versionField.setLong(markMonitor, handler.registrationVersion());
+	}
+}

--- a/integration-tests/src/test/java/org/eclipse/store/storage/types/GcSweepCountdownTest.java
+++ b/integration-tests/src/test/java/org/eclipse/store/storage/types/GcSweepCountdownTest.java
@@ -206,6 +206,65 @@ public class GcSweepCountdownTest
 			"a sweep threshold above the maximum (127) must be rejected");
 	}
 
+	@Test
+	@Timeout(value = 120, unit = TimeUnit.SECONDS)
+	void startup_customControllerWithOutOfRangeSweepThreshold_isRejected()
+	{
+		// a custom StorageHousekeepingController bypasses the builder validation, so the entity cache must
+		// enforce the upper bound itself: an out-of-range value would underflow the gcState byte otherwise.
+		final StorageHousekeepingController badController = new StorageHousekeepingController()
+		{
+			private final StorageHousekeepingController delegate = StorageHousekeepingController.New();
+
+			@Override
+			public long housekeepingIntervalMs()
+			{
+				return this.delegate.housekeepingIntervalMs();
+			}
+
+			@Override
+			public long housekeepingTimeBudgetNs()
+			{
+				return this.delegate.housekeepingTimeBudgetNs();
+			}
+
+			@Override
+			public long garbageCollectionTimeBudgetNs()
+			{
+				return this.delegate.garbageCollectionTimeBudgetNs();
+			}
+
+			@Override
+			public long liveCheckTimeBudgetNs()
+			{
+				return this.delegate.liveCheckTimeBudgetNs();
+			}
+
+			@Override
+			public long fileCheckTimeBudgetNs()
+			{
+				return this.delegate.fileCheckTimeBudgetNs();
+			}
+
+			@Override
+			public int garbageCollectionSweepThreshold()
+			{
+				return 200; // out of range: would underflow the gcState byte
+			}
+		};
+
+		final EmbeddedStorageFoundation<?> foundation = EmbeddedStorage.Foundation(
+			Storage.ConfigurationBuilder()
+				.setChannelCountProvider(Storage.ChannelCountProvider(1))
+				.setHousekeepingController(badController)
+				.setStorageFileProvider(Storage.FileProvider(this.tempDir.resolve("db-bad")))
+				.createConfiguration()
+		);
+
+		assertThrows(RuntimeException.class, foundation::start,
+			"an out-of-range sweep threshold from a custom controller must be rejected at startup");
+	}
+
 
 	///////////////////////////////////////////////////////////////////////////
 	// white-box sweep progression //
@@ -310,8 +369,8 @@ public class GcSweepCountdownTest
 		// safety net no longer reports the target as live (same code path a store triggers; see GC.md §8).
 		registry.cleanUp();
 
-		// a single explicit full GC must reclaim it despite the sweep threshold of 3: the full GC runs
-		// enough complete mark+sweep cycles internally to drive the countdown all the way to deletion.
+		// a single explicit full GC must reclaim it despite the sweep threshold of 3: an issued full GC
+		// bypasses the countdown and deletes unmarked entities immediately (effective threshold 1).
 		this.storage.issueFullGarbageCollection();
 
 		assertNull(entityCache.getEntry(targetOid),

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/ConfigurationCoreProperties.java
@@ -238,6 +238,15 @@ public enum ConfigurationCoreProperties
 	),
 
 	/**
+	 * Number of consecutive garbage-collection sweeps an entity must remain unmarked before it is
+	 * deleted (a safety net against rare, transient GC concurrency races). Range 1 to 127, default 3.
+	 */
+	GC_SWEEP_THRESHOLD(
+			Constants.PREFIX + "gc.sweep.threshold",
+			EmbeddedStorageConfigurationPropertyNames.GC_SWEEP_THRESHOLD
+	),
+
+	/**
 	 * Primary chunk-checksum algorithm: none, crc32c or sha256-chained. Default sha256-chained.
 	 */
 	CHUNK_CHECKSUM_ALGORITHM(

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/configuration/EclipseStoreProperties.java
@@ -144,6 +144,13 @@ public class EclipseStoreProperties
     private String housekeepingMaximumTimeBudget;
 
     /**
+     * Number of consecutive garbage-collection sweeps an entity must remain unmarked before it is
+     * deleted (a safety net against rare, transient GC concurrency races). Valid range is 1 to 127,
+     * default is 3.
+     */
+    private String gcSweepThreshold;
+
+    /**
      * The maximum size of a transaction file. If the file is larger than this value, it will be split into multiple files.
      * Default is 1 GiB.
      */
@@ -446,6 +453,16 @@ public class EclipseStoreProperties
     public void setHousekeepingMaximumTimeBudget(final String housekeepingMaximumTimeBudget)
     {
         this.housekeepingMaximumTimeBudget = housekeepingMaximumTimeBudget;
+    }
+
+    public String getGcSweepThreshold()
+    {
+        return this.gcSweepThreshold;
+    }
+
+    public void setGcSweepThreshold(final String gcSweepThreshold)
+    {
+        this.gcSweepThreshold = gcSweepThreshold;
     }
 
     public String getTransactionFileMaximumSize()

--- a/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
+++ b/integrations/spring-boot3/src/main/java/org/eclipse/store/integrations/spring/boot/types/converter/EclipseStoreConfigConverter.java
@@ -71,6 +71,7 @@ public class EclipseStoreConfigConverter
     protected static final String HOUSEKEEPING_INCREASE_THRESHOLD = EmbeddedStorageConfigurationPropertyNames.HOUSEKEEPING_INCREASE_THRESHOLD;
     protected static final String HOUSEKEEPING_INCREASE_AMOUNT = EmbeddedStorageConfigurationPropertyNames.HOUSEKEEPING_INCREASE_AMOUNT;
     protected static final String HOUSEKEEPING_MAXIMUM_TIME_BUDGET = EmbeddedStorageConfigurationPropertyNames.HOUSEKEEPING_MAXIMUM_TIME_BUDGET;
+    protected static final String GC_SWEEP_THRESHOLD = EmbeddedStorageConfigurationPropertyNames.GC_SWEEP_THRESHOLD;
 
     // Fields for the entity cache configuration
     protected static final String ENTITY_CACHE_THRESHOLD = EmbeddedStorageConfigurationPropertyNames.ENTITY_CACHE_THRESHOLD;
@@ -146,6 +147,7 @@ public class EclipseStoreConfigConverter
         configValues.put(HOUSEKEEPING_INCREASE_THRESHOLD, properties.getHousekeepingIncreaseThreshold());
         configValues.put(HOUSEKEEPING_INCREASE_AMOUNT, properties.getHousekeepingIncreaseAmount());
         configValues.put(HOUSEKEEPING_MAXIMUM_TIME_BUDGET, properties.getHousekeepingMaximumTimeBudget());
+        configValues.put(GC_SWEEP_THRESHOLD, properties.getGcSweepThreshold());
         configValues.put(ENTITY_CACHE_THRESHOLD, properties.getEntityCacheThreshold());
         configValues.put(ENTITY_CACHE_TIMEOUT, properties.getEntityCacheTimeout());
         configValues.put(DATA_FILE_MINIMUM_SIZE, properties.getDataFileMinimumSize());

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationBuilder.java
@@ -260,6 +260,18 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 	public EmbeddedStorageConfigurationBuilder setHousekeepingMaximumTimeBudget(Duration housekeepingMaximumTimeBudget);
 
 	/**
+	 * The number of consecutive garbage-collection sweeps an entity must remain unmarked before it is
+	 * actually deleted. A value of <code>1</code> deletes an unmarked entity on the first sweep (the
+	 * classic behavior); higher values keep unreachable entities for that many sweeps as a probabilistic
+	 * safety net against rare, transient garbage-collection concurrency races, at the cost of reclaiming
+	 * garbage slightly later. Valid range is <code>[1, 127]</code>, default is <code>3</code>.
+	 *
+	 * @param garbageCollectionSweepThreshold the new sweep threshold
+	 * @return this
+	 */
+	public EmbeddedStorageConfigurationBuilder setGarbageCollectionSweepThreshold(int garbageCollectionSweepThreshold);
+
+	/**
 	 * Abstract threshold value for the lifetime of entities in the cache. See
 	 * {@link StorageEntityCacheEvaluator#New(long, long)}. Default is <code>1.000.000.000</code>.
 	 *
@@ -731,6 +743,14 @@ public interface EmbeddedStorageConfigurationBuilder extends Configuration.Build
 		)
 		{
 			return this.set(HOUSEKEEPING_MAXIMUM_TIME_BUDGET, housekeepingMaximumTimeBudget.toString());
+		}
+
+		@Override
+		public EmbeddedStorageConfigurationBuilder setGarbageCollectionSweepThreshold(
+			final int garbageCollectionSweepThreshold
+		)
+		{
+			return this.set(GC_SWEEP_THRESHOLD, Integer.toString(garbageCollectionSweepThreshold));
 		}
 
 		@Override

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageConfigurationPropertyNames.java
@@ -141,6 +141,11 @@ public interface EmbeddedStorageConfigurationPropertyNames
 	public final static String HOUSEKEEPING_MAXIMUM_TIME_BUDGET = "housekeeping-maximum-time-budget";
 
 	/**
+	 * @see EmbeddedStorageConfigurationBuilder#setGarbageCollectionSweepThreshold(int)
+	 */
+	public final static String GC_SWEEP_THRESHOLD            = "gc-sweep-threshold";
+
+	/**
 	 * @see EmbeddedStorageConfigurationBuilder#setEntityCacheThreshold(long)
 	 */
 	public final static String ENTITY_CACHE_THRESHOLD        = "entity-cache-threshold";

--- a/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
+++ b/storage/embedded-configuration/src/main/java/org/eclipse/store/storage/embedded/configuration/types/EmbeddedStorageFoundationCreatorConfigurationBased.java
@@ -289,7 +289,9 @@ public interface EmbeddedStorageFoundationCreatorConfigurationBased extends Embe
 					.orElse(StorageHousekeepingController.Defaults.defaultHousekeepingIntervalMs()),
 				this.configuration.opt(HOUSEKEEPING_TIME_BUDGET, Duration.class)
 					.map(Duration::toNanos)
-					.orElse(StorageHousekeepingController.Defaults.defaultHousekeepingTimeBudgetNs())
+					.orElse(StorageHousekeepingController.Defaults.defaultHousekeepingTimeBudgetNs()),
+				this.configuration.optInteger(GC_SWEEP_THRESHOLD)
+					.orElse(StorageHousekeepingController.Defaults.defaultGarbageCollectionSweepThreshold())
 			);
 			
 			if(this.configuration.optBoolean(HOUSEKEEPING_ADAPTIVE).orElse(false))

--- a/storage/storage/GC.md
+++ b/storage/storage/GC.md
@@ -63,15 +63,19 @@ When all mark queues drain and `isMarkingComplete()` is true, `callToSweepRequir
 ```java
 // StorageEntityCache.Default#sweep, the keep-alive check:
 if (item.isGcMarked() || isReachableInApplication.test(item.objectId)) {
-    (last = item).markWhite();           // keep (reset to white for the next cycle)
+    (last = item).markWhite();                              // keep (resets the unmarked-sweep countdown)
+} else if (item.ageUnmarkedAndIsCondemned(sweepThreshold)) {
+    this.deleteEntity(item, sweepType, last);               // condemned: unmarked N sweeps in a row → delete
 } else {
-    this.deleteEntity(item, sweepType, last);   // delete
+    last = item;                                            // still unmarked but not yet condemned: keep
 }
 ```
 
 Two things can rescue an entity:
 1. It was gc-marked in the preceding mark phase — reachable from the persistent root (or a mark seed).
 2. The predicate `isReachableInApplication` returned true — the **registry safety net**.
+
+A third mechanism *defers* (but never prevents) deletion — the **unmarked-sweep countdown** (see §6.1).
 
 When the last channel finishes its sweep, `StorageEntityMarkMonitor.Default.completeSweep` seeds the next mark cycle with two complementary sets of roots: `determineAndEnqueueRootOid` enqueues the persistent root, and `enqueueLiveApplicationOids` enqueues every object id the application currently holds (see §9).
 
@@ -233,6 +237,16 @@ The mark monitor tracks two completion flags:
 Only cold completion shuts the GC off until the next store. Stores (via `resetCompletion`) reset both flags, kicking the GC back into work.
 
 The reason for two phases: the first sweep after a store cleans up the now-unreachable predecessors; the second sweep confirms the steady state. This two-pass pattern interacts with the registry safety net — which is why application-state OIDs are seeded at **every** sweep boundary that has a follow-up mark cycle (i.e. every sweep boundary except the cold-completing one — see §10.1).
+
+### 6.1. The unmarked-sweep countdown (safety net for transient races)
+
+The individual mark/sweep concurrency hazards are closed by the exact fixes in §10 and the registry safety net in §7–§8. On top of those, the sweep applies a **probabilistic** safety net for any *transient* mis-marking that might still slip through (a race that leaves a reachable entity unmarked for a single cycle): an unreachable entity is not deleted the first sweep it is found unmarked, but only after it has stayed unmarked for `gcSweepThreshold` **consecutive** sweeps. Any successful marking (or a keep-alive `markWhite`) resets the countdown.
+
+- **Configuration.** `StorageHousekeepingController.garbageCollectionSweepThreshold()`, config key `gc-sweep-threshold`, valid range `[1, 127]`, **default `3`**. A value of `1` restores the classic "delete on the first unmarked sweep" behavior.
+- **Storage.** The countdown reuses the otherwise unused negative range of `StorageEntity.Default.gcState`: `markWhite` sets it to `GC_WHITE` (`-1`) and each subsequent unmarked sweep decrements it (`-2`, `-3`, … down to `-gcSweepThreshold`), where the entity is condemned (`ageUnmarkedAndIsCondemned`). **No extra per-entity memory** — important with millions/billions of entities.
+- **Why it works.** Each full mark cycle re-seeds from the roots (§3.5) and re-marks every reachable entity, so a transient race hits a given entity in one cycle only; the probability it recurs on the *same* entity for `gcSweepThreshold` consecutive, independent cycles drops exponentially. It does **not** defend against a *deterministic* mis-marking bug (the countdown would never reset) — it is a last net, not a correctness substitute.
+- **Cost.** Genuine garbage lingers `gcSweepThreshold` sweeps longer, both on disk and in the entity cache / `oidHashTable`, before it is reclaimed.
+- **Full GC bypasses the countdown.** An explicitly issued full GC (`issuedGarbageCollection`) is a deliberate, complete reclaim: it deletes unmarked entities on the first sweep (effective threshold `1`), exactly as before the countdown existed, so a single call still reclaims all genuine garbage. It sets a per-channel `issuedGcImmediateSweep` flag (on its own thread, read only by its own sweep) for the duration of the call. The countdown therefore applies only to the **incremental background GC** — the path actually exposed to concurrent application activity and the transient races the countdown guards against. (A countdown-*honoring* full GC would have to run several complete mark+sweep cycles back-to-back; doing so per channel breaks the multi-channel completion lockstep — one channel resetting completion for the next cycle while a sibling is still finishing the current one deadlocks — so it is deliberately not attempted.)
 
 ---
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/Storage.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/Storage.java
@@ -308,6 +308,36 @@ public final class Storage
 	}
 
 	/**
+	 * Creates a new {@link StorageHousekeepingController} including the garbage collection sweep threshold.
+	 * <p>
+	 * For a detailed explanation see {@link StorageHousekeepingController#New(long, long, int)}.
+	 *
+	 * @param housekeepingIntervalMs the interval in milliseconds that the storage threads shall
+	 *        execute their various housekeeping actions. Must be greater than zero.
+	 * @param housekeepingTimeBudgetNs the time budget in nanoseconds that each storage thread will use
+	 *        to perform a housekeeping action. Must not be negative.
+	 * @param garbageCollectionSweepThreshold the number of consecutive garbage-collection sweeps an
+	 *        entity must remain unmarked before it is deleted, in range {@code [1, 127]}.
+	 *
+	 * @return a new {@link StorageHousekeepingController} instance.
+	 *
+	 * @see Storage#HousekeepingController(long, long)
+	 * @see StorageHousekeepingController#New(long, long, int)
+	 */
+	public static final StorageHousekeepingController HousekeepingController(
+		final long housekeepingIntervalMs        ,
+		final long housekeepingTimeBudgetNs      ,
+		final int  garbageCollectionSweepThreshold
+	)
+	{
+		return StorageHousekeepingController.New(
+			housekeepingIntervalMs         ,
+			housekeepingTimeBudgetNs       ,
+			garbageCollectionSweepThreshold
+		);
+	}
+
+	/**
 	 * Creates a new {@link StorageEntityCacheEvaluator}.
 	 * <p>
 	 * For a detailed explanation see {@link StorageEntityCacheEvaluator#New()}.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelsCreator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelsCreator.java
@@ -102,6 +102,7 @@ public interface StorageChannelsCreator
 			final long markingWaitTimeMs        =    10;
 			final int  loadingBufferSize        =  XMemory.defaultBufferSize();
 			final int  readingDefaultBufferSize =  XMemory.defaultBufferSize();
+			final int  gcSweepThreshold         =  housekeepingController.garbageCollectionSweepThreshold();
 
 			final StorageChannel.Default[] channels = new StorageChannel.Default[channelCount];
 
@@ -138,7 +139,8 @@ public interface StorageChannelsCreator
 					eventLogger                                      ,
 					liveObjectIdsHandler                             ,
 					markingWaitTimeMs                                ,
-					markBufferLength
+					markBufferLength                                 ,
+					gcSweepThreshold
 				);
 				
 				cacheMonitors[i] = new EntityCacheMonitor(entityCache);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntity.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntity.java
@@ -104,13 +104,25 @@ public interface StorageEntity
 		 * white: not yet marked, potentially unreachable/"condemned"
 		 *
 		 * For garbage collection algorithm, see http://en.wikipedia.org/wiki/Garbage_collection_(computer_science)
+		 *
+		 * The whole non-positive range below GC_INITIAL doubles as an unmarked-sweep countdown: an
+		 * unmarked entity is not deleted on the first sweep it is found white, but only after it has
+		 * stayed unmarked for a configurable number of consecutive sweeps. Every sweep that finds the
+		 * entity still unmarked decrements gcState further towards the negative floor (GC_WHITE, -2,
+		 * -3, ... down to -sweepThreshold), and the entity is deleted once it reaches that floor. Any
+		 * successful marking (markGray/markBlack) or a keep-alive sweep (markWhite) resets the
+		 * countdown. This is a probabilistic safety net against rare, transient GC concurrency races:
+		 * the chance that the same entity is erroneously left unmarked for N consecutive, independent
+		 * mark cycles drops exponentially. It reuses the otherwise unused negative gcState range, so it
+		 * costs no additional memory per entity (which matters with millions/billions of entities).
+		 * See StorageEntityCache.Default#sweep and #ageUnmarkedAndIsCondemned.
 		 */
 
 		// (14.07.2016 TM)TODO: remove useless initial state after switch to new StorageEntityCache implementation
 		static final byte GC_BLACK      = +2; // fully handled by marking
 		static final byte GC_GRAY       = +1; // marked but waiting for reference iteration marking
 		static final byte GC_INITIAL    =  0; // created/updated. Not marked, but not to be deleted in current GC round.
-		static final byte GC_WHITE      = -1; // not marked
+		static final byte GC_WHITE      = -1; // not marked (also the start of the unmarked-sweep countdown)
 
 
 		///////////////////////////////////////////////////////////////////////////
@@ -310,6 +322,37 @@ public interface StorageEntity
 		final boolean isGcMarked()
 		{
 			return this.gcState >= GC_INITIAL;
+		}
+
+		/**
+		 * Ages this unmarked ("white") entity by one sweep towards condemnation and reports whether it
+		 * is now condemned for deletion.
+		 * <p>
+		 * An unmarked entity must stay unmarked for {@code sweepThreshold} consecutive sweeps before it
+		 * is actually deleted; every successful marking (or keep-alive {@link #markWhite()}) resets the
+		 * countdown. The countdown reuses the free negative range of {@link #gcState} (from
+		 * {@link #GC_WHITE} down to {@code -sweepThreshold}), so it needs no extra per-entity memory.
+		 * This is a probabilistic safety net against rare, transient garbage-collection concurrency
+		 * races (a wrongly unmarked entity would have to be missed on {@code sweepThreshold} consecutive,
+		 * independent mark cycles to be lost).
+		 * <p>
+		 * Must only be called for entities that are not gc-marked, i.e. {@code gcState < GC_INITIAL}.
+		 *
+		 * @param sweepThreshold the number of consecutive unmarked sweeps required before deletion,
+		 *        in range {@code [1, 127]}. A value of {@code 1} deletes on the first unmarked sweep
+		 *        (the classic, countdown-less behavior).
+		 * @return {@code true} if the entity has now been unmarked for {@code sweepThreshold} consecutive
+		 *         sweeps and must be deleted, {@code false} if it is kept for another sweep.
+		 */
+		final boolean ageUnmarkedAndIsCondemned(final int sweepThreshold)
+		{
+			// gcState is in [-sweepThreshold, GC_WHITE] here; delete once it reached the -sweepThreshold floor.
+			if(this.gcState > -sweepThreshold)
+			{
+				this.gcState--;
+				return false;
+			}
+			return true;
 		}
 
 		final boolean hasOnlySimpleReferencesLoaded()

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -119,6 +119,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		private final StorageTypeDictionary              typeDictionary      ;
 		private final long[]                             markingOidBuffer    ;
 		private final StorageGCZombieOidHandler          zombieOidHandler    ;
+		private final int                                gcSweepThreshold    ; // consecutive unmarked sweeps before deletion
 		private final StorageRootOidSelector             rootOidSelector     ;
 		private final RootEntityRootOidSelectionIterator rootEntityIterator  ;
 		private final StorageEventLogger                 eventLogger         ;
@@ -145,6 +146,10 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		private final Set_long warnedObsoleteTypeIds = Set_long.New();
 		private boolean hasLoadPendingSweep  ;
 		private boolean loadMarkingRequired  ;
+
+		// true only while an explicitly issued (full) GC runs on this channel: its sweeps delete unmarked
+		// entities immediately (bypassing the countdown). Set and cleared on the channel's own thread.
+		private boolean issuedGcImmediateSweep;
 		
 		// Statistics for debugging / monitoring / checking to compare with other channels and with the markmonitor
 		private long sweepGeneration, lastSweepStart, lastSweepEnd;
@@ -192,7 +197,8 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final StorageEventLogger          eventLogger         ,
 			final LiveObjectIdsHandler        liveObjectIdsHandler,
 			final long                        markingWaitTimeMs   ,
-			final int                         markingBufferLength
+			final int                         markingBufferLength ,
+			final int                         gcSweepThreshold
 		)
 		{
 			super();
@@ -207,6 +213,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			this.oidMarkQueue         = notNull    (oidMarkQueue)     ;
 			this.eventLogger          =             eventLogger       ;
 			this.markingWaitTimeMs    = positive   (markingWaitTimeMs);
+			this.gcSweepThreshold     = positive   (gcSweepThreshold) ;
 			
 			// derived values
 			
@@ -1334,21 +1341,29 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				this.lastSweepStart = System.currentTimeMillis();
 				final StorageEntityType.Default typeHead = this.typeHead;
 
+				// an explicitly issued full GC collects immediately (threshold 1); background GC honors the countdown.
+				final int sweepThreshold = this.issuedGcImmediateSweep ? 1 : this.gcSweepThreshold;
+
 				for(StorageEntityType.Default sweepType = typeHead; (sweepType = sweepType.next) != typeHead;)
 				{
 					// get next item and check for end of type (switch to next type required)
 					for(StorageEntity.Default item, last = sweepType.head; (item = last.typeNext) != null;)
 					{
-						// actual sweep: white entities are deleted, non-white entities are marked white but not deleted
+						// actual sweep: white entities are aged towards deletion, non-white entities are marked white
 						if(item.isGcMarked() || isReachableInApplication.test(item.objectId))
 						{
-							// reset to white and advance one item
+							// reset to white (resets the unmarked-sweep countdown) and advance one item
 							(last = item).markWhite();
+						}
+						else if(item.ageUnmarkedAndIsCondemned(sweepThreshold))
+						{
+							// unmarked for the required number of consecutive sweeps now, so collect it
+							this.deleteEntity(item, sweepType, last);
 						}
 						else
 						{
-							// otherwise white entity, so collect it
-							this.deleteEntity(item, sweepType, last);
+							// still unmarked but not yet condemned: keep for another sweep and advance one item
+							last = item;
 						}
 					}
 				}
@@ -1841,7 +1856,36 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			{
 				return true;
 			}
-			
+
+			/*
+			 * An explicitly issued (full) garbage collection is a deliberate, complete reclaim and must
+			 * collect all actual garbage within this single call. It therefore bypasses the unmarked-sweep
+			 * countdown (see #sweep and gcSweepThreshold) and deletes unmarked entities on the first sweep,
+			 * exactly as before the countdown was introduced. The countdown remains fully in effect for the
+			 * incremental background garbage collection - the path exposed to concurrent application activity
+			 * and thus to the transient races the countdown guards against. (A countdown-honoring full GC
+			 * would have to run several complete mark+sweep cycles back-to-back, which cannot preserve the
+			 * multi-channel completion lockstep without a dedicated cross-channel barrier.)
+			 *
+			 * Set on this channel's own thread and read only by its own sweep on the same call stack, so no
+			 * synchronization is required; the finally guarantees it never leaks into a later background GC.
+			 */
+			this.issuedGcImmediateSweep = true;
+			try
+			{
+				return this.internalIssuedGarbageCollection(nanoTimeBudgetBound, channel);
+			}
+			finally
+			{
+				this.issuedGcImmediateSweep = false;
+			}
+		}
+
+		private boolean internalIssuedGarbageCollection(
+			final long           nanoTimeBudgetBound,
+			final StorageChannel channel
+		)
+		{
 			this.markMonitor.resetCompletion();
 
 			// check time budget first for explicitly issued calls.

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -213,7 +213,10 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			this.oidMarkQueue         = notNull    (oidMarkQueue)     ;
 			this.eventLogger          =             eventLogger       ;
 			this.markingWaitTimeMs    = positive   (markingWaitTimeMs);
-			this.gcSweepThreshold     = positive   (gcSweepThreshold) ;
+			// must enforce the upper bound here too: a custom StorageHousekeepingController could return a
+			// value > 127, which would underflow the gcState byte during the sweep countdown (see #sweep).
+			StorageHousekeepingController.Validation.validateGarbageCollectionSweepThreshold(gcSweepThreshold);
+			this.gcSweepThreshold     = gcSweepThreshold                ;
 			
 			// derived values
 			

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
@@ -72,8 +72,18 @@ public interface StorageHousekeepingController
 	 */
 	public long fileCheckTimeBudgetNs();
 
-	
-	
+	/**
+	 * The number of consecutive garbage-collection sweeps an entity must remain unmarked before it is
+	 * actually deleted. A value of {@code 1} deletes an unmarked entity on the first sweep (the classic
+	 * behavior); higher values keep unreachable entities for that many sweeps as a probabilistic safety
+	 * net against rare, transient GC concurrency races, at the cost of reclaiming garbage slightly later.
+	 *
+	 * @return the number of consecutive unmarked sweeps before an entity is collected, in range {@code [1, 127]}.
+	 */
+	public int garbageCollectionSweepThreshold();
+
+
+
 	/**
 	 * Static helpers exposing the lower bounds for {@link StorageHousekeepingController}
 	 * configuration values and a range-check that throws {@link IllegalArgumentException} on
@@ -85,15 +95,40 @@ public interface StorageHousekeepingController
 		{
 			return 1;
 		}
-		
+
 		public static long minimumHousekeepingTimeBudgetNs()
 		{
 			return 0;
 		}
-		
+
+		public static int minimumGarbageCollectionSweepThreshold()
+		{
+			return 1;
+		}
+
+		public static int maximumGarbageCollectionSweepThreshold()
+		{
+			// stored in the negative range of a single signed byte (see StorageEntity.gcState), so bounded by 127.
+			return 127;
+		}
+
 		public static void validateParameters(
 			final long housekeepingIntervalMs  ,
 			final long housekeepingTimeBudgetNs
+		)
+			throws IllegalArgumentException
+		{
+			validateParameters(
+				housekeepingIntervalMs                              ,
+				housekeepingTimeBudgetNs                            ,
+				Defaults.defaultGarbageCollectionSweepThreshold()
+			);
+		}
+
+		public static void validateParameters(
+			final long housekeepingIntervalMs        ,
+			final long housekeepingTimeBudgetNs      ,
+			final int  garbageCollectionSweepThreshold
 		)
 			throws IllegalArgumentException
 		{
@@ -113,6 +148,18 @@ public interface StorageHousekeepingController
 					+ housekeepingTimeBudgetNs
 					+ " is lower than the minimum value "
 					+ minimumHousekeepingTimeBudgetNs()+ "."
+				);
+			}
+			if(garbageCollectionSweepThreshold < minimumGarbageCollectionSweepThreshold()
+			|| garbageCollectionSweepThreshold > maximumGarbageCollectionSweepThreshold()
+			)
+			{
+				throw new IllegalArgumentException(
+					"Specified garbage collection sweep threshold of "
+					+ garbageCollectionSweepThreshold
+					+ " is outside the valid range ["
+					+ minimumGarbageCollectionSweepThreshold() + ", "
+					+ maximumGarbageCollectionSweepThreshold() + "]."
 				);
 			}
 		}
@@ -178,13 +225,46 @@ public interface StorageHousekeepingController
 	)
 	{
 		Validation.validateParameters(housekeepingIntervalMs, housekeepingTimeBudgetNs);
-		
+
 		return new StorageHousekeepingController.Default(
 			housekeepingIntervalMs  ,
 			housekeepingTimeBudgetNs
 		);
 	}
-	
+
+	/**
+	 * Pseudo-constructor method to create a new {@link StorageHousekeepingController} instance
+	 * using the passed values, including the garbage collection sweep threshold.
+	 *
+	 * @param housekeepingIntervalMs the interval in milliseconds that the storage threads shall
+	 *        execute their various housekeeping actions. Must be greater than zero.
+	 * @param housekeepingTimeBudgetNs the time budget in nanoseconds that each storage thread will use
+	 *        to perform a housekeeping action. Must not be negative.
+	 * @param garbageCollectionSweepThreshold the number of consecutive garbage-collection sweeps an
+	 *        entity must remain unmarked before it is deleted, in range {@code [1, 127]}.
+	 * @return a new {@link StorageHousekeepingController} instance.
+	 *
+	 * @see StorageHousekeepingController#New(long, long)
+	 */
+	public static StorageHousekeepingController New(
+		final long housekeepingIntervalMs        ,
+		final long housekeepingTimeBudgetNs      ,
+		final int  garbageCollectionSweepThreshold
+	)
+	{
+		Validation.validateParameters(
+			housekeepingIntervalMs         ,
+			housekeepingTimeBudgetNs       ,
+			garbageCollectionSweepThreshold
+		);
+
+		return new StorageHousekeepingController.Default(
+			housekeepingIntervalMs         ,
+			housekeepingTimeBudgetNs       ,
+			garbageCollectionSweepThreshold
+		);
+	}
+
 	/**
 	 * Static factory for the framework default housekeeping interval and time budget used by
 	 * {@link StorageHousekeepingController#New()}.
@@ -199,6 +279,12 @@ public interface StorageHousekeepingController
 		public static long defaultHousekeepingTimeBudgetNs()
 		{
 			return 10_000_000; // ns
+		}
+
+		public static int defaultGarbageCollectionSweepThreshold()
+		{
+			// safe-by-default: an unreachable entity must be unmarked on 3 consecutive sweeps before deletion.
+			return 3;
 		}
 	}
 
@@ -215,6 +301,7 @@ public interface StorageHousekeepingController
 		////////////////////
 
 		private final long intervalMs, nanoTimeBudget;
+		private final int  gcSweepThreshold;
 
 
 
@@ -224,9 +311,15 @@ public interface StorageHousekeepingController
 
 		Default(final long intervalMs, final long nanoTimeBudget)
 		{
+			this(intervalMs, nanoTimeBudget, Defaults.defaultGarbageCollectionSweepThreshold());
+		}
+
+		Default(final long intervalMs, final long nanoTimeBudget, final int gcSweepThreshold)
+		{
 			super();
-			this.intervalMs     = intervalMs    ;
-			this.nanoTimeBudget = nanoTimeBudget;
+			this.intervalMs       = intervalMs      ;
+			this.nanoTimeBudget   = nanoTimeBudget  ;
+			this.gcSweepThreshold = gcSweepThreshold;
 		}
 
 
@@ -269,12 +362,19 @@ public interface StorageHousekeepingController
 		}
 
 		@Override
+		public final int garbageCollectionSweepThreshold()
+		{
+			return this.gcSweepThreshold;
+		}
+
+		@Override
 		public String toString()
 		{
 			return VarString.New()
 				.add(this.getClass().getName()).add(':').lf()
-				.blank().add("house keeping interval"        ).tab().add('=').blank().add(this.intervalMs).lf()
-				.blank().add("house keeping nano time budget").tab().add('=').blank().add(this.nanoTimeBudget)
+				.blank().add("house keeping interval"           ).tab().add('=').blank().add(this.intervalMs).lf()
+				.blank().add("house keeping nano time budget"   ).tab().add('=').blank().add(this.nanoTimeBudget).lf()
+				.blank().add("garbage collection sweep threshold").tab().add('=').blank().add(this.gcSweepThreshold)
 				.toString()
 			;
 		}
@@ -742,7 +842,14 @@ public interface StorageHousekeepingController
 				this.delegate.fileCheckTimeBudgetNs() + this.increaseNs()
 			);
 		}
-		
+
+		@Override
+		public int garbageCollectionSweepThreshold()
+		{
+			// the sweep threshold is not time-adaptive; pass the wrapped controller's value through.
+			return this.delegate.garbageCollectionSweepThreshold();
+		}
+
 		@Override
 		public void logGarbageCollectorNotNeeded()
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
@@ -150,6 +150,22 @@ public interface StorageHousekeepingController
 					+ minimumHousekeepingTimeBudgetNs()+ "."
 				);
 			}
+			validateGarbageCollectionSweepThreshold(garbageCollectionSweepThreshold);
+		}
+
+		/**
+		 * Range-checks a garbage collection sweep threshold and throws {@link IllegalArgumentException}
+		 * if it is outside {@code [1, 127]}. The upper bound is mandatory: the sweep countdown is stored
+		 * in the negative range of {@link StorageEntity.Default}'s {@code gcState} byte, so a larger value
+		 * would let {@code gcState} underflow below {@link Byte#MIN_VALUE} and wrap around, corrupting the
+		 * GC state. Enforced both here (external configuration) and where the value enters the GC engine.
+		 *
+		 * @param garbageCollectionSweepThreshold the value to validate.
+		 * @throws IllegalArgumentException if the value is outside the valid range.
+		 */
+		public static void validateGarbageCollectionSweepThreshold(final int garbageCollectionSweepThreshold)
+			throws IllegalArgumentException
+		{
 			if(garbageCollectionSweepThreshold < minimumGarbageCollectionSweepThreshold()
 			|| garbageCollectionSweepThreshold > maximumGarbageCollectionSweepThreshold()
 			)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageHousekeepingController.java
@@ -77,10 +77,17 @@ public interface StorageHousekeepingController
 	 * actually deleted. A value of {@code 1} deletes an unmarked entity on the first sweep (the classic
 	 * behavior); higher values keep unreachable entities for that many sweeps as a probabilistic safety
 	 * net against rare, transient GC concurrency races, at the cost of reclaiming garbage slightly later.
+	 * <p>
+	 * Declared as a {@code default} method returning {@link Defaults#defaultGarbageCollectionSweepThreshold()}
+	 * so that pre-existing custom {@link StorageHousekeepingController} implementations keep compiling and
+	 * running unchanged (adding an abstract method would be a source- and binary-incompatible change).
 	 *
 	 * @return the number of consecutive unmarked sweeps before an entity is collected, in range {@code [1, 127]}.
 	 */
-	public int garbageCollectionSweepThreshold();
+	public default int garbageCollectionSweepThreshold()
+	{
+		return Defaults.defaultGarbageCollectionSweepThreshold();
+	}
 
 
 


### PR DESCRIPTION
## What

Adds a per-entity **unmarked-sweep countdown** to the storage GC. An unreachable entity is no longer deleted the first sweep it is found unmarked, but only after it has stayed unmarked for a configurable number of **consecutive** sweeps (`gc-sweep-threshold`, range `[1,127]`, **default 3**). Any successful marking resets the countdown.

## Why

On top of the exact, window-closing GC concurrency fixes (store#736 mid-cycle registration, internal#83 partial-sweep rescue, internal#85 multi-channel Window A/B, ...), this is a broad, architecture-independent net for any *transient* mis-marking. Because every full mark cycle re-seeds from the roots and re-marks all reachable entities, a transient race hits a given entity in one cycle only — so the probability it recurs on the *same* entity for N consecutive independent cycles drops exponentially.

Honest limitation: it guards against *transient* races only, not a *deterministic* marking bug (the countdown would never reset). It is a last net, not a correctness substitute.

## How

- **Zero extra memory per entity:** the countdown reuses the otherwise-unused negative range of `StorageEntity`'s `gcState` byte (`markWhite` = `-1`, then `-2`, `-3`, ... down to `-threshold`). No code compares `gcState` to `GC_WHITE` by equality; all condemnation checks go through `!isGcMarked()` (`gcState < 0`), which includes the new values.
- `StorageEntityCache.sweep(...)`: `ageUnmarkedAndIsCondemned(threshold)` decrements toward `-threshold` and keeps (advancing the `last` cursor), deleting only at the floor.
- **Config:** threshold on `StorageHousekeepingController` (validated, default 3), exposed via `Storage.HousekeepingController(long, long, int)` and the `gc-sweep-threshold` property, threaded through `StorageChannelsCreator` into the entity cache, and mirrored in the Spring Boot starter and CDI config.

## Full GC decision

An explicitly issued **full GC bypasses the countdown** (immediate deletion, effective threshold 1), preserving the "one `issueFullGarbageCollection()` call reclaims all garbage" contract. A countdown-honoring full GC would have to run several complete mark+sweep cycles back-to-back; doing that per channel breaks the multi-channel completion lockstep (one channel resetting completion for the next cycle while a sibling is still finishing the current one deadlocks — reproduced as a hang in `MultiChannelResidualWindowReproTest`) and would need a dedicated cross-channel barrier. The countdown therefore applies to the **incremental background GC** — the path exposed to concurrent application activity and thus to the transient races it guards against. Implemented via a per-channel `issuedGcImmediateSweep` flag set and read only on the channel's own thread.

## Trade-offs

- Genuine garbage lingers `threshold` sweeps longer, on disk and in the entity cache / `oidHashTable`.
- Byte range caps the threshold at `[1,127]` (ample).

## Testing

- New white-box `GcSweepCountdownTest`: countdown logic, config default/validation, the sweep survive/survive/delete progression, reset on re-marking, and the full-GC single-call reclamation contract.
- Regression (all green with default 3): `MidCycleRegistrationRaceTest`, `MultiChannelSweepEntryRaceReproTest`, `MultiChannelResidualWindowReproTest`, `PartialSweepRetryReproTest`, `FailedGcTaskChainRepairTest`, `Layer1LoadMarkingRaceTest`, the zombie + entitycache suites, and the Spring/CDI converter tests (incl. `ConfigFieldsTest`).

## Docs

`GC.md` §6.1 and the storage configuration property tables (`housekeeping.adoc`, `properties.adoc`).
