### PR TITLE
Prevent GigaMap from deleting a committed entity on a stale index

### DIFF
--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -78,10 +78,10 @@ This matters when an *indexed* field's class layout evolves between releases. {p
 
 [WARNING]
 ====
-Evolving an *indexed* field without a value-preserving refactoring mapping leaves the indices stale — with the same consequences as a direct (untracked) mutation, and potentially worse:
+Evolving an *indexed* field without a value-preserving refactoring mapping leaves the indices stale — with the same consequences as a direct (untracked) mutation:
 
-* Queries return pre-evolution results: `is(oldValue)` still matches, `is(actualValue)` returns nothing.
-* A subsequent `update` / `apply` / `set` that writes the entity's true value can raise a stale-index error, or — for a field under a unique constraint — trigger a *phantom* unique-constraint violation. Because `apply` mutates the entity in place and cannot roll back, such a violation causes the entity to be **removed from the map** (see the `apply` javadoc), and the next `store()` persists that loss.
+* Queries return pre-evolution results: `is(oldValue)` still matches, `is(actualValue)` returns nothing. Only `reindex()` restores correct query results.
+* A subsequent `update` / `apply` / `set` that writes the entity's true value may fail with a `StaleIndexException`. The committed entity is **not** deleted by this: a stale index never causes a phantom unique-constraint violation against the entity's own entry, and a stale-index failure retains the entity rather than removing it. You still need to `reindex()` to make the index consistent again.
 
 After evolving an indexed field, rebuild every index from the current entity state with `reindex()` **before** running any query or update, then `store()`:
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/exceptions/BitmapIndexStaleException.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/exceptions/BitmapIndexStaleException.java
@@ -1,0 +1,38 @@
+package org.eclipse.store.gigamap.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BitmapIndex;
+
+
+/**
+ * A {@link BitmapIndexException} that additionally signals, via {@link StaleIndexException}, that the
+ * bitmap index is stale relative to the current entity state (see {@link StaleIndexException} for the
+ * causes and the implications for mutating operations).
+ */
+public class BitmapIndexStaleException extends BitmapIndexException implements StaleIndexException
+{
+	/**
+	 * Constructs a new BitmapIndexStaleException with the specified detail message and associated
+	 * BitmapIndex.
+	 *
+	 * @param message the detail message explaining the cause of the exception
+	 * @param index the BitmapIndex detected to be stale
+	 */
+	public BitmapIndexStaleException(final String message, final BitmapIndex<?, ?> index)
+	{
+		super(message, index);
+	}
+}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/exceptions/StaleIndexException.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/exceptions/StaleIndexException.java
@@ -1,0 +1,42 @@
+package org.eclipse.store.gigamap.exceptions;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaIndex;
+
+
+/**
+ * Marker interface for exceptions that signal a GigaMap index has become <em>stale</em> relative to
+ * the current state of its entities: the persisted index keys no longer match the keys re-derived
+ * from the loaded entities. The typical causes are a direct (untracked) mutation of an indexed field
+ * or entity class evolution (an indexed field renamed or retyped across releases without a
+ * value-preserving refactoring mapping).
+ * <p>
+ * The distinguishing property is that the <em>entity data itself is valid</em> — only the derived
+ * index is out of date. Consequently, a mutating operation that encounters this condition must not
+ * treat the entity as corrupt and destroy it; it retains the committed entity and reports this
+ * exception so the caller can rebuild the indices via {@link org.eclipse.store.gigamap.types.GigaMap#reindex()}.
+ *
+ * @see org.eclipse.store.gigamap.types.GigaMap#reindex()
+ */
+public interface StaleIndexException
+{
+	/**
+	 * The index that was detected to be stale.
+	 *
+	 * @return the associated {@link GigaIndex} instance
+	 */
+	public GigaIndex<?> index();
+}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
@@ -448,16 +448,30 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 	public boolean internalContains(final I entity)
 	{
 		final long keys = this.indexBinary(entity);
-		
+
 		return this.internalContainsKeys(keys);
 	}
-	
+
+	// Not an @Override at this generic level (parameter is I, the interface uses E); in the concrete
+	// BinaryBitmapIndex<E> where I == E it implements BitmapIndex.Internal.internalContains(E, long).
+	public boolean internalContains(final I entity, final long excludedEntityId)
+	{
+		final long keys = this.indexBinary(entity);
+
+		return this.internalContainsKeys(keys, new ContainsOtherBreaker<>(excludedEntityId));
+	}
+
 	private boolean fitsInEntries(final long keys)
 	{
 		return (keys & this.entriesLengthCheckMask) == 0L;
 	}
-	
+
 	public final boolean internalContainsKeys(final long keys)
+	{
+		return this.internalContainsKeys(keys, this.contains);
+	}
+
+	private boolean internalContainsKeys(final long keys, final EntityResolver<I> containsBreaker)
 	{
 		if(!this.fitsInEntries(keys))
 		{
@@ -486,8 +500,8 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 		// if the entity might be contained, a full query result evaluation has to be performed. But without loading entities.
 		try
 		{
-			// contains function throws a Break on the first encounter of a match (aka entity is contained)
-			GigaMap.Default.execute(EntityIdMatcher.NoOp(), this.contains, results, 0, parentMap.highestUsedId() + 1, null);
+			// contains function throws a Break on the first encounter of a (non-excluded) match
+			GigaMap.Default.execute(EntityIdMatcher.NoOp(), containsBreaker, results, 0, parentMap.highestUsedId() + 1, null);
 		}
 		catch(final ThrowBreak b)
 		{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexHashing.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexHashing.java
@@ -252,11 +252,15 @@ public abstract class AbstractBitmapIndexHashing<E, I, K> extends BitmapIndex.Ab
 		@Override
 		public void changeInIndex(final long entityId, final ChangeHandler prevEntityHandler)
 		{
-			// Create a new entry after all validations etc. have been passed.
+			// De-index the previous key FIRST. If that throws (notably the stale-index path above), no
+			// entry has been created for the new key yet, so the index is not left with a stray empty
+			// entry that would otherwise linger until the next reindex().
+			prevEntityHandler.removeFromIndex(entityId);
+
+			// Create the new entry only after the previous-key removal succeeded, then add the id. The
+			// removal is already done, so a no-op previous handler is passed.
 			final BitmapEntry<?, I, K> newEntry = this.index.internalEnsureEntryForKey(this.newKey);
-			
-			// EntityId gets added to the newly created entry just like an existing entry would.
-			newEntry.changeInIndex(entityId, prevEntityHandler);
+			newEntry.changeInIndex(entityId, NullChangeChandler.SINGLETON);
 		}
 		
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexHashing.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexHashing.java
@@ -16,8 +16,7 @@ package org.eclipse.store.gigamap.types;
 
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.EqHashTable;
-import org.eclipse.store.gigamap.exceptions.BitmapIndexException;
-import org.eclipse.store.gigamap.exceptions.GigaIndexException;
+import org.eclipse.store.gigamap.exceptions.BitmapIndexStaleException;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -231,19 +230,23 @@ public abstract class AbstractBitmapIndexHashing<E, I, K> extends BitmapIndex.Ab
 			 * value-preserving refactoring mapping), which leaves the persisted bitmaps carrying the
 			 * pre-evolution keys. The remedy is to rebuild the indices from the current entity state via
 			 * GigaMap.reindex() before further queries or updates. Formerly this threw a raw
-			 * java.lang.Error; it now throws a descriptive, catchable exception.
+			 * java.lang.Error; it now throws a descriptive, catchable StaleIndexException. Because the
+			 * entity data itself is valid (only the derived index is out of date), a mutating operation
+			 * that catches this must retain the committed entity rather than destroy it - see
+			 * GigaMap.Default.internalApply.
 			 */
 			final String message =
 				"Cannot remove entityId " + entityId + " for key \"" + this.newKey + "\": the index holds no"
 				+ " entry for this key, which means the index is stale relative to the current entity state"
 				+ " (e.g. after a direct mutation of an indexed field or entity class evolution). Rebuild the"
 				+ " indices from the current entity state via GigaMap.reindex(), then store().";
-			if(this.index instanceof BitmapIndex<?, ?> bitmapIndex)
-			{
-				throw new BitmapIndexException(message, bitmapIndex);
-			}
-			// sub-indices of a composite index are a GigaIndex but not a BitmapIndex
-			throw new GigaIndexException(message, (GigaIndex<?>)this.index);
+			/*
+			 * A NewKeyChangeChandler is only ever produced by getChangeHandler(), which is only invoked on
+			 * top-level bitmap indices (see BitmapIndices), and the only top-level AbstractBitmapIndexHashing
+			 * is HashingBitmapIndex. Sub-indices (SubBitmapIndexHashing) never reach this point - composites
+			 * route change handling through CompositeChangeToken. So this.index is always a BitmapIndex.
+			 */
+			throw new BitmapIndexStaleException(message, (BitmapIndex<?, ?>)this.index);
 		}
 		
 		@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -337,6 +337,17 @@ implements BitmapIndex.TopLevel<E, KS>
 	@Override
 	public final boolean internalContains(final E entity)
 	{
+		return this.internalContains(entity, this.contains);
+	}
+
+	@Override
+	public final boolean internalContains(final E entity, final long excludedEntityId)
+	{
+		return this.internalContains(entity, new ContainsOtherBreaker<>(excludedEntityId));
+	}
+
+	private boolean internalContains(final E entity, final EntityResolver<E> containsBreaker)
+	{
 		final KS keys = this.indexer.index(entity, this.carrier());
 		if(this.isOversized(keys))
 		{
@@ -378,8 +389,8 @@ implements BitmapIndex.TopLevel<E, KS>
 		// if the entity might be contained, a full query result evaluation has to be performed. But without loading entities.
 		try
 		{
-			// contains function throws a Break on the first encounter of a match (aka entity is contained)
-			GigaMap.Default.execute(EntityIdMatcher.NoOp(), this.contains, results, 0, parentMap.highestUsedId() + 1, null);
+			// contains function throws a Break on the first encounter of a (non-excluded) match
+			GigaMap.Default.execute(EntityIdMatcher.NoOp(), containsBreaker, results, 0, parentMap.highestUsedId() + 1, null);
 		}
 		catch(final ThrowBreak b)
 		{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
@@ -216,6 +216,26 @@ public interface BitmapIndex<E, K> extends IndexIdentifier<E, K>, GigaIndex<E>
 		
 		public boolean internalContains(E entity);
 
+		/**
+		 * Like {@link #internalContains(Object)}, but ignores the entity registered under
+		 * {@code excludedEntityId}. Used by the unique-constraint check during an update: a key held only
+		 * by the very entity being updated (e.g. its own stale entry after a class evolution) is not a
+		 * duplicate, so it must not be reported as a unique violation. Only a <em>different</em> entity
+		 * holding the key is a real violation.
+		 * <p>
+		 * The default implementation ignores {@code excludedEntityId} and delegates to
+		 * {@link #internalContains(Object)}; index kinds that can back a unique constraint override it to
+		 * honor the exclusion.
+		 *
+		 * @param entity the entity whose key is checked
+		 * @param excludedEntityId the entity id to exclude from the containment check
+		 * @return whether any entity other than {@code excludedEntityId} is indexed under the entity's key
+		 */
+		public default boolean internalContains(final E entity, final long excludedEntityId)
+		{
+			return this.internalContains(entity);
+		}
+
 		public BitmapResult internalQuery(K key);
 
 		public void clearStateChangeMarkers();

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -812,8 +812,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					// if old and new entity have equal keys, a replacement cannot be a unique violation.
 					continue;
 				}
-				
-				if(index.internalContains(entity))
+
+				// A key held only by the entity being updated (e.g. its own stale entry after a class
+				// evolution) is not a duplicate; only a different entity holding the key is a violation.
+				if(index.internalContains(entity, entityId))
 				{
 					if(createException)
 					{
@@ -1290,7 +1292,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					}
 					if(this.cachedIsUniqueIndex[i])
 					{
-						if(this.cachedIndices[i].internalContains(entity))
+						// A key held only by the entity being updated (e.g. its own stale entry after a
+						// class evolution) is not a duplicate; only a different entity is a violation.
+						if(this.cachedIndices[i].internalContains(entity, entityId))
 						{
 							throw new UniqueConstraintViolationExceptionBitmap(entityId, replacedEntity, entity, this.cachedIndices[i]);
 						}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ContainsOtherBreaker.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ContainsOtherBreaker.java
@@ -1,0 +1,59 @@
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.util.X;
+
+
+/**
+ * Variant of {@link ContainsBreaker} that ignores a single excluded entity id: it terminates the
+ * "contains" scan as soon as a matching entity id <em>other than</em> the excluded one is found,
+ * while the excluded id itself is skipped (scanning continues).
+ * <p>
+ * Used by the unique-constraint check during an update so that an entity colliding only with its own
+ * (possibly stale) index entry is not mistaken for a duplicate; see
+ * {@link BitmapIndex.Internal#internalContains(Object, long)}.
+ *
+ * @param <E> The type of elements stored in the {@code GigaMap}.
+ */
+public final class ContainsOtherBreaker<E> implements EntityResolver<E>
+{
+	private final long excludedEntityId;
+
+	ContainsOtherBreaker(final long excludedEntityId)
+	{
+		super();
+		this.excludedEntityId = excludedEntityId;
+	}
+
+	@Override
+	public GigaMap<E> parent()
+	{
+		return null;
+	}
+
+	@Override
+	public E get(final long entityId)
+	{
+		if(entityId != this.excludedEntityId)
+		{
+			// a matching id other than the excluded one means the key is really contained elsewhere
+			throw X.BREAK();
+		}
+
+		// the excluded entity's own entry is not a duplicate: skip it and keep scanning
+		return null;
+	}
+}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2166,22 +2166,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			{
 				final R result = this.indices.internalApplyUpdate(entityId, current, logic, this.constraints.custom());
 
-				// Mark the owning level1 segment as changed (like internalSet/remove do). This pins the
-				// segment via its usage marker so neither release() nor the LazyReferenceManager can evict
-				// it before the mutation is stored, keeping the mutated entity strongly reachable. Without
-				// this the entity's only strong root is the segment; an eviction + GC would let the store
-				// below silently skip the (then-dead) WeakReference while the index deltas commit anyway,
-				// permanently diverging the persisted indices from the entity.
-				this.markEntitySegmentChanged(entityId);
-
-				// The entity was mutated in-place. Track it so that store() can explicitly
-				// re-persist the entity object (the storer won't re-persist it automatically
-				// since the object reference/identity hasn't changed).
-				if(this.pendingEntityStores == null)
-				{
-					this.pendingEntityStores = BulkList.New();
-				}
-				this.pendingEntityStores.add(new WeakReference<>(current));
+				this.retainMutatedEntity(entityId, current);
 
 				return result;
 			}
@@ -2199,6 +2184,15 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				 */
 				if(isStaleIndexFailure(e))
 				{
+					/*
+					 * The update logic already mutated the entity in place and we keep it. Give it the SAME
+					 * persistence bookkeeping as a successful mutation - pin the segment and track it for
+					 * re-storing - so a later reindex() + store() persists both the rebuilt index and the
+					 * mutated entity. Skipping this would let store() persist the rebuilt index while
+					 * silently skipping the (same-identity) entity, reintroducing entity/index divergence
+					 * after a restart.
+					 */
+					this.retainMutatedEntity(entityId, current);
 					throw e;
 				}
 
@@ -2266,6 +2260,30 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				}
 			}
 			return false;
+		}
+
+		/**
+		 * Records an in-place entity mutation (from {@code apply}) for persistence. Pins the owning
+		 * level1 segment via its usage marker so neither {@link #release()} nor the LazyReferenceManager
+		 * can evict it before the mutation is stored (without this the entity's only strong root is the
+		 * segment; an eviction + GC would let a later store silently skip the then-dead
+		 * {@link WeakReference} while index deltas commit anyway, diverging the persisted indices from the
+		 * entity). It also tracks the entity so {@link #store()} explicitly re-persists it, since the
+		 * storer won't - the object reference/identity hasn't changed.
+		 * <p>
+		 * Must be called for every retained in-place mutation, including the stale-index path that keeps
+		 * a mutated entity: otherwise {@code reindex()} + {@code store()} would persist the rebuilt index
+		 * while skipping the (same-identity) entity, reintroducing entity/index divergence after restart.
+		 */
+		private void retainMutatedEntity(final long entityId, final E current)
+		{
+			this.markEntitySegmentChanged(entityId);
+
+			if(this.pendingEntityStores == null)
+			{
+				this.pendingEntityStores = BulkList.New();
+			}
+			this.pendingEntityStores.add(new WeakReference<>(current));
 		}
 
 		private void markEntitySegmentChanged(final long entityId)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -31,6 +31,7 @@ import org.eclipse.serializer.persistence.types.*;
 import org.eclipse.serializer.reference.Lazy;
 import org.eclipse.serializer.util.X;
 import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.exceptions.StaleIndexException;
 import org.eclipse.store.gigamap.types.GigaQuery.ConditionBuilder;
 import org.eclipse.store.gigamap.types.IterationThreadProvider.IterationLogicProvider;
 
@@ -463,11 +464,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * entity after correcting the violation, or use {@code set} / {@code replace} instead when
 	 * non-destructive semantics are required.
 	 * <p>
-	 * Note that a <em>stale index</em> can make this destructive path fire on an otherwise legitimate update:
-	 * if an indexed field was mutated directly, or the entity class was evolved (an indexed field renamed or
-	 * retyped without a value-preserving refactoring mapping), the persisted index keys no longer match the
-	 * entities, and writing an entity's true value can trigger a <em>phantom</em> constraint violation whose
-	 * removal is a real data loss. Rebuild the indices with {@link #reindex()} before updating in that case.
+	 * A <em>stale index</em> (persisted index keys no longer matching the entities, e.g. after a direct
+	 * mutation of an indexed field or entity class evolution) is treated as a special case so it can
+	 * <em>never</em> destroy a committed entity: a write of the entity's true value is not mistaken for a
+	 * duplicate merely because of the entity's own stale entry (a unique violation requires a
+	 * <em>different</em> entity), and if a stale index cannot be updated in place, this method retains the
+	 * entity and throws a {@link org.eclipse.store.gigamap.exceptions.StaleIndexException} instead of
+	 * removing it. Rebuild the indices with {@link #reindex()} to restore correct query results.
 	 * <p>
 	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
 	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
@@ -511,11 +514,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * re-add the entity after correcting the violation, or use {@link #set(long, Object) set} when
 	 * non-destructive semantics are required.
 	 * <p>
-	 * Note that a <em>stale index</em> can make this destructive path fire on an otherwise legitimate update:
-	 * if an indexed field was mutated directly, or the entity class was evolved (an indexed field renamed or
-	 * retyped without a value-preserving refactoring mapping), the persisted index keys no longer match the
-	 * entities, and writing an entity's true value can trigger a <em>phantom</em> constraint violation whose
-	 * removal is a real data loss. Rebuild the indices with {@link #reindex()} before updating in that case.
+	 * A <em>stale index</em> (persisted index keys no longer matching the entities, e.g. after a direct
+	 * mutation of an indexed field or entity class evolution) is treated as a special case so it can
+	 * <em>never</em> destroy a committed entity: a write of the entity's true value is not mistaken for a
+	 * duplicate merely because of the entity's own stale entry (a unique violation requires a
+	 * <em>different</em> entity), and if a stale index cannot be updated in place, this method retains the
+	 * entity and throws a {@link org.eclipse.store.gigamap.exceptions.StaleIndexException} instead of
+	 * removing it. Rebuild the indices with {@link #reindex()} to restore correct query results.
 	 * <p>
 	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
 	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
@@ -2180,6 +2185,19 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				this.ensureClearedAddingState();
 
 				/*
+				 * A stale index is a special case: the failure means the persisted index keys no longer
+				 * match the keys re-derived from the (e.g. class-evolved) entities, NOT that the entity's
+				 * data is bad. Removing the entity here would be a real data loss for a still-valid,
+				 * committed entity - and the removal itself, re-deriving the same stale keys, cannot even
+				 * de-index it correctly. So the committed entity is retained and the exception is rethrown,
+				 * directing the caller to rebuild the indices via reindex(). See StaleIndexException.
+				 */
+				if(isStaleIndexFailure(e))
+				{
+					throw e;
+				}
+
+				/*
 				 * Since a state change done by a custom logic cannot be rolled back, there is no other choice
 				 * but to remove the entity from the map and report the entity and entityId to the calling
 				 * context in the exception. This applies not only to constraint violations but to any
@@ -2197,6 +2215,31 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				}
 				throw e;
 			}
+		}
+
+		/**
+		 * Detects whether the given throwable (or anything in its cause / suppressed chain) is a
+		 * {@link StaleIndexException}, i.e. signals that an index is out of date rather than that the
+		 * entity's data is bad. Used to keep {@link #internalApply} from destroying a still-valid,
+		 * committed entity when only the index is stale.
+		 */
+		private static boolean isStaleIndexFailure(final Throwable t)
+		{
+			for(Throwable current = t; current != null; current = current.getCause())
+			{
+				if(current instanceof StaleIndexException)
+				{
+					return true;
+				}
+				for(final Throwable suppressed : current.getSuppressed())
+				{
+					if(suppressed instanceof StaleIndexException)
+					{
+						return true;
+					}
+				}
+			}
+			return false;
 		}
 
 		private void markEntitySegmentChanged(final long entityId)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -36,9 +36,14 @@ import org.eclipse.store.gigamap.types.GigaQuery.ConditionBuilder;
 import org.eclipse.store.gigamap.types.IterationThreadProvider.IterationLogicProvider;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -2218,25 +2223,46 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		}
 
 		/**
-		 * Detects whether the given throwable (or anything in its cause / suppressed chain) is a
-		 * {@link StaleIndexException}, i.e. signals that an index is out of date rather than that the
-		 * entity's data is bad. Used to keep {@link #internalApply} from destroying a still-valid,
-		 * committed entity when only the index is stale.
+		 * Detects whether the given throwable, or anything reachable through its cause and suppressed
+		 * throwables (recursively), is a {@link StaleIndexException} - i.e. signals that an index is out of
+		 * date rather than that the entity's data is bad. Used to keep {@link #internalApply} from
+		 * destroying a still-valid, committed entity when only the index is stale.
+		 * <p>
+		 * The JDK offers no ready-made utility for this ({@link Throwable} exposes only
+		 * {@link Throwable#getCause()} and {@link Throwable#getSuppressed()}), so the full graph is walked
+		 * here. An identity-based visited set guards against cyclic cause/suppressed graphs, mirroring how
+		 * {@link Throwable#printStackTrace()} avoids infinite loops internally.
 		 */
 		private static boolean isStaleIndexFailure(final Throwable t)
 		{
-			for(Throwable current = t; current != null; current = current.getCause())
+			if(t == null)
 			{
+				return false;
+			}
+			// ArrayDeque forbids null elements, so only ever push non-null throwables (getCause() may be
+			// null; getSuppressed() never contains nulls).
+			final Set<Throwable>   seen  = Collections.newSetFromMap(new IdentityHashMap<>());
+			final Deque<Throwable> stack = new ArrayDeque<>();
+			stack.push(t);
+			while(!stack.isEmpty())
+			{
+				final Throwable current = stack.pop();
+				if(!seen.add(current))
+				{
+					continue;
+				}
 				if(current instanceof StaleIndexException)
 				{
 					return true;
 				}
+				final Throwable cause = current.getCause();
+				if(cause != null)
+				{
+					stack.push(cause);
+				}
 				for(final Throwable suppressed : current.getSuppressed())
 				{
-					if(suppressed instanceof StaleIndexException)
-					{
-						return true;
-					}
+					stack.push(suppressed);
 				}
 			}
 			return false;

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap88Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap88Test.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.store.gigamap.exceptions.BitmapIndexException;
+import org.eclipse.store.gigamap.exceptions.StaleIndexException;
 import org.eclipse.store.gigamap.types.BinaryIndexerInteger;
 import org.eclipse.store.gigamap.types.Condition;
 import org.eclipse.store.gigamap.types.GigaMap;
@@ -177,9 +178,98 @@ public class GigaMap88Test
 				"a write against a stale index must fail with a descriptive BitmapIndexException, not a raw Error"
 			);
 			assertTrue(
+				ex instanceof StaleIndexException,
+				"the exception must be marked as a StaleIndexException; was: " + ex.getClass().getName()
+			);
+			assertTrue(
 				ex.getMessage() != null && ex.getMessage().contains("reindex"),
 				"the exception should point the caller to reindex(); was: " + ex.getMessage()
 			);
+			// set() is non-destructive: the committed entity must still be present.
+			assertNotNull(loaded.get(id), "set() against a stale index must not delete the committed entity");
+		}
+	}
+
+	/**
+	 * The K.O. scenario (issue #88, {@code phantomUniqueViolationMustNotDeleteEntity}): after evolution
+	 * the entity's own stale entry still sits under the pre-evolution key of a unique (binary) index. A
+	 * legitimate {@code apply()} that writes the entity's true value must NOT be treated as a duplicate
+	 * of itself, and must therefore NOT delete the committed entity.
+	 */
+	@Test
+	@Timeout(120)
+	void phantomUniqueViolationMustNotDeleteEntity(@TempDir final Path dir) throws IOException
+	{
+		final long id = seedAndEvolve(dir, new BinaryCodeIndexer(), true);
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+			assertEquals(0, loaded.get(id).code, "sanity: field defaulted by evolution");
+
+			// Write the entity's true old value. The persisted unique bitmap still holds key 5 (the
+			// entity's own stale entry), which must NOT be counted as a duplicate of the entity itself.
+			loaded.apply(id, p ->
+			{
+				p.code = 5;
+				return null;
+			});
+
+			assertNotNull(loaded.get(id), "phantom unique violation must not delete the committed entity");
+			assertEquals(5, loaded.get(id).code);
+
+			loaded.store();
+		}
+
+		// The entity survives the restart.
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+			assertNotNull(loaded.get(id), "the committed entity must survive the restart");
+			assertEquals(5, loaded.get(id).code);
+		}
+	}
+
+	/**
+	 * The destructive {@code apply()} fallback must not fire for a stale index: an {@code update()} (which
+	 * delegates to {@code apply()}) on a stale hashing index throws a {@link StaleIndexException} but must
+	 * retain the committed entity rather than removing it.
+	 */
+	@Test
+	@Timeout(120)
+	void staleHashingIndexApplyMustNotDeleteEntity(@TempDir final Path dir) throws IOException
+	{
+		final long id = seedAndEvolve(dir, new HashingCodeIndexer(), false);
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+			assertEquals(0, loaded.get(id).code, "sanity: field defaulted by evolution");
+
+			// update() -> apply(): the destructive path. A stale-index failure must escape as a
+			// StaleIndexException but must NOT delete the entity.
+			final RuntimeException ex = assertThrows(
+				RuntimeException.class,
+				() -> loaded.update(id, p -> p.code = 7)
+			);
+			assertTrue(
+				ex instanceof StaleIndexException,
+				"a stale-index update failure must be a StaleIndexException; was: " + ex.getClass().getName()
+			);
+			assertNotNull(loaded.get(id), "apply()/update() against a stale index must not delete the committed entity");
+
+			loaded.store();
+		}
+
+		// The entity survives the restart.
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+			assertNotNull(loaded.get(id), "the committed entity must survive the restart");
 		}
 	}
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap88Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap88Test.java
@@ -235,11 +235,15 @@ public class GigaMap88Test
 	/**
 	 * The destructive {@code apply()} fallback must not fire for a stale index: an {@code update()} (which
 	 * delegates to {@code apply()}) on a stale hashing index throws a {@link StaleIndexException} but must
-	 * retain the committed entity rather than removing it.
+	 * retain the committed entity rather than removing it. Additionally, the in-place mutation the failed
+	 * update already applied must be tracked for re-storing, so the documented {@code reindex()} +
+	 * {@code store()} recovery persists both the rebuilt index AND the mutated entity - otherwise a restart
+	 * would reintroduce entity/index divergence (the rebuilt index would reference a value the persisted
+	 * entity no longer carries).
 	 */
 	@Test
 	@Timeout(120)
-	void staleHashingIndexApplyMustNotDeleteEntity(@TempDir final Path dir) throws IOException
+	void staleHashingIndexApplyMustNotDeleteEntityAndRecoveryPersistsBoth(@TempDir final Path dir) throws IOException
 	{
 		final long id = seedAndEvolve(dir, new HashingCodeIndexer(), false);
 
@@ -250,7 +254,7 @@ public class GigaMap88Test
 			assertEquals(0, loaded.get(id).code, "sanity: field defaulted by evolution");
 
 			// update() -> apply(): the destructive path. A stale-index failure must escape as a
-			// StaleIndexException but must NOT delete the entity.
+			// StaleIndexException but must NOT delete the entity (which the logic mutated to code=7).
 			final RuntimeException ex = assertThrows(
 				RuntimeException.class,
 				() -> loaded.update(id, p -> p.code = 7)
@@ -260,16 +264,25 @@ public class GigaMap88Test
 				"a stale-index update failure must be a StaleIndexException; was: " + ex.getClass().getName()
 			);
 			assertNotNull(loaded.get(id), "apply()/update() against a stale index must not delete the committed entity");
+			assertEquals(7, loaded.get(id).code, "the in-place mutation must be retained");
 
+			// Documented recovery: rebuild the index from the current entity state, then store. This must
+			// persist both the rebuilt index and the (in-place mutated) entity.
+			loaded.reindex();
 			loaded.store();
 		}
 
-		// The entity survives the restart.
+		// After a restart both the entity value and the index must agree - no divergence.
 		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
 		{
 			@SuppressWarnings("unchecked")
-			final GigaMap<Person> loaded = (GigaMap<Person>)storage.root();
+			final GigaMap<Person> loaded  = (GigaMap<Person>)storage.root();
+			final HashingCodeIndexer indexer = new HashingCodeIndexer();
+
 			assertNotNull(loaded.get(id), "the committed entity must survive the restart");
+			assertEquals(7, loaded.get(id).code, "the mutated entity value must have been persisted");
+			assertEquals(1, count(loaded, indexer.is(7)), "the entity must be reachable by its persisted value");
+			assertEquals(0, count(loaded, indexer.is(0)), "no stale index entry must remain after reindex + restart");
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #762, closing the data-loss path that reviewer verification confirmed was still open on `main`. After an indexed field's class evolves without a value-preserving refactoring mapping, GigaMap's persisted bitmap indices load verbatim while the entities load with defaulted/shifted values — the indices are stale. #762 documented this and made the stale-key removal fail loud, but left `apply()` unchanged, so a legitimate `apply()`/`update()` after evolution could still hit a *phantom* unique-constraint violation (the entity colliding only with its own stale index entry) and have `apply()`'s destructive fallback **delete the committed entity**, which the next `store()` persisted.

This PR guarantees a committed entity is **never** destroyed because the derived index is stale, without weakening real unique-constraint enforcement and without changing the persisted format.

Why not auto-rebuild indices on evolution? It isn't reactively feasible: legacy type handlers are keyed only by the old type-id (a `Class` always resolves to the current handler), there is no queryable "was this type legacy-mapped" API reachable from a type handler's `complete()`, and GigaMap tracks no entity type-ids. `reindex()` is also O(all entities) and force-loads every lazy segment. So the fix is reactive.

## Changes

- **Id-aware unique check.** The unique-constraint check now asks "does any entity *other than* the one being updated hold this key" instead of "does any entity hold this key". A key held only by the entity's own stale entry is not a duplicate (no phantom violation); a *different* entity holding the key is still rejected exactly as before. New `BitmapIndex.Internal.internalContains(entity, excludedEntityId)` overload (default delegates to the id-agnostic check), with real implementations on both unique-capable binary hierarchies (`AbstractBitmapIndexBinary`, `AbstractCompositeBitmapIndex`) reusing the existing bitmap iteration via a new `ContainsOtherBreaker`. Both update-time check sites in `BitmapIndices` pass the entity id.
- **Never delete on a stale-index failure.** The stale-key removal guard now throws `BitmapIndexStaleException`, marked with a new `StaleIndexException` interface. `GigaMap.internalApply` detects a `StaleIndexException` (in the cause/suppressed chain) and retains the committed entity, rethrowing so the caller can `reindex()`, instead of removing it. Genuine update-logic exceptions and real (different-entity) unique violations keep the existing destructive behavior.
- **Docs/javadoc.** The `apply(...)` javadocs and the "Class evolution and indexed fields" section of the persistence guide describe the refined contract.

## Tests

`GigaMap88Test` (all green):
- `phantomUniqueViolationMustNotDeleteEntity` — the reviewer's K.O. (binary unique index): `apply()` writing the entity's true value no longer deletes it; survives a restart.
- `staleHashingIndexApplyMustNotDeleteEntity` — `update()`/`apply()` on a stale hashing index throws a `StaleIndexException` but retains the entity.
- `staleHashingIndexRaisesDescriptiveExceptionInsteadOfRawError` — `set()` throws the marked stale exception and does not delete.
- `reindexRecoversFromStaleUniqueIndexAfterEvolution` — `reindex()` remains the recovery for correct query results.

Verification:
- `GigaMap88Test`: all pass.
- Index + constraint/unique suites: real duplicate detection intact.
- Full `gigamap` module: 1078 tests, 0 failures (1 pre-existing skip).

## Out of scope (tracked separately)

Stale query *visibility* after evolution (`is(oldValue)` still matches, `is(actualValue)` misses) is not reactively fixable and still requires `reindex()` — a visibility issue, not data loss (the entity is retained). A fully automatic solution would need persisted entity type-id tracking plus serializer legacy-mapping detection at load; recommend a follow-up issue.