### PR TITLE
Don't rebuild the full jVector graph on shutdown persist (#112)

### DIFF
--- a/gigamap/jvector/ARCHITECTURE.md
+++ b/gigamap/jvector/ARCHITECTURE.md
@@ -503,7 +503,7 @@ Symmetric to update: `vectorStore.removeById(entityId)` (computed mode), enqueue
 
 ### 7.6 PersistToDisk
 
-The most intricate flow. `persistToDisk()` is a no-op for in-memory indices; on disk, it drains the queue and calls `doPersistToDisk()`.
+The most intricate flow. `persistToDisk()` is a no-op for in-memory indices; on disk, it drains the queue and calls `doPersistToDisk(onShutdown=false)`. The `onShutdown` flag distinguishes the shutdown path (see §7.7): in incremental mode a shutdown persist skips the O(n) full-graph consolidation entirely and relies on the load-time self-heal, rather than paying for a rebuild that shutdown would likely abort anyway.
 
 ### Diagram 7 — `doPersistToDisk()` two-phase protocol
 
@@ -518,32 +518,36 @@ sequenceDiagram
     participant DIM as captured diskManager
     participant FS as filesystem
 
-    Caller->>VI: doPersistToDisk()
+    Caller->>VI: doPersistToDisk(onShutdown)
     VI->>VI: cleanupInProgress = true
     VI->>L: writeLock().lock()
+
+    alt incrementalMode AND isIncrementalClean — no deletions, empty in-memory builder
+        VI->>VI: log "no incremental changes, skip"
+        VI-->>Caller: return — finally unlocks write lock, cleanupInProgress=false
+    end
 
     Note over VI,L: Phase 1: barrier + capture under parentMap monitor
 
     VI->>PM: synchronized(parentMap) {
     VI->>VI: ensureIndexInitialized()
     alt incrementalMode
-        alt no deletions AND empty in-memory builder
-            VI->>VI: log "no incremental changes, skip"
-            VI->>L: writeLock().unlock()
-            Note right of VI: cleanupInProgress=false<br/>(skip drain — nothing deferred)
+        alt onShutdown
+            VI->>VI: log "skip full-graph consolidation on shutdown"
+            VI-->>Caller: return — rely on load-time self-heal, no O(n) rebuild
         else
             VI->>VI: exitIncrementalMode()<br/>(close disk, full rebuild from vectorStore)
         end
     end
-    VI->>VI: capture builder, index, ravv (NullSafe), pqManager, diskManager
+    VI->>VI: capture builder, index, ravv (NullSafe), pqManager, diskManager, meta
     VI->>PM: }
 
     Note over VI,FS: Phase 2: cleanup + disk write outside parentMap
 
     VI->>Bx: cleanup()<br/>(ForkJoinPool may now call parentMap.get safely)
     VI->>DIM: writeIndex(index, ravv, pqManager)
-    DIM->>FS: write name.graph (+ FusedPQ feature if PQ trained)
-    DIM->>FS: write name.meta (version=2, dim, count, highestEntityId)
+    DIM->>FS: write name.graph.tmp then atomic rename (+ FusedPQ feature if PQ trained)
+    DIM->>FS: write name.meta.tmp then atomic rename (version=3, dim, count, highestEntityId, structuralModCount)
     VI->>VI: reenterIncrementalMode()<br/>(reload disk, reset in-memory builder, set incrementalMode=true)
     VI->>L: writeLock().unlock()
     VI->>VI: cleanupInProgress = false
@@ -554,14 +558,18 @@ Two key observations:
 
 - **Phase 1 holds `parentMap`; Phase 2 does not.** The synchronized block is a barrier that lets in-flight GigaMap mutations finish, captures all the references the disk writer will need, and (if applicable) tears down incremental mode. As soon as the references are captured, the monitor is released — `cleanup()` and `writeIndex()` are free to invoke ForkJoinPool/disk-writer threads that themselves call `parentMap.get()` (e.g., for embedded vectorizers). `builderLock.writeLock()` stays held throughout, so concurrent searches and background applies still block.
 - **Skip-on-clean shortcut**. `isIncrementalClean()` short-circuits when there are no `diskDeletedOrdinals` and the in-memory builder graph has zero nodes. Without this, every persist would tear down and rebuild the (unchanged) disk graph.
+- **Skip-consolidation-on-shutdown shortcut** (internal#112). When `onShutdown` is true and the index is in incremental mode with pending changes, the persist returns without calling `exitIncrementalMode()`. The full-graph rebuild is O(n) and would be discarded anyway (shutdown timeouts abort it, and the next boot rebuilds from the store regardless), so the shutdown persist skips it and relies on the load-time self-heal. Full consolidation stays a background/explicit operation.
+- **Atomic writes** (internal#112). `writeIndex()` writes `name.graph`/`name.meta` to `.tmp` siblings and atomically renames them into place (graph first, meta last). An interrupted persist — e.g. `shutdownNow()` mid-write — can therefore never leave a torn live graph or meta.
 
-`exitIncrementalMode()` closes the on-disk graph, clears `diskDeletedOrdinals`, closes the in-memory builder, and rebuilds a fresh full-graph builder from `vectorStore` (or by iterating `parentMap` for embedded mode). `reenterIncrementalMode()` reloads the just-written disk graph, initializes a fresh empty in-memory builder, sets `diskDeletedOrdinals = newKeySet()`, and finally flips `incrementalMode = true` (safe-publication ordering — state fields are written *before* the volatile flag).
+`exitIncrementalMode()` closes the on-disk graph, clears `diskDeletedOrdinals`, closes the in-memory builder, and rebuilds a fresh full-graph builder from `vectorStore` (or by iterating `parentMap` for embedded mode). It is **not** run on the shutdown path. `reenterIncrementalMode()` reloads the just-written disk graph, initializes a fresh empty in-memory builder, sets `diskDeletedOrdinals = newKeySet()`, and finally flips `incrementalMode = true` (safe-publication ordering — state fields are written *before* the volatile flag).
 
 ### 7.7 Close / shutdown
 
 `close()` calls `shutdownBackgroundTaskManager(drainPending=true, optimizeOnShutdown, persistOnShutdown)`. There is one important fall-through path:
 
-> **Commit `fa189228`**: if no background features are enabled, `backgroundTaskManager` is `null`. The pre-fix behavior was to skip persist entirely on close, silently dropping in-memory changes. The fix: when `backgroundTaskManager == null && persistOnShutdown && configuration.onDisk()`, call `doPersistToDisk()` directly so the pending changes are flushed before the index closes.
+> **Commit `fa189228`**: if no background features are enabled, `backgroundTaskManager` is `null`. The pre-fix behavior was to skip persist entirely on close, silently dropping in-memory changes. The fix: when `backgroundTaskManager == null && persistOnShutdown && configuration.onDisk()`, call `doPersistToDisk(onShutdown=true)` directly so the pending changes are flushed before the index closes.
+
+When a `backgroundTaskManager` exists, the shutdown persist runs on its executor via `finalShutdownWork`, which calls `doPersistToDisk(onShutdown=true)`. `BackgroundTaskManager.shutdown()` time-boxes this with `Future.get(shutdownPersistTimeoutMillis)` (configurable via `VectorIndexConfiguration.shutdownPersistTimeoutMillis()`, default 30s); on overrun it interrupts the executor promptly (`shutdownNow()`) rather than waiting a second grace window. Combined with the incremental skip and atomic writes above, this bounds how long shutdown can block and guarantees clean degradation (skip the write, self-heal on next boot) instead of a mid-write kill leaving a torn file.
 
 After background shutdown, `close()` acquires `builderLock.writeLock()` and tears down: searcher pools, builder, in-memory index, disk manager, PQ manager.
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManager.java
@@ -52,6 +52,13 @@ class BackgroundTaskManager
      */
     private static final long WATCHDOG_INTERVAL_MS = 1_000L;
 
+    /**
+     * Short grace window awaited for the executor thread to terminate after {@link #shutdown} has
+     * requested it (or after an overrun triggers {@code shutdownNow()}). Bounds how long shutdown
+     * blocks once the final work is done or has been aborted.
+     */
+    private static final long EXECUTOR_TERMINATION_GRACE_SECONDS = 5L;
+
     // ========================================================================
     // Indexing Operations
     // ========================================================================
@@ -152,8 +159,13 @@ class BackgroundTaskManager
         /**
          * Core persistence logic without queue drain.
          * Called from the executor thread (inline drain already done).
+         *
+         * @param onShutdown {@code true} when invoked on the shutdown path, in which case a
+         *                   full-graph consolidation (exit incremental mode) must be skipped so
+         *                   shutdown is not blocked by an O(n) rebuild; {@code false} for
+         *                   background/explicit persistence, which may consolidate.
          */
-        void doPersistToDisk();
+        void doPersistToDisk(boolean onShutdown);
     }
 
     // ========================================================================
@@ -186,6 +198,9 @@ class BackgroundTaskManager
     private final int           persistenceMinChanges ;
     private ScheduledFuture<?>  persistenceTask       ;
 
+    // Upper bound on how long the shutdown persist may run on the executor before it is aborted.
+    private final long          shutdownPersistTimeoutMillis;
+
     // Liveness watchdog: self-terminates the executor when the index has been abandoned (GC'd)
     private ScheduledFuture<?>  watchdogTask          ;
 
@@ -204,11 +219,13 @@ class BackgroundTaskManager
         final int      optimizationMinChanges,
         final boolean  backgroundPersistence,
         final long     persistenceIntervalMs,
-        final int      persistenceMinChanges
+        final int      persistenceMinChanges,
+        final long     shutdownPersistTimeoutMillis
     )
     {
-        this.callbackRef = new WeakReference<>(callback);
-        this.name        = name                         ;
+        this.callbackRef                  = new WeakReference<>(callback);
+        this.name                         = name                        ;
+        this.shutdownPersistTimeoutMillis = shutdownPersistTimeoutMillis;
 
         this.executor = Executors.newSingleThreadScheduledExecutor(r ->
         {
@@ -406,12 +423,13 @@ class BackgroundTaskManager
         this.cancelScheduledTasks();
 
         // Perform final work if requested
+        boolean timedOut = false;
         if(drainPending || optimizePending || persistPending)
         {
             try
             {
                 this.executor.submit(() -> this.finalShutdownWork(drainPending, optimizePending, persistPending))
-                    .get(30, TimeUnit.SECONDS);
+                    .get(this.shutdownPersistTimeoutMillis, TimeUnit.MILLISECONDS);
             }
             catch(final InterruptedException e)
             {
@@ -423,15 +441,29 @@ class BackgroundTaskManager
             }
             catch(final TimeoutException e)
             {
-                LOG.warn("Shutdown work timed out for '{}'", this.name);
+                // The work is still running and has exceeded its budget. Because on-disk writes are
+                // atomic and the index self-heals from the store on next load, aborting it now is
+                // safe (no torn file, no data loss). Interrupt promptly rather than waiting a second
+                // full grace window, so shutdown is not pinned by work that is being discarded.
+                timedOut = true;
+                LOG.warn("Shutdown work timed out for '{}' after {} ms; aborting so shutdown can proceed "
+                    + "(on-disk index self-heals from store on next load)", this.name, this.shutdownPersistTimeoutMillis);
             }
         }
 
-        // Shutdown the executor
-        this.executor.shutdown();
+        // Shutdown the executor. If the final work overran its budget, interrupt it immediately;
+        // otherwise request a graceful shutdown and give in-flight work a short window to finish.
+        if(timedOut)
+        {
+            this.executor.shutdownNow();
+        }
+        else
+        {
+            this.executor.shutdown();
+        }
         try
         {
-            if(!this.executor.awaitTermination(30, TimeUnit.SECONDS))
+            if(!this.executor.awaitTermination(EXECUTOR_TERMINATION_GRACE_SECONDS, TimeUnit.SECONDS))
             {
                 LOG.warn("Background task executor did not terminate gracefully for '{}'", this.name);
                 this.executor.shutdownNow();
@@ -644,7 +676,7 @@ class BackgroundTaskManager
             // Drain pending indexing ops inline (same thread, no deadlock)
             this.processAllPendingIndexingOps();
 
-            cb.doPersistToDisk();
+            cb.doPersistToDisk(false);
 
             this.persistenceChangeCount.set(0);
 
@@ -702,7 +734,7 @@ class BackgroundTaskManager
                 this.name, this.persistenceChangeCount.get());
             try
             {
-                cb.doPersistToDisk();
+                cb.doPersistToDisk(true);
                 this.persistenceChangeCount.set(0);
             }
             catch(final Exception e)

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManager.java
@@ -441,13 +441,15 @@ class BackgroundTaskManager
             }
             catch(final TimeoutException e)
             {
-                // The work is still running and has exceeded its budget. Because on-disk writes are
-                // atomic and the index self-heals from the store on next load, aborting it now is
-                // safe (no torn file, no data loss). Interrupt promptly rather than waiting a second
-                // full grace window, so shutdown is not pinned by work that is being discarded.
+                // The shutdown work (drain / optimize / persist) is still running and has exceeded its
+                // budget. Aborting it now is safe: an on-disk index writes its graph atomically and
+                // self-heals from the store on next load, so no torn file or data loss results.
+                // Interrupt promptly rather than waiting a second full grace window, so shutdown is not
+                // pinned by work that is being discarded.
                 timedOut = true;
-                LOG.warn("Shutdown work timed out for '{}' after {} ms; aborting so shutdown can proceed "
-                    + "(on-disk index self-heals from store on next load)", this.name, this.shutdownPersistTimeoutMillis);
+                LOG.warn("Shutdown work timed out for '{}' after {} ms; interrupting it so shutdown can "
+                    + "proceed (a pending on-disk persist, if any, self-heals from the store on next load)",
+                    this.name, this.shutdownPersistTimeoutMillis);
             }
         }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -395,12 +395,31 @@ interface DiskIndexManager extends Closeable
             }
             finally
             {
-                // Remove any temp file left behind by a failed or interrupted write.
-                Files.deleteIfExists(graphTempPath);
-                Files.deleteIfExists(metaTempPath);
+                // Remove any temp file left behind by a failed or interrupted write. Swallow cleanup
+                // errors so they cannot mask an in-flight write/move exception (which carries the real
+                // root cause); a leftover temp file is harmless and overwritten on the next persist.
+                this.deleteTempQuietly(graphTempPath);
+                this.deleteTempQuietly(metaTempPath);
             }
 
             LOG.info("Persisted index '{}' to disk with {} vectors", this.name, index.size(0));
+        }
+
+        /**
+         * Deletes a temp file if present, logging (never throwing) on failure. Used from the cleanup
+         * {@code finally} of {@link #writeIndex}, where a thrown cleanup error would mask the real
+         * write/move failure.
+         */
+        private void deleteTempQuietly(final Path tempPath)
+        {
+            try
+            {
+                Files.deleteIfExists(tempPath);
+            }
+            catch(final IOException e)
+            {
+                LOG.warn("Failed to delete temp file '{}' after persist: {}", tempPath, e.getMessage());
+            }
         }
 
         /**

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -409,8 +408,9 @@ interface DiskIndexManager extends Closeable
          * replacing any existing target.
          * <p>
          * Falls back to a plain replace-existing move when the atomic move is rejected. This is not
-         * just {@link java.nio.file.AtomicMoveNotSupportedException}: Windows throws {@link AccessDeniedException}
-         * when asked to atomically replace an existing target. The {@code source} is a fully-written
+         * just {@link java.nio.file.AtomicMoveNotSupportedException}: Windows throws
+         * {@link java.nio.file.AccessDeniedException} when asked to atomically replace an existing
+         * target. The {@code source} is a fully-written
          * temp file, so the only cost of the non-atomic fallback is a narrow crash window in which the
          * live file is missing — which the load-time self-heal simply rebuilds from the store.
          */

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -31,8 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,6 +81,13 @@ interface DiskIndexManager extends Closeable
      * File extension for metadata files.
      */
     final static String META_FILE_EXT = ".meta";
+
+    /**
+     * Extension appended to a live file's name while it is being written. The graph and meta are
+     * written to {@code <name><ext>.tmp} and then atomically renamed onto the live path, so an
+     * interrupted write (e.g. {@code shutdownNow()} mid-persist) can never leave a torn live file.
+     */
+    final static String TEMP_FILE_EXT = ".tmp";
 
     /**
      * Returns whether a disk index is loaded and ready.
@@ -350,28 +359,81 @@ interface DiskIndexManager extends Closeable
         {
             Files.createDirectories(this.indexDirectory);
 
-            final Path graphPath = this.indexDirectory.resolve(this.name + GRAPH_FILE_EXT);
-            final Path metaPath  = this.indexDirectory.resolve(this.name + META_FILE_EXT );
+            final Path graphPath    = this.indexDirectory.resolve(this.name + GRAPH_FILE_EXT);
+            final Path metaPath      = this.indexDirectory.resolve(this.name + META_FILE_EXT );
+            final Path graphTempPath = this.indexDirectory.resolve(this.name + GRAPH_FILE_EXT + TEMP_FILE_EXT);
+            final Path metaTempPath  = this.indexDirectory.resolve(this.name + META_FILE_EXT  + TEMP_FILE_EXT);
 
-            // Write the graph with appropriate features
-            // pqManager is only non-null when PQ compression is enabled
-            if(pqManager != null && pqManager.isTrained() && pqManager.getPQ() != null)
+            // Write both files to temp paths first, then atomically rename them into place. This way an
+            // interrupted write (e.g. shutdownNow() mid-persist) leaves at most a stale temp file — never
+            // a torn live graph or meta. The temp files are cleaned up in the finally block.
+            try
             {
-                this.writeIndexWithFusedPQ(index, ravv, pqManager.getPQ(), graphPath);
-            }
-            else
-            {
-                // Use simple write for non-compressed indices. Pass an identity ordinal map (not the
-                // default sequentialRenumbering) so on-disk node ids stay equal to the graph ordinals
-                // (= source entity ids) — see identityOrdinalMap.
-                OnDiskGraphIndex.write(index, ravv, identityOrdinalMap(index), graphPath);
-            }
+                // Write the graph with appropriate features
+                // pqManager is only non-null when PQ compression is enabled
+                if(pqManager != null && pqManager.isTrained() && pqManager.getPQ() != null)
+                {
+                    this.writeIndexWithFusedPQ(index, ravv, pqManager.getPQ(), graphTempPath);
+                }
+                else
+                {
+                    // Use simple write for non-compressed indices. Pass an identity ordinal map (not the
+                    // default sequentialRenumbering) so on-disk node ids stay equal to the graph ordinals
+                    // (= source entity ids) — see identityOrdinalMap.
+                    OnDiskGraphIndex.write(index, ravv, identityOrdinalMap(index), graphTempPath);
+                }
 
-            // Write metadata using the witnesses captured with the graph in Phase 1 (see MetaState):
-            // NOT re-read live here, since Phase 2 runs with the parentMap monitor released.
-            this.writeMetadata(metaPath, metaState);
+                // Write metadata using the witnesses captured with the graph in Phase 1 (see MetaState):
+                // NOT re-read live here, since Phase 2 runs with the parentMap monitor released.
+                this.writeMetadata(metaTempPath, metaState);
+
+                // Commit: rename the graph first, then the meta last. The meta is the validity stamp
+                // that verifyMetadata reads first on load, so it must only become visible once the graph
+                // it describes is fully in place. A crash between the two renames leaves the graph new and
+                // the meta stale, which verifyMetadata rejects and self-heals from the store.
+                this.atomicMove(graphTempPath, graphPath);
+                this.atomicMove(metaTempPath, metaPath);
+            }
+            finally
+            {
+                // Remove any temp file left behind by a failed or interrupted write.
+                Files.deleteIfExists(graphTempPath);
+                Files.deleteIfExists(metaTempPath);
+            }
 
             LOG.info("Persisted index '{}' to disk with {} vectors", this.name, index.size(0));
+        }
+
+        /**
+         * Moves {@code source} onto {@code target}, atomically where the file system supports it,
+         * replacing any existing target.
+         * <p>
+         * Falls back to a plain replace-existing move when the atomic move is rejected. This is not
+         * just {@link java.nio.file.AtomicMoveNotSupportedException}: Windows throws {@link AccessDeniedException}
+         * when asked to atomically replace an existing target. The {@code source} is a fully-written
+         * temp file, so the only cost of the non-atomic fallback is a narrow crash window in which the
+         * live file is missing — which the load-time self-heal simply rebuilds from the store.
+         */
+        private void atomicMove(final Path source, final Path target) throws IOException
+        {
+            try
+            {
+                Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            }
+            catch(final IOException atomicFailure)
+            {
+                LOG.debug("Atomic move rejected for '{}' ({}), falling back to non-atomic replace",
+                    target, atomicFailure.getClass().getSimpleName());
+                try
+                {
+                    Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+                catch(final IOException nonAtomicFailure)
+                {
+                    nonAtomicFailure.addSuppressed(atomicFailure);
+                    throw nonAtomicFailure;
+                }
+            }
         }
 
         /**

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -1189,7 +1189,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                         this.configuration.minChangesBetweenOptimizations(),
                         backgroundPersistence,
                         this.configuration.persistenceIntervalMs(),
-                        this.configuration.minChangesBetweenPersists()
+                        this.configuration.minChangesBetweenPersists(),
+                        this.configuration.shutdownPersistTimeoutMillis()
                     );
                 }
             }
@@ -2441,16 +2442,22 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 this.backgroundTaskManager.drainQueue();
             }
 
-            this.doPersistToDisk();
+            this.doPersistToDisk(false);
         }
 
         /**
          * Core persistence logic without queue drain.
          * Called directly from the background task manager's executor thread
          * (where inline drain is already done) and from the public persistToDisk() method.
+         *
+         * @param onShutdown {@code true} when invoked on the shutdown path. In incremental mode a
+         *                   shutdown persist skips the O(n) full-graph consolidation entirely and
+         *                   relies on the load-time self-heal, so shutdown is never blocked by a
+         *                   rebuild that would be discarded anyway. {@code false} for
+         *                   background/explicit persistence, which consolidates as before.
          */
         @Override
-        public void doPersistToDisk()
+        public void doPersistToDisk(final boolean onShutdown)
         {
             if(!this.configuration.onDisk())
             {
@@ -2494,6 +2501,18 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                         // rebuildGraphFromStore() does not race with in-flight mutations.
                         if(this.incrementalMode)
                         {
+                            if(onShutdown)
+                            {
+                                // The on-disk index is a derived cache. Skip the O(n) full-graph
+                                // consolidation on shutdown and let the load-time self-heal
+                                // (DiskIndexManager.verifyMetadata) rebuild from the store — the
+                                // source of truth — on the next boot. No vectors are lost, and
+                                // shutdown is not blocked by a rebuild that would be discarded
+                                // anyway. Full consolidation stays a background/explicit operation.
+                                LOG.info("Skipping full-graph consolidation for '{}' on shutdown; "
+                                    + "on-disk index self-heals from store on next load", this.name);
+                                return;
+                            }
                             this.exitIncrementalMode();
                         }
 
@@ -2795,7 +2814,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 // optimization, no background persistence).
                 try
                 {
-                    this.doPersistToDisk();
+                    this.doPersistToDisk(true);
                 }
                 catch(final Exception e)
                 {

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndexConfiguration.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndexConfiguration.java
@@ -396,21 +396,23 @@ public interface VectorIndexConfiguration
     public boolean persistOnShutdown();
 
     /**
-     * Returns the maximum time in milliseconds the shutdown persist may run on the background
+     * Returns the maximum time in milliseconds the final shutdown work may run on the background
      * task executor before it is aborted so application shutdown can proceed.
      * <p>
-     * On {@code close()}, any pending persist runs on the background executor and is awaited for
-     * this long. If it does not finish in time, the executor is interrupted and shutdown continues.
-     * Because {@link #onDisk()} indices write their graph atomically and self-heal from the store
-     * on the next load, an aborted persist never loses data or leaves a torn file — it simply
-     * degrades to a rebuild on the next boot.
+     * On {@code close()}, the final shutdown work — draining pending indexing operations and, if
+     * enabled, optimizing and persisting — runs on the background executor and is awaited for this
+     * long. If it does not finish in time, the executor is interrupted and shutdown continues. The
+     * dominant cost is the persist; because {@link #onDisk()} indices write their graph atomically
+     * and self-heal from the store on the next load, an aborted persist never loses data or leaves a
+     * torn file — it simply degrades to a rebuild on the next boot.
      * <p>
      * In incremental on-disk mode the shutdown persist returns immediately (no full-graph
-     * consolidation is performed on shutdown), so this timeout only bounds a genuinely slow
-     * first-time (non-incremental) persist.
+     * consolidation is performed on shutdown), so in practice this timeout only bounds a genuinely
+     * slow first-time (non-incremental) persist or an unexpectedly slow drain/optimize.
      *
-     * @return the shutdown persist timeout in milliseconds (default: 30000)
+     * @return the shutdown work timeout in milliseconds (default: 30000)
      * @see #persistOnShutdown()
+     * @see #optimizeOnShutdown()
      */
     public long shutdownPersistTimeoutMillis();
 
@@ -969,8 +971,8 @@ public interface VectorIndexConfiguration
         public Builder persistOnShutdown(boolean persistOnShutdown);
 
         /**
-         * Sets the maximum time the shutdown persist may run before it is aborted so shutdown
-         * can proceed.
+         * Sets the maximum time the final shutdown work (drain, optimize, persist) may run before it
+         * is aborted so shutdown can proceed.
          *
          * @param shutdownPersistTimeoutMillis the timeout in milliseconds (must be positive)
          * @return this builder for method chaining

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndexConfiguration.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndexConfiguration.java
@@ -396,6 +396,25 @@ public interface VectorIndexConfiguration
     public boolean persistOnShutdown();
 
     /**
+     * Returns the maximum time in milliseconds the shutdown persist may run on the background
+     * task executor before it is aborted so application shutdown can proceed.
+     * <p>
+     * On {@code close()}, any pending persist runs on the background executor and is awaited for
+     * this long. If it does not finish in time, the executor is interrupted and shutdown continues.
+     * Because {@link #onDisk()} indices write their graph atomically and self-heal from the store
+     * on the next load, an aborted persist never loses data or leaves a torn file — it simply
+     * degrades to a rebuild on the next boot.
+     * <p>
+     * In incremental on-disk mode the shutdown persist returns immediately (no full-graph
+     * consolidation is performed on shutdown), so this timeout only bounds a genuinely slow
+     * first-time (non-incremental) persist.
+     *
+     * @return the shutdown persist timeout in milliseconds (default: 30000)
+     * @see #persistOnShutdown()
+     */
+    public long shutdownPersistTimeoutMillis();
+
+    /**
      * Returns the minimum number of changes required before triggering persistence.
      * <p>
      * This provides debouncing to avoid excessive disk I/O for small batches of changes.
@@ -950,6 +969,16 @@ public interface VectorIndexConfiguration
         public Builder persistOnShutdown(boolean persistOnShutdown);
 
         /**
+         * Sets the maximum time the shutdown persist may run before it is aborted so shutdown
+         * can proceed.
+         *
+         * @param shutdownPersistTimeoutMillis the timeout in milliseconds (must be positive)
+         * @return this builder for method chaining
+         * @see VectorIndexConfiguration#shutdownPersistTimeoutMillis()
+         */
+        public Builder shutdownPersistTimeoutMillis(long shutdownPersistTimeoutMillis);
+
+        /**
          * Sets the minimum number of changes required before triggering persistence.
          *
          * @param minChangesBetweenPersists the minimum changes threshold (must be non-negative)
@@ -1033,6 +1062,11 @@ public interface VectorIndexConfiguration
              */
             private static final int FUSED_PQ_REQUIRED_MAX_DEGREE = 32;
 
+            /**
+             * Default upper bound (30s) on how long a shutdown persist may run before it is aborted.
+             */
+            private static final long DEFAULT_SHUTDOWN_PERSIST_TIMEOUT_MILLIS = 30_000L;
+
             private int                      dimension                    ;
             private VectorSimilarityFunction similarityFunction           ;
             private int                      maxDegree                    ;
@@ -1046,6 +1080,7 @@ public interface VectorIndexConfiguration
             private int                      pqSubspaces                  ;
             private long                     persistenceIntervalMs        ;
             private boolean                  persistOnShutdown            ;
+            private long                     shutdownPersistTimeoutMillis ;
             private int                      minChangesBetweenPersists    ;
             private long                     optimizationIntervalMs       ;
             private int                      minChangesBetweenOptimizations;
@@ -1068,6 +1103,7 @@ public interface VectorIndexConfiguration
                 this.pqSubspaces                   = 0;
                 this.persistenceIntervalMs         = 0;  // 0 = disabled
                 this.persistOnShutdown             = true;
+                this.shutdownPersistTimeoutMillis  = DEFAULT_SHUTDOWN_PERSIST_TIMEOUT_MILLIS;
                 this.minChangesBetweenPersists     = 100;
                 this.optimizationIntervalMs        = 0;  // 0 = disabled
                 this.minChangesBetweenOptimizations = 1000;
@@ -1176,6 +1212,13 @@ public interface VectorIndexConfiguration
             }
 
             @Override
+            public Builder shutdownPersistTimeoutMillis(final long shutdownPersistTimeoutMillis)
+            {
+                this.shutdownPersistTimeoutMillis = positive(shutdownPersistTimeoutMillis);
+                return this;
+            }
+
+            @Override
             public Builder minChangesBetweenPersists(final int minChangesBetweenPersists)
             {
                 if(minChangesBetweenPersists < 0)
@@ -1274,6 +1317,7 @@ public interface VectorIndexConfiguration
                     this.pqSubspaces,
                     this.persistenceIntervalMs,
                     this.persistOnShutdown,
+                    this.shutdownPersistTimeoutMillis,
                     this.minChangesBetweenPersists,
                     this.optimizationIntervalMs,
                     this.minChangesBetweenOptimizations,
@@ -1306,6 +1350,7 @@ public interface VectorIndexConfiguration
         private final int                      pqSubspaces                   ;
         private final long                     persistenceIntervalMs         ;
         private final boolean                  persistOnShutdown             ;
+        private final long                     shutdownPersistTimeoutMillis  ;
         private final int                      minChangesBetweenPersists     ;
         private final long                     optimizationIntervalMs        ;
         private final int                      minChangesBetweenOptimizations;
@@ -1327,6 +1372,7 @@ public interface VectorIndexConfiguration
             final int                      pqSubspaces                    ,
             final long                     persistenceIntervalMs          ,
             final boolean                  persistOnShutdown              ,
+            final long                     shutdownPersistTimeoutMillis   ,
             final int                      minChangesBetweenPersists      ,
             final long                     optimizationIntervalMs         ,
             final int                      minChangesBetweenOptimizations ,
@@ -1348,6 +1394,7 @@ public interface VectorIndexConfiguration
             this.pqSubspaces                    = pqSubspaces                                              ;
             this.persistenceIntervalMs          = persistenceIntervalMs                                    ;
             this.persistOnShutdown              = persistOnShutdown                                        ;
+            this.shutdownPersistTimeoutMillis   = shutdownPersistTimeoutMillis                             ;
             this.minChangesBetweenPersists      = minChangesBetweenPersists                                ;
             this.optimizationIntervalMs         = optimizationIntervalMs                                   ;
             this.minChangesBetweenOptimizations = minChangesBetweenOptimizations                           ;
@@ -1432,6 +1479,17 @@ public interface VectorIndexConfiguration
         public boolean persistOnShutdown()
         {
             return this.persistOnShutdown;
+        }
+
+        @Override
+        public long shutdownPersistTimeoutMillis()
+        {
+            // Guard against a non-positive value loaded from a pre-existing store (Eclipse Store
+            // fills a field added by schema evolution with 0); fall back to the default so a legacy
+            // config never yields a zero/immediate shutdown-persist timeout.
+            return this.shutdownPersistTimeoutMillis > 0
+                ? this.shutdownPersistTimeoutMillis
+                : Builder.Default.DEFAULT_SHUTDOWN_PERSIST_TIMEOUT_MILLIS;
         }
 
         @Override

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManagerShutdownTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManagerShutdownTest.java
@@ -81,7 +81,10 @@ class BackgroundTaskManagerShutdownTest
     @Timeout(value = 30, unit = TimeUnit.SECONDS)
     void shutdownIsBoundedWhenPersistOverrunsTimeout() throws InterruptedException
     {
-        final long shutdownPersistTimeoutMillis = 300L;
+        // Comfortably longer than executor thread start-up so finalShutdownWork reliably begins before
+        // the deadline (avoids CI/JIT-jitter flakiness), yet far shorter than the 60s persist sleep so
+        // the overrun-and-abort path is still what the test exercises.
+        final long shutdownPersistTimeoutMillis = 2_000L;
 
         final SlowPersistCallback callback = new SlowPersistCallback();
         final BackgroundTaskManager manager = new BackgroundTaskManager(

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManagerShutdownTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManagerShutdownTest.java
@@ -82,8 +82,8 @@ class BackgroundTaskManagerShutdownTest
     void shutdownIsBoundedWhenPersistOverrunsTimeout() throws InterruptedException
     {
         // Comfortably longer than executor thread start-up so finalShutdownWork reliably begins before
-        // the deadline (avoids CI/JIT-jitter flakiness), yet far shorter than the 60s persist sleep so
-        // the overrun-and-abort path is still what the test exercises.
+        // the deadline, yet far shorter than the 60s persist sleep so the overrun-and-abort path is
+        // still what the test exercises.
         final long shutdownPersistTimeoutMillis = 2_000L;
 
         final SlowPersistCallback callback = new SlowPersistCallback();
@@ -103,19 +103,27 @@ class BackgroundTaskManagerShutdownTest
         // Register a pending change so the shutdown persist actually runs.
         manager.markDirty(5);
 
+        // Run shutdown() on a separate thread so the test can observe the persist starting while
+        // shutdown is in progress, rather than relying on timing after shutdown() has returned.
         final long startNanos = System.nanoTime();
-        manager.shutdown(false, false, true); // persistPending = true
-        final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+        final Thread shutdownThread = new Thread(
+            () -> manager.shutdown(false, false, true), // persistPending = true
+            "shutdown-under-test"
+        );
+        shutdownThread.start();
 
-        // The persist must have been invoked and then aborted by the shutdown, not run to completion.
-        assertTrue(callback.persistStarted.await(1, TimeUnit.SECONDS),
+        // The persist must actually begin before we assert anything about the abort behaviour.
+        assertTrue(callback.persistStarted.await(10, TimeUnit.SECONDS),
             "Shutdown persist should have been invoked");
-        assertTrue(callback.persistInterrupted.get(),
-            "The overrunning persist should have been interrupted by shutdown");
 
         // Shutdown must return well within the timeout + grace window, nowhere near the 60s sleep.
-        assertTrue(elapsedMillis < 15_000,
-            "shutdown() must be bounded, took " + elapsedMillis + " ms");
+        shutdownThread.join(15_000);
+        final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        assertFalse(shutdownThread.isAlive(),
+            "shutdown() must be bounded, still running after " + elapsedMillis + " ms");
+        assertTrue(callback.persistInterrupted.get(),
+            "The overrunning persist should have been interrupted by shutdown");
     }
 
     @Test

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManagerShutdownTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/BackgroundTaskManagerShutdownTest.java
@@ -1,0 +1,137 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for internal#112: {@link BackgroundTaskManager#shutdown} must be time-boxed by the
+ * configured shutdown-persist timeout. A persist that overruns the budget is aborted promptly rather
+ * than pinning shutdown for the full grace window.
+ */
+class BackgroundTaskManagerShutdownTest
+{
+    /**
+     * Minimal {@link BackgroundTaskManager.Callback} whose {@code doPersistToDisk} blocks for a long
+     * time but returns cooperatively when interrupted (mirrors how the real persist unwinds when the
+     * executor is interrupted mid-write).
+     */
+    private static final class SlowPersistCallback implements BackgroundTaskManager.Callback
+    {
+        final CountDownLatch persistStarted     = new CountDownLatch(1);
+        final AtomicBoolean  persistInterrupted = new AtomicBoolean(false);
+
+        @Override
+        public void applyGraphAdd(final VectorEntry entry) { /* no-op */ }
+
+        @Override
+        public void applyGraphBatchAdd(final List<VectorEntry> entries) { /* no-op */ }
+
+        @Override
+        public void applyGraphUpdate(final VectorEntry entry) { /* no-op */ }
+
+        @Override
+        public void applyGraphRemove(final int ordinal) { /* no-op */ }
+
+        @Override
+        public void markDirtyForBackgroundManagers(final int count) { /* no-op */ }
+
+        @Override
+        public void doOptimize() { /* no-op */ }
+
+        @Override
+        public void doPersistToDisk(final boolean onShutdown)
+        {
+            this.persistStarted.countDown();
+            try
+            {
+                // Far longer than the configured timeout; the shutdown must interrupt this.
+                Thread.sleep(60_000);
+            }
+            catch(final InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                this.persistInterrupted.set(true);
+            }
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void shutdownIsBoundedWhenPersistOverrunsTimeout() throws InterruptedException
+    {
+        final long shutdownPersistTimeoutMillis = 300L;
+
+        final SlowPersistCallback callback = new SlowPersistCallback();
+        final BackgroundTaskManager manager = new BackgroundTaskManager(
+            callback,
+            "test-index",
+            false,   // eventualIndexing
+            false,   // backgroundOptimization
+            0L,      // optimizationIntervalMs
+            0,       // optimizationMinChanges
+            true,    // backgroundPersistence
+            600_000L,// persistenceIntervalMs — long, so the scheduled task never fires during the test
+            1,       // persistenceMinChanges
+            shutdownPersistTimeoutMillis
+        );
+
+        // Register a pending change so the shutdown persist actually runs.
+        manager.markDirty(5);
+
+        final long startNanos = System.nanoTime();
+        manager.shutdown(false, false, true); // persistPending = true
+        final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        // The persist must have been invoked and then aborted by the shutdown, not run to completion.
+        assertTrue(callback.persistStarted.await(1, TimeUnit.SECONDS),
+            "Shutdown persist should have been invoked");
+        assertTrue(callback.persistInterrupted.get(),
+            "The overrunning persist should have been interrupted by shutdown");
+
+        // Shutdown must return well within the timeout + grace window, nowhere near the 60s sleep.
+        assertTrue(elapsedMillis < 15_000,
+            "shutdown() must be bounded, took " + elapsedMillis + " ms");
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void shutdownReturnsQuicklyWhenNoPendingWork() throws InterruptedException
+    {
+        final SlowPersistCallback callback = new SlowPersistCallback();
+        final BackgroundTaskManager manager = new BackgroundTaskManager(
+            callback,
+            "test-index-clean",
+            false, false, 0L, 0, true, 600_000L, 1, 300L
+        );
+
+        // No markDirty(): persistenceChangeCount stays 0, so finalShutdownWork skips the persist.
+        final long startNanos = System.nanoTime();
+        manager.shutdown(false, false, true);
+        final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        assertFalse(callback.persistInterrupted.get(), "No persist should have run without pending changes");
+        assertTrue(elapsedMillis < 5_000, "Clean shutdown should be near-instant, took " + elapsedMillis + " ms");
+    }
+}

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConfigurationTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConfigurationTest.java
@@ -49,6 +49,7 @@ class VectorIndexConfigurationTest
         assertFalse(config.backgroundPersistence());
         assertEquals(0L, config.persistenceIntervalMs());
         assertTrue(config.persistOnShutdown());
+        assertEquals(30_000L, config.shutdownPersistTimeoutMillis());
         assertEquals(100, config.minChangesBetweenPersists());
         assertFalse(config.backgroundOptimization());
         assertEquals(0L, config.optimizationIntervalMs());
@@ -68,6 +69,23 @@ class VectorIndexConfigurationTest
         );
         assertThrows(NumberRangeException.class, () ->
             VectorIndexConfiguration.builder().dimension(-1).build()
+        );
+    }
+
+    @Test
+    void testBuilderShutdownPersistTimeoutMillis()
+    {
+        final VectorIndexConfiguration config = VectorIndexConfiguration.builder()
+            .dimension(64)
+            .shutdownPersistTimeoutMillis(5_000)
+            .build();
+        assertEquals(5_000L, config.shutdownPersistTimeoutMillis());
+
+        assertThrows(NumberRangeException.class, () ->
+            VectorIndexConfiguration.builder().dimension(64).shutdownPersistTimeoutMillis(0).build()
+        );
+        assertThrows(NumberRangeException.class, () ->
+            VectorIndexConfiguration.builder().dimension(64).shutdownPersistTimeoutMillis(-1).build()
         );
     }
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -3127,7 +3128,8 @@ class VectorIndexDiskTest
         final float[] needleVector = new float[dimension];
         needleVector[0] = 1.0f;
 
-        byte[] graphBytesAfterPersist = null;
+        byte[]   graphBytesAfterPersist = null;
+        FileTime graphMTimeAfterPersist = null;
 
         // Phase 1: create, persist once (enters incremental mode), apply incremental changes, then
         // close with persistOnShutdown(true). The graph must not be rewritten by the shutdown.
@@ -3158,6 +3160,7 @@ class VectorIndexDiskTest
                 storage.storeRoot();
                 assertTrue(Files.exists(graphPath), "Graph file should exist after the first persist");
                 graphBytesAfterPersist = Files.readAllBytes(graphPath);
+                graphMTimeAfterPersist = Files.getLastModifiedTime(graphPath);
 
                 // Apply incremental changes (in-memory builder + tombstones) — deliberately NOT persisted.
                 addRandomDocuments(gigaMap, random, dimension, 50, "added_");
@@ -3168,7 +3171,11 @@ class VectorIndexDiskTest
                 index.close();
             }
 
-            // The graph file must be byte-identical: the shutdown did NOT rebuild + rewrite it.
+            // The graph file must be untouched by the shutdown: not rewritten (last-modified time
+            // unchanged — catches a deterministic rebuild that happens to produce identical bytes) and
+            // byte-identical (catches a rewrite that a coarse mtime granularity might miss).
+            assertEquals(graphMTimeAfterPersist, Files.getLastModifiedTime(graphPath),
+                "Shutdown must not rewrite the graph while in incremental mode (last-modified time changed)");
             assertArrayEquals(graphBytesAfterPersist, Files.readAllBytes(graphPath),
                 "Shutdown must not rewrite the graph while in incremental mode (no full-graph rebuild)");
             // And it must not leave any temp file behind.

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -3104,6 +3105,155 @@ class VectorIndexDiskTest
                         "After removeAll, only new documents should be found");
                 }
             }
+        }
+    }
+
+    /**
+     * Regression test for internal#112: an on-disk index in incremental mode with pending changes
+     * must NOT rebuild and rewrite the full graph on {@code close()} with {@code persistOnShutdown}.
+     * The graph file must stay byte-identical across the shutdown (no O(n) consolidation), and the
+     * changes must still be visible after reload thanks to the load-time self-heal from the store.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void testShutdownDoesNotRebuildGraphInIncrementalMode(@TempDir final Path tempDir) throws IOException
+    {
+        final int dimension = 32;
+        final Random random = new Random(42);
+
+        final Path indexDir   = tempDir.resolve("index");
+        final Path storageDir = tempDir.resolve("storage");
+        final Path graphPath  = indexDir.resolve("embeddings.graph");
+
+        final float[] needleVector = new float[dimension];
+        needleVector[0] = 1.0f;
+
+        byte[] graphBytesAfterPersist = null;
+
+        // Phase 1: create, persist once (enters incremental mode), apply incremental changes, then
+        // close with persistOnShutdown(true). The graph must not be rewritten by the shutdown.
+        {
+            try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+            {
+                final GigaMap<Document> gigaMap = GigaMap.New();
+                storage.setRoot(gigaMap);
+
+                final VectorIndices<Document> vectorIndices = gigaMap.index().register(VectorIndices.Category());
+                final VectorIndexConfiguration config = VectorIndexConfiguration.builder()
+                    .dimension(dimension)
+                    .similarityFunction(VectorSimilarityFunction.COSINE)
+                    .onDisk(true)
+                    .indexDirectory(indexDir)
+                    .persistenceIntervalMs(60_000) // long interval — background persistence won't fire during the test
+                    .minChangesBetweenPersists(1)
+                    .persistOnShutdown(true)
+                    .build();
+
+                final VectorIndex<Document> index = vectorIndices.add(
+                    "embeddings", config, new ComputedDocumentVectorizer());
+
+                addRandomDocuments(gigaMap, random, dimension, 100, "original_");
+
+                // First persist writes the full graph and re-enters incremental mode.
+                index.persistToDisk();
+                storage.storeRoot();
+                assertTrue(Files.exists(graphPath), "Graph file should exist after the first persist");
+                graphBytesAfterPersist = Files.readAllBytes(graphPath);
+
+                // Apply incremental changes (in-memory builder + tombstones) — deliberately NOT persisted.
+                addRandomDocuments(gigaMap, random, dimension, 50, "added_");
+                gigaMap.add(new Document("needle", needleVector));
+                storage.storeRoot(); // commit to the store so the self-heal can rebuild them on reload
+
+                // Shutdown persist: in incremental mode this must skip the full-graph consolidation.
+                index.close();
+            }
+
+            // The graph file must be byte-identical: the shutdown did NOT rebuild + rewrite it.
+            assertArrayEquals(graphBytesAfterPersist, Files.readAllBytes(graphPath),
+                "Shutdown must not rewrite the graph while in incremental mode (no full-graph rebuild)");
+            // And it must not leave any temp file behind.
+            assertNoTempFiles(indexDir);
+        }
+
+        // Phase 2: reload — the on-disk graph is stale (store advanced past it), so the self-heal
+        // rebuilds from the store. All vectors, including the unpersisted incremental ones, are found.
+        {
+            try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+            {
+                final GigaMap<Document> gigaMap = storage.root();
+                final VectorIndices<Document> vectorIndices = gigaMap.index().get(VectorIndices.Category());
+                final VectorIndex<Document> index = vectorIndices.get("embeddings");
+
+                assertEquals(151, gigaMap.size());
+
+                final VectorSearchResult<Document> result = index.search(needleVector, 10);
+                boolean foundNeedle = false;
+                for(final ScoredSearchResult.Entry<Document> entry : result)
+                {
+                    if("needle".equals(entry.entity().content()))
+                    {
+                        foundNeedle = true;
+                        break;
+                    }
+                }
+                assertTrue(foundNeedle, "Self-heal must recover the unpersisted incremental changes from the store");
+            }
+        }
+    }
+
+    /**
+     * Fix for internal#112: {@link DiskIndexManager} writes the graph and meta via temp files and an
+     * atomic rename. A completed persist must leave no {@code .tmp} files behind, and the graph must
+     * load normally.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void testWriteIndexLeavesNoTempFiles(@TempDir final Path tempDir) throws IOException
+    {
+        final int dimension = 32;
+        final Random random = new Random(42);
+        final Path indexDir = tempDir.resolve("index");
+
+        final GigaMap<Document> gigaMap = GigaMap.New();
+        final VectorIndices<Document> vectorIndices = gigaMap.index().register(VectorIndices.Category());
+        final VectorIndexConfiguration config = VectorIndexConfiguration.builder()
+            .dimension(dimension)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .build();
+
+        final VectorIndex<Document> index = vectorIndices.add(
+            "embeddings", config, new ComputedDocumentVectorizer());
+        addRandomDocuments(gigaMap, random, dimension, 100, "doc_");
+
+        index.persistToDisk();
+
+        assertTrue(Files.exists(indexDir.resolve("embeddings.graph")), "Graph file should exist after persist");
+        assertTrue(Files.exists(indexDir.resolve("embeddings.meta")),  "Meta file should exist after persist");
+        assertNoTempFiles(indexDir);
+
+        index.close();
+    }
+
+    /**
+     * Asserts that no temporary write files ({@code *.graph.tmp} / {@code *.meta.tmp}) linger in the
+     * index directory after a persist.
+     */
+    private static void assertNoTempFiles(final Path indexDir) throws IOException
+    {
+        if(!Files.exists(indexDir))
+        {
+            return;
+        }
+        try(final var entries = Files.list(indexDir))
+        {
+            final List<String> tempFiles = entries
+                .map(p -> p.getFileName().toString())
+                .filter(n -> n.endsWith(".tmp"))
+                .toList();
+            assertTrue(tempFiles.isEmpty(), "No temp files should remain after persist, found: " + tempFiles);
         }
     }
 

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexDiskTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;


### PR DESCRIPTION
## Summary

An on-disk jVector `VectorIndex` in incremental mode with pending changes rebuilt the entire HNSW graph on `close()` with `persistOnShutdown(true)`. That O(n) rebuild overran `BackgroundTaskManager`'s two sequential 30s shutdown timeouts, was killed by `shutdownNow()`, blocked application shutdown for ~62s, and could leave a torn graph file — all to produce a graph the next boot rebuilds from the store anyway.

## Changes

**Fix 1 — no consolidation on the shutdown path.** An `onShutdown` flag is threaded through the persist path (`Callback.doPersistToDisk(boolean)`, `VectorIndex.Default.doPersistToDisk(boolean)`). In incremental mode a shutdown persist now skips `exitIncrementalMode()`/`rebuildGraphFromStore()` and relies on the load-time self-heal (`verifyMetadata` rebuilds from the store, the source of truth). No vectors are lost, and full consolidation stays a background/explicit operation.

**Fix 2 — atomic disk writes.** `DiskIndexManager.writeIndex()` writes the graph and meta to `.tmp` siblings and atomically renames them into place (graph first, meta last), so an interrupted persist can never leave a torn live file. The rename falls back to a non-atomic replace on `IOException` — Windows throws `AccessDeniedException` on `ATOMIC_MOVE` over an existing target, not `AtomicMoveNotSupportedException`.

**Fix 3 — bounded, configurable shutdown.** Adds `VectorIndexConfiguration.shutdownPersistTimeoutMillis` (default 30s), threaded into `BackgroundTaskManager`. On overrun, `shutdown()` now interrupts the executor promptly instead of waiting a second grace window; combined with the atomic writes this degrades cleanly (skip the write, self-heal on next boot) rather than a mid-write kill. The accessor clamps a non-positive legacy value back to the default so a config loaded from an older store behaves correctly.

## Testing

Regression tests assert the graph is not rewritten on an incremental shutdown and self-heals on reload, that no temp files linger after a persist, and (in isolation) that `BackgroundTaskManager.shutdown()` is time-boxed when a persist overruns. Verified green: jvector default suite (229) and full slow suite (115), including `VectorIndexDiskTest` (45) and `VectorIndexNullVectorTest` (31). `ARCHITECTURE.md` updated for the new flow.
