### PR TITLE
Skip publishing for test-only modules: integration-tests and codegen-…

### DIFF
--- a/gigamap/codegen-test/pom.xml
+++ b/gigamap/codegen-test/pom.xml
@@ -19,8 +19,6 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <!-- not published -->
-        <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
     </properties>
 
@@ -94,6 +92,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/gigamap/codegen-test/pom.xml
+++ b/gigamap/codegen-test/pom.xml
@@ -96,7 +96,6 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <extensions>true</extensions>
                 <configuration>
                     <skipPublishing>true</skipPublishing>
                 </configuration>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -180,6 +180,14 @@
                     </argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -183,7 +183,6 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <extensions>true</extensions>
                 <configuration>
                     <skipPublishing>true</skipPublishing>
                 </configuration>


### PR DESCRIPTION
This pull request updates the Maven build configuration for both the `gigamap/codegen-test` and `integration-tests` modules to standardize the way publishing to Maven Central is skipped. The main changes involve replacing the old method of skipping deployment with the `central-publishing-maven-plugin` and its configuration.

**Build and Publishing Configuration Updates:**

* Removed the `<maven.deploy.skip>true</maven.deploy.skip>` property from `gigamap/codegen-test/pom.xml`, which was previously used to skip deployment.
* Added the `central-publishing-maven-plugin` with `<skipPublishing>true</skipPublishing>` to both `gigamap/codegen-test/pom.xml` and `integration-tests/pom.xml` to explicitly skip publishing artifacts to Maven Central using a consistent approach. [[1]](diffhunk://#diff-aa6d390893d2f6dcc45a7cd517991ba6beec476c8f93bd3ef787e8693b7d69c9R96-R103) [[2]](diffhunk://#diff-3b7c131fb9becff591ff3eb25a6b91b29420703e244fadc2096277504d3a2ae1R183-R190)…test