### PR TITLE
Guard composite-index remove against short key arrays

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -237,9 +237,16 @@ implements BitmapIndex.TopLevel<E, KS>
 	{
 		try
 		{
-			for(final Sub<E, KS, K> subIndex : this.subIndices)
+			for(int i = 0; i < this.subIndices.length; i++)
 			{
-				subIndex.internalRemove(entityId, keys);
+				if(this.isEmpty(keys, i))
+				{
+					// Symmetric with internalAddToEntry: no bit was ever set for an absent/null
+					// key at this position, so there is nothing to remove. Also guards against
+					// keys arrays shorter than the widest one ever indexed (keys.length <= i).
+					continue;
+				}
+				this.subIndices[i].internalRemove(entityId, keys);
 			}
 			// note: sub indices are never removed, even if they become empty.
 		}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeIndexNullHandlingTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeIndexNullHandlingTest.java
@@ -17,6 +17,7 @@ package org.eclipse.store.gigamap.indexer;
 
 
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.HashingCompositeIndexer;
 import org.eclipse.store.gigamap.types.IndexerInstant;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -204,5 +206,58 @@ public class CompositeIndexNullHandlingTest
 		// Verify queries after update
 		assertEquals(0, map.query(indexer.is((Instant) null)).count());
 		assertEquals(1, map.query(indexer.is((Instant) null).or(indexer.is(Instant.parse("2025-06-15T10:30:00Z")))).count());
+	}
+
+	/**
+	 * Entity whose composite key is a variable-length tag array.
+	 */
+	record Item(String name, List<String> tags)
+	{
+	}
+
+	/** Composite index with one sub-index position per tag, so the key-array length varies per entity. */
+	static final class TagsIndexer extends HashingCompositeIndexer.Abstract<Item>
+	{
+		@Override
+		public String name()
+		{
+			return "tags";
+		}
+
+		@Override
+		public Object[] index(final Item entity, final Object[] carrier)
+		{
+			return entity.tags().toArray();
+		}
+	}
+
+	/**
+	 * Removing an entity whose composite key array is shorter than the widest one ever indexed must
+	 * not throw. Before the fix, {@code internalRemoveForKeys} iterated all sub-indices unconditionally
+	 * and read {@code keys[position]} out of bounds for the trailing positions (Index 1 out of bounds
+	 * for length 1). The remove path now skips empty positions via {@code isEmpty(keys, i)}, symmetric
+	 * with the add and query paths.
+	 */
+	@Test
+	void variableLengthCompositeKeyRemoveShouldWork()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		final TagsIndexer   indexer = new TagsIndexer();
+		map.index().bitmap().add(indexer);
+
+		// First entity has TWO tags -> the composite index grows to two sub-indices (positions 0, 1).
+		map.add(new Item("A", List.of("red", "big")));
+
+		// Second entity has ONE tag -> position 1 is skipped on add via isEmpty().
+		final long bId = map.add(new Item("B", List.of("red")));
+		assertEquals(2, map.size());
+
+		// Before fix: ArrayIndexOutOfBoundsException (Index 1 out of bounds for length 1).
+		assertDoesNotThrow(() -> map.removeById(bId));
+
+		assertEquals(1, map.size());
+
+		// The single-tag entity is gone, the two-tag entity is still intact.
+		assertEquals(1, map.query(indexer.is(new Object[]{"red", "big"})).count());
 	}
 }


### PR DESCRIPTION
## Problem

Removing an entity from a `GigaMap` that carries a hashing composite bitmap index throws `ArrayIndexOutOfBoundsException` when the removed entity's key array is shorter than the widest key array the index has ever seen.

A composite index keeps one sub-index per key-array position and grows `subIndices` to the longest key array added so far (positions are never removed). The add, query, contains and change paths each guard every position with `isEmpty(keys, i)` (which tolerates `i >= keys.length`), but `AbstractCompositeBitmapIndex.internalRemoveForKeys` iterated all sub-indices unconditionally and passed the key array straight through, so a sub-index at a trailing position read `keys[position]` out of bounds.

### Reproducer

Entity A has two tags, so the index grows to two sub-indices. Entity B has one tag (position 1 skipped on add via `isEmpty`). `removeById(B)` then reads `keys[1]` on a length-1 array and throws `ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1`.

## Fix

Make remove symmetric with add and query: iterate by index and skip empty positions via `isEmpty(keys, i)`. Unlike the add and change paths, remove must not call `ensureSubIndices` — no bit was ever set for an empty position, so there is nothing to remove there. This mirrors the existing guard on `internalHandleChanged`, which was previously hardened against the same hazard.

## Tests

Added a regression test (`CompositeIndexNullHandlingTest.variableLengthCompositeKeyRemoveShouldWork`) that removes an entity whose composite key array is shorter than the widest one previously indexed. It reproduces the exact `Index 1 out of bounds for length 1` failure on the unpatched code and passes after the fix. The full `gigamap` module suite passes (1079 tests, 1 slow test skipped by default).
