### PR TITLE
Release channel-barrier waiters on a disruption

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelTask.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannelTask.java
@@ -250,7 +250,19 @@ public interface StorageChannelTask extends StorageTask
 			{
 				while(this.remainingForProcessing > 0)
 				{
-					this.problems.wait();
+					// A channel stopped by a disruption never decrements remainingForProcessing, so an
+					// untimed wait() would hang this sibling - and any later synchronizing task, shutdown
+					// included - forever. Wake periodically and abort on a disruption instead. Only
+					// disruptions are checked, not task-level problems (those always resolve, as
+					// finishProcessing() runs in a finally), so the normal completion dispatch is unchanged.
+					if(this.controller.hasDisruptions())
+					{
+						throw new StorageException(
+							"Aborting wait on processing after: ",
+							this.controller.disruptions().first()
+						);
+					}
+					this.problems.wait(100);
 				}
 			}
 		}


### PR DESCRIPTION
 StorageChannelTask.waitOnProcessing() did an untimed wait() with no
  disruption check. A channel stopped by a disruption (e.g. an I/O error
  during a housekeeping transfer) never decrements the task's processing
  counter, so sibling channels parked in that barrier - and any later
  synchronizing task, shutdown included - waited forever; shutdown() then
  deadlocked in joinChannelThreads and the JVM could not exit.

  Make the wait a timed wait(100) that aborts on controller.hasDisruptions(),
  mirroring waitOnCompletion(). The throw terminates the channel through the
  existing stop path (as an interrupt already does). Only disruptions are
  checked, not task-level problems - those always resolve because
  finishProcessing() runs in a finally - so the normal completion dispatch is
  unchanged.