### PR TITLE
Update version to 4.2.0 in documentation and configuration

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,6 +8,6 @@ nav:
 asciidoc:
   attributes:
     product-name: 'EclipseStore'
-    display-version: '4.1.0'
+    display-version: '4.2.0'
     api-version: '4'
-    maven-version: '4.1.0'
+    maven-version: '4.2.0'

--- a/docs/modules/intro/pages/changelog.adoc
+++ b/docs/modules/intro/pages/changelog.adoc
@@ -1,6 +1,67 @@
 = Changelog
 
 
+== 4.2.0
+
+=== Features
+
+* Storage restart: an embedded storage can be started again after it has been shut down https://github.com/eclipse-serializer/serializer/pull/278[[278]] https://github.com/eclipse-store/store/pull/701[[701]]
+* xref:storage:data-integrity.adoc[Data Integrity] (opt-in, disabled by default)
+** Chunk checksums on data files, verified on startup and on demand https://github.com/eclipse-store/store/pull/717[[717]] https://github.com/eclipse-store/store/pull/728[[728]]
+** Store-time reference validation with optional self-healing https://github.com/eclipse-store/store/pull/739[[739]] https://github.com/eclipse-store/store/pull/742[[742]] https://github.com/eclipse-serializer/serializer/pull/293[[293]] https://github.com/eclipse-serializer/serializer/pull/294[[294]] https://github.com/eclipse-serializer/serializer/pull/296[[296]] https://github.com/eclipse-serializer/serializer/pull/302[[302]]
+** Configurable escalation for zombie object ids found by the garbage collector https://github.com/eclipse-store/store/pull/743[[743]]
+* Power-loss durability: new `synchronize()` (fsync) barrier on the file system abstraction, applied on file rollover and commit https://github.com/eclipse-serializer/serializer/pull/301[[301]] https://github.com/eclipse-store/store/pull/751[[751]]
+* GigaMap
+** xref:gigamap:indexing/annotations.adoc[Annotation-based index generation] for Lucene and JVector, including a compile-time index metamodel https://github.com/eclipse-store/store/pull/692[[692]] https://github.com/eclipse-store/store/pull/695[[695]] https://github.com/eclipse-store/store/pull/699[[699]]
+** Structural index lifecycle: removal of indices and constraints across all index families, redefinition for bitmap indices https://github.com/eclipse-store/store/pull/694[[694]]
+** `reindex()` to rebuild all indices from the current entity state, plus Lucene back-fill when an index is registered on a populated GigaMap https://github.com/eclipse-store/store/issues/714[[714]] https://github.com/eclipse-store/store/issues/716[[716]] https://github.com/eclipse-store/store/pull/718[[718]] https://github.com/eclipse-store/store/pull/724[[724]]
+** Entity-id based `update()` / `apply()`, so Lucene-only and JVector-only maps can be reindexed without a bitmap index https://github.com/eclipse-store/store/issues/713[[713]] https://github.com/eclipse-store/store/pull/722[[722]]
+** External-directory Lucene index commits are now coupled to `store()` instead of committing eagerly https://github.com/eclipse-store/store/issues/715[[715]] https://github.com/eclipse-store/store/pull/719[[719]]
+** Opt-in null embeddings for the vector index, and `BitmapIndices.addWithoutInitialization` for lazy registration without back-fill https://github.com/eclipse-store/store/pull/748[[748]] https://github.com/eclipse-store/store/pull/759[[759]]
+* Binary type handler for `EqConstList` https://github.com/eclipse-serializer/serializer/pull/304[[304]] https://github.com/eclipse-serializer/serializer/pull/306[[306]]
+* `PersistenceShutdownReleasable`, an opt-in contract to release resources of persisted instances on storage shutdown https://github.com/eclipse-serializer/serializer/pull/305[[305]]
+
+=== Bugfixes
+
+* Storage garbage collector: mid-cycle registration race, multi-channel data-loss windows, broken task chain after a failed prepended task, destructive re-execution of partially aborted sweeps, and dangling object ids caused by concurrent data imports https://github.com/eclipse-store/store/pull/734[[734]] https://github.com/eclipse-store/store/pull/736[[736]] https://github.com/eclipse-store/store/pull/738[[738]] https://github.com/eclipse-store/store/pull/746[[746]] https://github.com/eclipse-store/store/pull/755[[755]] https://github.com/eclipse-store/store/pull/770[[770]] https://github.com/eclipse-serializer/serializer/pull/291[[291]]
+* Transactions file compaction reworked; the previous implementation could produce a transaction log that failed timestamp validation on the next start and destroyed history on a crash mid-rewrite https://github.com/eclipse-store/store/pull/760[[760]]
+* Backup and rollback hardening: byte-count validation on all backup-relevant copy and write sites, in-flight copies superseded by a truncation, and store rollback consistency https://github.com/eclipse-store/store/pull/744[[744]] https://github.com/eclipse-store/store/pull/749[[749]] https://github.com/eclipse-store/store/pull/775[[775]] https://github.com/eclipse-serializer/serializer/pull/298[[298]]
+* Lazy references and storing: lazily skipped instances are pinned until commit, premature links are avoided, loader-built instances are published to the object registry only after completion, used-marked references are exempt from evaluator-driven clearing, and an abandoned batch storer no longer leaks its flush scheduler https://github.com/eclipse-serializer/serializer/pull/289[[289]] https://github.com/eclipse-serializer/serializer/pull/290[[290]] https://github.com/eclipse-serializer/serializer/pull/292[[292]] https://github.com/eclipse-serializer/serializer/pull/299[[299]] https://github.com/eclipse-serializer/serializer/pull/307[[307]]
+* Storage engine: duplicate entity-cache entries on type id change, wrong hash key when rebuilding the type-in-file table, missing bounds check for variable-length members in `BinaryReferenceTraverser`, and a task broker reference that prevented auto-shutdown https://github.com/eclipse-serializer/serializer/issues/282[[282]] https://github.com/eclipse-serializer/serializer/pull/286[[286]] https://github.com/eclipse-store/store/pull/726[[726]] https://github.com/eclipse-store/store/pull/740[[740]] https://github.com/eclipse-store/store/pull/741[[741]] https://github.com/eclipse-store/store/pull/767[[767]]
+* GigaMap index correctness
+** Bitmap indices: `Error` on update/set/replace, exact-match results of binary composite indices, `BinaryIndexerString` collisions on keys containing NUL, null-valued Boolean-indexed entities, multi-value indexers dropping pre-existing shared values, `notNull()` on composite indexers, and remove with short key arrays https://github.com/eclipse-store/store/issues/685[[685]] https://github.com/eclipse-store/store/pull/686[[686]] https://github.com/eclipse-store/store/issues/687[[687]] https://github.com/eclipse-store/store/pull/688[[688]] https://github.com/eclipse-store/store/pull/689[[689]] https://github.com/eclipse-store/store/pull/690[[690]] https://github.com/eclipse-store/store/pull/691[[691]] https://github.com/eclipse-store/store/pull/756[[756]] https://github.com/eclipse-store/store/pull/776[[776]]
+** Use-after-free and double-free in bitmap segment decompression https://github.com/eclipse-store/store/pull/765[[765]] https://github.com/eclipse-store/store/pull/773[[773]]
+** Stale indices after class evolution no longer delete a committed entity, and stale-key removal now fails loudly https://github.com/eclipse-store/store/pull/762[[762]] https://github.com/eclipse-store/store/pull/771[[771]]
+** Anonymous indexer name resolution after reload, and restart idempotence of generated `@Unique` constraints https://github.com/eclipse-store/store/pull/693[[693]] https://github.com/eclipse-store/store/pull/702[[702]]
+* GigaMap consistency and concurrency
+** Read-lock leaks and deadlocks during iteration; the iteration contract is now enforced https://github.com/eclipse-store/store/issues/697[[697]] https://github.com/eclipse-store/store/pull/700[[700]]
+** Silent lost updates: dirty segments are retained in `release()` and segments mutated by `apply()` / `update()` are pinned https://github.com/eclipse-store/store/pull/737[[737]] https://github.com/eclipse-store/store/pull/757[[757]]
+** Exceptions thrown from user code (indexers, update logic) no longer leave the map inconsistent, and `replace()` / `apply()` validate their `current` argument https://github.com/eclipse-store/store/pull/705[[705]] https://github.com/eclipse-store/store/pull/758[[758]]
+** Lucene reader is no longer reopened on the write path https://github.com/eclipse-store/store/pull/777[[777]]
+** JVector: abandoned vector indices (thread and graph) are reclaimed, and the graph is no longer fully rebuilt on `complete()` or on shutdown persist https://github.com/eclipse-store/store/pull/754[[754]] https://github.com/eclipse-store/store/pull/764[[764]] https://github.com/eclipse-store/store/pull/774[[774]]
+* Configuration: correct Redis file system URI prefix, Azure `accountName` typo (deprecated alias retained), and null guards for optional cloud storage credentials https://github.com/eclipse-store/store/pull/732[[732]]
+
+=== Other changes
+
+* Documentation on mutex lock behavior, continuous-backup restore consistency and the sweep-retry contract https://github.com/eclipse-store/store/pull/732[[732]] https://github.com/eclipse-store/store/pull/745[[745]]
+* Fixes for the example projects https://github.com/eclipse-store/store/pull/733[[733]]
+
+[#migration-4-2-0]
+=== Migration
+
+[WARNING]
+====
+The transaction log compaction was reworked https://github.com/eclipse-store/store/pull/760[[760]].
+A transactions file compacted by 4.2.0 uses only the already existing entry kinds, so older versions can still read it.
+
+While rewriting the log, however, 4.2.0 first puts the complete compacted content into a checksummed swap file next to the transactions file (`<transactions file name>_compaction.swp`) and heals an interrupted rewrite from it on the next start.
+Versions prior to 4.2.0 do not know this file.
+If a crash interrupts a compaction and the storage is then opened with an older version, the rewrite is not healed and the leftover swap file is ignored.
+
+After a crash during compaction, open the storage with 4.2.0 once before downgrading, and do so in writable mode - a read-only start refuses to perform the repair write.
+====
+
+
 == 4.1.0
 
 === Features

--- a/storage/embedded-tools/storage-converter/README.md
+++ b/storage/embedded-tools/storage-converter/README.md
@@ -22,7 +22,7 @@ mvn -Pconverter-standalone clean package
 To configure the input and output storage an [external configuration](https://docs.eclipsestore.io/manual/storage/configuration/index.html#external-configuration) file for each storage is required.
 
 ```console
-java -jar storage-embedded-tools-storage-converter-5.0.0-SNAPSHOT-standalone.jar sourceConfig.ini targetConfig.ini
+java -jar storage-embedded-tools-storage-converter-<version>-standalone.jar sourceConfig.ini targetConfig.ini
 ```
 
 ### StorageConverter.java
@@ -42,7 +42,7 @@ To convert the binary representation of persisted objects BinaryConverter implem
 using the BinaryConverterBitmapLevel2 converter:
 
 ```console
-java -jar storage-embedded-tools-storage-converter-5.0.0-SNAPSHOT-standalone.jar src.ini dst.ini -c org.eclipse.store.storage.embedded.tools.storage.converter.BinaryConverterBitmapLevel2
+java -jar storage-embedded-tools-storage-converter-<version>-standalone.jar src.ini dst.ini -c org.eclipse.store.storage.embedded.tools.storage.converter.BinaryConverterBitmapLevel2
 ```
 
 If more than one BinaryConverter shall be applied the -c option, including the converters must be applied in quotation marks:

--- a/storage/embedded-tools/storage-converter/README.md
+++ b/storage/embedded-tools/storage-converter/README.md
@@ -22,7 +22,7 @@ mvn -Pconverter-standalone clean package
 To configure the input and output storage an [external configuration](https://docs.eclipsestore.io/manual/storage/configuration/index.html#external-configuration) file for each storage is required.
 
 ```console
-java -jar storage-embedded-tools-storage-converter-<version>-standalone.jar sourceConfig.ini targetConfig.ini
+java -jar storage-embedded-tools-storage-converter-4.2.0-standalone.jar sourceConfig.ini targetConfig.ini
 ```
 
 ### StorageConverter.java
@@ -42,7 +42,7 @@ To convert the binary representation of persisted objects BinaryConverter implem
 using the BinaryConverterBitmapLevel2 converter:
 
 ```console
-java -jar storage-embedded-tools-storage-converter-<version>-standalone.jar src.ini dst.ini -c org.eclipse.store.storage.embedded.tools.storage.converter.BinaryConverterBitmapLevel2
+java -jar storage-embedded-tools-storage-converter-4.2.0-standalone.jar src.ini dst.ini -c org.eclipse.store.storage.embedded.tools.storage.converter.BinaryConverterBitmapLevel2
 ```
 
 If more than one BinaryConverter shall be applied the -c option, including the converters must be applied in quotation marks:

--- a/storage/embedded-tools/storage-migrator/README.md
+++ b/storage/embedded-tools/storage-migrator/README.md
@@ -24,7 +24,7 @@ mvn -Pmigrator-standalone clean package -pl storage/embedded-tools/storage-migra
 The resulting JAR is located at:
 
 ````
-storage/embedded-tools/storage-migrator/target/storage-embedded-tools-storage-migrator-<version>-jar-with-dependencies.jar
+storage/embedded-tools/storage-migrator/target/storage-embedded-tools-storage-migrator-4.2.0-jar-with-dependencies.jar
 ````
 
 To install it into your local Maven repository:
@@ -36,17 +36,17 @@ mvn -Pmigrator-standalone install -pl storage/embedded-tools/storage-migrator -a
 ### Migration of both, source code and type dictionary:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -DeclipseStoreVersion=<version> -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.2.0 -DeclipseStoreVersion=4.2.0 -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
 ````
 
 ### Migration of source code only:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -DeclipseStoreVersion=<version>
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.2.0 -DeclipseStoreVersion=4.2.0
 ````
 
 ### Migration of type dictionary only:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.2.0 -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
 ````

--- a/storage/embedded-tools/storage-migrator/README.md
+++ b/storage/embedded-tools/storage-migrator/README.md
@@ -36,17 +36,17 @@ mvn -Pmigrator-standalone install -pl storage/embedded-tools/storage-migrator -a
 ### Migration of both, source code and type dictionary:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.0.0 -DeclipseStoreVersion=4.0.0 -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -DeclipseStoreVersion=<version> -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
 ````
 
 ### Migration of source code only:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.0.0 -DeclipseStoreVersion=4.0.0
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -DeclipseStoreVersion=<version>
 ````
 
 ### Migration of type dictionary only:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.0.0 -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
 ````


### PR DESCRIPTION
This pull request updates the documentation and configuration for the EclipseStore 4.2.0 release. It includes a comprehensive changelog for version 4.2.0, updates version references throughout the documentation, and ensures that example commands and instructions are consistent with the new release.

**Changelog and Documentation Updates:**

* Added a detailed changelog for version 4.2.0 to `changelog.adoc`, covering new features, bugfixes, other changes, and migration instructions.

**Version Reference Updates:**

* Updated `display-version` and `maven-version` attributes to `4.2.0` in `docs/antora.yml`.
* Updated all relevant example commands and artifact references in `storage-converter/README.md` and `storage-migrator/README.md` to use version `4.2.0` instead of previous versions or snapshots. [[1]](diffhunk://#diff-cba0d7514ffa3af31f656b55dd2eab03b9a7edfb547918a2055e78a7e80dd282L25-R25) [[2]](diffhunk://#diff-cba0d7514ffa3af31f656b55dd2eab03b9a7edfb547918a2055e78a7e80dd282L45-R45) [[3]](diffhunk://#diff-e755c6c65d0dcbc6b373d410f786138a46e4fe17b6eb7ca20a25c29aa5563a52L27-R27) [[4]](diffhunk://#diff-e755c6c65d0dcbc6b373d410f786138a46e4fe17b6eb7ca20a25c29aa5563a52L39-R51)

These changes ensure the documentation accurately reflects the new release and provides users with up-to-date instructions and information.