### PR TITLE
Free the partially built new block if BitmapLevel2.decompress fails mid-build

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -915,26 +915,56 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		setSegmentCount          (newLevel2Address, getSegmentCount(level2Address));           // unchanged, just copied.
 		setStandaloneSegmentCount(newLevel2Address, getStandaloneSegmentCount(level2Address)); // unchanged, just copied.
 				
-		for(int i = 0; i < level2IndexBound; i++)
+		try
 		{
-			final long oldLevel1Address;
-			if((oldLevel1Address = getLevel1SegmentAddress(level2Address, i)) < 0L)
+			for(int i = 0; i < level2IndexBound; i++)
 			{
-				// method do standalone segment count updating and pointer registering internally themselves.
-				if(oldLevel1Address == -1L)
+				final long oldLevel1Address;
+				if((oldLevel1Address = getLevel1SegmentAddress(level2Address, i)) < 0L)
 				{
-					allocateLevel1StandaloneSegmentFull(newLevel2Address, i);
+					// method do standalone segment count updating and pointer registering internally themselves.
+					if(oldLevel1Address == -1L)
+					{
+						allocateLevel1StandaloneSegmentFull(newLevel2Address, i);
+					}
+					else
+					{
+						decompressLevel1Segment(newLevel2Address, entryAddressUnmark(oldLevel1Address), i);
+					}
 				}
 				else
 				{
-					decompressLevel1Segment(newLevel2Address, entryAddressUnmark(oldLevel1Address), i);
+					// either null pointer or already decompressed/standalone level1 segment, keep as is.
+					setLevel1SegmentAddress(newLevel2Address, i, oldLevel1Address);
 				}
 			}
-			else
+		}
+		catch(final Throwable t)
+		{
+			// Exception safety for a mid-build allocation failure (e.g. OutOfMemoryError from the fresh level1
+			// allocations above). Free ONLY the freshly-allocated standalone segments plus the new block husk,
+			// then rethrow, leaving the old block fully intact so the live index stays consistent.
+			//
+			// A segment was freshly allocated at index i iff old[i] < 0 (a compressed or all-1-bits entry we
+			// expanded into a new standalone block) AND new[i] > 0 (the allocation succeeded and its pointer was
+			// registered on the new block). Indices with old[i] > 0 were copied BY POINTER and are still SHARED
+			// with the old block (the ownership-transfer second pass below has not run yet), so they must NOT be
+			// freed here: doing so would re-introduce the use-after-free / double-free that #765 fixed. Reading
+			// not-yet-built slots is safe because allocateNew zeroes the whole index array, so they read 0L. The
+			// new block itself is freed with a plain XMemory.free, NOT deallocate() (which would free the shared
+			// pointers too).
+			for(int i = 0; i < level2IndexBound; i++)
 			{
-				// either null pointer or already decompressed/standalone level1 segment, keep as is.
-				setLevel1SegmentAddress(newLevel2Address, i, oldLevel1Address);
+				final long newLevel1Address;
+				if(getLevel1SegmentAddress(level2Address, i) < 0L
+				&& (newLevel1Address = getLevel1SegmentAddress(newLevel2Address, i)) > 0L)
+				{
+					XMemory.free(newLevel1Address);
+				}
 			}
+			XMemory.free(newLevel2Address);
+
+			throw t;
 		}
 
 		// totalLength and level3Index have already been set by allocation method above
@@ -944,8 +974,8 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		// value, so the caller's deallocate(level2Address) must NOT free them (that would be a
 		// use-after-free plus, on a later release, a double free via the new block). Clear them from the
 		// old block here. This runs only after the build loop has completed successfully: if an
-		// allocation above throws mid-build, the old block is left fully intact (only the partially
-		// built new block leaks), preserving the exception safety of the original transform.
+		// allocation above throws mid-build, the catch block above frees the partially built new block
+		// and the old block is left fully intact, preserving the exception safety of the transform.
 		for(int i = 0; i < level2IndexBound; i++)
 		{
 			if(getLevel1SegmentAddress(level2Address, i) > 0L)


### PR DESCRIPTION
## Summary

`BitmapLevel2.decompress()` builds a new level2 block and populates it in a loop, freshly allocating standalone level1 segments for compressed and all-1-bits entries via `XMemory.allocate(Cleared)`, which can throw `OutOfMemoryError`. If an allocation threw part-way through, `decompress()` propagated the throw without ever installing the new block, so the partially built block and every freshly allocated segment already registered on it leaked off-heap memory.

This is a pre-existing latent leak that predates the use-after-free / double-free fix in #765 and only manifests on `OutOfMemoryError` during decompression, so it is low priority — but it is a genuine native-memory leak.

## Fix

Wrap the build loop in a `try`/`catch` that, on failure, frees **only** the freshly allocated segments plus the new block husk and rethrows.

A segment is freshly allocated at index `i` iff `old[i] < 0` (a compressed or all-1-bits entry we expanded) and `new[i] > 0` (the allocation succeeded and registered its pointer). Standalone pointers copied by value from the old block (`old[i] > 0`) are still **shared** with the fully-intact old block because the ownership-transfer second pass has not run yet, so they are deliberately left untouched — freeing them would re-introduce the use-after-free / double-free that #765 fixed. The husk is released with a plain `XMemory.free` rather than `deallocate()` for the same reason.

The old block stays fully intact on failure, so the live index remains consistent. The success path is unchanged.

## Testing

Full gigamap module test suite passes (1078 tests, 0 failures, 0 errors). The change is a no-op on the success path. The `OutOfMemoryError` branch is not deterministically reproducible without an allocation-failure seam, so it is covered by review rather than an automated test.