### PR TITLE
Remove hardcoced version, replace with placeholder

### DIFF
--- a/storage/embedded-tools/storage-converter/README.md
+++ b/storage/embedded-tools/storage-converter/README.md
@@ -21,8 +21,10 @@ mvn -Pconverter-standalone clean package
 
 To configure the input and output storage an [external configuration](https://docs.eclipsestore.io/manual/storage/configuration/index.html#external-configuration) file for each storage is required.
 
+Run the generated JAR file (replace `<version>` with your built version):
+
 ```console
-java -jar storage-embedded-tools-storage-converter-4.2.0-standalone.jar sourceConfig.ini targetConfig.ini
+java -jar storage-embedded-tools-storage-converter-<version>-standalone.jar sourceConfig.ini targetConfig.ini
 ```
 
 ### StorageConverter.java
@@ -42,7 +44,7 @@ To convert the binary representation of persisted objects BinaryConverter implem
 using the BinaryConverterBitmapLevel2 converter:
 
 ```console
-java -jar storage-embedded-tools-storage-converter-4.2.0-standalone.jar src.ini dst.ini -c org.eclipse.store.storage.embedded.tools.storage.converter.BinaryConverterBitmapLevel2
+java -jar storage-embedded-tools-storage-converter-<version>-standalone.jar src.ini dst.ini -c org.eclipse.store.storage.embedded.tools.storage.converter.BinaryConverterBitmapLevel2
 ```
 
 If more than one BinaryConverter shall be applied the -c option, including the converters must be applied in quotation marks:

--- a/storage/embedded-tools/storage-migrator/README.md
+++ b/storage/embedded-tools/storage-migrator/README.md
@@ -21,10 +21,10 @@ The standalone JAR (fat JAR with all dependencies) is not built by default. To b
 mvn -Pmigrator-standalone clean package -pl storage/embedded-tools/storage-migrator -am
 ````
 
-The resulting JAR is located at:
+The resulting JAR is located at: (Replace `<version>` with your built version):
 
 ````
-storage/embedded-tools/storage-migrator/target/storage-embedded-tools-storage-migrator-4.2.0-jar-with-dependencies.jar
+storage/embedded-tools/storage-migrator/target/storage-embedded-tools-storage-migrator-<version>-jar-with-dependencies.jar
 ````
 
 To install it into your local Maven repository:
@@ -36,17 +36,17 @@ mvn -Pmigrator-standalone install -pl storage/embedded-tools/storage-migrator -a
 ### Migration of both, source code and type dictionary:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.2.0 -DeclipseStoreVersion=4.2.0 -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -DeclipseStoreVersion=<version> -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
 ````
 
 ### Migration of source code only:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.2.0 -DeclipseStoreVersion=4.2.0
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version -DeclipseStoreVersion=<version>
 ````
 
 ### Migration of type dictionary only:
 
 ````
-mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:4.2.0 -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
+mvn org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.eclipse.store.storage.embedded.tools.storage.migrator.ConvertProject -Drewrite.recipeArtifactCoordinates=org.eclipse.store:storage-embedded-tools-storage-migrator:<version> -Drewrite.plainTextMasks=**/*.ptd  -DtypeDictionaryRelativeFilePath=src/main/resources/PersistenceTypeDictionary.ptd
 ````


### PR DESCRIPTION
This pull request updates the documentation for the storage converter and migrator tools to use a placeholder for the version number instead of a hardcoded version. This makes the instructions more flexible and easier to follow for users building different versions.

Documentation improvements:

* Updated all example commands in `storage-converter/README.md` and `storage-migrator/README.md` to use `<version>` as a placeholder for the version number, replacing the previously hardcoded `4.2.0`. [[1]](diffhunk://#diff-cba0d7514ffa3af31f656b55dd2eab03b9a7edfb547918a2055e78a7e80dd282R24-R27) [[2]](diffhunk://#diff-cba0d7514ffa3af31f656b55dd2eab03b9a7edfb547918a2055e78a7e80dd282L45-R47) [[3]](diffhunk://#diff-e755c6c65d0dcbc6b373d410f786138a46e4fe17b6eb7ca20a25c29aa5563a52L24-R27) [[4]](diffhunk://#diff-e755c6c65d0dcbc6b373d410f786138a46e4fe17b6eb7ca20a25c29aa5563a52L39-R51)
* Added clarifying instructions in the migrator README to indicate that `<version>` should be replaced with the user’s built version.