### PR TITLE
Fix power-loss corruption from a housekeeping transfer after a store

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/recovery/BelowBaselineDivergenceFailsLoudlyTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/BelowBaselineDivergenceFailsLoudlyTest.java
@@ -1,0 +1,121 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Recovery only ever cuts within the head file. When the cross-channel consensus store lies below a
+ * channel's head-file baseline - in a sealed, earlier file - it cannot be reached by a head-only
+ * rollback, so recovery must refuse to start loudly rather than silently discard the committed data
+ * the intact channels still hold. Small files force the ahead channel to seal the consensus store
+ * away before the crash.
+ * <p>
+ * Below-baseline is refused both before and after this change (never silent); this locks the precise
+ * diagnosis added here, which before was reported only via a generic consensus error.
+ */
+@Timeout(120)
+class BelowBaselineDivergenceFailsLoudlyTest
+{
+	private static final int MAX_FILE_SIZE = 4096;
+	private static final int PAYLOAD_SIZE  = 3000;
+	private static final int ROUNDS        = 8   ;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void consensusBelowASealedFileRefusesToStart()
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE));
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		for(int version = 1; version <= ROUNDS; version++)
+		{
+			final byte[] payload = new byte[PAYLOAD_SIZE];
+			payload[0]   = (byte)version;
+			root.version = version;
+			root.payload = payload;
+			this.storage.storeRoot();
+		}
+		this.storage.shutdown();
+		this.storage = null;
+
+		// the ahead channel rolled the early stores into sealed files
+		assertTrue(RecoverySimulation.dataFiles(this.directory, 0).size() > 1,
+			"staging: channel 0 must have rolled over so early stores are sealed");
+
+		// channel 1 keeps only its first store: the consensus now lies below channel 0's head baseline
+		RecoverySimulation.cutTrailingStores(this.directory, 1, ROUNDS - 1);
+
+		final RuntimeException failure = assertThrows(RuntimeException.class, () ->
+			this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE)));
+		assertTrue(causeChain(failure).contains("baseline"),
+			"the refusal must name the head-file baseline, not fail for another reason: " + causeChain(failure));
+	}
+
+	private static String causeChain(final Throwable throwable)
+	{
+		final StringBuilder chain = new StringBuilder();
+		for(Throwable t = throwable; t != null; t = t.getCause())
+		{
+			if(chain.length() > 0)
+			{
+				chain.append(" <- ");
+			}
+			chain.append(t.getMessage());
+		}
+		return chain.toString();
+	}
+
+
+	public static class Root
+	{
+		int    version;
+		byte[] payload;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/DeepTruncationSurvivesSecondCrashTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/DeepTruncationSurvivesSecondCrashTest.java
@@ -1,0 +1,123 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A deep (more than one store) head rollback writes a truncation entry and leaves the rolled-back
+ * store entries in the log. The replay must step the latest-store timestamp back to the surviving
+ * store, or that timestamp names a store that was rolled away - a phantom the next reconciliation
+ * would treat as the consensus and brick on. This drives two consecutive power losses: the first
+ * causes the deep rollback, the second must still reconcile to the true surviving store.
+ * <p>
+ * Fix-guard: before this change the phantom timestamp bricks the second recovery.
+ */
+@Timeout(120)
+class DeepTruncationSurvivesSecondCrashTest
+{
+	private static final int PAYLOAD_SIZE  = 512      ;
+	private static final int MAX_FILE_SIZE = 8_388_608; // 8 MiB: every store stays in one head file
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage  ;
+	private EmbeddedStorageManager reloaded1;
+	private EmbeddedStorageManager reloaded2;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager :
+			new EmbeddedStorageManager[]{this.reloaded2, this.reloaded1, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void deepRollbackLeavesNoPhantomLatestForTheNextRecovery()
+	{
+		// three stores, clean shutdown
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE));
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		this.storeVersions(this.storage, root, 1, 3);
+		this.storage.shutdown();
+		this.storage = null;
+
+		// first power loss: channel 1 loses v2 and v3, so channel 0 is two stores ahead
+		RecoverySimulation.cutTrailingStores(this.directory, 1, 2);
+
+		// recovery rolls channel 0 back to v1 with a deep truncation, then we store v4 and shut down
+		this.reloaded1 = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE));
+		final Root root1 = (Root)this.reloaded1.root();
+		assertEquals(1, root1.version, "the first recovery must roll back to the last common store");
+		this.storeVersions(this.reloaded1, root1, 4, 4);
+		this.reloaded1.shutdown();
+		this.reloaded1 = null;
+
+		// second power loss: channel 0 loses only its trailing v4 store (its truncation entry stays)
+		RecoverySimulation.cutLastStore(this.directory, 0);
+
+		// the surviving-store timestamp from the deep truncation must keep the consensus recoverable
+		this.reloaded2 = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE));
+		final Root root2 = (Root)this.reloaded2.root();
+		assertNotNull(root2, "root gone after the second recovery");
+		assertEquals(1, root2.version, "the second recovery must reconcile to the true surviving store");
+		assertNotNull(root2.payload, "the surviving store's payload was lost");
+		assertEquals((byte)1, root2.payload[0], "wrong surviving payload version");
+	}
+
+	private void storeVersions(final EmbeddedStorageManager manager, final Root root, final int from, final int to)
+	{
+		for(int version = from; version <= to; version++)
+		{
+			final byte[] payload = new byte[PAYLOAD_SIZE];
+			payload[0]   = (byte)version;
+			root.version = version;
+			root.payload = payload;
+			manager.storeRoot();
+		}
+	}
+
+
+	public static class Root
+	{
+		int    version;
+		byte[] payload;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/DurabilityGateDeferralTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/DurabilityGateDeferralTest.java
@@ -1,0 +1,174 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The physical deletion of a dissolved data file is gated on all-channel durability: a not-yet-durable
+ * store could still be rolled back and would then re-read the transferred bytes from that file. The
+ * deferral must resolve on its own - the deferring channel requests a flush, and once the flush
+ * raises the all-durable watermark the file cleanup deletes the file. This proves the gate does not
+ * starve the cleanup and never drops live data in the process.
+ * <p>
+ * Regression guard: the outcome (files reclaimed, nothing lost) holds before and after this change;
+ * this locks it against regressions in the durability gate added here.
+ */
+@Timeout(180)
+class DurabilityGateDeferralTest
+{
+	private static final int SLOTS      = 16  ;
+	private static final int BLOB_SIZE  = 2048;
+	private static final int ROUNDS     = 8   ;
+	private static final int MAX_FILE   = 8192;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void dissolvedFilesAreEventuallyDeletedMultiChannel() throws InterruptedException
+	{
+		this.runConvergence(2);
+	}
+
+	@Test
+	void dissolvedFilesAreEventuallyDeletedSingleChannel() throws InterruptedException
+	{
+		this.runConvergence(1);
+	}
+
+
+	private void runConvergence(final int channelCount) throws InterruptedException
+	{
+		this.storage = EmbeddedStorage.start(this.config(channelCount));
+
+		// full overwrites turn earlier data files into garbage: they fall below the fill ratio, get
+		// dissolved (live entities moved to the head) and become deletion candidates the gate defers
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+		for(int round = 0; round < ROUNDS; round++)
+		{
+			for(int i = 0; i < SLOTS; i++)
+			{
+				final byte[] blob = new byte[BLOB_SIZE];
+				blob[0] = (byte)round;
+				root.slots[i] = blob;
+			}
+			this.storage.store(root.slots);
+		}
+
+		final long peak = this.countDataFiles();
+
+		// GC marks the garbage dead, the file check dissolves and deletes; the flush the check enqueues
+		// clears the durability gate. System.gc() first so the superseded blobs' registry entries clear.
+		long remaining = peak;
+		for(int attempt = 0; attempt < 100 && remaining >= peak; attempt++)
+		{
+			System.gc();
+			this.storage.issueFullGarbageCollection();
+			this.storage.issueFullFileCheck();
+			remaining = this.countDataFiles();
+			if(remaining >= peak)
+			{
+				Thread.sleep(100);
+			}
+		}
+
+		assertTrue(remaining < peak,
+			"no data file was ever deleted (peak " + peak + ", now " + remaining + "): the gate starves cleanup");
+		assertTrue(remaining <= channelCount * 10L,
+			"file cleanup did not converge: " + remaining + " files remain of peak " + peak);
+
+		// the surviving files must still carry the complete latest state
+		this.storage.shutdown();
+		this.storage = null;
+		this.reloaded = EmbeddedStorage.start(this.config(channelCount));
+		final Root reloadedRoot = (Root)this.reloaded.root();
+		assertNotNull(reloadedRoot);
+		for(int i = 0; i < SLOTS; i++)
+		{
+			assertNotNull(reloadedRoot.slots[i], "slot " + i + " lost");
+			assertEquals((byte)(ROUNDS - 1), reloadedRoot.slots[i][0], "slot " + i + " has the wrong version");
+		}
+	}
+
+	private long countDataFiles()
+	{
+		try(Stream<Path> paths = Files.walk(this.directory))
+		{
+			return paths.filter(path -> path.getFileName().toString().endsWith(".dat")).count();
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private StorageConfiguration config(final int channelCount)
+	{
+		return StorageConfiguration.Builder()
+			.setStorageFileProvider(Storage.FileProvider(this.directory))
+			.setChannelCountProvider(Storage.ChannelCountProvider(channelCount))
+			.setHousekeepingController(Storage.HousekeepingController(50, 5_000_000L))
+			.setDataFileEvaluator(Storage.DataFileEvaluator(1024, MAX_FILE, 0.75))
+			.createConfiguration();
+	}
+
+
+	public static class Root
+	{
+		byte[][] slots = new byte[SLOTS][];
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/MultiChannelDivergenceRecoveryTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/MultiChannelDivergenceRecoveryTest.java
@@ -1,0 +1,247 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Cross-channel recovery when channels diverge after a power loss. Every channel logs each store
+ * with the same task timestamp, so the greatest store common to all channels is the minimum of the
+ * channels' latest timestamps. A channel that is ahead rolls back to the length its own log recorded
+ * for that consensus store; a channel that lost stores it never truncated must not silently discard
+ * the committed data the intact channels still hold.
+ * <p>
+ * A large file size keeps each channel in a single data file, so the divergence stays within the
+ * head file (no sealed-file rollback involved).
+ * <p>
+ * Fix-guard for divergence beyond one store, which is not reconciled before this change (start is
+ * refused); single-store divergence and the consensus-0 refusal already hold before it.
+ */
+@Timeout(120)
+class MultiChannelDivergenceRecoveryTest
+{
+	private static final int MAX_FILE_SIZE = 50_000_000;
+	private static final int ROUNDS        = 6         ;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void oneStoreAheadRollsBackToConsensus()
+	{
+		final long[][] size = this.storeRounds(2, ROUNDS);
+		// channel 0 keeps all rounds; the sibling lost the last store
+		this.truncateLaggingChannels(2, 0, size[ROUNDS - 1]);
+
+		assertEquals(ROUNDS - 1, this.reloadConsensusVersion(2));
+	}
+
+	@Test
+	void severalStoresAheadRollBackToConsensus()
+	{
+		// channel 0 is ahead by three stores: recovery must re-read its log to find the consensus length
+		final long[][] size = this.storeRounds(2, ROUNDS);
+		this.truncateLaggingChannels(2, 0, size[ROUNDS - 3]);
+
+		assertEquals(ROUNDS - 3, this.reloadConsensusVersion(2));
+	}
+
+	@Test
+	void fourChannelsRollBackToConsensus()
+	{
+		final long[][] size = this.storeRounds(4, ROUNDS);
+		this.truncateLaggingChannels(4, 0, size[ROUNDS - 2]);
+
+		assertEquals(ROUNDS - 2, this.reloadConsensusVersion(4));
+	}
+
+	@Test
+	void aChannelWithNoStoreWhileOthersHaveStoresRefusesToStart()
+	{
+		this.storeRounds(2, ROUNDS);
+		// channel 0 loses every store (only its file-creation entry survives) while channel 1 keeps them:
+		// truncating the intact channel back to "before any store" would discard committed data
+		final Path transactions0 = RecoverySimulation.transactionsFile(this.directory, 0);
+		assertTrue(RecoverySimulation.size(transactions0) > FILE_CREATION_ENTRY_LENGTH());
+		RecoverySimulation.truncate(transactions0, FILE_CREATION_ENTRY_LENGTH());
+
+		assertThrows(RuntimeException.class, () ->
+		{
+			this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE));
+		});
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// scenario //
+	/////////////
+
+	/** Runs {@code rounds} all-channel stores; returns each channel's transactions-log size after each round. */
+	private long[][] storeRounds(final int channelCount, final int rounds)
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, channelCount, MAX_FILE_SIZE));
+		final PersistenceObjectRegistry registry = this.storage.persistenceManager().objectRegistry();
+
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+
+		final Cell[]   cells = this.placeOnePerChannel(root, registry, channelCount);
+		final Object[] all   = objectArray(root, cells);
+
+		final long[][] size = new long[rounds + 1][channelCount];
+		for(int r = 1; r <= rounds; r++)
+		{
+			root.version = r;
+			for(final Cell cell : cells)
+			{
+				cell.version = r;
+			}
+			this.storage.storeAll(all);
+			for(int channel = 0; channel < channelCount; channel++)
+			{
+				size[r][channel] = RecoverySimulation.size(RecoverySimulation.transactionsFile(this.directory, channel));
+			}
+		}
+
+		this.storage.shutdown();
+		this.storage = null;
+		return size;
+	}
+
+	/** Truncates every channel except {@code keptChannel} to its recorded size, dropping its later stores. */
+	private void truncateLaggingChannels(final int channelCount, final int keptChannel, final long[] sizePerChannel)
+	{
+		for(int channel = 0; channel < channelCount; channel++)
+		{
+			if(channel != keptChannel)
+			{
+				RecoverySimulation.truncate(RecoverySimulation.transactionsFile(this.directory, channel), sizePerChannel[channel]);
+			}
+		}
+	}
+
+	private int reloadConsensusVersion(final int channelCount)
+	{
+		this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, channelCount, MAX_FILE_SIZE));
+		final Root root = (Root)this.reloaded.root();
+		for(final Cell cell : root.cells)
+		{
+			assertEquals(root.version, cell.version, "every channel must roll back to the same consensus store");
+		}
+		return root.version;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// staging helpers //
+	////////////////////
+
+	/** Places one cell on each channel so every round's store touches - and logs on - every channel. */
+	private Cell[] placeOnePerChannel(final Root root, final PersistenceObjectRegistry registry, final int channelCount)
+	{
+		// store a pool of cells in one call: their object ids are consecutive and cover every channel
+		final List<Cell> pool = new ArrayList<>();
+		for(int i = 0; i < channelCount * 8; i++)
+		{
+			pool.add(new Cell());
+		}
+		root.cells = pool.toArray(new Cell[0]);
+		this.storage.store(root);
+
+		final Map<Integer, Cell> byChannel = new HashMap<>();
+		for(final Cell candidate : pool)
+		{
+			byChannel.putIfAbsent(
+				RecoverySimulation.channelOf(RecoverySimulation.objectId(registry, candidate), channelCount),
+				candidate
+			);
+		}
+		assertEquals(channelCount, byChannel.size(), "could not place a cell on every channel");
+
+		final Cell[] cells = new Cell[channelCount];
+		byChannel.forEach((channel, cell) -> cells[channel] = cell);
+		root.cells = cells;
+		this.storage.store(root);
+		return cells;
+	}
+
+	private static Object[] objectArray(final Root root, final Cell[] cells)
+	{
+		final Object[] all = new Object[cells.length + 1];
+		all[0] = root;
+		System.arraycopy(cells, 0, all, 1, cells.length);
+		return all;
+	}
+
+	private static long FILE_CREATION_ENTRY_LENGTH()
+	{
+		return org.eclipse.store.storage.types.StorageTransactionsAnalysis.Logic.entryLengthFileCreation();
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// model //
+	//////////
+
+	public static class Root
+	{
+		int    version;
+		Cell[] cells  ;
+	}
+
+	public static class Cell
+	{
+		int version;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/OrphanFileRecoveryTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/OrphanFileRecoveryTest.java
@@ -1,0 +1,173 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.serializer.afs.types.WriteController;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.StorageWriteControllerReadOnlyMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A data file whose number is above the highest file the transactions log knows is the artifact of
+ * a crash between creating a successor file and logging its creation. It is unrecoverable content
+ * the log never referenced: writable recovery removes it and proceeds; read-only recovery, unable
+ * to remove it, refuses to start rather than proceed on an inconsistent inventory.
+ * <p>
+ * Fix-guard: before this change the orphan is neither removed nor refused in read-only mode.
+ */
+@Timeout(120)
+class OrphanFileRecoveryTest
+{
+	private static final int MAX_FILE_SIZE = 20_000;
+	private static final int MARKER        = 42    ;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void emptyOrphanFileAboveLogIsRemovedOnRecovery()
+	{
+		this.stageMultiFileStorage();
+		final Path orphan = this.createOrphanFile(new byte[0]);
+
+		this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+
+		assertEquals(MARKER, ((Root)this.reloaded.root()).marker, "committed data must survive");
+		assertFalse(Files.exists(orphan), "the orphan file must have been removed");
+	}
+
+	@Test
+	void dataBearingOrphanFileAboveLogIsRemovedOnRecovery()
+	{
+		this.stageMultiFileStorage();
+		// an interrupted rollover managed to write some (valid) records before the crash
+		final byte[] content = RecoverySimulation.readRange(
+			RecoverySimulation.dataFiles(this.directory, 0).firstEntry().getValue(), 0, 64
+		);
+		final Path orphan = this.createOrphanFile(content);
+
+		this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+
+		assertEquals(MARKER, ((Root)this.reloaded.root()).marker, "committed data must survive");
+		assertFalse(Files.exists(orphan), "the orphan file must have been removed");
+	}
+
+	@Test
+	void orphanFileAboveLogInReadOnlyModeRefusesToStart()
+	{
+		this.stageMultiFileStorage();
+		this.createOrphanFile(new byte[0]);
+
+		final StorageWriteControllerReadOnlyMode readOnly =
+			new StorageWriteControllerReadOnlyMode(WriteController.Enabled());
+		readOnly.setReadOnly(true);
+
+		assertThrows(RuntimeException.class, () ->
+			this.reloaded = EmbeddedStorage.Foundation(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE))
+				.setWriteController(readOnly)
+				.start()
+		);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// staging //
+	////////////
+
+	/** Stores enough oversized data to roll the head over several times, then shuts down cleanly. */
+	private void stageMultiFileStorage()
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+		final Root root = new Root();
+		root.marker = MARKER;
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+		for(int i = 0; i < 3; i++)
+		{
+			root.blob = new byte[MAX_FILE_SIZE * 2];
+			this.storage.store(root);
+		}
+		this.storage.shutdown();
+		this.storage = null;
+	}
+
+	/**
+	 * Writes a data file numbered well above the highest existing file - a file the log never
+	 * recorded. The gap keeps the orphan's number clear of any file the engine creates itself when
+	 * it rolls the (oversized) head over on restart.
+	 */
+	private Path createOrphanFile(final byte[] content)
+	{
+		final long orphanNumber = RecoverySimulation.dataFiles(this.directory, 0).lastKey() + 10;
+		final Path orphan       = this.directory.resolve("channel_0").resolve("channel_0_" + orphanNumber + ".dat");
+		try
+		{
+			Files.write(orphan, content);
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+		assertTrue(Files.exists(orphan), "staging: orphan file not created");
+		return orphan;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// model //
+	//////////
+
+	public static class Root
+	{
+		int    marker;
+		byte[] blob  ;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/PostStoreTransferAnchorTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/PostStoreTransferAnchorTest.java
@@ -1,0 +1,119 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static test.eclipse.store.recovery.RecoverySimulation.aggregatorField;
+import static test.eclipse.store.recovery.RecoverySimulation.feed;
+
+import org.eclipse.store.storage.types.StorageTransactionsAnalysis.EntryAggregator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Log-replay anchor semantics the cross-channel store reconciliation relies on: a channel that is
+ * one store "ahead" is rolled back to {@code (lastConsistentStoreTimestamp, lastConsistentStoreLength)},
+ * so that pair must always name the last confirmed store - never a length above an unconfirmed store's
+ * chunk, or a timestamp of a store that gets rolled back.
+ * <p>
+ * Fix-guard: before this change these anchors are computed wrongly; they are only correct afterwards.
+ */
+class PostStoreTransferAnchorTest
+{
+	private static final long BASE_LENGTH = 100;
+
+	@Test
+	void storesAloneAnchorAtThePreviousStore()
+	{
+		final EntryAggregator aggregator = replay(
+			RecoverySimulation.fileCreationEntry(BASE_LENGTH, 1, 1),
+			RecoverySimulation.storeEntry(500, 2000),
+			RecoverySimulation.storeEntry(800, 3000)
+		);
+
+		assertEquals(2000, aggregatorField(aggregator, "lastConsistentStoreTimestamp"));
+		assertEquals( 500, aggregatorField(aggregator, "lastConsistentStoreLength"   ));
+		assertEquals(3000, aggregatorField(aggregator, "currentStoreTimestamp"       ));
+		assertEquals( 800, aggregatorField(aggregator, "currentStoreLength"          ));
+	}
+
+	@Test
+	void transferKeepsTheRollbackAnchorAtThePreStoreLength()
+	{
+		// a housekeeping transfer lands after the latest (still unconfirmed) store
+		final EntryAggregator aggregator = replay(
+			RecoverySimulation.fileCreationEntry(BASE_LENGTH, 1, 1),
+			RecoverySimulation.storeEntry(500, 2000),
+			RecoverySimulation.storeEntry(800, 3000),
+			RecoverySimulation.transferEntry(1100, 3500, 1, 0)
+		);
+
+		// the transfer grows the head, kept only if the latest store survives reconciliation
+		assertEquals(1100, aggregatorField(aggregator, "currentStoreLength"),
+			"a surviving store keeps its post-transfer head length");
+		assertEquals(3000, aggregatorField(aggregator, "currentStoreTimestamp"),
+			"a transfer must not count as a store");
+
+		// the rollback anchor must still be the pre-store length, or rolling the latest store back
+		// would truncate above its chunk and keep half of it
+		assertEquals(2000, aggregatorField(aggregator, "lastConsistentStoreTimestamp"),
+			"a transfer must not move the rollback anchor timestamp");
+		assertEquals(500, aggregatorField(aggregator, "lastConsistentStoreLength"),
+			"a transfer must not move the rollback anchor past the unconfirmed store");
+	}
+
+	@Test
+	void shallowTruncationFoldsTheAnchorToThePreviousStore()
+	{
+		// truncation back to the previous store's length: that store becomes the current one
+		final EntryAggregator aggregator = replay(
+			RecoverySimulation.fileCreationEntry(BASE_LENGTH, 1, 1),
+			RecoverySimulation.storeEntry(500, 2000),
+			RecoverySimulation.storeEntry(800, 3000),
+			RecoverySimulation.fileTruncationEntry(500, 2000, 1, 800)
+		);
+
+		assertEquals(2000, aggregatorField(aggregator, "currentStoreTimestamp"));
+		assertEquals( 500, aggregatorField(aggregator, "currentStoreLength"   ));
+	}
+
+	@Test
+	void deepTruncationTakesTheSurvivingTimestampFromTheEntry()
+	{
+		// cut below the previous store: neither retained anchor matches, so the surviving store's
+		// timestamp is the one recovery stamped onto the truncation entry - not the rolled-back store
+		final EntryAggregator aggregator = replay(
+			RecoverySimulation.fileCreationEntry(BASE_LENGTH, 1, 1),
+			RecoverySimulation.storeEntry(500, 2000),
+			RecoverySimulation.storeEntry(800, 3000),
+			RecoverySimulation.fileTruncationEntry(300, 2000, 1, 800)
+		);
+
+		assertEquals(2000, aggregatorField(aggregator, "currentStoreTimestamp"),
+			"a deep cut must name the survivor stamped on the entry, not the rolled-back store");
+		assertEquals(2000, aggregatorField(aggregator, "lastConsistentStoreTimestamp"));
+		assertEquals( 300, aggregatorField(aggregator, "currentStoreLength"));
+	}
+
+
+	private static EntryAggregator replay(final byte[]... entries)
+	{
+		final EntryAggregator aggregator = new EntryAggregator(0);
+		for(final byte[] entry : entries)
+		{
+			feed(aggregator, entry);
+		}
+		return aggregator;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/ReadOnlyRolloverDurabilityTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/ReadOnlyRolloverDurabilityTest.java
@@ -1,0 +1,120 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import org.eclipse.serializer.afs.types.WriteController;
+import org.eclipse.serializer.persistence.exceptions.PersistenceExceptionStoringDisabled;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.StorageWriteControllerReadOnlyMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Read-only mode and file rollovers.
+ * <p>
+ * Storing is rejected up front in read-only mode, so no write - and therefore no rollover - can
+ * originate while the storage is read-only. Toggling read-only around a rolling store must leave the
+ * storage healthy: the channel keeps running, writes and rollovers resume once writable again, and no
+ * committed data is lost across a restart.
+ * <p>
+ * Regression guard: this behaviour holds before and after this change; it locks in read-only store
+ * rejection and durability across a read-only round-trip.
+ */
+@Timeout(120)
+class ReadOnlyRolloverDurabilityTest
+{
+	private static final int CHANNELS      = 2      ;
+	private static final int MAX_FILE_SIZE = 20_000 ;
+	private static final int BLOB_SIZE     = 25_000 ; // > file size: every stored blob forces a rollover
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void readOnlyRejectsStoresAndSurvivesTogglingWithoutDataLoss()
+	{
+		final StorageWriteControllerReadOnlyMode writeController =
+			new StorageWriteControllerReadOnlyMode(WriteController.Enabled());
+		writeController.setReadOnly(false);
+
+		this.storage = EmbeddedStorage.Foundation(RecoverySimulation.quietConfig(this.directory, CHANNELS, MAX_FILE_SIZE))
+			.setWriteController(writeController)
+			.start();
+
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		root.blobs.add(new byte[BLOB_SIZE]); // rollover while writable
+		this.storage.store(root.blobs);
+		this.storage.storeRoot();
+
+		// read-only rejects stores up front, so a rollover cannot originate here
+		writeController.setReadOnly(true);
+		assertThrows(PersistenceExceptionStoringDisabled.class, () -> this.storage.store(new byte[BLOB_SIZE]),
+			"storing must be rejected in read-only mode");
+		assertTrue(this.storage.isRunning(), "a rejected read-only store must not disrupt the channel");
+
+		// writable again: stores and rollovers resume and stay durable
+		writeController.setReadOnly(false);
+		root.blobs.add(new byte[BLOB_SIZE]);
+		this.storage.store(root.blobs);
+		assertTrue(this.storage.issueStorageFlush(), "flush must succeed once writable again");
+
+		final int expected = root.blobs.size();
+		this.storage.shutdown();
+		this.storage = null;
+
+		this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, CHANNELS, MAX_FILE_SIZE));
+		final Root reloadedRoot = (Root)this.reloaded.root();
+		assertEquals(expected, reloadedRoot.blobs.size(), "no data lost across the read-only toggling");
+	}
+
+
+	public static class Root
+	{
+		ArrayList<byte[]> blobs = new ArrayList<>();
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/RecoverySimulation.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/RecoverySimulation.java
@@ -1,0 +1,433 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.function.LongConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.eclipse.serializer.afs.types.AFile;
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageConfiguration;
+import org.eclipse.store.storage.types.StorageTransactionsAnalysis.EntryAggregator;
+import org.eclipse.store.storage.types.StorageTransactionsAnalysis.Logic;
+import org.eclipse.store.storage.types.StorageTransactionsEntries;
+import org.eclipse.store.storage.types.StorageTransactionsEntryType;
+
+/**
+ * Shared harness for the power-loss and durability recovery tests.
+ * <p>
+ * A power loss is simulated deterministically: run the storage, shut it down cleanly (everything
+ * flushed), then edit the on-disk files to the exact state a crash with a given flush order would
+ * leave - append log entries the engine itself would have written, truncate what never reached the
+ * medium - and restart. The log entries are synthesized byte-exactly through the engine's own
+ * {@link Logic} writers, so the surgery cannot drift from the real format.
+ */
+final class RecoverySimulation
+{
+	///////////////////////////////////////////////////////////////////////////
+	// configuration //
+	//////////////////
+
+	/** Multi-channel storage with a small file size (frequent rollovers) and immediate housekeeping. */
+	static StorageConfiguration config(final Path directory, final int channelCount, final int maxFileSize)
+	{
+		return StorageConfiguration.Builder()
+			.setStorageFileProvider(Storage.FileProvider(directory))
+			.setChannelCountProvider(Storage.ChannelCountProvider(channelCount))
+			.setHousekeepingController(Storage.HousekeepingController(1_000L, 10_000_000L))
+			.setDataFileEvaluator(Storage.DataFileEvaluator(1024, maxFileSize, 0.75))
+			.createConfiguration();
+	}
+
+	/**
+	 * Like {@link #config} but with periodic housekeeping starved to a token budget, so file checks,
+	 * garbage collection and dissolution only run when a test triggers them explicitly. Keeps
+	 * staging deterministic.
+	 */
+	static StorageConfiguration quietConfig(final Path directory, final int channelCount, final int maxFileSize)
+	{
+		return StorageConfiguration.Builder()
+			.setStorageFileProvider(Storage.FileProvider(directory))
+			.setChannelCountProvider(Storage.ChannelCountProvider(channelCount))
+			.setHousekeepingController(Storage.HousekeepingController(60L * 60L * 1000L, 1_000L))
+			.setDataFileEvaluator(Storage.DataFileEvaluator(1024, maxFileSize, 0.75))
+			.createConfiguration();
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// channel / object id //
+	////////////////////////
+
+	/** The channel an object id maps to (channel count is always a power of two). */
+	static int channelOf(final long objectId, final int channelCount)
+	{
+		return (int)(objectId & (channelCount - 1));
+	}
+
+	static long objectId(final PersistenceObjectRegistry registry, final Object instance)
+	{
+		final long objectId = registry.lookupObjectId(instance);
+		assertTrue(objectId > 0, "object id unresolved for " + instance.getClass().getSimpleName());
+		return objectId;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// file locations //
+	///////////////////
+
+	static Path transactionsFile(final Path directory, final int channel)
+	{
+		final Path file = directory.resolve("channel_" + channel).resolve("transactions_" + channel + ".sft");
+		assertTrue(Files.exists(file), "no transactions file " + file);
+		return file;
+	}
+
+	/** The channel's data files by file number, ascending. */
+	static NavigableMap<Long, Path> dataFiles(final Path directory, final int channel)
+	{
+		final Path                     channelDir = directory.resolve("channel_" + channel);
+		final Pattern                  pattern    = Pattern.compile("channel_" + channel + "_(\\d+)\\.dat");
+		final NavigableMap<Long, Path> files      = new TreeMap<>();
+		try(Stream<Path> list = Files.list(channelDir))
+		{
+			list.forEach(path ->
+			{
+				final Matcher matcher = pattern.matcher(path.getFileName().toString());
+				if(matcher.matches())
+				{
+					files.put(Long.parseLong(matcher.group(1)), path);
+				}
+			});
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+		assertTrue(!files.isEmpty(), "no data files under " + channelDir);
+		return files;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// surgery //
+	////////////
+
+	static long size(final Path file)
+	{
+		try
+		{
+			return Files.size(file);
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	static void truncate(final Path file, final long length)
+	{
+		try(FileChannel channel = FileChannel.open(file, StandardOpenOption.WRITE))
+		{
+			channel.truncate(length);
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	static void append(final Path file, final byte[] bytes)
+	{
+		try
+		{
+			Files.write(file, bytes, StandardOpenOption.APPEND);
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	static void delete(final Path file)
+	{
+		try
+		{
+			Files.delete(file);
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	/** Truncates the channel's transactions log to drop its trailing {@code lost} store entries. */
+	static void cutTrailingStores(final Path directory, final int channel, final int lost)
+	{
+		final AFile logFile = Storage.FileProvider(directory).provideTransactionsFile(channel);
+		final Iterable<? extends StorageTransactionsEntries.Entry> entries =
+			StorageTransactionsEntries.parseFile(logFile).entries();
+
+		long totalStores = 0;
+		for(final StorageTransactionsEntries.Entry entry : entries)
+		{
+			if(entry.type() == StorageTransactionsEntryType.DATA_STORE)
+			{
+				totalStores++;
+			}
+		}
+		assertTrue(totalStores > lost, "not enough store entries to cut");
+
+		final long keep = totalStores - lost;
+		long offset = 0;
+		long seen   = 0;
+		for(final StorageTransactionsEntries.Entry entry : entries)
+		{
+			offset += entry.type().length();
+			if(entry.type() == StorageTransactionsEntryType.DATA_STORE && ++seen == keep)
+			{
+				break;
+			}
+		}
+		truncate(transactionsFile(directory, channel), offset);
+	}
+
+	/** Truncates the channel's log to drop ONLY its last store entry, keeping any trailing non-store entry. */
+	static void cutLastStore(final Path directory, final int channel)
+	{
+		final AFile logFile = Storage.FileProvider(directory).provideTransactionsFile(channel);
+		final Iterable<? extends StorageTransactionsEntries.Entry> entries =
+			StorageTransactionsEntries.parseFile(logFile).entries();
+
+		long offset          = 0;
+		long lastStoreOffset = -1;
+		for(final StorageTransactionsEntries.Entry entry : entries)
+		{
+			if(entry.type() == StorageTransactionsEntryType.DATA_STORE)
+			{
+				lastStoreOffset = offset;
+			}
+			offset += entry.type().length();
+		}
+		assertTrue(lastStoreOffset >= 0, "no store entry to cut");
+		truncate(transactionsFile(directory, channel), lastStoreOffset);
+	}
+
+	static byte[] readRange(final Path file, final long offset, final long length)
+	{
+		final ByteBuffer buffer = ByteBuffer.allocate((int)length);
+		try(FileChannel channel = FileChannel.open(file, StandardOpenOption.READ))
+		{
+			while(buffer.hasRemaining())
+			{
+				if(channel.read(buffer, offset + buffer.position()) < 0)
+				{
+					throw new IOException("unexpected end of file in " + file);
+				}
+			}
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+		return buffer.array();
+	}
+
+	/** One binary storage record: 24-byte header [length][typeId][objectId] followed by the payload. */
+	record EntityRecord(long offset, long length, long typeId, long objectId)
+	{
+		// carrier only
+	}
+
+	/** Walks the entity records of a data file, skipping gaps and stopping at a torn or zero tail. */
+	static List<EntityRecord> walkEntities(final Path dataFile)
+	{
+		final byte[] bytes;
+		try
+		{
+			bytes = Files.readAllBytes(dataFile);
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+		final ByteBuffer         buffer  = ByteBuffer.wrap(bytes).order(ByteOrder.nativeOrder());
+		final List<EntityRecord> records = new ArrayList<>();
+		long position = 0;
+		while(position + Long.BYTES <= bytes.length)
+		{
+			final long length = buffer.getLong((int)position);
+			if(length == 0)
+			{
+				break; // zero-filled tail
+			}
+			if(length < 0)
+			{
+				position += -length; // gap
+				continue;
+			}
+			if(position + length > bytes.length)
+			{
+				break; // torn tail
+			}
+			records.add(new EntityRecord(
+				position,
+				length,
+				buffer.getLong((int)position + 8),
+				buffer.getLong((int)position + 16)
+			));
+			position += length;
+		}
+		return records;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// transactions-log entry synthesis //
+	/////////////////////////////////////
+
+	static byte[] fileCreationEntry(final long fileLength, final long timestamp, final long fileNumber)
+	{
+		return entry(Logic.entryLengthFileCreation(), address ->
+		{
+			Logic.initializeEntryFileCreation(address);
+			Logic.setEntryFileCreation(address, fileLength, timestamp, fileNumber);
+		});
+	}
+
+	static byte[] storeEntry(final long fileLength, final long timestamp)
+	{
+		return entry(Logic.entryLengthStore(), address ->
+		{
+			Logic.initializeEntryStore(address);
+			Logic.setEntryStore(address, fileLength, timestamp);
+		});
+	}
+
+	static byte[] fileTruncationEntry(
+		final long newLength ,
+		final long timestamp ,
+		final long fileNumber,
+		final long oldLength
+	)
+	{
+		return entry(Logic.entryLengthFileTruncation(), address ->
+		{
+			Logic.initializeEntryFileTruncation(address);
+			Logic.setEntryFileTruncation(address, newLength, timestamp, fileNumber, oldLength);
+		});
+	}
+
+	static byte[] transferEntry(
+		final long newFileLength   ,
+		final long timestamp       ,
+		final long sourceFileNumber,
+		final long sourceFileOffset
+	)
+	{
+		return entry(Logic.entryLengthTransfer(), address ->
+		{
+			Logic.initializeEntryTransfer(address);
+			Logic.setEntryTransfer(address, newFileLength, timestamp, sourceFileNumber, sourceFileOffset);
+		});
+	}
+
+	static byte[] fileDeletionEntry(final long fileLength, final long timestamp, final long fileNumber)
+	{
+		return entry(Logic.entryLengthFileDeletion(), address ->
+		{
+			Logic.initializeEntryFileDeletion(address);
+			Logic.setEntryFileDeletion(address, fileLength, timestamp, fileNumber);
+		});
+	}
+
+	private static byte[] entry(final int length, final LongConsumer writer)
+	{
+		final ByteBuffer buffer = XMemory.allocateDirectNative(length);
+		try
+		{
+			writer.accept(XMemory.getDirectByteBufferAddress(buffer));
+			final byte[] bytes = new byte[length];
+			buffer.get(bytes);
+			return bytes;
+		}
+		finally
+		{
+			XMemory.deallocateDirectByteBuffer(buffer);
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// white-box log replay //
+	/////////////////////////
+
+	/** Feeds a single synthesized log entry to an aggregator, exactly as the read loop would. */
+	static void feed(final EntryAggregator aggregator, final byte[] entry)
+	{
+		final ByteBuffer buffer = XMemory.allocateDirectNative(entry.length);
+		try
+		{
+			final long address = XMemory.getDirectByteBufferAddress(buffer);
+			buffer.put(entry);
+			aggregator.accept(address, entry.length);
+		}
+		finally
+		{
+			XMemory.deallocateDirectByteBuffer(buffer);
+		}
+	}
+
+	/** Reads a private long field of an aggregator - the anchors are not otherwise observable. */
+	static long aggregatorField(final EntryAggregator aggregator, final String name)
+	{
+		try
+		{
+			final Field field = EntryAggregator.class.getDeclaredField(name);
+			field.setAccessible(true);
+			return field.getLong(aggregator);
+		}
+		catch(final ReflectiveOperationException e)
+		{
+			throw new AssertionError("cannot read EntryAggregator." + name, e);
+		}
+	}
+
+
+	private RecoverySimulation()
+	{
+		throw new UnsupportedOperationException();
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/StorageFlushBarrierTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/StorageFlushBarrierTest.java
@@ -1,0 +1,116 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.afs.types.WriteController;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.StorageWriteControllerReadOnlyMode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The explicit storage-flush barrier and its honesty contract: it reports {@code true} only when it
+ * actually synchronized every channel, and {@code false} when it was skipped - so a caller can never
+ * mistake a skipped flush for a durability guarantee it does not hold.
+ * <p>
+ * New-feature guard: the storage-flush barrier did not exist before this change.
+ */
+@Timeout(120)
+class StorageFlushBarrierTest
+{
+	private static final int MAX_FILE_SIZE = 50_000_000;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage;
+
+	@AfterEach
+	void shutdown()
+	{
+		if(this.storage != null && this.storage.isRunning())
+		{
+			try
+			{
+				this.storage.shutdown();
+			}
+			catch(final RuntimeException ignored)
+			{
+				// best effort
+			}
+		}
+	}
+
+	@Test
+	void flushReportsSuccessWhenWritable()
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE));
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		root.payload = new byte[512];
+		this.storage.storeRoot();
+
+		assertTrue(this.storage.issueStorageFlush(), "a writable flush must report success");
+	}
+
+	@Test
+	void repeatedFlushWithoutStoresReportsSuccess()
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE));
+		this.storage.setRoot(new Root());
+		this.storage.storeRoot();
+
+		assertTrue(this.storage.issueStorageFlush(), "first flush must succeed");
+		assertTrue(this.storage.issueStorageFlush(), "a no-op flush must still report success");
+	}
+
+	@Test
+	void flushReportsSkipInReadOnlyMode()
+	{
+		final StorageWriteControllerReadOnlyMode writeController =
+			new StorageWriteControllerReadOnlyMode(WriteController.Enabled());
+		writeController.setReadOnly(false);
+
+		this.storage = EmbeddedStorage.Foundation(RecoverySimulation.quietConfig(this.directory, 2, MAX_FILE_SIZE))
+			.setWriteController(writeController)
+			.start();
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		root.payload = new byte[512];
+		this.storage.storeRoot();
+
+		assertTrue(this.storage.issueStorageFlush(), "writable: flush must succeed");
+
+		writeController.setReadOnly(true);
+		assertFalse(this.storage.issueStorageFlush(), "read-only: a skipped flush must report no durability");
+
+		writeController.setReadOnly(false);
+		assertTrue(this.storage.issueStorageFlush(), "writable again: flush must succeed again");
+	}
+
+
+	public static class Root
+	{
+		byte[] payload;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/SustainedTrafficDurabilityTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/SustainedTrafficDurabilityTest.java
@@ -1,0 +1,180 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Under continuous store traffic the durability-covered maintenance must keep making progress: a
+ * store rolling in behind every barrier must not permanently defer the file cleanup, or dissolved
+ * files would accumulate at the write rate. The data-file count must stay bounded during sustained
+ * traffic and converge afterwards, with no live data lost.
+ * <p>
+ * Regression guard: cleanup keeps up before and after this change; this locks it against regressions
+ * in the maintenance path added here.
+ */
+@Tag("slow")
+@Timeout(180)
+class SustainedTrafficDurabilityTest
+{
+	private static final int  SLOTS         = 16    ;
+	private static final int  BLOB_SIZE     = 2048  ;
+	private static final int  MAX_FILE      = 8192  ;
+	private static final int  CHANNELS      = 2     ;
+	private static final long TRAFFIC_MS    = 4000  ;
+	private static final int  SENTINEL      = 0x5A  ;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void fileCleanupKeepsUpUnderContinuousStoreTraffic() throws InterruptedException
+	{
+		this.storage = EmbeddedStorage.start(this.config());
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+
+		final long deadline = java.lang.System.currentTimeMillis() + TRAFFIC_MS;
+		final Thread traffic = new Thread(() ->
+		{
+			int round = 0;
+			while(java.lang.System.currentTimeMillis() < deadline)
+			{
+				for(int i = 0; i < SLOTS; i++)
+				{
+					final byte[] blob = new byte[BLOB_SIZE];
+					blob[0] = (byte)round;
+					root.slots[i] = blob;
+				}
+				this.storage.store(root.slots);
+				round++;
+			}
+		}, "recovery-traffic");
+		traffic.start();
+
+		// drive the durability-covered maintenance concurrently with the store traffic
+		while(traffic.isAlive())
+		{
+			this.storage.issueFullGarbageCollection();
+			this.storage.issueFullFileCheck();
+			Thread.sleep(50);
+		}
+		traffic.join();
+
+		// settle: a final known write, then converge - cleanup must reclaim the accumulated garbage
+		for(int i = 0; i < SLOTS; i++)
+		{
+			final byte[] blob = new byte[BLOB_SIZE];
+			blob[0] = (byte)SENTINEL;
+			root.slots[i] = blob;
+		}
+		this.storage.store(root.slots);
+
+		long remaining = Long.MAX_VALUE;
+		for(int attempt = 0; attempt < 40 && remaining > CHANNELS * 12L; attempt++)
+		{
+			System.gc();
+			this.storage.issueFullGarbageCollection();
+			this.storage.issueFullFileCheck();
+			remaining = this.countDataFiles();
+			if(remaining > CHANNELS * 12L)
+			{
+				Thread.sleep(50);
+			}
+		}
+		assertTrue(remaining <= CHANNELS * 12L,
+			"file cleanup did not converge after sustained traffic: " + remaining + " files remain");
+
+		this.storage.shutdown();
+		this.storage = null;
+		this.reloaded = EmbeddedStorage.start(this.config());
+		final Root reloadedRoot = (Root)this.reloaded.root();
+		assertNotNull(reloadedRoot);
+		for(int i = 0; i < SLOTS; i++)
+		{
+			assertNotNull(reloadedRoot.slots[i], "slot " + i + " lost");
+			assertEquals((byte)SENTINEL, reloadedRoot.slots[i][0], "slot " + i + " has the wrong version");
+		}
+	}
+
+	private long countDataFiles()
+	{
+		try(Stream<Path> paths = Files.walk(this.directory))
+		{
+			return paths.filter(path -> path.getFileName().toString().endsWith(".dat")).count();
+		}
+		catch(final IOException e)
+		{
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private StorageConfiguration config()
+	{
+		return StorageConfiguration.Builder()
+			.setStorageFileProvider(Storage.FileProvider(this.directory))
+			.setChannelCountProvider(Storage.ChannelCountProvider(CHANNELS))
+			.setHousekeepingController(Storage.HousekeepingController(50, 5_000_000L))
+			.setDataFileEvaluator(Storage.DataFileEvaluator(1024, MAX_FILE, 0.75))
+			.createConfiguration();
+	}
+
+
+	public static class Root
+	{
+		byte[][] slots = new byte[SLOTS][];
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/TornTailRecoveryTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/TornTailRecoveryTest.java
@@ -1,0 +1,131 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A power loss rarely stops on a clean record boundary: it can leave a half-written record or
+ * zero-filled preallocated space at the tail of the head data file or the transactions log. Such an
+ * uncommitted tail must be healed (truncated) on the next start and the last committed state must
+ * remain intact - never a refusal or silent loss.
+ * <p>
+ * Regression guard: torn-tail healing works before and after this change; this only locks it against regressions.
+ */
+@Timeout(120)
+class TornTailRecoveryTest
+{
+	private static final int MAX_FILE_SIZE = 50_000_000;
+	private static final int MARKER        = 77       ;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void garbageTailOnTheHeadDataFileIsTruncated()
+	{
+		this.stageMarker();
+		final byte[] garbage = new byte[128];
+		Arrays.fill(garbage, (byte)0xEE);
+		RecoverySimulation.append(this.headDataFile(), garbage);
+
+		this.assertMarkerRecovers();
+	}
+
+	@Test
+	void zeroFilledTailOnTheHeadDataFileIsTruncated()
+	{
+		this.stageMarker();
+		RecoverySimulation.append(this.headDataFile(), new byte[128]);
+
+		this.assertMarkerRecovers();
+	}
+
+	@Test
+	void partialTailOnTheTransactionsLogIsHealed()
+	{
+		this.stageMarker();
+		// a few zero bytes: a torn trailing entry, shorter than any real entry
+		RecoverySimulation.append(RecoverySimulation.transactionsFile(this.directory, 0), new byte[8]);
+
+		this.assertMarkerRecovers();
+	}
+
+
+	private void stageMarker()
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+		final Root root = new Root();
+		root.marker  = MARKER;
+		root.payload = new byte[1024];
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+		this.storage.shutdown();
+		this.storage = null;
+	}
+
+	private Path headDataFile()
+	{
+		return RecoverySimulation.dataFiles(this.directory, 0).lastEntry().getValue();
+	}
+
+	private void assertMarkerRecovers()
+	{
+		this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+		final Root root = (Root)this.reloaded.root();
+		assertNotNull(root, "root gone after healing the torn tail");
+		assertEquals(MARKER, root.marker, "the last committed state must survive the torn tail");
+	}
+
+
+	public static class Root
+	{
+		int    marker ;
+		byte[] payload;
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/TransactionsLogCompactionRecoveryTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/TransactionsLogCompactionRecoveryTest.java
@@ -1,0 +1,184 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Compacting the transactions log must preserve the exact reconciliation state - the store anchors
+ * and the post-store transfer entries recovery re-reads - so a restart after a compaction rebuilds
+ * the same live state as before. A compaction that dropped a transfer would leave recovery unable to
+ * find relocated bytes; this proves the compacted log still restarts with complete data.
+ * <p>
+ * Regression guard: compaction recovery works before and after this change; this only locks it against regressions.
+ */
+@Timeout(180)
+class TransactionsLogCompactionRecoveryTest
+{
+	private static final int SLOTS     = 16  ;
+	private static final int BLOB_SIZE = 2048;
+	private static final int ROUNDS    = 8   ;
+	private static final int MAX_FILE  = 8192;
+	private static final int CHANNELS  = 2   ;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void compactedLogRestartsWithCompleteState() throws InterruptedException
+	{
+		this.storage = EmbeddedStorage.start(this.config());
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+
+		this.overwriteAllSlots(root);
+
+		// dissolve garbage (produces transfers into the head), then compact the log
+		for(int attempt = 0; attempt < 20; attempt++)
+		{
+			System.gc();
+			this.storage.issueFullGarbageCollection();
+			this.storage.issueFullFileCheck();
+			this.storage.issueTransactionsLogCleanup();
+		}
+		final long compactedSize = this.totalTransactionsLogSize();
+
+		// keep going after the compaction: further stores append onto the compacted log
+		this.overwriteAllSlots(root);
+
+		this.storage.shutdown();
+		this.storage = null;
+
+		this.reloaded = EmbeddedStorage.start(this.config());
+		final Root reloadedRoot = (Root)this.reloaded.root();
+		assertNotNull(reloadedRoot);
+		for(int i = 0; i < SLOTS; i++)
+		{
+			assertNotNull(reloadedRoot.slots[i], "slot " + i + " lost after compaction");
+			assertEquals((byte)(ROUNDS - 1), reloadedRoot.slots[i][0], "slot " + i + " has the wrong version");
+		}
+		assertTrue(compactedSize > 0, "the transactions log must not be empty after compaction");
+	}
+
+	@Test
+	void compactionReducesAGarbageHeavyLog() throws InterruptedException
+	{
+		this.storage = EmbeddedStorage.start(this.config());
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+		this.overwriteAllSlots(root);
+
+		// dissolve and delete files, filling the log with creation/deletion entries
+		for(int attempt = 0; attempt < 20; attempt++)
+		{
+			System.gc();
+			this.storage.issueFullGarbageCollection();
+			this.storage.issueFullFileCheck();
+		}
+		final long beforeCompaction = this.totalTransactionsLogSize();
+
+		long afterCompaction = beforeCompaction;
+		for(int attempt = 0; attempt < 20 && afterCompaction >= beforeCompaction; attempt++)
+		{
+			this.storage.issueTransactionsLogCleanup();
+			afterCompaction = this.totalTransactionsLogSize();
+			if(afterCompaction >= beforeCompaction)
+			{
+				Thread.sleep(50);
+			}
+		}
+
+		assertTrue(afterCompaction < beforeCompaction,
+			"compaction must shrink a garbage-heavy log (before " + beforeCompaction + ", after " + afterCompaction + ")");
+	}
+
+
+	private void overwriteAllSlots(final Root root)
+	{
+		for(int round = 0; round < ROUNDS; round++)
+		{
+			for(int i = 0; i < SLOTS; i++)
+			{
+				final byte[] blob = new byte[BLOB_SIZE];
+				blob[0] = (byte)round;
+				root.slots[i] = blob;
+			}
+			this.storage.store(root.slots);
+		}
+	}
+
+	private long totalTransactionsLogSize()
+	{
+		long total = 0;
+		for(int channel = 0; channel < CHANNELS; channel++)
+		{
+			total += RecoverySimulation.size(RecoverySimulation.transactionsFile(this.directory, channel));
+		}
+		return total;
+	}
+
+	private StorageConfiguration config()
+	{
+		return StorageConfiguration.Builder()
+			.setStorageFileProvider(Storage.FileProvider(this.directory))
+			.setChannelCountProvider(Storage.ChannelCountProvider(CHANNELS))
+			.setHousekeepingController(Storage.HousekeepingController(50, 5_000_000L))
+			.setDataFileEvaluator(Storage.DataFileEvaluator(1024, MAX_FILE, 0.75))
+			.createConfiguration();
+	}
+
+
+	public static class Root
+	{
+		byte[][] slots = new byte[SLOTS][];
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/TransactionsLogEntryFormatTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/TransactionsLogEntryFormatTest.java
@@ -1,0 +1,126 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.store.storage.types.StorageTransactionsAnalysis.Logic;
+import org.eclipse.store.storage.types.StorageTransactionsEntryType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Byte layout of the transactions-log entries. Recovery re-reads these entries and the compactor
+ * re-writes them, so their fixed lengths and field offsets must stay stable; a drift silently
+ * corrupts every log this build writes or reads.
+ * <p>
+ * Regression guard: the entry layout is the same before and after this change; this only locks it against regressions.
+ */
+class TransactionsLogEntryFormatTest
+{
+	private java.nio.ByteBuffer buffer ;
+	private long                address;
+
+	@BeforeEach
+	void allocate()
+	{
+		this.buffer  = XMemory.allocateDirectNative(64);
+		this.address = XMemory.getDirectByteBufferAddress(this.buffer);
+	}
+
+	@AfterEach
+	void free()
+	{
+		XMemory.deallocateDirectByteBuffer(this.buffer);
+	}
+
+	@Test
+	void entryLengthsAreStable()
+	{
+		assertEquals(26, Logic.entryLengthFileCreation()  );
+		assertEquals(18, Logic.entryLengthStore()         );
+		assertEquals(34, Logic.entryLengthTransfer()      );
+		assertEquals(34, Logic.entryLengthFileTruncation());
+		assertEquals(26, Logic.entryLengthFileDeletion()  );
+	}
+
+	@Test
+	void fileCreationRoundTrips()
+	{
+		Logic.initializeEntryFileCreation(this.address);
+		Logic.setEntryFileCreation(this.address, 4096, 111, 7);
+
+		assertEquals(StorageTransactionsEntryType.FILE_CREATION, Logic.resolveEntryType(this.address));
+		assertEquals(Logic.entryLengthFileCreation(), Logic.getEntryLength(this.address));
+		assertEquals(4096, Logic.getFileLength(this.address)   );
+		assertEquals( 111, Logic.getEntryTimestamp(this.address));
+		assertEquals(   7, Logic.getFileNumber(this.address)   );
+	}
+
+	@Test
+	void storeRoundTrips()
+	{
+		Logic.initializeEntryStore(this.address);
+		Logic.setEntryStore(this.address, 8192, 222);
+
+		assertEquals(StorageTransactionsEntryType.DATA_STORE, Logic.resolveEntryType(this.address));
+		assertEquals(Logic.entryLengthStore(), Logic.getEntryLength(this.address));
+		assertEquals(8192, Logic.getFileLength(this.address)   );
+		assertEquals( 222, Logic.getEntryTimestamp(this.address));
+	}
+
+	@Test
+	void transferRoundTrips()
+	{
+		Logic.initializeEntryTransfer(this.address);
+		Logic.setEntryTransfer(this.address, 12288, 333, 5, 640);
+
+		assertEquals(StorageTransactionsEntryType.DATA_TRANSFER, Logic.resolveEntryType(this.address));
+		assertEquals(Logic.entryLengthTransfer(), Logic.getEntryLength(this.address));
+		assertEquals(12288, Logic.getFileLength(this.address)   );
+		assertEquals(  333, Logic.getEntryTimestamp(this.address));
+		assertEquals(    5, Logic.getFileNumber(this.address)   );
+		assertEquals(  640, Logic.getSpecialOffset(this.address));
+	}
+
+	@Test
+	void fileTruncationRoundTrips()
+	{
+		Logic.initializeEntryFileTruncation(this.address);
+		Logic.setEntryFileTruncation(this.address, 2048, 444, 9, 4096);
+
+		assertEquals(StorageTransactionsEntryType.FILE_TRUNCATION, Logic.resolveEntryType(this.address));
+		assertEquals(Logic.entryLengthFileTruncation(), Logic.getEntryLength(this.address));
+		assertEquals(2048, Logic.getFileLength(this.address)   );
+		assertEquals( 444, Logic.getEntryTimestamp(this.address));
+		assertEquals(   9, Logic.getFileNumber(this.address)   );
+		assertEquals(4096, Logic.getSpecialOffset(this.address));
+	}
+
+	@Test
+	void fileDeletionRoundTrips()
+	{
+		Logic.initializeEntryFileDeletion(this.address);
+		Logic.setEntryFileDeletion(this.address, 1024, 555, 3);
+
+		assertEquals(StorageTransactionsEntryType.FILE_DELETION, Logic.resolveEntryType(this.address));
+		assertEquals(Logic.entryLengthFileDeletion(), Logic.getEntryLength(this.address));
+		assertEquals(1024, Logic.getFileLength(this.address)   );
+		assertEquals( 555, Logic.getEntryTimestamp(this.address));
+		assertEquals(   3, Logic.getFileNumber(this.address)   );
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/TransferAfterStoreRollbackTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/TransferAfterStoreRollbackTest.java
@@ -1,0 +1,386 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.NavigableMap;
+
+import org.eclipse.serializer.persistence.types.PersistenceObjectRegistry;
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import test.eclipse.store.recovery.RecoverySimulation.EntityRecord;
+
+/**
+ * A housekeeping transfer that lands after a store must not defeat the cross-channel store rollback.
+ * <p>
+ * All channels log a store with the same task timestamp; on restart a channel that is "ahead"
+ * (its sibling never flushed that store) is rolled back to its pre-store length. If a transfer
+ * grew the head above the store's chunk and moved the rollback anchor with it, the channel keeps
+ * its half of the store while the sibling drops it: a torn, half-visible store. Because nothing in
+ * the store is eagerly root-reachable, the storage restarts cleanly and the tear only detonates on
+ * a later load - the silent corruption these tests guard against.
+ * <p>
+ * The power loss is simulated on a cleanly shut-down (fully flushed) state: the post-store transfer
+ * is appended to channel A exactly as the engine writes it, and channel B's store entry is truncated
+ * away ("never reached disk").
+ * <p>
+ * Fix-guard: before this change this post-store transfer tears the store; it stays intact only afterwards.
+ */
+@Timeout(120)
+class TransferAfterStoreRollbackTest
+{
+	private static final int  CHANNEL_COUNT = 2      ;
+	private static final int  MAX_FILE_SIZE = 20_000 ;
+	private static final int  BLOB_SIZE     = 25_000 ;
+	private static final long MARKER_STAMP  = 0xC0FFEEL;
+
+	private enum Mode
+	{
+		NO_TRANSFER,
+		TRANSFER,
+		TRANSFER_SOURCE_DELETED
+	}
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void powerLossWithoutTransferRollsTheStoreBackConsistently()
+	{
+		// control: proves the surgery models the cut faithfully and plain reconciliation handles it
+		final Outcome outcome = this.run(Mode.NO_TRANSFER);
+
+		assertTrue(outcome.started, "restart must succeed");
+		assertEquals(0, outcome.version, "the unconfirmed store must roll back on every channel");
+		assertTrue(outcome.consistent, "the rolled-back state must be consistent");
+		assertTrue(outcome.markerIntact, "the committed marker must survive");
+	}
+
+	@Test
+	void powerLossAfterPostStoreTransferKeepsTheStoreAllOrNothing()
+	{
+		final Outcome outcome = this.run(Mode.TRANSFER);
+
+		assertTrue(outcome.started, "restart must succeed");
+		assertTrue(outcome.consistent,
+			"the store must be fully visible or fully rolled back, never half kept by one channel");
+		assertTrue(outcome.markerIntact, "the committed marker must survive the recovery");
+	}
+
+	@Test
+	void powerLossAfterTransferWithDeletedSourceNeverLosesDataSilently()
+	{
+		final Outcome outcome = this.run(Mode.TRANSFER_SOURCE_DELETED);
+
+		// a loud fail-stop is acceptable here: with the transfer's source unlinked, rolling the store
+		// back cannot restore the transferred entity, so refusing to start beats losing it silently
+		if(!outcome.started)
+		{
+			return;
+		}
+		assertTrue(outcome.consistent, "the store must be all-or-nothing");
+		assertTrue(outcome.markerIntact,
+			"the transferred committed entity is the marker's only copy; recovery must not drop it");
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// scenario //
+	/////////////
+
+	private Outcome run(final Mode mode)
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, CHANNEL_COUNT, MAX_FILE_SIZE));
+		final PersistenceObjectRegistry registry = this.storage.persistenceManager().objectRegistry();
+
+		final DataRoot       root  = new DataRoot();
+		final VersionedState state = new VersionedState();
+		root.state = Lazy.Reference(state);
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+
+		final int channelA = RecoverySimulation.channelOf(RecoverySimulation.objectId(registry, state), CHANNEL_COUNT);
+
+		// seal a file on channel A whose only live content is the marker (oversized blobs force rollovers)
+		this.storeBlobOn(root, registry, 1, channelA);
+		final Marker marker    = this.storeMarkerOn(root, registry, channelA);
+		final long   markerOid = RecoverySimulation.objectId(registry, marker);
+		this.storeBlobOn(root, registry, 2, channelA);
+		root.blob1 = null;
+		root.blob2 = null;
+		this.storage.store(root);
+
+		// store Tn-1: fresh entities on both channels plus a re-store of root and state
+		root.settle1 = new Marker(101);
+		root.settle2 = new Marker(102);
+		this.storage.storeAll(root, state);
+
+		final Path transactionsB     = RecoverySimulation.transactionsFile(this.directory, 1 - channelA);
+		final long transactionsBSize = RecoverySimulation.size(transactionsB);
+
+		// store Tn: flip the state and attach one payload per channel; nothing of it is root-reachable
+		state.version = 1;
+		final Payload payloadA = new Payload(1);
+		final Payload payloadB = new Payload(2);
+		state.a = payloadA;
+		state.b = payloadB;
+		this.storage.store(state);
+		assertNotEquals(
+			RecoverySimulation.channelOf(RecoverySimulation.objectId(registry, payloadA), CHANNEL_COUNT),
+			RecoverySimulation.channelOf(RecoverySimulation.objectId(registry, payloadB), CHANNEL_COUNT),
+			"the store's payloads must land on different channels"
+		);
+
+		this.storage.shutdown();
+		this.storage = null;
+
+		assertEquals(transactionsBSize + org.eclipse.store.storage.types.StorageTransactionsAnalysis.Logic.entryLengthStore(),
+			RecoverySimulation.size(transactionsB),
+			"channel B's log must have grown by exactly the store entry");
+
+		if(mode != Mode.NO_TRANSFER)
+		{
+			this.appendPostStoreTransfer(channelA, markerOid, mode);
+		}
+
+		// the power-loss cut: drop the store entry - and only it - from channel B's log
+		RecoverySimulation.truncate(transactionsB, transactionsBSize);
+
+		return this.restartAndInspect();
+	}
+
+	/** Appends the post-store transfer to channel A exactly as a housekeeping dissolution would write it. */
+	private void appendPostStoreTransfer(final int channelA, final long markerOid, final Mode mode)
+	{
+		final NavigableMap<Long, Path> files      = RecoverySimulation.dataFiles(this.directory, channelA);
+		final long                     headNumber = files.lastKey();
+		final Path                     headFile   = files.get(headNumber);
+
+		long         sourceNumber = -1  ;
+		Path         sourceFile   = null;
+		EntityRecord markerRecord = null;
+		for(final var entry : files.entrySet())
+		{
+			for(final EntityRecord record : RecoverySimulation.walkEntities(entry.getValue()))
+			{
+				if(record.objectId() == markerOid)
+				{
+					sourceNumber = entry.getKey();
+					sourceFile   = entry.getValue();
+					markerRecord = record;
+				}
+			}
+		}
+		assertTrue(markerRecord != null, "marker record not found in channel A");
+		assertNotEquals(headNumber, sourceNumber, "the marker must live in a sealed non-head file");
+
+		RecoverySimulation.append(headFile, RecoverySimulation.readRange(sourceFile, markerRecord.offset(), markerRecord.length()));
+
+		final Path transactionsA = RecoverySimulation.transactionsFile(this.directory, channelA);
+		final long timestamp     = System.currentTimeMillis() * 1_000_000L;
+		RecoverySimulation.append(transactionsA, RecoverySimulation.transferEntry(
+			RecoverySimulation.size(headFile), timestamp, sourceNumber, markerRecord.offset()
+		));
+
+		if(mode == Mode.TRANSFER_SOURCE_DELETED)
+		{
+			RecoverySimulation.append(transactionsA, RecoverySimulation.fileDeletionEntry(
+				RecoverySimulation.size(sourceFile), timestamp + 1, sourceNumber
+			));
+			RecoverySimulation.delete(sourceFile);
+		}
+	}
+
+	private Outcome restartAndInspect()
+	{
+		final Outcome outcome = new Outcome();
+		try
+		{
+			this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, CHANNEL_COUNT, MAX_FILE_SIZE));
+			outcome.started = true;
+		}
+		catch(final RuntimeException e)
+		{
+			return outcome;
+		}
+
+		final DataRoot root = (DataRoot)this.reloaded.root();
+
+		// first touch of the torn half: a torn store detonates here, after a clean startup
+		boolean stateLoaded = false;
+		try
+		{
+			final VersionedState state = Lazy.get(root.state);
+			stateLoaded = state != null;
+			if(stateLoaded)
+			{
+				outcome.version = state.version;
+				final boolean payloadA = state.a != null && state.a.value == 1;
+				final boolean payloadB = state.b != null && state.b.value == 2;
+				outcome.consistent = outcome.version == 0
+					? !payloadA && !payloadB
+					: outcome.version == 1 && payloadA && payloadB;
+			}
+		}
+		catch(final RuntimeException torn)
+		{
+			outcome.consistent = false;
+		}
+		if(!stateLoaded)
+		{
+			outcome.consistent = false;
+		}
+
+		outcome.markerIntact = markerIntact(root);
+		return outcome;
+	}
+
+	private static boolean markerIntact(final DataRoot root)
+	{
+		try
+		{
+			final Marker marker = Lazy.get(root.marker);
+			return marker != null && marker.stamp == MARKER_STAMP;
+		}
+		catch(final RuntimeException e)
+		{
+			return false;
+		}
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// staging helpers //
+	////////////////////
+
+	private void storeBlobOn(final DataRoot root, final PersistenceObjectRegistry registry, final int slot, final int channel)
+	{
+		for(int attempt = 0; attempt < 4; attempt++)
+		{
+			final byte[] blob = new byte[BLOB_SIZE];
+			if(slot == 1)
+			{
+				root.blob1 = blob;
+			}
+			else
+			{
+				root.blob2 = blob;
+			}
+			this.storage.store(root);
+			if(RecoverySimulation.channelOf(RecoverySimulation.objectId(registry, blob), CHANNEL_COUNT) == channel)
+			{
+				return;
+			}
+		}
+		throw new IllegalStateException("could not place a blob on channel " + channel);
+	}
+
+	private Marker storeMarkerOn(final DataRoot root, final PersistenceObjectRegistry registry, final int channel)
+	{
+		for(int attempt = 0; attempt < 4; attempt++)
+		{
+			final Marker marker = new Marker(MARKER_STAMP);
+			root.marker = Lazy.Reference(marker);
+			this.storage.store(root);
+			if(RecoverySimulation.channelOf(RecoverySimulation.objectId(registry, marker), CHANNEL_COUNT) == channel)
+			{
+				return marker;
+			}
+		}
+		throw new IllegalStateException("could not place the marker on channel " + channel);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// model //
+	//////////
+
+	private static final class Outcome
+	{
+		boolean started     ;
+		int     version = -1 ;
+		boolean consistent  ;
+		boolean markerIntact;
+	}
+
+	public static class DataRoot
+	{
+		Lazy<VersionedState> state  ;
+		Lazy<Marker>         marker ;
+		Marker               settle1;
+		Marker               settle2;
+		byte[]               blob1  ;
+		byte[]               blob2  ;
+	}
+
+	public static class VersionedState
+	{
+		int     version;
+		Payload a      ;
+		Payload b      ;
+	}
+
+	public static class Payload
+	{
+		final long value;
+
+		Payload(final long value)
+		{
+			this.value = value;
+		}
+	}
+
+	public static class Marker
+	{
+		final long stamp;
+
+		Marker(final long stamp)
+		{
+			this.stamp = stamp;
+		}
+	}
+}

--- a/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
+++ b/integrations/cdi4/src/main/java/org/eclipse/store/integrations/cdi/types/config/StorageManagerProxy.java
@@ -263,6 +263,12 @@ public class StorageManagerProxy extends UsageMarkable.Default implements Storag
     }
 
     @Override
+    public boolean issueStorageFlush()
+    {
+        return this.getStorageManager().issueStorageFlush();
+    }
+
+    @Override
     public StorageRawFileStatistics createStorageStatistics()
     {
         return this.getStorageManager().createStorageStatistics();

--- a/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
+++ b/storage/embedded/src/main/java/org/eclipse/store/storage/embedded/types/EmbeddedStorageManager.java
@@ -667,6 +667,12 @@ public interface EmbeddedStorageManager extends StorageManager
 		{
 			this.singletonConnection().issueTransactionsLogCleanup();
 		}
+
+		@Override
+		public boolean issueStorageFlush()
+		{
+			return this.singletonConnection().issueStorageFlush();
+		}
 		
 		@Override
 		public List<AdjacencyFiles> exportAdjacencyData(

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -40,6 +40,8 @@ import org.eclipse.serializer.util.BufferSizeProviderIncremental;
 import org.eclipse.serializer.util.X;
 import org.eclipse.serializer.util.logging.Logging;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistencyDanglingReference;
+import org.eclipse.store.storage.exceptions.StorageExceptionDisruptingExceptions;
+import org.eclipse.store.storage.exceptions.StorageExceptionNotRunning;
 import org.eclipse.store.storage.exceptions.StorageExceptionTransactionsFileCompaction;
 import org.eclipse.store.storage.monitoring.StorageChannelHousekeepingMonitor;
 import org.eclipse.store.storage.types.StorageAdjacencyDataExporter.AdjacencyFiles;
@@ -280,6 +282,50 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	 *         required.
 	 */
 	public boolean issuedTransactionsLogCleanup();
+
+	/**
+	 * Synchronizes this channel's storage files (head data file, then transactions log) to the
+	 * storage medium. Processing part of the all-channel durability barrier, see
+	 * {@link StorageRequestTaskStorageFlush}.
+	 *
+	 * @return {@code true} if the files were synchronized; {@code false} if skipped because the
+	 *         storage is not writable, in which case the all-durable watermark must not advance.
+	 */
+	public boolean flushStorage();
+
+	/**
+	 * Reads and clears whether this channel rolled a file over during the current task. If it did,
+	 * the task's completion barrier makes every channel durable (eager rollover durability), so the
+	 * store the new file's creation entry collapses the recovery baseline onto is durable everywhere
+	 * before the task returns.
+	 *
+	 * @return whether this channel rolled a file over since the last poll.
+	 */
+	public boolean pollRolloverOccurred();
+
+	/**
+	 * Called on this channel after an all-channel storage flush completed successfully: every
+	 * store below the passed task timestamp is then fully durable on every channel. Pure state
+	 * commit (watermark raise); the deferred maintenance the raised watermark enables runs
+	 * separately via {@link #executeDurabilityCoveredMaintenance()}.
+	 *
+	 * @param allDurableTimestamp the completed flush task's timestamp.
+	 */
+	public void commitStorageFlush(long allDurableTimestamp);
+
+	/**
+	 * Executes the durability-gated maintenance this channel may have deferred (head-file
+	 * rollover, log compaction, the file-cleanup pass at the configured file-check budget).
+	 * <p>
+	 * Processing part of {@link StorageRequestTaskDurabilityMaintenance}, which the broker
+	 * enqueues directly behind every gate-requested storage-flush barrier: queue adjacency guarantees no store
+	 * task runs between the barrier's watermark raise ({@link #commitStorageFlush(long)}) and
+	 * this maintenance, so the durability gates pass for its whole duration. Under sustained
+	 * store traffic this is the ONLY reclamation slot (a store per cycle re-defers the periodic
+	 * housekeeping's dissolution forever). Self-guarded: without the raised watermark (barrier
+	 * failed or skipped) every gate simply re-defers and re-arms its request.
+	 */
+	public void executeDurabilityCoveredMaintenance();
 
 	/**
 	 * Exports this channel's live data into the directory layout described by the passed
@@ -603,8 +649,8 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			
 			// turn budget into the budget bounding value for easier and faster checking
 			final long nanoTimeBudgetBound = XTime.calculateNanoTimeBudgetBound(nanoTimeBudget);
-			
-			return this.fileManager.issuedFileCleanupCheck(nanoTimeBudgetBound);
+
+			return this.afterStorageFlushPoll(this.fileManager.issuedFileCleanupCheck(nanoTimeBudgetBound));
 		}
 		
 		@Override
@@ -745,7 +791,7 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		{
 			try
 			{
-				return this.housekeepingBroker.performTransactionFileCheck(this, false);
+				return this.afterStorageFlushPoll(this.housekeepingBroker.performTransactionFileCheck(this, false));
 			}
 			catch(final StorageExceptionTransactionsFileCompaction e)
 			{
@@ -754,12 +800,59 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 				 * on the next initialization; any further append would be discarded by that heal.
 				 * Unlike ordinary task problems, this failure must therefore stop the channel.
 				 */
-				this.operationController.registerDisruption(e);
-				this.operationController.setChannelProcessingEnabled(false);
-				throw e;
+				throw this.escalateChannelStoppingFailure(e);
 			}
 		}
 		
+		@Override
+		public final boolean flushStorage()
+		{
+			return this.fileManager.flushStorage();
+		}
+
+		@Override
+		public final boolean pollRolloverOccurred()
+		{
+			return this.fileManager.pollRolloverOccurred();
+		}
+
+		@Override
+		public final void commitStorageFlush(final long allDurableTimestamp)
+		{
+			this.fileManager.commitStorageFlush(allDurableTimestamp);
+		}
+
+		@Override
+		public final void executeDurabilityCoveredMaintenance()
+		{
+			/*
+			 * Runs as the maintenance task enqueued directly behind the flush barrier (see the
+			 * interface contract): the barrier's issuer already continued at fsync latency, but no
+			 * store can slip in before this pass, so the durability gates pass for its whole
+			 * duration. Running here instead of on the next housekeeping cycle removes the race
+			 * with the next store under sustained traffic - under which this pass is the ONLY
+			 * reclamation slot, so it gets the full file-check budget a periodic housekeeping pass
+			 * would get (a token slice would starve the dissolution and let garbage accumulate at
+			 * the write rate).
+			 */
+			try
+			{
+				// deferred rollover + log compaction + the file-cleanup pass at the configured
+				// file-check budget. Deliberately NOT clamped by calculateSpecificHousekeepingTimeBudget:
+				// that caps at the PERIODIC interval's remaining countdown, which is ~zero outside the
+				// idle-housekeeping slot - this pass replaces that slot under traffic, it does not share it.
+				this.fileManager.executeDurabilityCoveredMaintenance(
+					this.housekeepingController.fileCheckTimeBudgetNs()
+				);
+			}
+			catch(final RuntimeException e)
+			{
+				// same containment as the work loop's housekeeping catch: a failed rollover or broken
+				// compaction (retained swap) must stop the channel, not degrade silently.
+				throw this.escalateChannelStoppingFailure(e);
+			}
+		}
+
 		private long calculateSpecificHousekeepingTimeBudget(final long nanoTimeBudget)
 		{
 			return Math.min(nanoTimeBudget, this.housekeepingIntervalBudgetNs);
@@ -771,12 +864,67 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			{
 				return true;
 			}
-			
+
 			final long nanoTimeBudget = this.calculateSpecificHousekeepingTimeBudget(
 				this.housekeepingController.fileCheckTimeBudgetNs()
 			);
-			
-			return this.housekeepingBroker.performFileCleanupCheck(this, nanoTimeBudget);
+
+			return this.afterStorageFlushPoll(this.housekeepingBroker.performFileCleanupCheck(this, nanoTimeBudget));
+		}
+
+		/**
+		 * Completes a housekeeping/issued check: a durability gate may have deferred work to a
+		 * storage flush during the check, so the requested barrier is enqueued before the
+		 * check's result is passed through.
+		 */
+		private boolean afterStorageFlushPoll(final boolean checkResult)
+		{
+			this.enqueueStorageFlushIfRequested();
+			return checkResult;
+		}
+
+		private void enqueueStorageFlushIfRequested()
+		{
+			if(!this.fileManager.pollStorageFlushRequest())
+			{
+				return;
+			}
+			try
+			{
+				this.taskBroker.issueCoalescingStorageFlush();
+			}
+			catch(final StorageExceptionNotRunning | StorageExceptionDisruptingExceptions e)
+			{
+				// storage is shutting down or already disrupted: the deferred deletion/rollover this
+				// flush would have enabled will not run either, so nothing durable-but-unflushed can
+				// be lost. Drop the request quietly instead of registering a spurious disruption.
+			}
+			catch(final InterruptedException e)
+			{
+				// re-arm for the next housekeeping cycle, let the work loop handle the interruption
+				this.fileManager.requestStorageFlush();
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		/**
+		 * Escalates a failure that leaves this channel unable to continue safely (e.g. a broken
+		 * transactions-log compaction whose only heal source is the retained swap file): register
+		 * the disruption and stop processing, so the fault surfaces on the next request instead
+		 * of the storage degrading silently.
+		 * <p>
+		 * The stop is EFFECTED by the two side effects (register + disable), which MUST run before the
+		 * return: on the fire-and-forget maintenance task (see
+		 * {@link #executeDurabilityCoveredMaintenance()}) the {@code throw escalate...(e)} is swallowed
+		 * into the task's problem registry, which no issuer ever reads, so only these side effects stop
+		 * the channel (a waited path additionally propagates the throw to its issuer). Throwing before
+		 * the side effects would silently disarm the fire-and-forget stop - keep them ordered as written.
+		 */
+		private <E extends RuntimeException> E escalateChannelStoppingFailure(final E failure)
+		{
+			this.operationController.registerDisruption(failure);
+			this.operationController.setChannelProcessingEnabled(false);
+			return failure;
 		}
 
 		final boolean houseKeepingGarbageCollection()
@@ -799,7 +947,7 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		
 		final boolean houseKeepingTransactionFile()
 		{
-			return this.housekeepingBroker.performTransactionFileCheck(this, true);
+			return this.afterStorageFlushPoll(this.housekeepingBroker.performTransactionFileCheck(this, true));
 		}
 
 		private void work() throws InterruptedException

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelSynchronizingTask.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelSynchronizingTask.java
@@ -26,6 +26,62 @@ public interface StorageChannelSynchronizingTask extends StorageChannelTask
 
 
 
+	/**
+	 * Per-channel boolean results of a completing task: each channel writes only its own slot
+	 * (a single shared flag would be a last-writer-wins race between the channel threads), the
+	 * issuer aggregates after the completion barrier, whose monitor provides the happens-before
+	 * edge for the reads.
+	 */
+	public final class ChannelResults
+	{
+		private final boolean[] results;
+
+		public ChannelResults(final int channelCount)
+		{
+			super();
+			this.results = new boolean[channelCount];
+		}
+
+		public void set(final int channelIndex, final boolean result)
+		{
+			this.results[channelIndex] = result;
+		}
+
+		/**
+		 * @return whether every channel reported {@code true}; one channel's failure or
+		 *         deferral must not be masked by another channel's success.
+		 */
+		public boolean allTrue()
+		{
+			for(final boolean result : this.results)
+			{
+				if(!result)
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+
+		/**
+		 * @return whether any channel reported {@code true} - e.g. any channel rolled a file over,
+		 *         so every channel must make its files durable before the collapse can be relied on.
+		 */
+		public boolean anyTrue()
+		{
+			for(final boolean result : this.results)
+			{
+				if(result)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+
+
 	public abstract class AbstractCompletingTask<R>
 	extends StorageChannelTask.Abstract<R>
 	implements StorageChannelSynchronizingTask

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelTaskInitialize.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelTaskInitialize.java
@@ -137,6 +137,16 @@ public interface StorageChannelTaskInitialize extends StorageChannelTask
 			return firstIsNull;
 		}
 
+		/*
+		 * Every channel logs every store with the same task timestamp, so the channels' store
+		 * timestamp sequences are prefixes of one global sequence and a power loss can only cut a
+		 * suffix off a channel's log. The greatest store timestamp common to all channels is
+		 * therefore the minimum of the channels' latest timestamps. Each channel ahead of it rolls
+		 * back to the length its own log recorded for that timestamp (see
+		 * StorageFileManager#determineLastFileLength). Recovery is head-file only: a consensus below
+		 * a channel's head-file baseline (the store lies in a sealed file) is refused loudly during
+		 * recovery (reconcileForHeadOnlyRecovery), consensus 0 while another channel has stores here.
+		 */
 		private long determineConsistentStoreTimestamp()
 		{
 			if(this.checkAllTransactionsFilesMissing())
@@ -144,40 +154,40 @@ public interface StorageChannelTaskInitialize extends StorageChannelTask
 				return 0;
 			}
 
-			final long firstChannelLatestTimestamp = this.result[0].transactionsFileAnalysis().headFileLatestTimestamp();
-
+			long consistentTimestamp = Long.MAX_VALUE;
 			for(final StorageInventory inventory : this.result)
 			{
-				if(!isCompatibleTimestamp(firstChannelLatestTimestamp, inventory.transactionsFileAnalysis()))
+				final long latestTimestamp = inventory.transactionsFileAnalysis().headFileLatestTimestamp();
+				if(latestTimestamp < consistentTimestamp)
 				{
-					return this.fallbackDetermineConsistentStoreTimestamp();
+					consistentTimestamp = latestTimestamp;
 				}
 			}
-			return firstChannelLatestTimestamp;
-		}
 
-		private long fallbackDetermineConsistentStoreTimestamp()
-		{
-			final long firstChannelLastTimestamp = this.result[0].transactionsFileAnalysis().headFileLastConsistentStoreTimestamp();
-
-			for(final StorageInventory inventory : this.result)
+			/*
+			 * Timestamp 0 is not a common store but "before every store": a channel whose log
+			 * contains no store entry at all. Truncating the intact channels to their pre-first-
+			 * store state would silently discard all committed data they still hold - that is
+			 * never acceptable, so refuse loudly unless the whole storage is genuinely fresh.
+			 */
+			if(consistentTimestamp == 0)
 			{
-				if(!isCompatibleTimestamp(firstChannelLastTimestamp, inventory.transactionsFileAnalysis()))
+				for(final StorageInventory inventory : this.result)
 				{
-					throw new StorageExceptionConsistency("Inconsistent store timestamps between channels");
+					if(inventory.transactionsFileAnalysis().headFileLatestTimestamp() > 0)
+					{
+						throw new StorageExceptionConsistency(
+							"Inconsistent store timestamps between channels: a channel's"
+							+ " transactions log contains no store entry while others do."
+						);
+					}
 				}
+				return 0;
 			}
-			return firstChannelLastTimestamp;
-		}
 
-		private static boolean isCompatibleTimestamp(
-			final long                        candidateTimestamp,
-			final StorageTransactionsAnalysis transactionsFile
-		)
-		{
-			return transactionsFile.headFileLatestTimestamp()              == candidateTimestamp
-				|| transactionsFile.headFileLastConsistentStoreTimestamp() == candidateTimestamp
-			;
+			// a consensus below a channel's head baseline is handled in recovery
+			// (reconcileForHeadOnlyRecovery: a loud fail-stop); only consensus 0 is refused above.
+			return consistentTimestamp;
 		}
 
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
@@ -281,8 +281,38 @@ public interface StorageConnection extends UsageMarkable, Persister
 	 * only the head file keeps its latest store timestamps. FileDeletion entries are kept if the
 	 * storage data file still exists on the file system; otherwise, all entries of the deleted
 	 * file are removed.
+	 * <p>
+	 * Compaction collapses the store history a rollback might still need, so it waits for the
+	 * latest store to become durable on every channel. Under sustained store traffic the cleanup
+	 * may therefore be deferred and completed asynchronously at the next durability barrier rather
+	 * than within this call; the log is still compacted regardless of its size.
 	 */
 	public void issueTransactionsLogCleanup();
+
+	/**
+	 * Issues an all-channel storage flush and waits for completion: when this returns {@code true},
+	 * every store that returned before this call is physically written to the storage medium (data
+	 * files first, then transactions logs, on every channel).
+	 * <p>
+	 * Stores are not synchronized individually by default - a power loss can roll the storage back
+	 * to an older consistent state. This is the explicit durability point, e.g. before acknowledging
+	 * an external commit, taking a backup or stopping a machine; called periodically it bounds the
+	 * power-loss rollback window to the invocation interval.
+	 * <p>
+	 * This is a PURE durability point: the call returns once every channel synchronized its
+	 * files, and it carries none of the deferred durability-covered maintenance (head-file
+	 * rollover, log compaction, file cleanup) - that work rides exclusively on the internal
+	 * barriers the housekeeping durability gates request. The watermark this flush raises lets
+	 * such deferred work proceed once its durability gates next evaluate: with no further store
+	 * traffic that is the next housekeeping cycle, running inline; under sustained traffic the
+	 * gates are re-spoiled each cycle and the work runs at the next gate-requested barrier's
+	 * maintenance slot instead.
+	 *
+	 * @return {@code true} if every channel synchronized its files; {@code false} if the flush was
+	 *         skipped (e.g. read-only mode) or the calling thread was interrupted - the durability
+	 *         guarantee then does NOT hold.
+	 */
+	public boolean issueStorageFlush();
 
 	/**
 	 * Export storage graph adjacecy data to the specified directory.
@@ -652,6 +682,23 @@ public interface StorageConnection extends UsageMarkable, Persister
 			typeDictionaryExporter.exportTypeDictionary(this.persistenceManager().typeDictionary());
 		}
 		
+		@Override
+		public boolean issueStorageFlush()
+		{
+			try
+			{
+				return this.connectionRequestAcceptor.issueStorageFlush();
+			}
+			catch(final InterruptedException e)
+			{
+				// thread interrupted, task aborted: the durability guarantee does not hold. Restore
+				// the interrupt flag so the caller can distinguish this from a read-only skip (both
+				// return false) and terminate a commit-acknowledgement retry loop instead of spinning.
+				Thread.currentThread().interrupt();
+				return false;
+			}
+		}
+
 		@Override
 		public void issueTransactionsLogCleanup()
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -32,11 +32,14 @@ import org.eclipse.serializer.collections.XSort;
 import org.eclipse.serializer.collections.types.XGettingSequence;
 import org.eclipse.serializer.exceptions.MultiCauseException;
 import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.time.XTime;
 import org.eclipse.serializer.typing.Disposable;
+import org.eclipse.serializer.typing.KeyValue;
 import org.eclipse.serializer.typing.XTypes;
 import org.eclipse.serializer.util.BufferSizeProvider;
 import org.eclipse.serializer.util.X;
 import org.eclipse.serializer.util.logging.Logging;
+import org.eclipse.store.storage.types.StorageTransactionsAnalysis.Logic;
 import org.eclipse.store.storage.exceptions.StorageException;
 import org.eclipse.store.storage.exceptions.StorageExceptionCommitSizeExceeded;
 import org.eclipse.store.storage.exceptions.StorageExceptionConsistency;
@@ -257,6 +260,25 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 		// cleared in reset() directly, but kind of irrelevant.
 		private int pendingFileDeletes;
+
+		// all channel-local, written only by the channel thread; cleared in reset().
+		// durability gate state, see StorageRequestTaskStorageFlush:
+		// - lastWrittenStoreTimestamp: highest store timestamp written to the transactions log.
+		// - allDurableStoreTimestamp: every store below it is fully durable on every channel
+		//   (learned from this channel's own participation in a completed storage-flush task).
+		// - durabilityDeferredDeletes: file number -> guard timestamp frozen at the first
+		//   deletion attempt, so ongoing stores cannot defer a deletion forever.
+		private long lastWrittenStoreTimestamp;
+		private long allDurableStoreTimestamp ;
+		private boolean storageFlushRequested ;
+		// an UNCONDITIONAL (checkSize=false) log cleanup deferred by the durability gate: it must be
+		// completed unconditionally at barrier completion, not downgraded to the size-gated check.
+		private boolean unconditionalCompactionPending;
+		// set whenever this channel rolls a file over; polled (and cleared) by the current task so its
+		// completion barrier can make the sealed store durable on every channel (eager rollover
+		// durability - prevents a baseline collapse onto a not-yet-all-durable store).
+		private boolean rolloverOccurred;
+		private final EqHashTable<Long, Long> durabilityDeferredDeletes = EqHashTable.New();
 		
 		
 		// state 3.1: variable length content
@@ -821,12 +843,208 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 		private void checkForNewFile()
 		{
-			if(this.headFile.needsRetirement(this.dataFileEvaluator))
+			if(this.headFile == null || !this.headFile.needsRetirement(this.dataFileEvaluator))
 			{
-				this.createNextStorageFile();
+				return;
+			}
+
+			// Prompt, ungated rollover: files stay ~fileMaximumSize (no over-fill, no single-channel
+			// starvation). Eager durability comes from the store-task barrier fsync and the
+			// housekeeping/flush-completion pass; a residual below-baseline is a loud fail-stop in recovery.
+			this.createNextStorageFile();
+		}
+
+		/**
+		 * Synchronizes this channel's storage files: head data file first, then the transactions
+		 * log - a durable store entry whose chunk bytes are still volatile would fail the next
+		 * start's length validation, so data must reach the medium before its metadata (the same
+		 * order the deletion barrier uses). Sealed data files were already synchronized at their
+		 * rollover. Processing part of {@link StorageRequestTaskStorageFlush}.
+		 */
+		final boolean flushStorage()
+		{
+			if(!this.writeController.isWritable())
+			{
+				// read-only: nothing was synchronized, so the all-durable watermark must not advance
+				// and the durability gates keep deferring. Deliberately NO re-arm of the flush request
+				// here: this method cannot tell a gate-requested barrier from a PURE public one, and a
+				// pure barrier must not manufacture a request (it would produce a maintenance pass no
+				// gate ever asked for). A skipped gate barrier loses nothing - its adjacent maintenance
+				// still runs, and every gate with deferred work re-arms the request itself.
+				return false;
+			}
+			this.synchronizeStorageFiles();
+			return true;
+		}
+
+		/**
+		 * Synchronizes the head data file, then the transactions log - data before its metadata, so
+		 * a durable store entry never precedes its own chunk bytes on the medium. Unguarded: the
+		 * deletion barrier must synchronize regardless of {@link StorageWriteController#isWritable()}
+		 * (the source file is about to be unlinked), so it calls this directly; {@link #flushStorage()}
+		 * wraps it in the writability guard.
+		 */
+		private void synchronizeStorageFiles()
+		{
+			if(this.headFile != null)
+			{
+				this.headFile.synchronize();
+			}
+			if(this.fileTransactions != null)
+			{
+				this.fileTransactions.synchronize();
 			}
 		}
 
+		/**
+		 * Called after an all-channel storage flush completed successfully: every store below
+		 * the passed task timestamp is fully durable on every channel, so deferred file
+		 * lifecycle events below it may proceed with the next housekeeping check.
+		 * <p>
+		 * Pure watermark raise. Deliberately does NOT clear {@link #storageFlushRequested}: both
+		 * barrier flavors run this, but only the gate-requested one provides the maintenance slot
+		 * the request demands - a PURE public barrier clearing the request would strand the
+		 * deferred work it promises (e.g. an unconditional log compaction that periodic size-gated
+		 * passes can never pick up). The clear happens in
+		 * {@link #executeDurabilityCoveredMaintenance(long)}, the request's actual fulfillment.
+		 */
+		final void commitStorageFlush(final long allDurableTimestamp)
+		{
+			if(allDurableTimestamp > this.allDurableStoreTimestamp)
+			{
+				this.allDurableStoreTimestamp = allDurableTimestamp;
+			}
+		}
+
+		/**
+		 * Whether the passed store timestamp is durable on every channel - the single durability
+		 * predicate the rollover, deletion and compaction gates share.
+		 */
+		private boolean isStoreDurable(final long storeTimestamp)
+		{
+			return storeTimestamp <= this.allDurableStoreTimestamp;
+		}
+
+		/**
+		 * Executes the durability-gated maintenance this channel may have deferred, at the one
+		 * moment the gates pass by construction: within the storage-flush task's processing
+		 * (post-completion, after the watermark raise) this channel cannot yet have processed any
+		 * store task queued behind the flush, so its latest written store is provably durable on
+		 * every channel - and stays so for the whole
+		 * pass. Waiting for the next housekeeping cycle instead would race the next store under
+		 * sustained traffic: a store per cycle re-defers the periodic dissolution forever, so this
+		 * completion pass is the ONLY reclamation slot under sustained traffic and must run at the
+		 * full housekeeping file-check budget - a token slice here caps the reclamation rate far
+		 * below the write rate and lets garbage accumulate without bound.
+		 *
+		 * @param nanoTimeBudget the time budget for the file-cleanup pass - the caller passes the
+		 *        housekeeping file-check time budget.
+		 */
+		final void executeDurabilityCoveredMaintenance(final long nanoTimeBudget)
+		{
+			// This pass IS the fulfillment of a pending flush request, so the request is cleared
+			// here and only here - never at the bare watermark raise (commitStorageFlush), which a
+			// PURE public barrier also performs without providing this slot. Cleared only when the
+			// watermark caught up (a skipped barrier raised nothing); the gates below re-arm it for
+			// any work they must defer again.
+			if(this.isStoreDurable(this.lastWrittenStoreTimestamp))
+			{
+				this.storageFlushRequested = false;
+			}
+
+			// both entry points are self-guarded no-ops when nothing is pending
+			this.checkForNewFile();
+			// Honor a deferred UNCONDITIONAL (checkSize=false) log cleanup unconditionally: an explicit
+			// issueTransactionsLogCleanup() promises compaction regardless of the log's current size, so
+			// completing it size-gated would silently skip a below-limit garbage-heavy log. Consumed
+			// here (the store is durable by construction at barrier completion, so it no longer defers).
+			final boolean checkSize = !this.unconditionalCompactionPending;
+			this.unconditionalCompactionPending = false;
+			this.internalTransactionFileCheck(checkSize);
+
+			// the deferred dissolution/deletion work at the configured file-check budget, see above.
+			// The deadline is taken fresh so a slow compaction above cannot starve the cleanup pass.
+			// Skipped if cleanup is off.
+			if(this.isFileCleanupEnabled())
+			{
+				this.internalCheckForCleanup(
+					XTime.calculateNanoTimeBudgetBound(nanoTimeBudget),
+					this.dataFileEvaluator
+				);
+			}
+		}
+
+		final boolean pollStorageFlushRequest()
+		{
+			if(!this.storageFlushRequested)
+			{
+				return false;
+			}
+			// read-only: leave the request armed and do not signal an enqueue. A barrier issued now
+			// would only skip on every channel, churning one futile all-channel rendezvous per
+			// housekeeping cycle for the whole read-only window; it fires on the first cycle after
+			// writability returns instead.
+			if(!this.writeController.isWritable())
+			{
+				return false;
+			}
+			// cleared on poll: one enqueued task per request; a still-failing gate re-requests
+			this.storageFlushRequested = false;
+			return true;
+		}
+
+		final void requestStorageFlush()
+		{
+			this.storageFlushRequested = true;
+		}
+
+		/**
+		 * Gates the physical deletion of a dissolved file (transactions entry and unlink alike)
+		 * on all-channel durability: rolling back a not-everywhere-durable store truncates the
+		 * transfers logged above it, and their bytes are then re-acquired from the source files
+		 * - which must therefore still exist. Deferred deletions are revisited by the file
+		 * cleanup cursor once the requested storage flush raised the watermark.
+		 */
+		private boolean deletionDurabilityGatePassed(final StorageLiveDataFile.Default file)
+		{
+			Long guardTimestamp = this.durabilityDeferredDeletes.get(file.number());
+			if(guardTimestamp == null)
+			{
+				guardTimestamp = this.lastWrittenStoreTimestamp;
+			}
+			if(this.isStoreDurable(guardTimestamp))
+			{
+				this.durabilityDeferredDeletes.removeFor(file.number());
+				return true;
+			}
+			this.durabilityDeferredDeletes.put(file.number(), guardTimestamp);
+			this.storageFlushRequested = true;
+			return false;
+		}
+
+		private boolean isDurabilityDeferred(final StorageLiveDataFile.Default file)
+		{
+			return this.durabilityDeferredDeletes.get(file.number()) != null;
+		}
+
+		/**
+		 * Retires the head file and opens its successor. The new file-creation entry collapses the
+		 * reload's rollback baseline onto the latest store, so recovery can never cut below it: a
+		 * consensus below a channel's head-file baseline is a loud fail-stop
+		 * ({@link #reconcileForHeadOnlyRecovery}), recovery being head-file only.
+		 * <p>
+		 * No caller gates this on durability; instead every rollover is made EAGERLY durable, so the
+		 * store the baseline collapses onto is all-channel durable before a crash:
+		 * <ul>
+		 *   <li>a rollover during a store task is fsync'd on every channel at that task's completion
+		 *       barrier (see {@code StorageRequestTaskStoreEntities});</li>
+		 *   <li>a rollover with no following store (housekeeping dissolution, import) requests a flush
+		 *       and is fsync'd at the flush-barrier completion ({@link #executeDurabilityCoveredMaintenance(long)}).</li>
+		 * </ul>
+		 * A NEW caller MUST preserve this: sealing a not-yet-all-durable store with no fsync catching up
+		 * before a crash lets a power loss leave a consensus below the new baseline that BRICKS the
+		 * storage (permanent startup refusal), not merely degraded recovery.
+		 */
 		final void createNextStorageFile()
 		{
 			// Durability floor: the outgoing head is now complete and will not be appended again.
@@ -835,6 +1053,30 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// then rolled over mid-dissolution.
 			this.headFile.synchronize();
 			this.createNewStorageFile(this.headFile.number() + 1);
+
+			// Eager rollover durability: the new file's creation entry collapses the recovery baseline
+			// onto the latest store, which must be all-channel durable before a crash (else a power loss
+			// leaves an unrecoverable consensus below the baseline).
+			// (1) flag the rollover so the current task's completion barrier makes it durable everywhere;
+			//     also covers a housekeeping rollover picked up by the next store task.
+			// (2) if the sealed store is not yet all-durable, request a flush so a rollover with no
+			//     following store on this channel (housekeeping / import) still becomes durable soon.
+			this.rolloverOccurred = true;
+			if(!this.isStoreDurable(this.lastWrittenStoreTimestamp))
+			{
+				this.storageFlushRequested = true;
+			}
+		}
+
+		/**
+		 * Reads and clears the rollover flag: whether this channel rolled a file over since the last
+		 * poll. Called once per task on the channel thread, so the plain read-and-clear is race-free.
+		 */
+		final boolean pollRolloverOccurred()
+		{
+			final boolean occurred = this.rolloverOccurred;
+			this.rolloverOccurred = false;
+			return occurred;
 		}
 		
 		private long ensureHeadFileTotalLength()
@@ -1278,17 +1520,23 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			final StorageChannel   parent
 		)
 		{
+			// a consensus store below this channel's head baseline (a sealed-file store), or a
+			// data-bearing file orphaned above the log's head, is a multi-file divergence; reduce it
+			// to the head-only path (remove the files above the cut, truncate the log to the store),
+			// so everything below runs unchanged on the head-only case.
+			final StorageInventory inventory =
+				this.reconcileForHeadOnlyRecovery(consistentStoreTimestamp, storageInventory);
 
 			final EqHashTable<Long, StorageDataInventoryFile> supplementedMissingEmptyFiles = EqHashTable.New();
-			
+
 			// validate file lengths, even in case of no files, to validate transactions entries to that state
 			final long unregisteredEmptyLastFileNumber = this.validateStorageDataFilesLength(
-				storageInventory,
+				inventory,
 				supplementedMissingEmptyFiles
 			);
-			
+
 			final StorageInventory effectiveStorageInventory = this.determineEffectiveStorageInventory(
-				storageInventory,
+				inventory,
 				supplementedMissingEmptyFiles
 			);
 
@@ -1351,7 +1599,90 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				}
 			}
 		}
-		
+
+		/**
+		 * Head-file-only recovery guard, run before validation. Recovery only ever cuts within the head
+		 * file, so a consensus store below this channel's head-file baseline (in a sealed, earlier file)
+		 * is not repairable and is refused loudly - a rollover sealed a not-yet-all-durable store (made
+		 * rare by eager rollover durability) or a channel directory was restored from an older
+		 * generation. A data file orphaned above the log head by a crash mid-rollover is removed (a
+		 * recoverable artifact). No-op when the consensus lies in the head file and no orphan sits above.
+		 */
+		private StorageInventory reconcileForHeadOnlyRecovery(
+			final long             consistentStoreTimestamp,
+			final StorageInventory storageInventory
+		)
+		{
+			final StorageTransactionsAnalysis tf = storageInventory.transactionsFileAnalysis();
+			if(tf == null || tf.isEmpty() || consistentStoreTimestamp <= 0)
+			{
+				return storageInventory;
+			}
+
+			// cheap pre-checks so anomaly handling runs only for a genuine divergence:
+			// (a) the consensus lies below the head baseline (a sealed-file store -> fail-stop), or
+			// (b) ANY file sits above the highest file the log knows (an orphan from an interrupted
+			//     rollover -> remove it). Include 0-byte orphans: a crash between creating the successor
+			//     and writing its FILE_CREATION entry leaves a file the log never recorded, else picked
+			//     up as the head on re-read.
+			// File creations use strictly increasing numbers, so the log's highest file is its last entry.
+			final long maxLoggedFileNumber = tf.transactionsFileEntries().values().peek().fileNumber();
+			boolean orphanFileAboveLog = false;
+			for(final StorageDataInventoryFile file : storageInventory.dataFiles().values())
+			{
+				if(file.number() > maxLoggedFileNumber)
+				{
+					orphanFileAboveLog = true;
+					break;
+				}
+			}
+			if(consistentStoreTimestamp >= tf.headFileBaselineTimestamp() && !orphanFileAboveLog)
+			{
+				return storageInventory;
+			}
+
+			// A consensus below the head-file baseline lies in a sealed, earlier file and is NOT
+			// repairable by the head-only rollback. Refuse loudly rather than span: eager rollover
+			// durability makes a power loss practically never produce this, and the remaining cause -
+			// a directory restored from an older generation - must not silently discard the intact
+			// channels' committed data.
+			if(consistentStoreTimestamp < tf.headFileBaselineTimestamp())
+			{
+				throw new StorageExceptionConsistency(
+					this.channelIndex() + " consensus store timestamp " + consistentStoreTimestamp
+					+ " lies below this channel's head-file baseline " + tf.headFileBaselineTimestamp()
+					+ ": below-baseline divergence. Recovery is head-file only - a rollover sealed a"
+					+ " not-yet-all-durable store, or a channel directory was restored from an older"
+					+ " generation. Refusing to start rather than discard committed data."
+				);
+			}
+
+			// consensus IS head-recoverable, but a data file is orphaned above the log head: an
+			// interrupted rollover created the physical successor before its FILE_CREATION entry reached
+			// the log. Remove it (and its backup copy); the head-only recovery below then proceeds.
+			if(!this.writeController.isWritable())
+			{
+				throw new StorageExceptionConsistency(
+					this.channelIndex() + " an orphaned data file above the log head cannot be removed in read-only mode"
+				);
+			}
+			for(final StorageDataInventoryFile file : storageInventory.dataFiles().values())
+			{
+				if(file.number() > maxLoggedFileNumber)
+				{
+					AFS.executeWriting(file.file(), wf ->
+					{
+						if(wf.exists())
+						{
+							wf.delete();
+						}
+					});
+					this.deleteBackupDataFile(file.number());
+				}
+			}
+			return this.readStorage();
+		}
+
 		protected StorageInventory determineEffectiveStorageInventory(
 			final StorageInventory                            storageInventory             ,
 			final EqHashTable<Long, StorageDataInventoryFile> supplementedMissingEmptyFiles
@@ -1408,33 +1739,58 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			this.backupHandler.synchronize(inventory);
 		}
 
+		/**
+		 * Mirrors a recovery-time data-file removal to the backup - used when
+		 * {@link #reconcileForHeadOnlyRecovery} removes an orphan file left above the log head by an
+		 * interrupted rollover - with the same rescue-move / raw-delete semantics as
+		 * {@link #deleteBackupTransactionsFile()}. Runs during recovery, before the backup handler
+		 * registers its inventory, so the subsequent synchronization no longer sees the backup as ahead
+		 * of the primary and a restore no longer resurrects the removed file.
+		 */
+		private void deleteBackupDataFile(final long fileNumber)
+		{
+			if(this.backupHandler == null)
+			{
+				return;
+			}
+			this.deleteBackupFile(
+				this.backupHandler.setup().backupFileProvider().provideBackupDataFile(this.channelIndex(), fileNumber),
+				"backup data file"
+			);
+		}
+
 		private void deleteBackupTransactionsFile()
 		{
-			final StorageBackupFileProvider backupFileProvider =
-				this.backupHandler.setup().backupFileProvider();
-			final StorageBackupTransactionsFile backupTransactionsFile =
-				backupFileProvider.provideBackupTransactionsFile(this.channelIndex());
-			final AFile backupFile = backupTransactionsFile.file();
-			if(!backupFile.exists())
+			this.deleteBackupFile(
+				this.backupHandler.setup().backupFileProvider().provideBackupTransactionsFile(this.channelIndex()),
+				"backup transactions file"
+			);
+		}
+
+		/**
+		 * Removes a backup file during recovery with the backup handler's own deletion semantics:
+		 * rescue-move when a deletion target is configured, otherwise a raw delete. Raw, released AFS
+		 * accesses - a retained lease would collide with the handler's own file wrapper during the
+		 * subsequent synchronization. A silently retained file would defeat the removal (at equal length
+		 * the synchronization keeps the stale backup content), so a failed raw delete throws.
+		 */
+		private void deleteBackupFile(final StorageBackupChannelFile backupFile, final String description)
+		{
+			final AFile file = backupFile.file();
+			if(!file.exists())
 			{
 				return;
 			}
 
-			// mirror the backup handler's own deletion semantics: rescue-move when configured.
-			// Raw, released AFS accesses: a retained lease would collide with the handler's
-			// own file wrapper during the subsequent synchronization.
-			final AFile deletionTargetFile = backupFileProvider.provideDeletionTargetFile(backupTransactionsFile);
-			AFS.executeWriting(backupFile, wf ->
+			final AFile deletionTargetFile =
+				this.backupHandler.setup().backupFileProvider().provideDeletionTargetFile(backupFile);
+			AFS.executeWriting(file, wf ->
 			{
 				if(deletionTargetFile == null)
 				{
 					if(wf.exists() && !wf.delete())
 					{
-						// a silently retained file would defeat the invalidation: at equal
-						// length, the synchronization would keep the stale backup content
-						throw new StorageException(
-							"Could not delete backup transactions file " + backupFile.toPathString()
-						);
+						throw new StorageException("Could not delete " + description + " " + file.toPathString());
 					}
 				}
 				else
@@ -1484,7 +1840,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			this.ensureTransactionsFile(taskTimestamp, storageInventory, unregisteredEmptyLastFileNumber);
 
 			// special-case handle the last file
-			this.handleLastFile(this.headFile, lastFileLength);
+			this.handleLastFile(this.headFile, lastFileLength, consistentStoreTimestamp);
 
 			// check if last file is over-sized and should be retired right away.
 			this.checkForNewFile();
@@ -1526,16 +1882,177 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			}
 			else if(tFileAnalysis.headFileLastConsistentStoreTimestamp() == consistentStoreTimestamp)
 			{
-				// note: covers a successful transfer (which is channel-local) that happened after the store as well!
-				return tFileAnalysis.headFileLastConsistentStoreLength();
+				// common case of a one-store divergence: the cut length is already derived
+				return this.validatedCutLength(tFileAnalysis, tFileAnalysis.headFileLastConsistentStoreLength());
 			}
 			else
+			{
+				/*
+				 * Consensus below both retained anchors: divergence by more than one store, or
+				 * every head store rolled back onto the head's creation baseline. The cut length
+				 * is the consensus store's recorded head length advanced over the channel-local
+				 * transfers that followed it (incl. across a baseline collapse onto it). It is
+				 * re-read from the log only in this rare case instead of being retained in
+				 * memory - a head file can accumulate millions of store entries. The baseline
+				 * case must use the same folding: cutting at the raw creation length would cut
+				 * below transfers logged between the head's creation and its first store.
+				 */
+				return this.validatedCutLength(
+					tFileAnalysis,
+					this.readStoreAnchorLength(tFileAnalysis, consistentStoreTimestamp)
+				);
+			}
+		}
+
+		/**
+		 * Determines, in one pass over this channel's transactions log, the head length to roll back
+		 * to for the passed consistent store timestamp: the store's recorded length advanced over any
+		 * channel-local transfers and truncations logged before the next store (the same folding
+		 * {@code handleEntryStore} / {@code handleEntryFileTruncation} apply). Missing a transfer would
+		 * cut below relocated bytes {@link #validatedCutLength} must keep; missing a truncation would
+		 * cut above truncated-away bytes and load stale data.
+		 * <p>
+		 * The consensus store's window survives the log events that collapse onto it: a recovery
+		 * truncation stamped with its timestamp re-opens the window at the cut length, and a file
+		 * creation while the window is open re-anchors at the new head's creation length (the
+		 * baseline collapse) - so transfers logged after either event still fold into the anchor.
+		 */
+		private long readStoreAnchorLength(
+			final StorageTransactionsAnalysis tFileAnalysis           ,
+			final long                        consistentStoreTimestamp
+		)
+		{
+			final long[]    anchorLength = {-1L}  ;
+			final boolean[] capturing    = {false};
+			tFileAnalysis.transactionsFile().processBy((address, availableEntryLength) ->
+			{
+				if(availableEntryLength < 0)
+				{
+					return true; // gap / comment, signaled by the read loop
+				}
+				if(availableEntryLength < Logic.getEntryLength(address))
+				{
+					// entry cut by the read-window boundary: re-read at this position
+					return false;
+				}
+				switch(Logic.getEntryType(address))
+				{
+					case Logic.TYPE_FILE_CREATION:
+					{
+						/*
+						 * A creation collapses the rollback baseline onto the current store. If that
+						 * is the consensus store (window open), the anchor moves into the new head's
+						 * coordinates - its creation length - and the window stays open for the
+						 * transfers that follow (exactly the collapse handleEntryFileCreation applies).
+						 * Otherwise prior hits belong to a closed file and are invalid as head cut
+						 * coordinates.
+						 */
+						anchorLength[0] = capturing[0] ? Logic.getFileLength(address) : -1L;
+						return true;
+					}
+					case Logic.TYPE_STORE:
+					{
+						if(Logic.getEntryTimestamp(address) == consistentStoreTimestamp)
+						{
+							// anchor at this store's length, then extend it over the transfers that
+							// follow until the next store - they are channel-local and kept, exactly
+							// as handleEntryStore folds them into lastConsistentStoreLength.
+							anchorLength[0] = Logic.getFileLength(address);
+							capturing[0]    = true;
+						}
+						else
+						{
+							// a different store ends the matched store's transfer window
+							capturing[0] = false;
+						}
+						return true;
+					}
+					case Logic.TYPE_TRANSFER:
+					{
+						// channel-local growth inside the window; last one wins.
+						if(capturing[0])
+						{
+							anchorLength[0] = Logic.getFileLength(address);
+						}
+						return true;
+					}
+					case Logic.TYPE_FILE_TRUNCATION:
+					{
+						/*
+						 * A recovery truncation stamped with the consensus store's timestamp collapses
+						 * the head back onto that store (see handleLastFile), so the anchor re-opens at
+						 * the cut length and transfers logged after it belong to the survivor's window
+						 * again - exactly as handleEntryFileTruncation stamps the survivor on a deep cut.
+						 * Missing this re-open would cut below such a transfer's bytes: a spurious
+						 * fail-stop when its source file is already deleted (validatedCutLength).
+						 */
+						if(Logic.getEntryTimestamp(address) == consistentStoreTimestamp)
+						{
+							anchorLength[0] = Logic.getFileLength(address);
+							capturing[0]    = true;
+						}
+						else if(capturing[0])
+						{
+							// a cut inside the open window; last length wins.
+							anchorLength[0] = Logic.getFileLength(address);
+						}
+						return true;
+					}
+					case Logic.TYPE_FILE_DELETION:
+					{
+						// length-neutral for the head file (source-file deletion); never moves the anchor.
+						// Enumerated so the default below can fail-loud on any unclassified type.
+						return true;
+					}
+					default:
+					{
+						// all length-affecting entry types are handled above; an unclassified one here
+						// could hide a truncated head, so refuse rather than risk a stale cut.
+						throw new StorageExceptionConsistency(
+							"Unexpected transactions entry type " + Logic.getEntryType(address)
+							+ " while re-reading the rollback anchor of channel " + this.channelIndex()
+						);
+					}
+				}
+			});
+
+			if(anchorLength[0] < 0)
 			{
 				// should never happen because of all the validations before
 				throw new StorageExceptionConsistency(
 					"Inconsistent last timestamps in last file of channel " + this.channelIndex()
 				);
 			}
+			return anchorLength[0];
+		}
+
+		/**
+		 * Guards the rollback of unconfirmed stores: transfers whose bytes lie above the cut are
+		 * truncated with the stores' chunks and recovered from their source files
+		 * ({@link StorageTransactionsAnalysis#headFileTransfers()}). If such a source file is
+		 * already deleted, truncating would destroy the transferred entities' last copy -
+		 * refuse to initialize instead of losing committed data silently.
+		 */
+		private long validatedCutLength(final StorageTransactionsAnalysis tFileAnalysis, final long cutLength)
+		{
+			for(final KeyValue<Long, Long> transfer : tFileAnalysis.headFileTransfers())
+			{
+				if(transfer.value() <= cutLength)
+				{
+					continue; // below the cut: survives the truncation
+				}
+				final StorageTransactionEntry sourceFile = tFileAnalysis.transactionsFileEntries().get(transfer.key());
+				if(sourceFile == null || sourceFile.isDeleted())
+				{
+					throw new StorageExceptionConsistency(
+						"Channel " + this.channelIndex() + " cannot roll back its unconfirmed latest stores:"
+						+ " a transfer logged above the rollback point has the already deleted file "
+						+ transfer.key() + " as its source, so truncating the transferred bytes"
+						+ " would destroy their last copy."
+					);
+				}
+			}
+			return cutLength;
 		}
 								
 		private void initializeForNoFiles(final long taskTimestamp, final StorageInventory storageInventory)
@@ -1658,6 +2175,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				headFileNewTotalLength      ,
 				timestamp
 			);
+			this.lastWrittenStoreTimestamp = timestamp;
 			this.writer.writeTransactionEntryStore(
 				this.fileTransactions    ,
 				this.entryBufferWrapStore,
@@ -1755,6 +2273,16 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			
 			// at this point, it is either 0 already or it won't matter since everything has been cleared.
 			this.pendingFileDeletes = 0;
+
+			// durability gate state: cleared timestamps make the gates pass trivially, which is
+			// correct after a reset - everything readable at initialization is the reconciled
+			// baseline, and only stores of the new session can be subject to a rollback.
+			this.lastWrittenStoreTimestamp      = 0;
+			this.allDurableStoreTimestamp       = 0;
+			this.storageFlushRequested          = false;
+			this.unconditionalCompactionPending = false;
+			this.rolloverOccurred               = false;
+			this.durabilityDeferredDeletes.clear();
 		}
 		
 		/**
@@ -1778,18 +2306,21 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		}
 
 		final void handleLastFile(
-			final StorageLiveDataFile.Default lastFile      ,
-			final long                        lastFileLength
+			final StorageLiveDataFile.Default lastFile              ,
+			final long                        lastFileLength        ,
+			final long                        survivorStoreTimestamp
 		)
 		{
 			if(lastFileLength != lastFile.size())
 			{
 				// reaching here means in any case that the file has to be truncated and its header must be updated
 
-				final long timestamp = this.timestampProvider.currentNanoTimestamp();
-				
-				// write truncation entry (BEFORE the actual truncate)
-				this.writeTransactionsEntryFileTruncation(lastFile, timestamp, lastFileLength);
+				// Stamp the truncation entry with the surviving (consensus) store's timestamp, not a fresh
+				// one: a deep rollback cuts below the anchors the log replay retains, and
+				// handleEntryFileTruncation recovers the survivor's timestamp from this entry so
+				// headFileLatestTimestamp (the consensus key) no longer names a rolled-back store. For a
+				// shallow cut the length-matched anchor drives the reset, so this timestamp is safe there too.
+				this.writeTransactionsEntryFileTruncation(lastFile, survivorStoreTimestamp, lastFileLength);
 
 				// (20.06.2014 TM)TODO: truncator function to give a chance to evaluate / rescue the doomed data
 				this.writer.truncate(lastFile, lastFileLength, this.fileProvider);
@@ -2105,22 +2636,37 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				// delete pending file and do special case checking. This never applies to head files automatically
 				if(!this.fileCleanupCursor.hasUsers())
 				{
-					// an iterable (non-detached) file with no users can only mean a pending delete.
-					if(!this.fileCleanupCursor.executeIfUnsuedData(this.pendingDeleter))
+					// durability gate: a deferred file is skipped and revisited after the flush
+					if(this.deletionDurabilityGatePassed(this.fileCleanupCursor))
 					{
-						// should a new usage have been registered right after checking, then break and try again later
-						break;
-					}
-					
-					// account for special case of removed file being the anchor file (sadly redundant to below)
-					if(this.fileCleanupCursor == cycleAnchorFile)
-					{
-						this.fileCleanupCursor = cycleAnchorFile = cycleAnchorFile.next;
-						continue;
+						// an iterable (non-detached) file with no users can only mean a pending delete.
+						if(!this.fileCleanupCursor.executeIfUnsuedData(this.pendingDeleter))
+						{
+							// should a new usage have been registered right after checking, then break and try again later
+							break;
+						}
+
+						// account for special case of removed file being the anchor file (sadly redundant to below)
+						if(this.fileCleanupCursor == cycleAnchorFile)
+						{
+							this.fileCleanupCursor = cycleAnchorFile = cycleAnchorFile.next;
+							continue;
+						}
 					}
 				}
 				else if(fileDissolver.needsDissolving(this.fileCleanupCursor))
 				{
+					// Eager rollover durability: dissolving transfers live chains into the head may roll it
+					// over, collapsing the recovery baseline onto the head's latest store. Defer the whole
+					// dissolution while that store is not yet all-channel durable, so no rollover seals a
+					// non-durable store; request a flush, and the deferred dissolution then runs at the
+					// flush-barrier completion (executeDurabilityCoveredMaintenance), where it is durable.
+					if(!this.isStoreDurable(this.lastWrittenStoreTimestamp))
+					{
+						this.storageFlushRequested = true;
+						break;
+					}
+
 					if(this.fileCleanupCursor == this.headFile)
 					{
 						this.createNextStorageFile();
@@ -2128,12 +2674,17 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 					if(!this.incrementalDissolveStorageFile(this.fileCleanupCursor, nanoTimeBudgetBound))
 					{
-						continue;
+						if(!this.isDurabilityDeferred(this.fileCleanupCursor))
+						{
+							continue;
+						}
+						// deletion deferred by the durability gate: advance past the file and
+						// revisit it once the requested flush raised the watermark
 					}
 					// file has been dissolved completely and deleted, do special case checking here as well.
 
 					// account for special case of removed file being the anchor file (sadly redundant to above)
-					if(this.fileCleanupCursor == cycleAnchorFile)
+					else if(this.fileCleanupCursor == cycleAnchorFile)
 					{
 						this.fileCleanupCursor = cycleAnchorFile = cycleAnchorFile.next;
 						continue;
@@ -2147,8 +2698,8 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				// Advance to next file, abort if full cycle is completed.
 				if((this.fileCleanupCursor = this.fileCleanupCursor.next) == cycleAnchorFile)
 				{
-					// if there are still pending deletes, file house keeping cannot be turned off
-					if(this.pendingFileDeletes > 0)
+					// if there are still pending or durability-deferred deletes, file house keeping cannot be turned off
+					if(this.pendingFileDeletes > 0 || !this.durabilityDeferredDeletes.isEmpty())
 					{
 
 						// at least one more file is pending deletion
@@ -2174,6 +2725,13 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 			if(this.incrementalTransferEntities(file, nanoTimeBudgetBound))
 			{
+				// durability gate; the caller recognizes the deferral via isDurabilityDeferred
+				// and advances past the file instead of retrying within this check.
+				if(!this.deletionDurabilityGatePassed(file))
+				{
+					return false;
+				}
+
 				if(file.unregisterUsageClosingData(this, this.deleter))
 				{
 					return true;
@@ -2216,9 +2774,9 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			// already forced at their rollover, this covers the not-yet-rolled current head - and
 			// (b) the transactions file must hold the transfer + deletion entries durably, so a crash
 			// can never leave the source unlinked while the records that relocated its data, or the
-			// record explaining its absence, are still in page cache.
-			this.headFile.synchronize();
-			this.fileTransactions.synchronize();
+			// record explaining its absence, are still in page cache. Unguarded on purpose: this must
+			// run even in a non-writable state, since the file is being unlinked regardless.
+			this.synchronizeStorageFiles();
 
 			// physically delete file after the transactions entry is ensured
 			this.writer.delete(file, this.writeController, this.fileProvider);
@@ -2637,9 +3195,36 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			{
 				return true;
 			}
-			
+
+			// nothing to compact: never request a durability barrier for a no-op - a steadily
+			// storing application would otherwise enqueue one futile all-channel fsync barrier
+			// per housekeeping cycle
+			if(!this.transactionFileCleaner.requiresCompaction(checkSize))
+			{
+				return true;
+			}
+
+			/*
+			 * Compaction durability gate: compacting collapses the log's store history, which
+			 * the rollback of a not-everywhere-durable store might still need as its cut
+			 * coordinate. Deferred until a storage flush confirmed every own store durable on
+			 * all channels - collapsed history is then never rollback-relevant again.
+			 */
+			if(!this.isStoreDurable(this.lastWrittenStoreTimestamp))
+			{
+				this.storageFlushRequested = true;
+				// remember an UNCONDITIONAL request so its intent survives the deferral: the barrier
+				// completion must then compact regardless of size, not size-gated (see the contract of
+				// executeDurabilityCoveredMaintenance and issueTransactionsLogCleanup).
+				if(!checkSize)
+				{
+					this.unconditionalCompactionPending = true;
+				}
+				return false;
+			}
+
 			this.transactionFileCleaner.compactTransactionsFile(checkSize);
-			
+
 			return true;
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestAcceptor.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestAcceptor.java
@@ -79,7 +79,10 @@ public interface StorageRequestAcceptor
 
 	public void issueTransactionsLogCleanup()
 		throws InterruptedException;
-	 
+
+	public boolean issueStorageFlush()
+		throws InterruptedException;
+
 	// exporting //
 	
 	public List<AdjacencyFiles> exportAdjacencyData(long rootID, Path workingDir)
@@ -228,7 +231,21 @@ public interface StorageRequestAcceptor
 		public boolean issueFileCheck(final long nanoTimeBudget)
 			throws InterruptedException
 		{
-			return waitOnTask(this.taskBroker.issueFileCheck(nanoTimeBudget)).result();
+			boolean completed = waitOnTask(this.taskBroker.issueFileCheck(nanoTimeBudget)).result();
+
+			/*
+			 * A durability-gated deletion defers to the all-channel storage flush the check
+			 * itself enqueues (see StorageRequestTaskStorageFlush); the next pass then executes
+			 * it, so an unlimited-budget ("full") check retries to preserve its complete-in-one-
+			 * call semantics. Bounded: incompleteness from still-registered file users does not
+			 * resolve by repeating. Finite-budget checks keep their poll-and-continue contract.
+			 */
+			for(int retry = 0; !completed && nanoTimeBudget == Long.MAX_VALUE && retry < 2; retry++)
+			{
+				completed = waitOnTask(this.taskBroker.issueFileCheck(nanoTimeBudget)).result();
+			}
+
+			return completed;
 		}
 
 		@Override
@@ -239,10 +256,26 @@ public interface StorageRequestAcceptor
 		}
 
 		@Override
+		public boolean issueStorageFlush()
+			throws InterruptedException
+		{
+			// on demand, never coalesced: the returned durability must cover every store
+			// enqueued before this call, which an older pending barrier would not
+			return waitOnTask(this.taskBroker.issueOnDemandStorageFlush()).result();
+		}
+
+		@Override
 		public void issueTransactionsLogCleanup()
 			throws InterruptedException
 		{
-			waitOnTask(this.taskBroker.issueTransactionsLogCleanup());
+			boolean completed = waitOnTask(this.taskBroker.issueTransactionsLogCleanup()).result();
+
+			// the compaction durability gate defers to the storage flush the cleanup itself
+			// enqueues; the next pass then compacts. Bounded like issueFileCheck's retry.
+			for(int retry = 0; !completed && retry < 2; retry++)
+			{
+				completed = waitOnTask(this.taskBroker.issueTransactionsLogCleanup()).result();
+			}
 		}
 		
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskCreator.java
@@ -104,6 +104,17 @@ public interface StorageRequestTaskCreator
 		int                        channelCount       ,
 		StorageOperationController operationController
 	);
+
+	public StorageRequestTaskStorageFlush createStorageFlushTask(
+		int                        channelCount       ,
+		StorageOperationController operationController,
+		boolean                    carriesMaintenance
+	);
+
+	public StorageRequestTaskDurabilityMaintenance createDurabilityMaintenanceTask(
+		int                        channelCount       ,
+		StorageOperationController operationController
+	);
 	
 	public StorageRequestTaskExportAdjacencyData createExportAdjacencyDataTask
 	(
@@ -353,6 +364,34 @@ public interface StorageRequestTaskCreator
 			final StorageOperationController operationController)
 		{
 			return new StorageRequestTaskTransactionsLogCleanup.Default(
+				this.timestampProvider.currentNanoTimestamp(),
+				channelCount,
+				operationController
+			);
+		}
+
+		@Override
+		public StorageRequestTaskStorageFlush createStorageFlushTask(
+			final int                        channelCount       ,
+			final StorageOperationController operationController,
+			final boolean                    carriesMaintenance
+		)
+		{
+			return new StorageRequestTaskStorageFlush.Default(
+				this.timestampProvider.currentNanoTimestamp(),
+				channelCount,
+				operationController,
+				carriesMaintenance
+			);
+		}
+
+		@Override
+		public StorageRequestTaskDurabilityMaintenance createDurabilityMaintenanceTask(
+			final int                        channelCount       ,
+			final StorageOperationController operationController
+		)
+		{
+			return new StorageRequestTaskDurabilityMaintenance.Default(
 				this.timestampProvider.currentNanoTimestamp(),
 				channelCount,
 				operationController

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskDurabilityMaintenance.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskDurabilityMaintenance.java
@@ -1,0 +1,70 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * Executes each channel's deferred durability-covered maintenance (head-file rollover, log
+ * compaction, the file-cleanup pass at the configured file-check budget); see
+ * {@link StorageChannel#executeDurabilityCoveredMaintenance()}.
+ * <p>
+ * Always enqueued by the broker directly behind a gate-requested
+ * {@link StorageRequestTaskStorageFlush} under the same monitor hold (public on-demand barriers
+ * stay pure): queue adjacency guarantees no store task is processed between the barrier's
+ * watermark raise and this maintenance, so the durability gates provably pass for the
+ * maintenance's whole duration - the property that makes the barrier the only reclamation slot
+ * under sustained store traffic. Enqueued separately (instead of running inside the barrier
+ * task) so issuers waiting on the barrier wake at pure file-synchronization latency and the two
+ * concerns stay independent.
+ * <p>
+ * Self-guarded: if the barrier failed or was skipped (read-only), the watermark was not raised
+ * and every gate inside the maintenance simply re-defers and re-arms its flush request - this
+ * task then degrades to a cheap no-op. Fire-and-forget; a maintenance failure escalates to the
+ * operation controller inside the channel's maintenance method itself.
+ */
+public interface StorageRequestTaskDurabilityMaintenance extends StorageRequestTask
+{
+	public final class Default
+	extends StorageChannelSynchronizingTask.AbstractCompletingTask<Void>
+	implements StorageRequestTaskDurabilityMaintenance
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(
+			final long                       timestamp   ,
+			final int                        channelCount,
+			final StorageOperationController controller
+		)
+		{
+			super(timestamp, channelCount, controller);
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		protected final Void internalProcessBy(final StorageChannel channel)
+		{
+			channel.executeDurabilityCoveredMaintenance();
+			return null;
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskFileCheck.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskFileCheck.java
@@ -29,8 +29,8 @@ public interface StorageRequestTaskFileCheck extends StorageRequestTask
 		// instance fields //
 		////////////////////
 
-		final long    nanoTimeBudget;
-		      boolean completed     ;
+		final long                                            nanoTimeBudget;
+		final StorageChannelSynchronizingTask.ChannelResults completed     ;
 
 
 
@@ -47,6 +47,7 @@ public interface StorageRequestTaskFileCheck extends StorageRequestTask
 		{
 			super(timestamp, channelCount, controller);
 			this.nanoTimeBudget = nanoTimeBudget;
+			this.completed      = new ChannelResults(channelCount);
 		}
 
 
@@ -58,14 +59,14 @@ public interface StorageRequestTaskFileCheck extends StorageRequestTask
 		@Override
 		protected final Void internalProcessBy(final StorageChannel channel)
 		{
-			this.completed = channel.issuedFileCleanupCheck(this.nanoTimeBudget);
+			this.completed.set(channel.channelIndex(), channel.issuedFileCleanupCheck(this.nanoTimeBudget));
 			return null;
 		}
 
 		@Override
 		public final boolean result()
 		{
-			return this.completed;
+			return this.completed.allTrue();
 		}
 
 	}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStorageFlush.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStorageFlush.java
@@ -1,0 +1,186 @@
+package org.eclipse.store.storage.types;
+
+/*-
+ * #%L
+ * EclipseStore Storage
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+/**
+ * All-channel durability barrier: every channel synchronizes its storage files (head data file,
+ * then transactions log) during processing; on completion every store issued before this task's
+ * timestamp is durable on every channel.
+ * <p>
+ * Each channel learns this from its own participation alone: on success it raises its local
+ * all-durable watermark to this task's timestamp. The reasoning is the task queue's global order -
+ * a store task with a smaller timestamp was processed by every channel before this one, so its
+ * data and log entries were written before the synchronization.
+ * <p>
+ * Two issuers create these barriers ({@link #carriesMaintenance()} tells them apart): a channel
+ * whose durability gate deferred a file lifecycle event (source-file deletion, head rollover,
+ * log compaction; see {@code StorageFileManager}) requests a GATE barrier, and the public
+ * {@code StorageConnection#issueStorageFlush()} requests a PURE on-demand barrier. Either way
+ * this task ONLY synchronizes files and raises the watermark - the deferred maintenance the
+ * watermark enables is a separate concern, handled by a
+ * {@link StorageRequestTaskDurabilityMaintenance} the broker enqueues directly behind
+ * gate-requested (or tail-upgraded) instances under the same monitor hold: queue adjacency
+ * guarantees no store is processed between the watermark raise and the maintenance, so the
+ * durability gates hold for the maintenance exactly as they do here. Issuers waiting on this
+ * task wake at pure file-synchronization latency.
+ * <p>
+ * Failure surfacing differs per issuer: a gate-requested barrier is enqueued fire-and-forget
+ * (a channel cannot wait on a barrier it must itself process without deadlocking), so a failed
+ * synchronization has no caller to surface it - it escalates to the operation controller (see
+ * {@link #fail}): the channel stops and the next request reports the fault, instead of the
+ * barrier silently ceasing to raise the watermark. A public on-demand barrier additionally HAS a
+ * waiting caller, which observes a skip via {@link #result()} returning {@code false} and a
+ * failure via the task problem thrown from its wait; the {@link #fail} escalation applies to
+ * both flavors alike.
+ */
+public interface StorageRequestTaskStorageFlush extends StorageRequestTask, StorageChannelSynchronizingTask
+{
+	/**
+	 * Whether every channel actually synchronized its files. {@code false} if any channel
+	 * skipped (e.g. read-only mode) or failed. Only meaningful after the task completed.
+	 *
+	 * @return whether the storage is durable through this task's timestamp.
+	 */
+	public boolean result();
+
+	/**
+	 * Whether this barrier has a {@link StorageRequestTaskDurabilityMaintenance} enqueued
+	 * directly behind it. THE canonical statement of the barrier-flavor invariant:
+	 * <p>
+	 * Gate-requested barriers carry the maintenance ({@code true}) - the adjacent task is the
+	 * slot where the durability gates' deferred work (source-file deletion, head rollover, log
+	 * compaction) provably passes, and only such barriers may serve as the broker's coalescing
+	 * target: a gate request coalescing onto a maintenance-less barrier would be swallowed
+	 * without its deferred work ever running, starving reclamation under sustained store
+	 * traffic. Public on-demand barriers are pure ({@code false}) - file synchronization and
+	 * watermark raise only, never a coalescing target; the deferred work they incidentally
+	 * enable is picked up when the gates next run.
+	 * <p>
+	 * Constructor-set intent, with one broker-side transition: a gate request finding a pure
+	 * barrier at the queue tail appends the maintenance task behind it and
+	 * {@linkplain #upgradeToCarryMaintenance() upgrades} the flag, so it stays truthful. In the
+	 * broker's shutdown race the maintenance enqueue behind a gate barrier can fail, but such a
+	 * barrier is then never registered as a coalescing target, so this flag is never consulted
+	 * for it.
+	 *
+	 * @return whether a durability-maintenance task is enqueued directly behind this barrier.
+	 */
+	public boolean carriesMaintenance();
+
+	/**
+	 * Broker-internal: records that a durability-maintenance task was appended directly behind
+	 * this (previously pure) barrier while it was the queue tail, making
+	 * {@link #carriesMaintenance()} true in fact and in flag. Must only be called under the
+	 * task broker's monitor, which also guards every read of the flag.
+	 */
+	public void upgradeToCarryMaintenance();
+
+
+	public final class Default
+	extends StorageChannelSynchronizingTask.AbstractCompletingTask<Boolean>
+	implements StorageRequestTaskStorageFlush
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final ChannelResults flushed           ;
+		private       boolean        carriesMaintenance;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(
+			final long                       timestamp         ,
+			final int                        channelCount      ,
+			final StorageOperationController controller        ,
+			final boolean                    carriesMaintenance
+		)
+		{
+			super(timestamp, channelCount, controller);
+			this.flushed            = new ChannelResults(channelCount);
+			this.carriesMaintenance = carriesMaintenance;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		/////////////////////
+
+		@Override
+		protected final Boolean internalProcessBy(final StorageChannel channel)
+		{
+			final boolean flushed = channel.flushStorage();
+			// record every channel's result BEFORE the processing barrier, so succeed() (which runs
+			// only after waitOnProcessing) can consult the all-channel outcome, not just this channel's.
+			this.flushed.set(channel.channelIndex(), flushed);
+			return flushed;
+		}
+
+		@Override
+		public final boolean result()
+		{
+			return this.flushed.allTrue();
+		}
+
+		@Override
+		public final boolean carriesMaintenance()
+		{
+			return this.carriesMaintenance;
+		}
+
+		@Override
+		public final void upgradeToCarryMaintenance()
+		{
+			this.carriesMaintenance = true;
+		}
+
+		@Override
+		protected final void succeed(final StorageChannel channel, final Boolean flushed)
+		{
+			// The all-durable watermark means "durable on EVERY channel", so raise it only when the
+			// whole barrier synchronized: a channel skipping (read-only toggled mid-barrier) must not
+			// let others mark stores durable it never fsynced. A skipped channel re-armed, so the
+			// barrier retries once all are writable. allTrue() is safe here - waitOnProcessing has
+			// passed, so every result is set and visible via the same monitor.
+			if(this.flushed.allTrue())
+			{
+				channel.commitStorageFlush(this.timestamp());
+			}
+		}
+
+		@Override
+		protected final void fail(final StorageChannel channel, final Boolean result)
+		{
+			// A durability barrier that cannot fsync is unrecoverable in place and has no waiting caller.
+			// Escalate the channel's cause to the operation controller (as a broken log compaction does)
+			// so processing stops and the next request surfaces the fault instead of silent degradation.
+			final Throwable cause = this.problemForChannel(channel);
+			// An InterruptedException is an orderly stop signal (an external thread interrupting a
+			// channel mid-barrier), not an fsync failure - do not escalate it to a storage disruption.
+			if(cause != null && !(cause instanceof InterruptedException))
+			{
+				this.controller.registerDisruption(cause);
+				this.controller.setChannelProcessingEnabled(false);
+			}
+		}
+
+	}
+
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
@@ -46,6 +46,9 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 		private final Binary                           data                      ;
 		private final StorageReferenceValidationPolicy referenceValidationPolicy ;
 		private final long[][]                         trustedObjectIdsPerChannel;
+		// per-channel "rolled a file over this task" flags; if any channel did, the completion barrier
+		// makes every channel durable so the new file's baseline collapse is never over a non-durable store.
+		private final StorageChannelSynchronizingTask.ChannelResults rolledOver;
 
 
 
@@ -74,6 +77,7 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 				? partitionPerChannel(data.trustedObjectIds(), data.channelCount())
 				: null
 			;
+			this.rolledOver = new StorageChannelSynchronizingTask.ChannelResults(data.channelCount());
 		}
 
 		/**
@@ -129,12 +133,44 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 				);
 			}
 
-			return channel.storeEntities(this.timestamp(), this.data.channelChunk(channel.channelIndex()));
+			final KeyValue<ByteBuffer[], long[]> stored =
+				channel.storeEntities(this.timestamp(), this.data.channelChunk(channel.channelIndex()));
+
+			// record whether this channel rolled a file over, for the completion barrier below. Set
+			// before finishProcessing so every channel's succeed sees it after waitOnProcessing.
+			this.rolledOver.set(channel.channelIndex(), channel.pollRolloverOccurred());
+
+			return stored;
 		}
 
 		@Override
 		protected final void succeed(final StorageChannel channel, final KeyValue<ByteBuffer[], long[]> result)
 		{
+			// Eager rollover durability: if any channel rolled a file over, every channel fsyncs here in
+			// its own succeed, so the just-sealed store is durable everywhere before the store returns.
+			// The processing barrier has passed, so rolledOver reflects all channels. Ordered BEFORE the
+			// commit: a channel then never commits entities its own fsync failed to make durable, and
+			// the failing channel leaves nothing committed (its uncommitted write heals as an
+			// unconfirmed tail on the next start). Channels completing later roll back via fail();
+			// a channel that already committed did so only after its own successful fsync, and the
+			// restart's consensus reconciliation restores all-or-nothing across channels.
+			if(this.rolledOver.anyTrue())
+			{
+				try
+				{
+					channel.flushStorage();
+				}
+				catch(final RuntimeException e)
+				{
+					// fsync failed on a medium fault. Escalate as the flush task does: register the
+					// disruption and stop processing so the fault surfaces loudly instead of the channel
+					// accepting further non-durable stores. Rethrow so this store also reports it.
+					this.controller.registerDisruption(e);
+					this.controller.setChannelProcessingEnabled(false);
+					throw e;
+				}
+			}
+
 			// no storing operation of the other hash channels failed, so definitely commit the write here.
 			channel.commitChunkStorage();
 		}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskStoreEntities.java
@@ -149,11 +149,14 @@ public interface StorageRequestTaskStoreEntities extends StorageRequestTask
 			// Eager rollover durability: if any channel rolled a file over, every channel fsyncs here in
 			// its own succeed, so the just-sealed store is durable everywhere before the store returns.
 			// The processing barrier has passed, so rolledOver reflects all channels. Ordered BEFORE the
-			// commit: a channel then never commits entities its own fsync failed to make durable, and
-			// the failing channel leaves nothing committed (its uncommitted write heals as an
-			// unconfirmed tail on the next start). Channels completing later roll back via fail();
-			// a channel that already committed did so only after its own successful fsync, and the
-			// restart's consensus reconciliation restores all-or-nothing across channels.
+			// commit so a channel never commits after its own fsync FAILED; a later-completing sibling
+			// rolls back via fail(), and the restart's consensus reconciliation restores all-or-nothing.
+			// A false return means the storage went read-only mid-task (stores are rejected up front
+			// otherwise), where no fsync is possible: a benign skip, not a fault - the commit proceeds
+			// (as any non-synchronized store does) and the baseline's durability is backstopped by the
+			// flush the rollover requested (createNextStorageFile), which fires once the storage is
+			// writable again. Only an fsync EXCEPTION (a medium fault) escalates and stops the channel
+			// (see catch); escalating a read-only skip would brick the channel on a benign toggle.
 			if(this.rolledOver.anyTrue())
 			{
 				try

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskTransactionsLogCleanup.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskTransactionsLogCleanup.java
@@ -27,9 +27,9 @@ public interface StorageRequestTaskTransactionsLogCleanup extends StorageRequest
 		// instance fields //
 		////////////////////
 
-	    boolean completed;
+		final StorageChannelSynchronizingTask.ChannelResults completed;
 
-	    
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
@@ -41,6 +41,7 @@ public interface StorageRequestTaskTransactionsLogCleanup extends StorageRequest
 		)
 		{
 			super(timestamp, channelCount, controller);
+			this.completed = new ChannelResults(channelCount);
 		}
 
 
@@ -52,14 +53,14 @@ public interface StorageRequestTaskTransactionsLogCleanup extends StorageRequest
 		@Override
 		protected final Void internalProcessBy(final StorageChannel channel)
 		{
-			this.completed = channel.issuedTransactionsLogCleanup();
+			this.completed.set(channel.channelIndex(), channel.issuedTransactionsLogCleanup());
 			return null;
 		}
 
 		@Override
 		public final boolean result()
 		{
-			return this.completed;
+			return this.completed.allTrue();
 		}
 
 	}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTaskBroker.java
@@ -27,6 +27,7 @@ import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.persistence.types.PersistenceIdSet;
 import org.eclipse.serializer.util.UtilStackTrace;
 import org.eclipse.store.storage.exceptions.StorageException;
+import org.eclipse.store.storage.exceptions.StorageExceptionDisruptingExceptions;
 import org.eclipse.store.storage.exceptions.StorageExceptionNotRunning;
 
 public interface StorageTaskBroker
@@ -101,7 +102,37 @@ public interface StorageTaskBroker
 
 	public StorageRequestTaskTransactionsLogCleanup issueTransactionsLogCleanup()
 		throws InterruptedException;
-	
+
+	/**
+	 * Enqueues a GATE-REQUESTED all-channel storage flush (durability barrier) with its
+	 * durability-maintenance task directly behind it, coalescing onto a pending
+	 * maintenance-carrying barrier when one exists; see
+	 * {@link StorageRequestTaskStorageFlush#carriesMaintenance()} for the flavor invariant.
+	 * Named for the coalescing: the returned barrier may be an EARLIER pending one that does
+	 * not cover stores enqueued after it - callers wanting a fresh durability point must use
+	 * {@link #issueOnDemandStorageFlush()}. Does not wait for the tasks' completion, so it is
+	 * safe to call from a channel thread (the channel processes them in its own work loop).
+	 *
+	 * @return the enqueued or coalesced-onto barrier task.
+	 * @throws InterruptedException if interrupted while enqueueing.
+	 */
+	public StorageRequestTaskStorageFlush issueCoalescingStorageFlush()
+		throws InterruptedException;
+
+	/**
+	 * Enqueues a fresh, PURE all-channel storage flush and returns it for the caller to wait on:
+	 * file synchronization and watermark raise only, no maintenance task behind it. Unlike
+	 * {@link #issueCoalescingStorageFlush()}, the barrier is never coalesced onto an earlier pending one:
+	 * stores enqueued after that earlier barrier would sit behind it in the task queue and thus
+	 * not be covered by its synchronization. On the barrier's completion, every store enqueued
+	 * before this call is durable on every channel.
+	 *
+	 * @return the enqueued barrier task.
+	 * @throws InterruptedException if interrupted while enqueueing.
+	 */
+	public StorageRequestTaskStorageFlush issueOnDemandStorageFlush()
+		throws InterruptedException;
+
 	public StorageRequestTaskExportAdjacencyData exportAdjacencyData(Path workingDir)
 		throws InterruptedException;
 	
@@ -131,6 +162,21 @@ public interface StorageTaskBroker
 		private final WeakReference<StorageSystem>  storageSystemReference;
 
 		private volatile StorageTask currentHead;
+
+		// the most recently enqueued maintenance-carrying storage flush and its adjacent
+		// maintenance task, kept to coalesce concurrent gate requests and to detect tail-adjacency
+		// (see issueCoalescingStorageFlush / issueOnDemandStorageFlush). Only maintenance-carrying
+		// barriers register here (the coalesce condition additionally checks carriesMaintenance()
+		// - the canonical invariant lives on that accessor). Accessed only under this broker's
+		// monitor.
+		private StorageRequestTaskStorageFlush         pendingStorageFlush      ;
+		private StorageRequestTaskDurabilityMaintenance pendingStorageMaintenance;
+
+		// set once the shutdown task is issued: from then on enqueueTask rejects every enqueue, so no
+		// task can chain after the shutdown barrier. Such a task would leave a channel parked in
+		// awaitNext, missing shutdown's endAwaitNext wake (it targets only the shutdown task) and
+		// stalling shutdown. Accessed only under this broker's monitor (every enqueue is synchronized).
+		private boolean channelShutdownIssued;
 
 
 
@@ -227,7 +273,16 @@ public interface StorageTaskBroker
 			{
 				throw new StorageExceptionNotRunning("Storage is shut down.");
 			}
-			
+
+			// No task may follow the shutdown task: it would chain behind the shutdown barrier (whose
+			// succeed() resets the channel) and leave a channel parked in awaitNext on it, missing
+			// shutdown's endAwaitNext wake. Reject like a disabled controller; the sole channel-driven
+			// enqueue (the storage flush) treats this as a benign shutdown signal, see StorageChannel.
+			if(this.channelShutdownIssued)
+			{
+				throw new StorageExceptionNotRunning("Storage shutdown has been initiated.");
+			}
+
 			return this.uncheckedEnqueueTask(nextTask, newHeadTask);
 		}
 		
@@ -322,6 +377,151 @@ public interface StorageTaskBroker
 			);
 			this.enqueueTaskAndNotifyAll(task);
 			return task;
+		}
+
+		@Override
+		public final synchronized StorageRequestTaskStorageFlush issueCoalescingStorageFlush()
+			throws InterruptedException
+		{
+			/*
+			 * A PURE barrier at the queue tail is the best target: appending the maintenance task
+			 * directly behind it under this monitor reproduces the gate pair's adjacency exactly
+			 * (nothing can sit between the tail and the append), on the NEWEST barrier - covering
+			 * more stores than a pending older pair would - and saves the all-channel fsync a
+			 * separate gate barrier would cost. The barrier is upgraded and registered only after
+			 * the append succeeded, so the flavor flag and the coalescing-target invariant stay
+			 * truthful. Note: despite its name, currentHead is the most recently enqueued task.
+			 */
+			if(this.currentHead instanceof StorageRequestTaskStorageFlush
+				&& !((StorageRequestTaskStorageFlush)this.currentHead).carriesMaintenance()
+			)
+			{
+				final StorageRequestTaskStorageFlush tailBarrier =
+					(StorageRequestTaskStorageFlush)this.currentHead;
+				final StorageRequestTaskDurabilityMaintenance maintenance = this.enqueueMaintenanceTask();
+				if(maintenance != null)
+				{
+					tailBarrier.upgradeToCarryMaintenance();
+					this.pendingStorageFlush       = tailBarrier;
+					this.pendingStorageMaintenance = maintenance;
+				}
+				return tailBarrier;
+			}
+
+			// Coalesce concurrent requests: a flush already queued and not yet fully processed covers
+			// every channel's deferred gate in this wave, so N channels deferring in the same cycle
+			// share one barrier instead of enqueuing N (each otherwise fsynced by all N channels).
+			// Stores issued after it re-request next cycle. The carriesMaintenance check is the
+			// machine-guard of the flavor invariant (canonical statement on that accessor): only the
+			// gate path registers the field, so it is normally redundant - but a future change
+			// registering a pure barrier then degrades to enqueueing a fresh pair here instead of
+			// silently starving the gate's deferred work.
+			if(this.pendingStorageFlush != null
+				&& !this.pendingStorageFlush.isProcessed()
+				&& this.pendingStorageFlush.carriesMaintenance()
+			)
+			{
+				return this.pendingStorageFlush;
+			}
+
+			return this.enqueueStorageFlushWithMaintenance();
+		}
+
+		@Override
+		public final synchronized StorageRequestTaskStorageFlush issueOnDemandStorageFlush()
+			throws InterruptedException
+		{
+			/*
+			 * Tail-adjacent reuse: if the pending gate pair's maintenance task is still the queue
+			 * tail, nothing was enqueued after its barrier, so that barrier covers every store
+			 * enqueued before this call - exactly a fresh barrier's contract, without the second
+			 * all-channel fsync. Only an unprocessed barrier is reused: a processed one may have
+			 * skipped under a writability state a fresh barrier would not repeat.
+			 */
+			if(this.pendingStorageFlush != null
+				&& !this.pendingStorageFlush.isProcessed()
+				&& this.currentHead == this.pendingStorageMaintenance
+			)
+			{
+				return this.pendingStorageFlush;
+			}
+
+			/*
+			 * A PURE barrier: file synchronization and watermark raise only - no maintenance task
+			 * behind it, and deliberately NOT registered as a coalescing target (see
+			 * StorageRequestTaskStorageFlush#carriesMaintenance() for the flavor invariant; a gate
+			 * request finding this barrier at the tail may append the maintenance and upgrade it).
+			 * This issuer's contract is pure durability; deferred work it incidentally enables (the
+			 * raised watermark) is picked up when the durability gates next run.
+			 */
+			return this.enqueueStorageFlush(false);
+		}
+
+		/**
+		 * Enqueues a storage-flush barrier and its durability-maintenance task as an adjacent pair
+		 * under this broker's monitor (all enqueues are synchronized here): no store can be enqueued
+		 * between them, so the maintenance provably runs with the barrier's watermark still covering
+		 * every processed store - the property the durability gates rely on. Kept as separate tasks
+		 * so the barrier's issuers wake at pure file-synchronization latency and the two concerns
+		 * stay independent (the maintenance is self-guarded if the barrier fails or skips). For the
+		 * flavor invariant see {@link StorageRequestTaskStorageFlush#carriesMaintenance()}.
+		 */
+		private StorageRequestTaskStorageFlush enqueueStorageFlushWithMaintenance()
+			throws InterruptedException
+		{
+			final StorageRequestTaskStorageFlush task = this.enqueueStorageFlush(true);
+
+			final StorageRequestTaskDurabilityMaintenance maintenance = this.enqueueMaintenanceTask();
+			if(maintenance != null)
+			{
+				// registered only AFTER the maintenance enqueue succeeded: every coalescing target
+				// provides the adjacent maintenance slot, without exception. No coalescer can observe
+				// the intermediate state - this whole method runs under the broker's monitor.
+				this.pendingStorageFlush       = task;
+				this.pendingStorageMaintenance = maintenance;
+			}
+
+			return task;
+		}
+
+		/** The single construction site for flush barriers of either flavor. */
+		private StorageRequestTaskStorageFlush enqueueStorageFlush(final boolean carriesMaintenance)
+			throws InterruptedException
+		{
+			final StorageRequestTaskStorageFlush task = this.taskCreator.createStorageFlushTask(
+				this.channelCount,
+				this.operationController,
+				carriesMaintenance
+			);
+			this.enqueueTaskAndNotifyAll(task);
+			return task;
+		}
+
+		/**
+		 * Enqueues a durability-maintenance task at the queue tail, or returns {@code null} if the
+		 * storage began shutting down or was disrupted (the operation controller's state is not
+		 * guarded by this broker's monitor): the preceding barrier then still provides its
+		 * durability guarantee to waiting issuers, the skipped maintenance is moot (its gates would
+		 * re-defer and re-arm on a dead storage anyway), and the caller must NOT register the
+		 * barrier as a coalescing target nor upgrade its flavor flag.
+		 */
+		private StorageRequestTaskDurabilityMaintenance enqueueMaintenanceTask()
+			throws InterruptedException
+		{
+			try
+			{
+				final StorageRequestTaskDurabilityMaintenance maintenance =
+					this.taskCreator.createDurabilityMaintenanceTask(
+						this.channelCount,
+						this.operationController
+					);
+				this.enqueueTaskAndNotifyAll(maintenance);
+				return maintenance;
+			}
+			catch(final StorageExceptionNotRunning | StorageExceptionDisruptingExceptions e)
+			{
+				return null;
+			}
 		}
 
 		@Override
@@ -596,6 +796,12 @@ public interface StorageTaskBroker
 			);
 			// special case: cannot wait on the task before the channel threads are started
 			this.enqueueTaskAndNotifyAll(task);
+
+			// From here enqueueTask rejects every further enqueue, keeping the shutdown task the last
+			// task in the chain (see channelShutdownIssued). Set after enqueuing the shutdown task so
+			// its own enqueue passes; safe because every enqueue path runs under this broker's monitor.
+			this.channelShutdownIssued = true;
+
 			return task;
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsAnalysis.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsAnalysis.java
@@ -25,10 +25,12 @@ import org.eclipse.serializer.afs.types.AFS;
 import org.eclipse.serializer.afs.types.AFile;
 import org.eclipse.serializer.afs.types.AReadableFile;
 import org.eclipse.serializer.chars.VarString;
+import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.ConstList;
 import org.eclipse.serializer.collections.EqHashTable;
 import org.eclipse.serializer.collections.types.XGettingSequence;
 import org.eclipse.serializer.collections.types.XGettingTable;
+import org.eclipse.serializer.typing.KeyValue;
 import org.eclipse.serializer.exceptions.IndexBoundsException;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.store.storage.exceptions.StorageException;
@@ -46,6 +48,43 @@ public interface StorageTransactionsAnalysis
 	public long headFileLatestLength();
 
 	public long headFileLatestTimestamp();
+
+	/**
+	 * The latest store entry's own recorded head length - the value the entry itself carries,
+	 * before subsequent transfers grew the head further ({@link #headFileLatestLength()}
+	 * includes that growth). A truncation collapses it onto the new length.
+	 *
+	 * @return the latest store entry's own recorded length.
+	 */
+	public long headFileLatestStoreOwnLength();
+
+	/**
+	 * The latest store timestamp the head file's creation collapsed both rollback anchors onto,
+	 * 0 if no store preceded it. Its cut coordinate is {@link #headFileBaselineLength()}.
+	 * <p>
+	 * Any store timestamp between this baseline and {@link #headFileLatestTimestamp()} is a valid
+	 * head-file rollback cut; the cut length lives in that store's log entry and is re-read on
+	 * demand rather than retained (a head file can hold millions of stores).
+	 *
+	 * @return the head file's creation collapse timestamp.
+	 */
+	public long headFileBaselineTimestamp();
+
+	/**
+	 * @return the head file's creation length - the cut coordinate of
+	 *         {@link #headFileBaselineTimestamp()}.
+	 */
+	public long headFileBaselineLength();
+
+	/**
+	 * The head file's transfer entries as (source file number, post-transfer head length) pairs
+	 * in log order. Truncating the head below such a length also truncates that transfer's
+	 * bytes, which is only safe while its source file still exists;
+	 * {@code StorageFileManager#determineLastFileLength} must refuse the rollback otherwise.
+	 *
+	 * @return the head file's transfers; empty if the head file received no transfers.
+	 */
+	public XGettingSequence<KeyValue<Long, Long>> headFileTransfers();
 
 	public long maxTimestamp();
 
@@ -738,12 +777,19 @@ public interface StorageTransactionsAnalysis
 	{
 		private final EqHashTable<Long, StorageTransactionEntry.Default> files = EqHashTable.New();
 
+		// the head file's transfers as (source file number, post-transfer length) pairs; see
+		// headFileTransfers(). Bounded by the transfers into one head file, cleared on rollover.
+		private final BulkList<KeyValue<Long, Long>> headFileTransfers = BulkList.New();
+
 		private final int  hashIndex;
 
 		private long lastConsistentStoreLength   ;
 		private long lastConsistentStoreTimestamp;
 		private long currentStoreLength          ;
 		private long currentStoreTimestamp       ;
+		private long latestStoreOwnLength        ;
+		private long headFileBaselineTimestamp   ;
+		private long headFileBaselineLength      ;
 		private long maxTimeStamp;
 
 		private long currentFileNumber            = -1;
@@ -817,6 +863,13 @@ public interface StorageTransactionsAnalysis
 			this.lastConsistentStoreLength    = this.currentStoreLength    = fileLength;
 			this.currentFileNumber            = number;
 
+			// the new head resets the cut coordinates: a rollback truncates only the head file,
+			// so transfers into the now closed file keep their bytes regardless
+			this.headFileBaselineTimestamp = this.currentStoreTimestamp;
+			this.headFileBaselineLength    = fileLength;
+			this.latestStoreOwnLength      = fileLength;
+			this.headFileTransfers.clear();
+
 			return true;
 		}
 
@@ -862,6 +915,8 @@ public interface StorageTransactionsAnalysis
 			this.lastConsistentStoreLength    = this.currentStoreLength;
 			this.currentStoreTimestamp        = timestamp;
 			this.currentStoreLength           = fileLength;
+			this.latestStoreOwnLength         = fileLength;
+
 			return true;
 		}
 
@@ -882,15 +937,17 @@ public interface StorageTransactionsAnalysis
 			}
 
 			this.updateMaxTimestamp(Logic.getEntryTimestamp(address));
-			
-			/* lastConsistentStoreTimestamp is not updated to associate the new file length with the old timestamp
-			 * i.e. when an inter-channel rollback has to occur, the transfer part is not rolled back, as it is
-			 * channel-local
+
+			/* Transferred bytes lie above the covering store's chunk, so a rollback below them
+			 * re-acquires them from the source file later. Only currentStoreLength advances - the
+			 * rollback anchor must not pass a store that might still be rolled back. Source and
+			 * position are kept so the rollback can refuse when the source is already deleted
+			 * (see headFileTransfers()).
 			 */
-			this.lastConsistentStoreLength = this.currentStoreLength = fileLength;
-			/* currentStoreTimestamp is NOT updated as a transfer is channel-local, therefore won't affect
-			 * store consistency anyway and can happen after the store has been issued but before it is processed.
-			 */
+			this.currentStoreLength = fileLength;
+			this.headFileTransfers.add(KeyValue.New(Logic.getFileNumber(address), fileLength));
+			// currentStoreTimestamp is not updated: a transfer is channel-local and may occur after
+			// its store was issued, so it must not advance store consistency.
 			return true;
 		}
 
@@ -928,7 +985,46 @@ public interface StorageTransactionsAnalysis
 			}
 
 			this.updateMaxTimestamp(Logic.getEntryTimestamp(address));
+
+			/*
+			 * When the head is cut below the current store, the latest-store timestamp (surfaced as
+			 * headFileLatestTimestamp, the consensus key) must stop naming it. The entry's stamped
+			 * timestamp is consulted first: recovery stamps the surviving store's timestamp, and a
+			 * stamp naming the current store means the cut keeps it entirely - store lengths do NOT
+			 * strictly increase (an empty store shares its predecessor's length), so a bare length
+			 * match against a retained anchor could misname the survivor. Only for an unmatched
+			 * stamp (legacy entries carry a fresh timestamp) does newLength identify the survivor:
+			 * a retained anchor's length (the store below or the baseline), or a deeper cut whose
+			 * survivor's timestamp is then taken from the entry after all - else
+			 * currentStoreTimestamp would keep naming a rolled-back store and brick after a later
+			 * crash. Applied before the length fields below.
+			 */
+			if(Logic.getEntryTimestamp(address) == this.currentStoreTimestamp)
+			{
+				// stamped with the current latest store: it survives the cut, the timestamp stands
+			}
+			else if(newLength == this.lastConsistentStoreLength)
+			{
+				this.currentStoreTimestamp = this.lastConsistentStoreTimestamp;
+			}
+			else if(newLength == this.headFileBaselineLength)
+			{
+				this.currentStoreTimestamp = this.headFileBaselineTimestamp;
+			}
+			else if(newLength < this.lastConsistentStoreLength)
+			{
+				this.currentStoreTimestamp = this.lastConsistentStoreTimestamp = Logic.getEntryTimestamp(address);
+			}
+
 			this.lastConsistentStoreLength = this.currentStoreLength = newLength;
+
+			// the truncation already cut everything above the new length
+			this.latestStoreOwnLength = newLength;
+			this.headFileTransfers.removeBy(transfer -> transfer.value() > newLength);
+			if(newLength < this.headFileBaselineLength)
+			{
+				this.headFileBaselineLength = newLength;
+			}
 
 			return true;
 		}
@@ -965,6 +1061,10 @@ public interface StorageTransactionsAnalysis
 				this.lastConsistentStoreTimestamp,
 				this.currentStoreLength          ,
 				this.currentStoreTimestamp       ,
+				this.latestStoreOwnLength        ,
+				this.headFileBaselineTimestamp   ,
+				this.headFileBaselineLength      ,
+				this.headFileTransfers           ,
 				this.maxTimeStamp
 			);
 		}
@@ -990,10 +1090,14 @@ public interface StorageTransactionsAnalysis
 		private final long                                                   headFileLastConsistentStoreTimestamp;
 		private final long                                                   headFileLatestLength                ;
 		private final long                                                   headFileLatestTimestamp             ;
+		private final long                                                   headFileLatestStoreOwnLength        ;
+		private final long                                                   headFileBaselineTimestamp           ;
+		private final long                                                   headFileBaselineLength              ;
+		private final XGettingSequence<KeyValue<Long, Long>>                 headFileTransfers                   ;
 		private final long                                                   maxTimestamp                        ;
 
 
-		
+
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
 		/////////////////
@@ -1005,17 +1109,25 @@ public interface StorageTransactionsAnalysis
 			final long                                                   headFileLastConsistentStoreTimestamp,
 			final long                                                   headFileLatestLength                ,
 			final long                                                   headFileLatestTimestamp             ,
+			final long                                                   headFileLatestStoreOwnLength        ,
+			final long                                                   headFileBaselineTimestamp           ,
+			final long                                                   headFileBaselineLength              ,
+			final XGettingSequence<KeyValue<Long, Long>>                 headFileTransfers                   ,
 			final long                                                   maxTimestamp
 		)
 		{
 			super();
-			this.transactionsFile                     = notNull(transactionsFile)           ;
-			this.transactionsFileEntries              = transactionsFileEntries             ;
-			this.headFileLastConsistentStoreLength    = headFileLastConsistentStoreLength   ;
+			this.transactionsFile                     = notNull(transactionsFile)         ;
+			this.transactionsFileEntries              = transactionsFileEntries           ;
+			this.headFileLastConsistentStoreLength    = headFileLastConsistentStoreLength ;
 			this.headFileLastConsistentStoreTimestamp = headFileLastConsistentStoreTimestamp;
-			this.headFileLatestLength                 = headFileLatestLength                ;
-			this.headFileLatestTimestamp              = headFileLatestTimestamp             ;
-			this.maxTimestamp                         = maxTimestamp                        ;
+			this.headFileLatestLength                 = headFileLatestLength              ;
+			this.headFileLatestTimestamp              = headFileLatestTimestamp           ;
+			this.headFileLatestStoreOwnLength         = headFileLatestStoreOwnLength      ;
+			this.headFileBaselineTimestamp            = headFileBaselineTimestamp         ;
+			this.headFileBaselineLength               = headFileBaselineLength            ;
+			this.headFileTransfers                    = notNull(headFileTransfers)        ;
+			this.maxTimestamp                         = maxTimestamp                      ;
 		}
 
 
@@ -1059,7 +1171,31 @@ public interface StorageTransactionsAnalysis
 		{
 			return this.headFileLatestTimestamp;
 		}
-		
+
+		@Override
+		public final long headFileLatestStoreOwnLength()
+		{
+			return this.headFileLatestStoreOwnLength;
+		}
+
+		@Override
+		public final long headFileBaselineTimestamp()
+		{
+			return this.headFileBaselineTimestamp;
+		}
+
+		@Override
+		public final long headFileBaselineLength()
+		{
+			return this.headFileBaselineLength;
+		}
+
+		@Override
+		public final XGettingSequence<KeyValue<Long, Long>> headFileTransfers()
+		{
+			return this.headFileTransfers;
+		}
+
 		@Override
 		public final long maxTimestamp()
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsFileCleaner.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageTransactionsFileCleaner.java
@@ -45,6 +45,16 @@ public interface StorageTransactionsFileCleaner
 	public void compactTransactionsFile(boolean checkSize);
 
 	/**
+	 * Whether {@link #compactTransactionsFile(boolean)} would actually compact under the passed
+	 * size-check mode, without performing any work. Lets callers avoid requesting durability
+	 * barriers for a compaction that would be skipped anyway.
+	 *
+	 * @param checkSize the size-check mode, see {@link #compactTransactionsFile(boolean)}.
+	 * @return whether a compaction is due.
+	 */
+	public boolean requiresCompaction(boolean checkSize);
+
+	/**
 	 * Heals a compaction that was interrupted by a crash. A complete swap file (length and
 	 * checksum match its header) is the authoritative state of an interrupted rewrite and is
 	 * restored into the transactions file; an incomplete one means the live file was never
@@ -74,8 +84,11 @@ public interface StorageTransactionsFileCleaner
 		/////////////////
 
 		/**
-		 * Captures the per-file values the {@link StorageTransactionsAnalysis.EntryAggregator}
-		 * validates but does not retain: creation and deletion timestamps and lengths.
+		 * Captures the values the {@link StorageTransactionsAnalysis.EntryAggregator} validates
+		 * but does not retain: creation and deletion timestamps and lengths, and the transfer
+		 * entries logged after the latest store. The latter must survive the compaction
+		 * verbatim: the initialization's rollback guard reads their source files from the
+		 * reloaded log.
 		 */
 		private static final class EntrySupplements
 		{
@@ -87,7 +100,16 @@ public interface StorageTransactionsFileCleaner
 				long deletionFileLength;
 			}
 
-			final LinkedHashMap<Long, FileSupplement> files = new LinkedHashMap<>();
+			static final class TransferSupplement
+			{
+				long fileLength      ;
+				long timeStamp       ;
+				long sourceFileNumber;
+				long sourceFileOffset;
+			}
+
+			final LinkedHashMap<Long, FileSupplement> files              = new LinkedHashMap<>();
+			final BulkList<TransferSupplement>        postStoreTransfers = BulkList.New()      ;
 
 			void accept(final long address)
 			{
@@ -99,6 +121,9 @@ public interface StorageTransactionsFileCleaner
 						supplement.creationTimeStamp  = Logic.getEntryTimestamp(address);
 						supplement.creationFileLength = Logic.getFileLength(address);
 						this.files.put(Logic.getFileNumber(address), supplement);
+						// transfers into the now closed file are absorbed into its length; only
+						// transfers above the current head's latest store need reproducing
+						this.postStoreTransfers.clear();
 						break;
 					}
 					case Logic.TYPE_FILE_DELETION:
@@ -111,9 +136,29 @@ public interface StorageTransactionsFileCleaner
 						}
 						break;
 					}
+					case Logic.TYPE_STORE:
+					{
+						this.postStoreTransfers.clear();
+						break;
+					}
+					case Logic.TYPE_TRANSFER:
+					{
+						final TransferSupplement transfer = new TransferSupplement();
+						transfer.fileLength       = Logic.getFileLength(address)   ;
+						transfer.timeStamp        = Logic.getEntryTimestamp(address);
+						transfer.sourceFileNumber = Logic.getFileNumber(address)   ;
+						transfer.sourceFileOffset = Logic.getSpecialOffset(address);
+						this.postStoreTransfers.add(transfer);
+						break;
+					}
+					case Logic.TYPE_FILE_TRUNCATION:
+					{
+						// the truncation already cut any transfers above the new length
+						this.postStoreTransfers.clear();
+						break;
+					}
 					default:
 					{
-						// stores, transfers and truncations are fully covered by the aggregator
 						break;
 					}
 				}
@@ -127,28 +172,39 @@ public interface StorageTransactionsFileCleaner
 		}
 
 		/**
-		 * The assembled compacted log plus the section boundaries the writer needs: creation
-		 * entries in {@code [0, storesOffset)}, store entries in {@code [storesOffset,
-		 * deletionsOffset)}, deletion entries in {@code [deletionsOffset, buffer limit)}.
+		 * The assembled compacted log plus its contiguous, type-homogeneous sections, each
+		 * written through the matching mirrored writer call.
 		 */
 		private static final class CompactedContent
 		{
-			final ByteBuffer buffer          ;
-			final int        storesOffset    ;
-			final int        deletionsOffset ;
-			final long       headLatestLength;
+			static final class Section
+			{
+				final byte type ;
+				final int  start;
+				final int  end  ;
+
+				Section(final byte type, final int start, final int end)
+				{
+					super();
+					this.type  = type ;
+					this.start = start;
+					this.end   = end  ;
+				}
+			}
+
+			final ByteBuffer        buffer          ;
+			final BulkList<Section> sections        ;
+			final long              headLatestLength;
 
 			CompactedContent(
-				final ByteBuffer buffer          ,
-				final int        storesOffset    ,
-				final int        deletionsOffset ,
-				final long       headLatestLength
+				final ByteBuffer        buffer          ,
+				final BulkList<Section> sections        ,
+				final long              headLatestLength
 			)
 			{
 				super();
 				this.buffer           = buffer          ;
-				this.storesOffset     = storesOffset    ;
-				this.deletionsOffset  = deletionsOffset ;
+				this.sections         = sections        ;
 				this.headLatestLength = headLatestLength;
 			}
 		}
@@ -444,6 +500,11 @@ public interface StorageTransactionsFileCleaner
 		private final StorageFileWriter storageFileWriter;
 		private final StorageLiveFileProvider fileProvider;
 
+		// the log's length after the last completed compaction; the log is append-only between
+		// compactions, so an unchanged length means unchanged content whose compaction would be
+		// a verbatim no-op. -1 = no compaction happened yet this session.
+		private long lastCompactedLength = -1;
+
 
 		///////////////////////////////////////////////////////////////////////////
 		// constructors //
@@ -504,6 +565,7 @@ public interface StorageTransactionsFileCleaner
 				{
 					// already compacted: rewriting byte-identical content would only churn the
 					// swap file, two fsyncs and the backup queue on every housekeeping cycle
+					this.lastCompactedLength = this.storageLiveTransactionsFile.size();
 					return;
 				}
 
@@ -551,6 +613,8 @@ public interface StorageTransactionsFileCleaner
 						);
 					}
 				}
+
+				this.lastCompactedLength = this.storageLiveTransactionsFile.size();
 			}
 			finally
 			{
@@ -596,14 +660,16 @@ public interface StorageTransactionsFileCleaner
 
 		/**
 		 * Assembles the compacted log into one buffer (content length = buffer limit): one
-		 * FileCreation entry per still existing file, carrying the file's latest length - the
-		 * pattern the initialization's derive fallback boots from. Only the head file keeps
-		 * store entries: its two anchors, reproduced verbatim, so cross-channel crash
-		 * reconciliation behaves exactly as with the uncompacted log.
+		 * FileCreation entry per still existing file, carrying the file's latest length - the pattern
+		 * the initialization's derive fallback boots from. The head file keeps its store anchors and
+		 * post-store transfers, so the reloaded reconciliation state (both anchors, transfer sources)
+		 * matches the uncompacted log's. A store-less head collapses both anchors at its creation; to
+		 * reproduce that, the latest-store anchor is emitted in the preceding file's group - stamping
+		 * it under the head would let a reconciliation that cannot agree on it silently keep or
+		 * truncate content the uncompacted log guards loudly.
 		 * <p>
-		 * Deletion entries come after all per-file groups: on reload, a file is registered only
-		 * once the next file's creation entry is reached, so an inline deletion entry would not
-		 * find its file yet.
+		 * Deletion entries come after all per-file groups: on reload a file is registered only when
+		 * the next file's creation entry is reached, so an inline deletion would not find its file.
 		 */
 		private CompactedContent assembleCompactedContent(
 			final StorageTransactionsAnalysis analysis   ,
@@ -628,15 +694,29 @@ public interface StorageTransactionsFileCleaner
 				}
 			}
 
+			final long latestTs = analysis.headFileLatestTimestamp();
+			final long lcTs     = analysis.headFileLastConsistentStoreTimestamp();
+			final long lcLen    = analysis.headFileLastConsistentStoreLength();
+
+			// store timestamps are strictly increasing, so a head with an own store separates the
+			// anchors while a store-less head carries both collapsed onto the latest timestamp
+			final boolean headHasOwnStore = latestTs > 0 && lcTs < latestTs;
+
 			// upper bound; the actual content length is set as the buffer's limit after assembly
 			final long maximumLength = files.size() * (long)(
 				Logic.entryLengthFileCreation() + Logic.entryLengthFileDeletion()
-			) + 2L * Logic.entryLengthStore();
+			)
+				+ 3L * Logic.entryLengthStore()
+				+ supplements.postStoreTransfers.size() * (long)Logic.entryLengthTransfer()
+			;
 
 			final ByteBuffer content = XMemory.allocateDirectNative(X.checkArrayRange(maximumLength));
 			final long       address = XMemory.getDirectByteBufferAddress(content);
 
-			int offset = 0;
+			final BulkList<CompactedContent.Section> sections = BulkList.New();
+
+			int offset       = 0;
+			int sectionStart = 0;
 			for(final StorageTransactionEntry file : files)
 			{
 				if(file != headFile)
@@ -647,41 +727,76 @@ public interface StorageTransactionsFileCleaner
 					offset += Logic.entryLengthFileCreation();
 				}
 			}
+			offset = addSection(sections, Logic.TYPE_FILE_CREATION, sectionStart, offset);
 
-			final long latestTs = analysis.headFileLatestTimestamp();
-			final long lcTs     = analysis.headFileLastConsistentStoreTimestamp();
+			final boolean headFollowsClosedFile = files.size() > 1;
+			if(!headHasOwnStore && latestTs > 0 && headFollowsClosedFile)
+			{
+				/*
+				 * The anchor collapse must be reproduced: the latest store happened before the
+				 * head's creation, so its entry belongs to the preceding file's group (with that
+				 * file's final length as its coordinate). On reload, the head's creation entry
+				 * then re-collapses both anchors exactly like the uncompacted log did.
+				 */
+				final StorageTransactionEntry lastClosedFile = files.at(files.size() - 2);
+				sectionStart = offset;
+				Logic.initializeEntryStore(address + offset);
+				Logic.setEntryStore(address + offset, lastClosedFile.length(), latestTs);
+				offset = addSection(sections, Logic.TYPE_STORE, sectionStart, offset + Logic.entryLengthStore());
+			}
 
-			/*
-			 * The head's creation entry carries the last consistent store length: it seeds the
-			 * reloaded rollback anchor when both anchors collapse onto one timestamp
-			 * (store-less head - equal-timestamp store entries cannot be written), so a
-			 * reconciliation degenerating to timestamp 0 truncates to the correct length.
-			 * With two anchors, the first store entry overwrites it anyway.
-			 */
+			// the head's creation entry carries the pre-latest-store length: it seeds the
+			// reloaded rollback anchor until (and unless) a store entry overwrites it
+			sectionStart = offset;
 			Logic.initializeEntryFileCreation(address + offset);
 			Logic.setEntryFileCreation(
 				address + offset,
-				analysis.headFileLastConsistentStoreLength(),
+				lcLen,
 				supplements.get(headFile.fileNumber()).creationTimeStamp,
 				headFile.fileNumber()
 			);
-			offset += Logic.entryLengthFileCreation();
+			offset = addSection(sections, Logic.TYPE_FILE_CREATION, sectionStart, offset + Logic.entryLengthFileCreation());
 
-			final int storesOffset = offset;
-			if(latestTs > 0)
+			sectionStart = offset;
+			if(headHasOwnStore)
 			{
-				if(lcTs > 0 && lcTs < latestTs)
+				if(lcTs > 0)
 				{
 					Logic.initializeEntryStore(address + offset);
-					Logic.setEntryStore(address + offset, analysis.headFileLastConsistentStoreLength(), lcTs);
+					Logic.setEntryStore(address + offset, lcLen, lcTs);
 					offset += Logic.entryLengthStore();
 				}
+				// the store's own length; transfers logged above it are reproduced behind it
 				Logic.initializeEntryStore(address + offset);
-				Logic.setEntryStore(address + offset, analysis.headFileLatestLength(), latestTs);
+				Logic.setEntryStore(address + offset, analysis.headFileLatestStoreOwnLength(), latestTs);
 				offset += Logic.entryLengthStore();
 			}
+			else if(latestTs > 0 && !headFollowsClosedFile)
+			{
+				// no preceding group can host the anchor (its file was removed): keep it under
+				// the head with the head's base coordinate
+				Logic.initializeEntryStore(address + offset);
+				Logic.setEntryStore(address + offset, lcLen, latestTs);
+				offset += Logic.entryLengthStore();
+			}
+			offset = addSection(sections, Logic.TYPE_STORE, sectionStart, offset);
 
-			final int deletionsOffset = offset;
+			sectionStart = offset;
+			for(final EntrySupplements.TransferSupplement transfer : supplements.postStoreTransfers)
+			{
+				Logic.initializeEntryTransfer(address + offset);
+				Logic.setEntryTransfer(
+					address + offset,
+					transfer.fileLength      ,
+					transfer.timeStamp       ,
+					transfer.sourceFileNumber,
+					transfer.sourceFileOffset
+				);
+				offset += Logic.entryLengthTransfer();
+			}
+			offset = addSection(sections, Logic.TYPE_TRANSFER, sectionStart, offset);
+
+			sectionStart = offset;
 			for(final StorageTransactionEntry file : files)
 			{
 				if(file.isDeleted())
@@ -692,43 +807,73 @@ public interface StorageTransactionsFileCleaner
 					offset += Logic.entryLengthFileDeletion();
 				}
 			}
+			offset = addSection(sections, Logic.TYPE_FILE_DELETION, sectionStart, offset);
+
 			content.limit(offset);
 
-			return new CompactedContent(content, storesOffset, deletionsOffset, analysis.headFileLatestLength());
+			return new CompactedContent(content, sections, analysis.headFileLatestLength());
+		}
+
+		private static int addSection(
+			final BulkList<CompactedContent.Section> sections,
+			final byte                               type    ,
+			final int                                start   ,
+			final int                                end
+		)
+		{
+			if(end > start)
+			{
+				sections.add(new CompactedContent.Section(type, start, end));
+			}
+			return end;
 		}
 
 		/**
-		 * Writes the assembled content into the truncated live file: three contiguous,
+		 * Writes the assembled content into the truncated live file: contiguous,
 		 * type-homogeneous sections, one mirrored writer call each, preserving writer semantics
 		 * such as backup mirroring.
 		 */
 		private void writeCompactedContent(final CompactedContent compacted)
 		{
-			if(compacted.storesOffset > 0)
+			for(final CompactedContent.Section section : compacted.sections)
 			{
-				this.storageFileWriter.writeTransactionEntryCreate(
-					this.storageLiveTransactionsFile,
-					sectionView(compacted.buffer, 0, compacted.storesOffset),
-					null
-				);
-			}
-			if(compacted.deletionsOffset > compacted.storesOffset)
-			{
-				this.storageFileWriter.writeTransactionEntryStore(
-					this.storageLiveTransactionsFile,
-					sectionView(compacted.buffer, compacted.storesOffset, compacted.deletionsOffset),
-					null,
-					0,
-					compacted.headLatestLength
-				);
-			}
-			if(compacted.buffer.limit() > compacted.deletionsOffset)
-			{
-				this.storageFileWriter.writeTransactionEntryDelete(
-					this.storageLiveTransactionsFile,
-					sectionView(compacted.buffer, compacted.deletionsOffset, compacted.buffer.limit()),
-					null
-				);
+				final Iterable<? extends ByteBuffer> view =
+					sectionView(compacted.buffer, section.start, section.end);
+				switch(section.type)
+				{
+					case Logic.TYPE_FILE_CREATION:
+					{
+						this.storageFileWriter.writeTransactionEntryCreate(
+							this.storageLiveTransactionsFile, view, null
+						);
+						break;
+					}
+					case Logic.TYPE_STORE:
+					{
+						this.storageFileWriter.writeTransactionEntryStore(
+							this.storageLiveTransactionsFile, view, null, 0, compacted.headLatestLength
+						);
+						break;
+					}
+					case Logic.TYPE_TRANSFER:
+					{
+						this.storageFileWriter.writeTransactionEntryTransfer(
+							this.storageLiveTransactionsFile, view, null, 0, compacted.headLatestLength
+						);
+						break;
+					}
+					case Logic.TYPE_FILE_DELETION:
+					{
+						this.storageFileWriter.writeTransactionEntryDelete(
+							this.storageLiveTransactionsFile, view, null
+						);
+						break;
+					}
+					default:
+					{
+						throw new StorageException("Unhandled compacted section type: " + section.type);
+					}
+				}
 			}
 		}
 
@@ -737,17 +882,32 @@ public interface StorageTransactionsFileCleaner
 		/////////////////////
 
 		@Override
+		public boolean requiresCompaction(final boolean checkSize)
+		{
+			// unchanged length since the last compaction = unchanged content = verbatim no-op:
+			// skips the acceptor's retry after the flush barrier's completion already compacted,
+			// and the every-cycle recompaction of a compacted log still above the size limit.
+			if(this.storageLiveTransactionsFile.size() == this.lastCompactedLength)
+			{
+				return false;
+			}
+			return !checkSize
+				|| this.storageLiveTransactionsFile.size() > this.transactionFileSizeLimit
+			;
+		}
+
+		@Override
 		public void compactTransactionsFile(final boolean checkSize)
 		{
-			if(checkSize == true && this.storageLiveTransactionsFile.size() > this.transactionFileSizeLimit)
+			if(!this.requiresCompaction(checkSize))
+			{
+				return;
+			}
+			if(checkSize)
 			{
 				logger.info("Transaction file {} size exceeds limit of {} bytes", this.storageLiveTransactionsFile.identifier(), this.transactionFileSizeLimit);
-				this.compactTransactionsFileInternal();
 			}
-			else if(!checkSize)
-			{
-				this.compactTransactionsFileInternal();
-			}
+			this.compactTransactionsFileInternal();
 		}
 
 	}


### PR DESCRIPTION
A housekeeping transfer that lands after a store could defeat the
  cross-channel store rollback and turn a power loss into a silently torn
  store: one channel kept its half of a store the other channels rolled
  back. Because the affected entities need not be eagerly reachable from the
  root, the storage restarted cleanly and the tear surfaced only on a later
  load.

  Root cause: replaying a TRANSFER entry advanced the rollback anchor
  (lastConsistentStoreLength) to the post-transfer head length, which lies
  above the covering store's chunk. A rollback to the last consistent store
  then cut above that store instead of below it, keeping half of it.

  Store rollback:
  - A transfer now advances only the current head length, never the rollback anchor, so an unconfirmed store is always rolled back as a whole.
  - A deep head truncation stamps the surviving store's timestamp onto the truncation entry, so the latest-store timestamp never names a rolled-back store (which would brick the next recovery).
  - A rollback refuses to start when a transfer above the cut point has an already-deleted source file, instead of dropping the relocated entity's last copy.

  Multi-channel recovery:
  - The consensus is the greatest store common to all channels (minimum of the channels' latest store timestamps). A channel more than one store ahead is rolled back by re-reading its log in one pass to find the consensus store's length, instead of refusing to start.
  - A consensus below a channel's sealed head-file baseline, or below any store while another channel still holds committed data, is refused loudly rather than silently discarding committed data.
  - A data file left above the log head by a crash mid-rollover is removed on writable recovery and refused in read-only mode.

  Durability:
  - File deletion, head rollover and transactions-log compaction are gated on all-channel durability and resolved by an all-channel storage-flush barrier the deferring channel enqueues; the barrier's completion runs the deferred maintenance while the durability predicate provably holds.
  - Every rollover is made eagerly durable (store-task completion fsync, or a requested flush for a rollover with no following store), so a power loss cannot leave a consensus below a not-yet-durable baseline.
  - A flush that cannot fsync escalates to the operation controller and stops the channel instead of silently ceasing to become durable.
  - Log compaction preserves the post-store transfer entries recovery needs.
  - Adds StorageConnection.issueStorageFlush(), an explicit, never-coalesced all-channel durability barrier.