### PR TITLE
Absorb in flight backup copies superseded by a truncation

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
@@ -14,6 +14,10 @@ package org.eclipse.store.storage.types;
  * #L%
  */
 
+import org.eclipse.serializer.util.logging.Logging;
+import org.eclipse.store.storage.exceptions.StorageExceptionBackupCopying;
+import org.slf4j.Logger;
+
 public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, StorageFileUser
 {
 	public boolean processNextItem(StorageBackupHandler handler, long timeoutMs) throws InterruptedException;
@@ -27,10 +31,12 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 	
 	public final class Default implements StorageBackupItemQueue
 	{
+		private final static Logger logger = Logging.getLogger(StorageBackupItemQueue.class);
+
 		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
-		
+
 		private final Item head = new Item(null);
 		private       Item tail = this.head;
 		
@@ -110,9 +116,12 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 		public void trimPendingCopyItemsBeyond(final StorageLiveChannelFile<?> file, final long newLength)
 		{
 			// A start-only check (>= newLength) suffices: copy items are enqueued at exact write
-			// boundaries (sourcePosition == the file length before that write), and the only truncation
-			// that reaches here is a rollback to the committed length - itself a write boundary. So an
+			// boundaries (sourcePosition == the file length before that write), and every truncation
+			// that reaches here cuts at a write boundary (a store rollback to the committed length, or
+			// the transactions-log compaction's rewrite truncating to 0). So an
 			// item either lies fully below newLength or starts at/after it; none can straddle newLength.
+			// NOTE: this removes QUEUED items only - an item the backup thread already dequeued is
+			// handled by the obsolescence check in processNextItem when its read fails.
 			this.removeMatching(item ->
 				item.sourceFile == file
 				&& item instanceof CopyItem
@@ -229,6 +238,29 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 			{
 				itemToBeProcessed.processBy(handler);
 			}
+			catch(final StorageExceptionBackupCopying e)
+			{
+				if(!this.isSupersededByPendingItem(itemToBeProcessed))
+				{
+					throw e;
+				}
+				/*
+				 * The item was in flight while the channel truncated (or deleted) its source at or
+				 * below the copied range - the pre-truncation trim only surgeries QUEUED items, an
+				 * already dequeued one is invisible to it. The failed copy contributes nothing to
+				 * the backup's final state: the truncating item still queued behind it discards the
+				 * range anyway and the subsequent items re-append the rewritten content, so
+				 * skipping is a semantic no-op. Failing loudly here would disrupt the whole storage
+				 * over a self-reconciling state.
+				 */
+				final CopyItem copyItem = (CopyItem)itemToBeProcessed; // guarded: predicate is copy-item-only
+				logger.debug(
+					"Skipped an in-flight backup copy ({} @{}+{}) superseded by a truncation enqueued behind it",
+					copyItem.sourceFile.identifier(),
+					copyItem.sourcePosition,
+					copyItem.length
+				);
+			}
 			finally
 			{
 				// the backup thread can be the last active part of an already shutdown storage, so it has to clean up.
@@ -236,6 +268,41 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 			}
 
 			return true;
+		}
+
+		/**
+		 * Whether the passed (just failed, formerly in-flight) item's copied range is discarded by
+		 * a truncation - or the whole file by a deletion - still queued behind it. Queue order
+		 * makes this exact: the superseding item was enqueued after the passed item was dequeued
+		 * (the pre-truncation trim removes all queued copy items for the range first), and the
+		 * single processing thread cannot have processed it yet. Ranges never straddle a
+		 * truncation boundary (copy items are enqueued at write boundaries and truncations cut at
+		 * write boundaries), so the position comparison suffices.
+		 */
+		private boolean isSupersededByPendingItem(final Item item)
+		{
+			if(!(item instanceof CopyItem))
+			{
+				return false;
+			}
+			final long sourcePosition = ((CopyItem)item).sourcePosition;
+			synchronized(this.head)
+			{
+				for(Item i = this.head.next; i != null; i = i.next)
+				{
+					if(i.sourceFile != item.sourceFile)
+					{
+						continue;
+					}
+					if(i instanceof TruncationItem && ((TruncationItem)i).length <= sourcePosition
+						|| i instanceof DeletionItem
+					)
+					{
+						return true;
+					}
+				}
+			}
+			return false;
 		}
 		
 		static class Item

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
@@ -249,10 +249,11 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 				 */
 				final CopyItem copyItem = (CopyItem)itemToBeProcessed; // guarded: predicate is copy-item-only
 				logger.debug(
-					"Skipped an in-flight backup copy ({} @{}+{}) superseded by a truncation enqueued behind it",
+					"Skipped an in-flight backup copy ({} @{}+{}) superseded by a truncation or deletion enqueued behind it",
 					copyItem.sourceFile.identifier(),
 					copyItem.sourcePosition,
-					copyItem.length
+					copyItem.length,
+					e
 				);
 			}
 			finally
@@ -286,7 +287,7 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 					{
 						continue;
 					}
-					if(i instanceof TruncationItem && ((TruncationItem)i).length <= sourcePosition
+					if((i instanceof TruncationItem && ((TruncationItem)i).length <= sourcePosition)
 						|| i instanceof DeletionItem
 					)
 					{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageBackupItemQueue.java
@@ -115,13 +115,10 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 		@Override
 		public void trimPendingCopyItemsBeyond(final StorageLiveChannelFile<?> file, final long newLength)
 		{
-			// A start-only check (>= newLength) suffices: copy items are enqueued at exact write
-			// boundaries (sourcePosition == the file length before that write), and every truncation
-			// that reaches here cuts at a write boundary (a store rollback to the committed length, or
-			// the transactions-log compaction's rewrite truncating to 0). So an
-			// item either lies fully below newLength or starts at/after it; none can straddle newLength.
-			// NOTE: this removes QUEUED items only - an item the backup thread already dequeued is
-			// handled by the obsolescence check in processNextItem when its read fails.
+			// A start-only check (>= newLength) suffices: copy items start at write boundaries and
+			// every truncation reaching here cuts at a write boundary, so an item lies fully below
+			// newLength or starts at/after it - none straddles it. Removes QUEUED items only; an
+			// already-dequeued in-flight copy is absorbed by processNextItem when its read fails.
 			this.removeMatching(item ->
 				item.sourceFile == file
 				&& item instanceof CopyItem
@@ -245,13 +242,10 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 					throw e;
 				}
 				/*
-				 * The item was in flight while the channel truncated (or deleted) its source at or
-				 * below the copied range - the pre-truncation trim only surgeries QUEUED items, an
-				 * already dequeued one is invisible to it. The failed copy contributes nothing to
-				 * the backup's final state: the truncating item still queued behind it discards the
-				 * range anyway and the subsequent items re-append the rewritten content, so
-				 * skipping is a semantic no-op. Failing loudly here would disrupt the whole storage
-				 * over a self-reconciling state.
+				 * An in-flight copy the trim could not reach failed because its source was truncated
+				 * (or deleted) at/below the copied range. The truncating item queued behind it
+				 * discards that range and later items re-append the rewritten content, so skipping is
+				 * a no-op; failing loudly would disrupt the whole storage over a self-reconciling state.
 				 */
 				final CopyItem copyItem = (CopyItem)itemToBeProcessed; // guarded: predicate is copy-item-only
 				logger.debug(
@@ -271,13 +265,11 @@ public interface StorageBackupItemQueue extends StorageBackupItemEnqueuer, Stora
 		}
 
 		/**
-		 * Whether the passed (just failed, formerly in-flight) item's copied range is discarded by
-		 * a truncation - or the whole file by a deletion - still queued behind it. Queue order
-		 * makes this exact: the superseding item was enqueued after the passed item was dequeued
-		 * (the pre-truncation trim removes all queued copy items for the range first), and the
-		 * single processing thread cannot have processed it yet. Ranges never straddle a
-		 * truncation boundary (copy items are enqueued at write boundaries and truncations cut at
-		 * write boundaries), so the position comparison suffices.
+		 * Whether a truncation discarding the passed copy item's range - or a deletion of its whole
+		 * file - is still queued behind it. {@link StorageFileWriterBackupping} enqueues the
+		 * superseding item before the physical truncate/delete that fails the copy, so a failed
+		 * in-flight copy always finds it here. Ranges never straddle a truncation boundary, so
+		 * comparing the start position suffices.
 		 */
 		private boolean isSupersededByPendingItem(final Item item)
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriterBackupping.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileWriterBackupping.java
@@ -259,14 +259,15 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 			final StorageFileProvider       fileProvider
 		)
 		{
-			// trim queued copy items for the bytes about to be removed BEFORE the physical truncate:
-			// processed afterwards they would copy a source range that no longer exists, throw, and
-			// escalate to a storage-wide disruption over an already-handled rollback.
+			// Both queue mutations must run BEFORE the physical truncate: the trim drops queued copy
+			// items for the removed range, and the truncating item must already be queued when an
+			// in-flight copy (invisible to the trim) fails on the shortened source, so its absorption
+			// check finds it. Enqueuing afterwards leaves a race that escalates a handled rollback.
 			this.itemEnqueuer.trimPendingCopyItemsBeyond(file, newLength);
+			this.itemEnqueuer.enqueueTruncatingItem(file, newLength);
 
 			// no user increment since only the identifier is required and the actual file can well be deleted.
 			this.delegate.truncate(file, newLength, fileProvider);
-			this.itemEnqueuer.enqueueTruncatingItem(file, newLength);
 		}
 		
 		@Override
@@ -276,14 +277,15 @@ public interface StorageFileWriterBackupping extends StorageFileWriter
 			final StorageFileProvider    fileProvider
 		)
 		{
-			// cancel any still-queued item for this file BEFORE it physically disappears: a stale
-			// copy/truncate item processed afterwards would try to act on a source that no longer
-			// exists, throw, and register a storage-wide disruption over an intended deletion.
+			// Both queue mutations must run BEFORE the physical delete: cancel drops still-queued
+			// items for the file, and the deletion item must already be queued when an in-flight
+			// copy fails on the vanished source, so its absorption check finds it. Enqueuing
+			// afterwards leaves a race that escalates an intended deletion.
 			this.itemEnqueuer.cancelPendingItemsFor(file);
+			this.itemEnqueuer.enqueueDeletionItem(file);
 
 			// no user increment since only the identifier is required and the actual file can well be deleted.
 			this.delegate.delete(file, writeController, fileProvider);
-			this.itemEnqueuer.enqueueDeletionItem(file);
 		}
 		
 	}


### PR DESCRIPTION
Problem                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                   
  When the backup is enabled, a live-file truncation (notably the transactions-log compaction's truncate-and-rewrite) can land while the backup thread is mid-copy of that file. The pre-truncation queue surgery (trimPendingCopyItemsBeyond) only
  removes queued copy items — an item the backup thread has already dequeued is invisible to it. That in-flight copy then reads past the new file end, fails the byte-count check, and escalates to a storage-wide disruption — even though the    
  truncation that shortened the source makes the copied range irrelevant.                                                                                                                                                                          
                                                                                                                                                                                                                                                   
  Latent since transaction-file housekeeping was introduced; turned from silent backup corruption into a loud fail-stop once copy sites gained byte-count validation.                                                                              
                                                                                                                                                                                                                                                   
  Fix                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                   
  StorageBackupItemQueue.processNextItem now inspects the queue when a copy fails: if a truncation discarding the copied range — or a deletion of the whole file — is queued behind the failed item, the failure is absorbed (debug-logged, not    
  escalated). The trailing items reconcile the backup, so skipping is a no-op. Genuine copy failures, with nothing superseding them, escalate exactly as before.                                                                                   
                                                                                                                                                                                                                                                   
  To make that check sound, StorageFileWriterBackupping enqueues the truncation/deletion marker before the physical op rather than after. Since the physical op is what fails the copy, the marker is guaranteed present when the absorption check 
  runs — closing the window where the check could miss it and escalate spuriously.                                                                                                                                                                 
                                                                                                                                                                                                                                                   
  Scope & safety                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                   
  - Two files: StorageBackupItemQueue, StorageFileWriterBackupping. No API or format change.                                                                                                                                                       
  - Non-blocking: the absorption scan briefly takes the existing queue monitor and holds no file monitors across it — the queue's leaf-lock discipline is preserved, no new lock ordering.                                                         
  - A physical op failing after its marker is enqueued only affects a transient crash window; restart resynchronization already rebuilds a diverged backup file.