### PR TITLE
Stop reopening the Lucene reader on the write path

### DIFF
--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.*;
+import org.apache.lucene.util.IOUtils;
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.exceptions.IORuntimeException;
 import org.eclipse.serializer.math.XMath;
@@ -831,31 +832,48 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
          * searcher once per document, which dominated ingest cost. Write paths therefore only mark the
          * reader stale (see {@link Default#readerStale}); the reopen is deferred to the next search.
          * <p>
+         * A failed initialization leaves no state behind: the fields are published only once the writer
+         * exists, so the next call retries instead of operating on a half-initialized index.
+         * <p>
          * Must be called while holding the {@code this.gigaMap} monitor.
          */
         private void ensureWriter() throws IOException
         {
-            if(this.directory != null)
+            if(this.writer != null)
             {
                 return;
             }
 
-            this.directory = this.createDirectory();
-            final IndexWriterConfig writerConfig = new IndexWriterConfig(
-                this.analyzer = this.context.analyzerCreator().createAnalyzer()
-            );
-            if(this.usesGraphDirectory())
+            final Directory directory = this.createDirectory();
+            final Analyzer  analyzer  = this.context.analyzerCreator().createAnalyzer();
+            final IndexWriter indexWriter;
+            try
             {
-                // GraphDirectory stores index data in the persistent fileEntries map.
-                // ConcurrentMergeScheduler would modify that map from background threads,
-                // racing with GigaMap#store serialization. SerialMergeScheduler ensures
-                // merges run on the caller's thread, which holds the GigaMap lock.
-                writerConfig.setMergeScheduler(new SerialMergeScheduler());
+                final IndexWriterConfig writerConfig = new IndexWriterConfig(analyzer);
+                if(this.usesGraphDirectory())
+                {
+                    // GraphDirectory stores index data in the persistent fileEntries map.
+                    // ConcurrentMergeScheduler would modify that map from background threads,
+                    // racing with GigaMap#store serialization. SerialMergeScheduler ensures
+                    // merges run on the caller's thread, which holds the GigaMap lock.
+                    writerConfig.setMergeScheduler(new SerialMergeScheduler());
+                }
+                indexWriter = new IndexWriter(
+                    directory,
+                    writerConfig
+                );
             }
-            this.writer = new IndexWriter(
-                this.directory,
-                writerConfig
-            );
+            catch(final Throwable t)
+            {
+                // e.g. the writer lock is held elsewhere: discard what was created so far instead of
+                // leaking it, and let the caller decide whether to retry.
+                IOUtils.closeWhileHandlingException(analyzer, directory);
+                throw t;
+            }
+
+            this.directory = directory;
+            this.analyzer  = analyzer;
+            this.writer    = indexWriter;
         }
 
         /**

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -293,12 +293,31 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 		 */
 		ConcurrentHashMap<String, FileEntry> fileEntries;
 
-		private transient Analyzer        analyzer;
-		private transient Directory       directory;
-		private transient IndexWriter     writer;
-		private transient DirectoryReader reader;
-		private transient IndexSearcher   searcher;
-		
+		private transient Analyzer      analyzer;
+		private transient Directory     directory;
+		private transient IndexWriter   writer;
+		private transient IndexSearcher searcher;
+
+		/**
+		 * The near-real-time reader, opened from {@link #writer} and (re)opened exclusively by
+		 * {@link #refreshReaderIfNeeded()}.
+		 * <p>
+		 * Package-private rather than private so that {@code LuceneWritePathReaderTest} can assert that the
+		 * write path never (re)opens it, matching the visibility already used for {@link #gigaMap},
+		 * {@link #context} and {@link #fileEntries}.
+		 */
+		transient DirectoryReader reader;
+
+		/**
+		 * {@code true} when {@link #writer} mutations happened that {@link #reader} does not reflect yet.
+		 * Write operations only set this flag instead of reopening the near-real-time reader; the reopen is
+		 * deferred to the next search (see {@link #refreshReaderIfNeeded()}).
+		 * <p>
+		 * Deliberately not {@code volatile}: like all other transient Lucene state of this class it is
+		 * exclusively read and written inside {@code synchronized(this.gigaMap)}.
+		 */
+		private transient boolean readerStale;
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
@@ -341,9 +360,10 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
+					this.ensureWriter();
 
 					this.writer.addDocument(this.toDocument(entityId, entity));
+					this.readerStale = true;
                     this.optCommit();
 				}
 			}
@@ -360,8 +380,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
-				
+					this.ensureWriter();
+
 					final List<Document> documents       = new ArrayList<>();
 					long                 currentEntityId = firstEntityId;
 					
@@ -371,6 +391,7 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 					}
 					
 					this.writer.addDocuments(documents);
+					this.readerStale = true;
                     this.optCommit();
 				}
 			}
@@ -393,9 +414,10 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
-				
+					this.ensureWriter();
+
 					this.writer.deleteDocuments(queryFor(entityId));
+					this.readerStale = true;
                     this.optCommit();
 				}
 			}
@@ -412,9 +434,10 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
-				
+					this.ensureWriter();
+
 					this.writer.deleteAll();
+					this.readerStale = true;
                     this.optCommit();
 				}
 			}
@@ -446,17 +469,18 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			// Documents are added incrementally (no per-entity commit, no buffering of the whole corpus)
 			// and committed once at the end via optCommit, which honors the manual-commit contract: with
 			// context.autoCommit() == false the back-fill performs no commit, leaving durability to the
-			// user's explicit commit() (the near-real-time reader still makes the documents queryable in
-			// the meantime, just like internalAdd).
+			// user's explicit commit() (the near-real-time reader makes the documents queryable at the
+			// next search, just like internalAdd).
 			try
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
+					this.ensureWriter();
 
 					if(clearFirst)
 					{
 						this.writer.deleteAll();
+						this.readerStale = true;
 					}
 
 					this.gigaMap.iterateIndexed(this::backfillDocument);
@@ -481,6 +505,7 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			try
 			{
 				this.writer.addDocument(this.toDocument(entityId, entity));
+				this.readerStale = true;
 			}
 			catch(final IOException e)
 			{
@@ -520,9 +545,10 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
+					this.ensureWriter();
 
 					this.writer.updateDocuments(queryFor(entityId), List.of(this.toDocument(entityId, entity)));
+					this.readerStale = true;
                     this.optCommit();
 				}
 			}
@@ -554,8 +580,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
-					
+					this.refreshReaderIfNeeded();
+
 					final StandardQueryParser queryParser = new StandardQueryParser(this.analyzer);
 					queryParser.setAllowLeadingWildcard(true);
 					final Query query = queryParser.parse(queryText, ENTITY_ID_FIELD);
@@ -591,8 +617,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
-				
+					this.refreshReaderIfNeeded();
+
 					this.syncInternalQuery(query, maxResults, searchResultAcceptor);
 				}
 			}
@@ -654,7 +680,7 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
+					this.refreshReaderIfNeeded();
 					return this.syncInternalSearch(query, maxResults);
 				}
 			}
@@ -676,7 +702,7 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			{
 				synchronized(this.gigaMap)
 				{
-					this.lazyInit();
+					this.refreshReaderIfNeeded();
 
 					final StandardQueryParser queryParser = new StandardQueryParser(this.analyzer);
 					queryParser.setAllowLeadingWildcard(true);
@@ -784,11 +810,12 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 					}
 				}
 				
-				this.analyzer  = null;
-				this.directory = null;
-				this.writer    = null;
-				this.reader    = null;
-				this.searcher  = null;
+				this.analyzer    = null;
+				this.directory   = null;
+				this.writer      = null;
+				this.reader      = null;
+				this.searcher    = null;
+				this.readerStale = false;
 			}
 		}
 
@@ -797,29 +824,71 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			return XMath.cap_int(this.gigaMap.size());
         }
 
-        private void lazyInit() throws IOException
+        /**
+         * Ensures the write side is initialized: {@link Default#directory}, {@link Default#analyzer} and
+         * {@link Default#writer}. Deliberately does <b>not</b> touch {@link Default#reader} or
+         * {@link Default#searcher}: reopening the near-real-time reader per mutation rebuilt reader and
+         * searcher once per document, which dominated ingest cost. Write paths therefore only mark the
+         * reader stale (see {@link Default#readerStale}); the reopen is deferred to the next search.
+         * <p>
+         * Must be called while holding the {@code this.gigaMap} monitor.
+         */
+        private void ensureWriter() throws IOException
         {
-            if(this.directory == null)
+            if(this.directory != null)
             {
-                this.directory = this.createDirectory();
-                final IndexWriterConfig writerConfig = new IndexWriterConfig(
-                    this.analyzer = this.context.analyzerCreator().createAnalyzer()
-                );
-                if(this.usesGraphDirectory())
-                {
-                    // GraphDirectory stores index data in the persistent fileEntries map.
-                    // ConcurrentMergeScheduler would modify that map from background threads,
-                    // racing with GigaMap#store serialization. SerialMergeScheduler ensures
-                    // merges run on the caller's thread, which holds the GigaMap lock.
-                    writerConfig.setMergeScheduler(new SerialMergeScheduler());
-                }
-                this.searcher              = new IndexSearcher(
-                    this.reader            = DirectoryReader.open(
-                        this.writer        = new IndexWriter(
-                            this.directory,
-                            writerConfig
-                        )
-                    )
+                return;
+            }
+
+            this.directory = this.createDirectory();
+            final IndexWriterConfig writerConfig = new IndexWriterConfig(
+                this.analyzer = this.context.analyzerCreator().createAnalyzer()
+            );
+            if(this.usesGraphDirectory())
+            {
+                // GraphDirectory stores index data in the persistent fileEntries map.
+                // ConcurrentMergeScheduler would modify that map from background threads,
+                // racing with GigaMap#store serialization. SerialMergeScheduler ensures
+                // merges run on the caller's thread, which holds the GigaMap lock.
+                writerConfig.setMergeScheduler(new SerialMergeScheduler());
+            }
+            this.writer = new IndexWriter(
+                this.directory,
+                writerConfig
+            );
+        }
+
+        /**
+         * Ensures {@link Default#searcher} reflects all writer mutations performed so far, opening the
+         * near-real-time reader on first use and reopening it only when a mutation marked it stale. This is
+         * the read-path counterpart of {@link Default#ensureWriter()} and the only place where the reader is
+         * (re)opened.
+         * <p>
+         * Read-your-writes is preserved: a reader opened from the writer includes buffered, uncommitted
+         * changes, and {@link DirectoryReader#openIfChanged(DirectoryReader)} on such a writer-derived reader
+         * performs the same near-real-time reopen the write path used to do eagerly. Only the timing moves
+         * from per-write to next-read.
+         * <p>
+         * Must be called while holding the {@code this.gigaMap} monitor.
+         */
+        private void refreshReaderIfNeeded() throws IOException
+        {
+            // a read can be the very first operation on this index, so the writer may not exist yet.
+            // This also initializes the analyzer, which the query-string read paths use.
+            this.ensureWriter();
+
+            if(this.reader != null && !this.readerStale)
+            {
+                // no mutation since the last refresh, so the current searcher is up to date.
+                return;
+            }
+
+            if(this.reader == null)
+            {
+                // first read after initialization or after close(): a reader opened from the writer already
+                // reflects everything written so far, so no additional reopen is needed.
+                this.searcher = new IndexSearcher(
+                    this.reader = DirectoryReader.open(this.writer)
                 );
             }
             else
@@ -833,6 +902,10 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
                     );
                 }
             }
+
+            // cleared only after a successful (re)open, so an IOException leaves the index stale and the
+            // next search retries.
+            this.readerStale = false;
         }
 
 		private boolean usesGraphDirectory()

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -914,10 +914,14 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
                 final DirectoryReader newReader = DirectoryReader.openIfChanged(this.reader);
                 if(newReader != null && newReader != this.reader)
                 {
-                    this.reader.close();
+                    final DirectoryReader supersededReader = this.reader;
                     this.searcher = new IndexSearcher(
                         this.reader = newReader
                     );
+
+                    // closed only after the new reader is published: a failing close must not leak the
+                    // reader that was just opened, and it leaves the index on the up-to-date one.
+                    supersededReader.close();
                 }
             }
 

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleTest.java
@@ -255,30 +255,29 @@ public class LuceneLifecycleTest
 	@Test
 	void failedWriterInitializationIsRetried(@TempDir final Path lucenePath) throws Exception
 	{
-		final GigaMap<Article>        map = GigaMap.New();
-		final LuceneIndex.Default<Article> idx = new LuceneIndex.Default<>(
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex.Default<Article> idx = new LuceneIndex.Default<>(
 			map,
 			LuceneContext.New(DirectoryCreator.MMap(lucenePath), new ArticlePopulator())
-		);
-
-		// an external writer holds the directory's write lock, so the index cannot create its own writer
-		try(final Directory blockedDirectory = new MMapDirectory(lucenePath);
-		    final IndexWriter lockHolder     = new IndexWriter(blockedDirectory, new IndexWriterConfig()))
+		))
 		{
-			assertThrows(IORuntimeException.class,
-				() -> idx.internalAdd(1L, new Article("blocked", "content")),
-				"Acquiring the writer lock must fail while it is held elsewhere");
+			// an external writer holds the directory's write lock, so the index cannot create its own writer
+			try(final Directory blockedDirectory = new MMapDirectory(lucenePath);
+			    final IndexWriter lockHolder     = new IndexWriter(blockedDirectory, new IndexWriterConfig()))
+			{
+				assertThrows(IORuntimeException.class,
+					() -> idx.internalAdd(1L, new Article("blocked", "content")),
+					"Acquiring the writer lock must fail while it is held elsewhere");
+			}
+
+			// the failed attempt must not have left a half-initialized index behind
+			assertDoesNotThrow(
+				() -> idx.internalAdd(1L, new Article("retried", "content")),
+				"A failed writer initialization must be retried on the next operation");
+			// an explicit limit is required here: the default limit is the GigaMap size, and this index was
+			// written directly, without adding the entities to the map
+			assertEquals(1, idx.search("title:retried", 10).size(),
+				"The document written after the retry must be findable");
 		}
-
-		// the failed attempt must not have left a half-initialized index behind
-		assertDoesNotThrow(
-			() -> idx.internalAdd(1L, new Article("retried", "content")),
-			"A failed writer initialization must be retried on the next operation");
-		// an explicit limit is required here: the default limit is the GigaMap size, and this index was
-		// written directly, without adding the entities to the map
-		assertEquals(1, idx.search("title:retried", 10).size(),
-			"The document written after the retry must be findable");
-
-		idx.close();
 	}
 }

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleTest.java
@@ -81,7 +81,7 @@ public class LuceneLifecycleTest
 	void closeAndReopenGraphDirectoryRetainsData()
 	{
 		// null directoryCreator → GraphDirectory stores index data in fileEntries inside GigaMap.
-		// After close(), the fileEntries map is still in memory; lazyInit re-uses it.
+		// After close(), the fileEntries map is still in memory; ensureWriter re-uses it.
 		final LuceneContext<Article> ctx = LuceneContext.New(new ArticlePopulator());
 
 		final GigaMap<Article> map = GigaMap.New();

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneLifecycleTest.java
@@ -15,9 +15,16 @@ package org.eclipse.store.gigamap.lucene;
  */
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.eclipse.serializer.exceptions.IORuntimeException;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -240,5 +247,38 @@ public class LuceneLifecycleTest
 			assertEquals(WRITE_THREADS * ADDS_PER_THREAD, finalHits.size(),
 				"All added entities must be findable after concurrent writes complete");
 		}
+	}
+
+
+	// ── failed initialization ─────────────────────────────────────────────────
+
+	@Test
+	void failedWriterInitializationIsRetried(@TempDir final Path lucenePath) throws Exception
+	{
+		final GigaMap<Article>        map = GigaMap.New();
+		final LuceneIndex.Default<Article> idx = new LuceneIndex.Default<>(
+			map,
+			LuceneContext.New(DirectoryCreator.MMap(lucenePath), new ArticlePopulator())
+		);
+
+		// an external writer holds the directory's write lock, so the index cannot create its own writer
+		try(final Directory blockedDirectory = new MMapDirectory(lucenePath);
+		    final IndexWriter lockHolder     = new IndexWriter(blockedDirectory, new IndexWriterConfig()))
+		{
+			assertThrows(IORuntimeException.class,
+				() -> idx.internalAdd(1L, new Article("blocked", "content")),
+				"Acquiring the writer lock must fail while it is held elsewhere");
+		}
+
+		// the failed attempt must not have left a half-initialized index behind
+		assertDoesNotThrow(
+			() -> idx.internalAdd(1L, new Article("retried", "content")),
+			"A failed writer initialization must be retried on the next operation");
+		// an explicit limit is required here: the default limit is the GigaMap size, and this index was
+		// written directly, without adding the entities to the map
+		assertEquals(1, idx.search("title:retried", 10).size(),
+			"The document written after the retry must be findable");
+
+		idx.close();
 	}
 }

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneWritePathReaderTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneWritePathReaderTest.java
@@ -1,0 +1,151 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Verifies that the write path of {@link LuceneIndex} never (re)opens the near-real-time reader, and that the
+ * deferred reopen on the next search still provides read-your-writes semantics.
+ * <p>
+ * These assertions are white-box on purpose: the per-mutation reader reopen was functionally invisible, which is
+ * why it could dominate ingest cost unnoticed. The reader field is package-private so this test can observe it
+ * without reflection.
+ */
+public class LuceneWritePathReaderTest
+{
+	private static class Article
+	{
+		final String title;
+		final String content;
+
+		Article(final String title, final String content)
+		{
+			this.title   = title;
+			this.content = content;
+		}
+	}
+
+	private static class ArticlePopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			document.add(createTextField("title",   entity.title));
+			document.add(createTextField("content", entity.content));
+		}
+	}
+
+	private static LuceneContext<Article> standardContext()
+	{
+		return LuceneContext.New(DirectoryCreator.ByteBuffers(), new ArticlePopulator());
+	}
+
+	private static LuceneContext<Article> manualCommitContext()
+	{
+		return LuceneContext.New(
+			DirectoryCreator.ByteBuffers(),
+			AnalyzerCreator.Standard()    ,
+			new ArticlePopulator()        ,
+			false
+		);
+	}
+
+	private static DirectoryReader readerOf(final LuceneIndex<Article> index)
+	{
+		return ((LuceneIndex.Default<Article>)index).reader;
+	}
+
+
+	@Test
+	void writePathDoesNotOpenReader()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(standardContext())))
+		{
+			for(int i = 0; i < 10; i++)
+			{
+				map.add(new Article("write", "content " + i));
+			}
+
+			assertNull(readerOf(idx), "Index mutations must not open a near-real-time reader");
+
+			assertEquals(10, idx.query("title:write", 100).size(),
+				"The first search must open the reader and see all uncommitted documents");
+			assertNotNull(readerOf(idx), "The first search must open the near-real-time reader");
+		}
+	}
+
+	@Test
+	void writesAfterFirstSearchDoNotReopenReader()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(standardContext())))
+		{
+			final long id = map.add(new Article("first", "content"));
+			assertEquals(1, idx.query("title:first").size());
+
+			final DirectoryReader readerAfterFirstSearch = readerOf(idx);
+			assertNotNull(readerAfterFirstSearch);
+
+			for(int i = 0; i < 20; i++)
+			{
+				map.add(new Article("later", "content " + i));
+			}
+			map.removeById(id);
+
+			assertSame(readerAfterFirstSearch, readerOf(idx),
+				"Index mutations must not reopen the near-real-time reader");
+
+			// read-your-writes: the deferred reopen happens now
+			assertEquals(20, idx.query("title:later", 100).size(),
+				"The next search must see all documents added since the previous search");
+			assertEquals(0, idx.query("title:first").size(),
+				"The next search must not see the removed document");
+			assertNotSame(readerAfterFirstSearch, readerOf(idx),
+				"The next search must pick up a refreshed reader");
+		}
+	}
+
+	@Test
+	void commitAndRepeatedSearchDoNotReopenReader()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(manualCommitContext())))
+		{
+			map.add(new Article("eclipse", "content"));
+			assertEquals(1, idx.query("title:eclipse").size());
+
+			final DirectoryReader reader = readerOf(idx);
+			assertNotNull(reader);
+
+			idx.commit();
+			assertSame(reader, readerOf(idx), "A commit alone must not reopen the reader");
+
+			assertEquals(1, idx.query("title:eclipse").size(), "Committed documents must stay visible");
+			assertSame(reader, readerOf(idx),
+				"A search without a preceding mutation must reuse the existing searcher");
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`LuceneIndex.Default` called a single `lazyInit()` from both the write and the read path. Its already-initialized branch reopened the near-real-time reader:

```java
final DirectoryReader newReader = DirectoryReader.openIfChanged(this.reader);
if(newReader != null && newReader != this.reader)
{
    this.reader.close();
    this.searcher = new IndexSearcher(this.reader = newReader);
}
```

Since `this.reader` is opened from the `IndexWriter`, every uncommitted `addDocument` makes `openIfChanged` return a fresh reader, so the index rebuilt `DirectoryReader` + `IndexSearcher` **once per document**. Reopening a reader per write is the classic Lucene anti-pattern and dominated single-add ingest cost. The batch path (`internalAddAll`) was unaffected because it called `lazyInit()` once for the whole batch.

## Change

`lazyInit()` is split in two:

- `ensureWriter()` - initializes `directory`, `analyzer` and `writer` on first use, never touches reader or searcher. Used by `internalAdd`, `internalAddAll`, `internalRemove`, `internalRemoveAll`, `internalRebuild` and `internalUpdateIndices`.
- `refreshReaderIfNeeded()` - the only place the reader is (re)opened. Used by the four `query`/`search` entry points.

Write operations set a `readerStale` flag next to each of the seven `IndexWriter` mutations; the reopen is deferred to the next search. Commits deliberately do not mark the reader stale, since they only flush what was already written and never change the document set a reader sees.

Since the write path no longer opens a reader, the invariant "`directory != null` implies `reader != null`" is gone, so `refreshReaderIfNeeded()` opens the reader from the writer when it is still `null` (a read can be the very first operation on the index) and calls `ensureWriter()` first, which is also what guarantees `analyzer` for the query-string paths.

The `reader` field is now package-private, matching `gigaMap`, `context` and `fileEntries`, so the new test can observe it without reflection.

## Semantics

Read-your-writes is unchanged: a reader opened from the writer includes buffered, uncommitted changes, and `openIfChanged` on such a writer-derived reader performs the same near-real-time reopen the write path used to do eagerly. Only the timing moves from per-write to next-read.

Unchanged as well: `synchronized(gigaMap)` guarding of all Lucene state (so the new flag needs no `volatile`), `SerialMergeScheduler` for the graph directory, the store-boundary commit coupling via `internalCommitOnStore()`, the persistence format, and the public API.

## Tests

New `LuceneWritePathReaderTest`:

1. `writePathDoesNotOpenReader` - 10 adds leave the reader `null`; the first search opens it and sees all 10 uncommitted documents.
2. `writesAfterFirstSearchDoNotReopenReader` - a reader captured after the first search is the identical instance after 20 further adds plus a `removeById`; the next search refreshes it and sees exactly the expected documents.
3. `commitAndRepeatedSearchDoNotReopenReader` - with `autoCommit=false`, a bare `commit()` and a repeat search with no intervening mutation reuse the same reader.

Existing suites stay green: `gigamap/lucene` 68/68 (including `LuceneStoreBoundaryCommitTest`, `LuceneLifecycleTest.concurrentAddAndSearch`, `manualCommitWorksCorrectly`, `closeAndReopenGraphDirectoryRetainsData`, `LuceneBackfillTest`, `LuceneReindexTest`) and `GeneratedLuceneVectorTest` 7/7 in `gigamap/codegen-test`.

## Robustness fixes from review

Two pre-existing flaws in the same code paths surfaced during review and are fixed here, since this PR makes `ensureWriter()` / `refreshReaderIfNeeded()` the single owners of the writer and reader lifecycle:

- **Failed initialization was never retried** (09eb358a). `directory` was assigned before the `IndexWriter` was constructed and served as the "initialized" guard, so a failed construction, for instance because the write lock is held elsewhere, left the index permanently half-initialized: every later call returned early and then dereferenced the null writer, turning a recoverable `IOException` into a `NullPointerException`. The old `lazyInit()` had the same flaw, dereferencing the null reader instead. The guard is now the writer itself, the three fields are published only once the writer exists, and what was created before the failure is closed instead of leaked. Covered by `LuceneLifecycleTest.failedWriterInitializationIsRetried`.
- **Reader leak on a failing close** (7a22e106). The refresh closed the superseded reader before publishing the new one, so a failing close left the freshly opened reader unreferenced and unclosed. The new reader and searcher are published first now; the close still propagates rather than being swallowed.

## Measurement

20k single `add()` calls against a `ByteBuffers` directory with `autoCommit=false`, warm run, compared against the same benchmark on the base commit:

| path | before | after |
| --- | --- | --- |
| single `add()` | 521 us/doc | 6.2 us/doc |
| batch `addAll()` | 3.0 us/doc | 3.9 us/doc |

Single-add is now within ~1.6x of the batch path instead of ~172x.
