### PR TITLE
Rework storage lock-file manager (lifecycle, exclusion, scheduling)

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/locking/LockFileTestSupport.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/LockFileTestSupport.java
@@ -1,0 +1,198 @@
+package test.eclipse.store.locking;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.Callable;
+import java.util.stream.Stream;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+
+/**
+ * Shared helpers for the storage lock-file integration tests: starting managers that model distinct
+ * processes on the same directory, observing the lock-file worker thread, and asserting lock refusals.
+ */
+final class LockFileTestSupport
+{
+	static final String LOCK_THREAD_NAME = "StorageLockFileManager";
+
+	private LockFileTestSupport()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Starts a manager with an explicit database name and process identity, so a single JVM can model
+	 * two independent processes competing for the same storage directory: distinct database names
+	 * bypass the JVM-local database registry, leaving the lock file as the only remaining gate.
+	 */
+	static EmbeddedStorageManager startManager(
+		final Path   directory       ,
+		final String databaseName     ,
+		final String processIdentity  ,
+		final long   updateIntervalMs
+	)
+	{
+		return EmbeddedStorage.Foundation(directory)
+			.setDataBaseName(databaseName)
+			.setLockFileSetupProvider(Storage.LockFileSetupProvider(updateIntervalMs))
+			.setProcessIdentityProvider(() -> processIdentity)
+			.start();
+	}
+
+	static long liveLockThreadCount()
+	{
+		return Thread.getAllStackTraces().keySet().stream()
+			.filter(Thread::isAlive)
+			.filter(thread -> !thread.isDaemon())
+			.filter(thread -> LOCK_THREAD_NAME.equals(thread.getName()))
+			.count();
+	}
+
+	static boolean awaitLockThreadCount(final long expected, final long timeoutMs) throws InterruptedException
+	{
+		final long deadline = System.nanoTime() + timeoutMs * 1_000_000L;
+		do
+		{
+			if(liveLockThreadCount() == expected)
+			{
+				return true;
+			}
+			Thread.sleep(20);
+		}
+		while(System.nanoTime() < deadline);
+
+		return liveLockThreadCount() == expected;
+	}
+
+	/**
+	 * Asserts that opening the given manager is refused with a lock-related error. If it is wrongly
+	 * admitted, the manager is shut down before the assertion fails so a stray manager cannot leak.
+	 */
+	static void assertRefused(final Callable<EmbeddedStorageManager> open)
+	{
+		EmbeddedStorageManager admitted = null;
+		try
+		{
+			admitted = open.call();
+		}
+		catch(final Throwable refusal)
+		{
+			assertTrue(isLockRefusal(refusal), "expected a lock refusal, but was: " + refusal);
+			return;
+		}
+
+		try
+		{
+			admitted.shutdown();
+		}
+		catch(final Throwable ignore)
+		{
+			// best-effort cleanup of the wrongly-admitted manager
+		}
+		fail("second manager was admitted but must have been refused");
+	}
+
+	private static boolean isLockRefusal(final Throwable t)
+	{
+		for(Throwable cause = t; cause != null; cause = cause.getCause())
+		{
+			final String message = cause.getMessage();
+			if(message != null)
+			{
+				final String lower = message.toLowerCase();
+				if(lower.contains("in use") || lower.contains("unreadable"))
+				{
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	static Object fieldValueOfType(final Object owner, final String typeName) throws Exception
+	{
+		final Class<?> target = Class.forName(typeName);
+		for(Class<?> c = owner.getClass(); c != null && c != Object.class; c = c.getSuperclass())
+		{
+			for(final Field field : c.getDeclaredFields())
+			{
+				if(target.isAssignableFrom(field.getType()))
+				{
+					field.setAccessible(true);
+					final Object value = field.get(owner);
+					if(value != null)
+					{
+						return value;
+					}
+				}
+			}
+		}
+		throw new AssertionError("no non-null field of type " + typeName + " found on " + owner.getClass());
+	}
+
+	static void forceStop(final Object lockFileManager)
+	{
+		if(lockFileManager == null)
+		{
+			return;
+		}
+		try
+		{
+			final Method stop = lockFileManager.getClass().getMethod("stop");
+			stop.invoke(lockFileManager);
+		}
+		catch(final Throwable ignore)
+		{
+			// best-effort safety net so a failed assertion cannot leave a non-daemon thread hanging the fork
+		}
+	}
+
+	static void deleteQuietly(final Path root)
+	{
+		if(root == null)
+		{
+			return;
+		}
+		try(final Stream<Path> paths = Files.walk(root))
+		{
+			paths.sorted(Comparator.reverseOrder()).forEach(path ->
+			{
+				try
+				{
+					Files.deleteIfExists(path);
+				}
+				catch(final IOException ignore)
+				{
+					// files may still be held briefly after a non-graceful stop; leave them to the OS
+				}
+			});
+		}
+		catch(final IOException ignore)
+		{
+			// best-effort recursive delete
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/locking/LockFileTestSupport.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/LockFileTestSupport.java
@@ -17,14 +17,10 @@ package test.eclipse.store.locking;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.concurrent.Callable;
-import java.util.stream.Stream;
 
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -167,32 +163,6 @@ final class LockFileTestSupport
 		catch(final Throwable ignore)
 		{
 			// best-effort safety net so a failed assertion cannot leave a non-daemon thread hanging the fork
-		}
-	}
-
-	static void deleteQuietly(final Path root)
-	{
-		if(root == null)
-		{
-			return;
-		}
-		try(final Stream<Path> paths = Files.walk(root))
-		{
-			paths.sorted(Comparator.reverseOrder()).forEach(path ->
-			{
-				try
-				{
-					Files.deleteIfExists(path);
-				}
-				catch(final IOException ignore)
-				{
-					// files may still be held briefly after a non-graceful stop; leave them to the OS
-				}
-			});
-		}
-		catch(final IOException ignore)
-		{
-			// best-effort recursive delete
 		}
 	}
 }

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileCompatibilityTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileCompatibilityTest.java
@@ -1,0 +1,82 @@
+package test.eclipse.store.locking;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static test.eclipse.store.locking.LockFileTestSupport.startManager;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies lock-file behavior across restarts: the same process may reopen its own storage, and a lock
+ * file written in the previous on-disk format is accepted (and rewritten) rather than rejected, so an
+ * upgrade never fails to start on a leftover lock file.
+ */
+public class StorageLockFileCompatibilityTest
+{
+	@Test
+	@Timeout(120)
+	void restartBySameProcessReusesLock(@TempDir final Path dir)
+	{
+		final EmbeddedStorageManager first = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		first.setRoot("v1");
+		first.storeRoot();
+		first.shutdown();
+
+		final EmbeddedStorageManager second = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		try
+		{
+			assertEquals("v1", second.root());
+		}
+		finally
+		{
+			second.shutdown();
+		}
+	}
+
+	@Test
+	@Timeout(120)
+	void lockFileInPreviousFormatIsAcceptedOnRestart(@TempDir final Path dir) throws Exception
+	{
+		final Path   lockFile = dir.resolve("used.lock");
+		final String identity = "PROCESS-A";
+		final long   now      = System.currentTimeMillis();
+
+		// The previous on-disk format carried no session marker: lastWriteTime;expirationTime;identifier.
+		// A manager with the same identity must reuse it rather than reject it as unreadable.
+		final String previousFormat = now + ";" + (now + 60_000L) + ";" + identity;
+		Files.write(lockFile, previousFormat.getBytes(StandardCharsets.UTF_8));
+
+		final EmbeddedStorageManager manager = startManager(dir, "DB", identity, 60_000L);
+		try
+		{
+			manager.setRoot("data");
+			manager.storeRoot();
+			assertTrue(Files.size(lockFile) > 0, "lock file must be rewritten in the current format");
+		}
+		finally
+		{
+			manager.shutdown();
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileCompatibilityTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileCompatibilityTest.java
@@ -38,12 +38,12 @@ public class StorageLockFileCompatibilityTest
 	@Timeout(120)
 	void restartBySameProcessReusesLock(@TempDir final Path dir)
 	{
-		final EmbeddedStorageManager first = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		final EmbeddedStorageManager first = startManager(dir, "lock-compat-restart", "PROCESS-A", 60_000L);
 		first.setRoot("v1");
 		first.storeRoot();
 		first.shutdown();
 
-		final EmbeddedStorageManager second = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		final EmbeddedStorageManager second = startManager(dir, "lock-compat-restart", "PROCESS-A", 60_000L);
 		try
 		{
 			assertEquals("v1", second.root());
@@ -67,7 +67,7 @@ public class StorageLockFileCompatibilityTest
 		final String previousFormat = now + ";" + (now + 60_000L) + ";" + identity;
 		Files.write(lockFile, previousFormat.getBytes(StandardCharsets.UTF_8));
 
-		final EmbeddedStorageManager manager = startManager(dir, "DB", identity, 60_000L);
+		final EmbeddedStorageManager manager = startManager(dir, "lock-compat-legacy", identity, 60_000L);
 		try
 		{
 			manager.setRoot("data");

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileExclusionTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileExclusionTest.java
@@ -69,6 +69,7 @@ public class StorageLockFileExclusionTest
 			// Emptying the lock file models both the truncate window of a heartbeat and an externally
 			// cleared file; neither must be treated as a free directory.
 			Files.write(lockFile, new byte[0]);
+			assertTrue(Files.size(lockFile) == 0L, "precondition: lock file must be empty");
 
 			assertRefused(() -> startManager(dir, "lock-excl-cleared-b", "PROCESS-B", 600_000_000L));
 		}

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileExclusionTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileExclusionTest.java
@@ -1,0 +1,80 @@
+package test.eclipse.store.locking;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static test.eclipse.store.locking.LockFileTestSupport.assertRefused;
+import static test.eclipse.store.locking.LockFileTestSupport.startManager;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that the storage-directory lock file excludes a second, independently-identified storage
+ * from opening a directory that is already in use - including when the lock file has been emptied,
+ * which must never be interpreted as a free directory.
+ */
+public class StorageLockFileExclusionTest
+{
+	@Test
+	@Timeout(120)
+	void secondProcessIsRefusedWhileFirstIsActive(@TempDir final Path dir)
+	{
+		final EmbeddedStorageManager first = startManager(dir, "DB-A", "PROCESS-A", 60_000L);
+		try
+		{
+			first.setRoot("owned-by-A");
+			first.storeRoot();
+
+			assertRefused(() -> startManager(dir, "DB-B", "PROCESS-B", 60_000L));
+		}
+		finally
+		{
+			first.shutdown();
+		}
+	}
+
+	@Test
+	@Timeout(120)
+	void secondProcessIsRefusedWhenLockFileIsCleared(@TempDir final Path dir) throws Exception
+	{
+		final Path lockFile = dir.resolve("used.lock");
+
+		// A very large interval keeps the active manager from rewriting the lock file during the test,
+		// so the emptied state below is what the second manager actually observes.
+		final EmbeddedStorageManager first = startManager(dir, "DB-A", "PROCESS-A", 600_000_000L);
+		try
+		{
+			first.setRoot("owned-by-A");
+			first.storeRoot();
+			assertTrue(Files.size(lockFile) > 0, "lock file must exist while the storage is in use");
+
+			// Emptying the lock file models both the truncate window of a heartbeat and an externally
+			// cleared file; neither must be treated as a free directory.
+			Files.write(lockFile, new byte[0]);
+
+			assertRefused(() -> startManager(dir, "DB-B", "PROCESS-B", 600_000_000L));
+		}
+		finally
+		{
+			first.shutdown();
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileExclusionTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileExclusionTest.java
@@ -37,13 +37,13 @@ public class StorageLockFileExclusionTest
 	@Timeout(120)
 	void secondProcessIsRefusedWhileFirstIsActive(@TempDir final Path dir)
 	{
-		final EmbeddedStorageManager first = startManager(dir, "DB-A", "PROCESS-A", 60_000L);
+		final EmbeddedStorageManager first = startManager(dir, "lock-excl-active-a", "PROCESS-A", 60_000L);
 		try
 		{
 			first.setRoot("owned-by-A");
 			first.storeRoot();
 
-			assertRefused(() -> startManager(dir, "DB-B", "PROCESS-B", 60_000L));
+			assertRefused(() -> startManager(dir, "lock-excl-active-b", "PROCESS-B", 60_000L));
 		}
 		finally
 		{
@@ -59,7 +59,7 @@ public class StorageLockFileExclusionTest
 
 		// A very large interval keeps the active manager from rewriting the lock file during the test,
 		// so the emptied state below is what the second manager actually observes.
-		final EmbeddedStorageManager first = startManager(dir, "DB-A", "PROCESS-A", 600_000_000L);
+		final EmbeddedStorageManager first = startManager(dir, "lock-excl-cleared-a", "PROCESS-A", 600_000_000L);
 		try
 		{
 			first.setRoot("owned-by-A");
@@ -70,7 +70,7 @@ public class StorageLockFileExclusionTest
 			// cleared file; neither must be treated as a free directory.
 			Files.write(lockFile, new byte[0]);
 
-			assertRefused(() -> startManager(dir, "DB-B", "PROCESS-B", 600_000_000L));
+			assertRefused(() -> startManager(dir, "lock-excl-cleared-b", "PROCESS-B", 600_000_000L));
 		}
 		finally
 		{

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileThreadLifecycleTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileThreadLifecycleTest.java
@@ -16,14 +16,12 @@ package test.eclipse.store.locking;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static test.eclipse.store.locking.LockFileTestSupport.awaitLockThreadCount;
-import static test.eclipse.store.locking.LockFileTestSupport.deleteQuietly;
 import static test.eclipse.store.locking.LockFileTestSupport.fieldValueOfType;
 import static test.eclipse.store.locking.LockFileTestSupport.forceStop;
 import static test.eclipse.store.locking.LockFileTestSupport.liveLockThreadCount;
 import static test.eclipse.store.locking.LockFileTestSupport.startManager;
 
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -54,11 +52,8 @@ public class StorageLockFileThreadLifecycleTest
 
 	@Test
 	@Timeout(120)
-	void nonGracefulStopStopsLockThread() throws Exception
+	void nonGracefulStopStopsLockThread(@TempDir final Path dir) throws Exception
 	{
-		// A manually managed directory (not @TempDir) is used because a non-graceful stop does not join
-		// the channel threads, so files may still be held briefly; cleanup is therefore best-effort.
-		final Path dir = Files.createTempDirectory("lockfile-kill-");
 		final long baseline = liveLockThreadCount();
 
 		final EmbeddedStorageManager manager = startManager(dir, "lock-life-kill", "PROCESS-A", 60_000L);
@@ -78,7 +73,6 @@ public class StorageLockFileThreadLifecycleTest
 		finally
 		{
 			forceStop(lockFileManager);
-			deleteQuietly(dir);
 		}
 	}
 }

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileThreadLifecycleTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileThreadLifecycleTest.java
@@ -1,0 +1,84 @@
+package test.eclipse.store.locking;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static test.eclipse.store.locking.LockFileTestSupport.awaitLockThreadCount;
+import static test.eclipse.store.locking.LockFileTestSupport.deleteQuietly;
+import static test.eclipse.store.locking.LockFileTestSupport.fieldValueOfType;
+import static test.eclipse.store.locking.LockFileTestSupport.forceStop;
+import static test.eclipse.store.locking.LockFileTestSupport.liveLockThreadCount;
+import static test.eclipse.store.locking.LockFileTestSupport.startManager;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that the lock file's non-daemon worker thread is always released when the storage stops,
+ * both on a graceful shutdown and on a non-graceful (kill) teardown, so a stopped storage never keeps
+ * the JVM alive. Counts are taken relative to a baseline so the assertions are independent of any
+ * unrelated threads that may exist in the test JVM.
+ */
+public class StorageLockFileThreadLifecycleTest
+{
+	@Test
+	@Timeout(120)
+	void gracefulShutdownStopsLockThread(@TempDir final Path dir) throws Exception
+	{
+		final long baseline = liveLockThreadCount();
+
+		final EmbeddedStorageManager manager = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		assertTrue(awaitLockThreadCount(baseline + 1, 2_000L), "lock thread must be running after start");
+
+		manager.shutdown();
+		assertTrue(awaitLockThreadCount(baseline, 3_000L), "lock thread must be gone after shutdown");
+	}
+
+	@Test
+	@Timeout(120)
+	void nonGracefulStopStopsLockThread() throws Exception
+	{
+		// A manually managed directory (not @TempDir) is used because a non-graceful stop does not join
+		// the channel threads, so files may still be held briefly; cleanup is therefore best-effort.
+		final Path dir = Files.createTempDirectory("lockfile-kill-");
+		final long baseline = liveLockThreadCount();
+
+		final EmbeddedStorageManager manager = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		Object lockFileManager = null;
+		try
+		{
+			assertTrue(awaitLockThreadCount(baseline + 1, 2_000L), "lock thread must be running after start");
+
+			final Object storageSystem = fieldValueOfType(manager, "org.eclipse.store.storage.types.StorageSystem");
+			lockFileManager = fieldValueOfType(storageSystem, "org.eclipse.store.storage.types.StorageLockFileManager");
+
+			final Method killStorage = storageSystem.getClass().getMethod("killStorage", Throwable.class);
+			killStorage.invoke(storageSystem, (Throwable)null);
+
+			assertTrue(awaitLockThreadCount(baseline, 3_000L), "lock thread must be gone after a non-graceful stop");
+		}
+		finally
+		{
+			forceStop(lockFileManager);
+			deleteQuietly(dir);
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileThreadLifecycleTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/locking/StorageLockFileThreadLifecycleTest.java
@@ -45,7 +45,7 @@ public class StorageLockFileThreadLifecycleTest
 	{
 		final long baseline = liveLockThreadCount();
 
-		final EmbeddedStorageManager manager = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		final EmbeddedStorageManager manager = startManager(dir, "lock-life-graceful", "PROCESS-A", 60_000L);
 		assertTrue(awaitLockThreadCount(baseline + 1, 2_000L), "lock thread must be running after start");
 
 		manager.shutdown();
@@ -61,7 +61,7 @@ public class StorageLockFileThreadLifecycleTest
 		final Path dir = Files.createTempDirectory("lockfile-kill-");
 		final long baseline = liveLockThreadCount();
 
-		final EmbeddedStorageManager manager = startManager(dir, "DB", "PROCESS-A", 60_000L);
+		final EmbeddedStorageManager manager = startManager(dir, "lock-life-kill", "PROCESS-A", 60_000L);
 		Object lockFileManager = null;
 		try
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
@@ -168,7 +168,7 @@ public interface StorageLockFileManager extends Runnable
 		public StorageLockFileManager.Default start()
 		{
 			logger.info("Starting log file manager thread ");
-			this.executor.scheduleWithFixedDelay(this, 0, this.setup.updateInterval(), TimeUnit.MICROSECONDS);
+			this.executor.scheduleWithFixedDelay(this, 0, this.setup.updateInterval(), TimeUnit.MILLISECONDS);
 			return this;
 		}
 
@@ -183,7 +183,10 @@ public interface StorageLockFileManager extends Runnable
 				}
 				else
 				{
-					logger.error("Lock File Manager is not ready!");
+					// controller deactivated (teardown) without a disruption: nothing to recover, so stop
+					// instead of ticking (and logging) forever on a leaked non-daemon thread.
+					logger.info("Lock file manager no longer ready, stopping.");
+					this.stop();
 				}
 			}
 			catch(final Exception e)
@@ -197,8 +200,9 @@ public interface StorageLockFileManager extends Runnable
 		@Override
 		public StorageLockFileManager stop()
 		{
-			if(this.executor.isShutdown()) return this;
-			
+			// No early return on an already-shutdown executor: initialize()'s refusal path shuts it down
+			// before throwing, so the lock file must still be closed here. awaitTermination joins any
+			// still-running task before the finally closes the file, avoiding a close-vs-read race.
 			this.executor.shutdown();
 			try
 			{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
@@ -403,23 +403,38 @@ public interface StorageLockFileManager extends Runnable
 		
 		private LockFileData readLockFileData()
 		{
-			// format: lastWriteTime;expirationTime;nonce;identifier
+			// current format: lastWriteTime;expirationTime;nonce;identifier
+			// legacy format (pre-nonce): lastWriteTime;expirationTime;identifier
+			// The legacy form is tolerated so an existing lock file written by an older version does not
+			// fail closed on the first start after an upgrade; a fresh claim rewrites it in the current format.
 			final String s = this.readString();
 
 			final int i1 = s.indexOf(';');
 			final int i2 = i1 < 0 ? -1 : s.indexOf(';', i1 + 1);
-			final int i3 = i2 < 0 ? -1 : s.indexOf(';', i2 + 1);
-			if(i1 < 0 || i2 < 0 || i3 < 0)
+			if(i1 < 0 || i2 < 0)
 			{
 				throw new StorageException("Malformed storage lock file content.");
 			}
+			final int i3 = s.indexOf(';', i2 + 1);
 
 			try
 			{
 				final long   lastWriteTime  = Long.parseLong(s.substring(0, i1));
 				final long   expirationTime = Long.parseLong(s.substring(i1 + 1, i2));
-				final String nonce          = s.substring(i2 + 1, i3);
-				final String identifier     = s.substring(i3 + 1);
+
+				final String nonce;
+				final String identifier;
+				if(i3 < 0)
+				{
+					// legacy: no nonce present.
+					nonce      = "";
+					identifier = s.substring(i2 + 1);
+				}
+				else
+				{
+					nonce      = s.substring(i2 + 1, i3);
+					identifier = s.substring(i3 + 1);
+				}
 
 				return new LockFileData(lastWriteTime, expirationTime, nonce, identifier);
 			}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
@@ -98,20 +98,20 @@ public interface StorageLockFileManager extends Runnable
 		// instance fields //
 		////////////////////
 		
-		private final StorageLockFileSetup                 setup              ;
-		private final StorageOperationController           operationController;
+		private final StorageLockFileSetup               setup              ;
+		private final StorageOperationController         operationController;
 		
 		// cached values
-		private transient StorageLockFile       lockFile                ;
-		private transient LockFileData          lockFileData            ;
-		private transient String                sessionNonce            ;
-		private transient ByteBuffer[]          wrappedByteBuffer       ;
-		private transient ArrayView<ByteBuffer> wrappedWrappedByteBuffer;
-		private transient ByteBuffer            directByteBuffer        ;
-		private transient byte[]                stringReadBuffer        ;
-		private transient VarString vs                                  ;
-		private transient AFileSystem fileSystem                        ;
-		private transient ScheduledExecutorService executor             ;
+		private transient StorageLockFile                lockFile                ;
+		private transient LockFileData                   lockFileData            ;
+		private transient String                         sessionNonce            ;
+		private final transient ByteBuffer[]             wrappedByteBuffer       ;
+		private final transient ArrayView<ByteBuffer>    wrappedWrappedByteBuffer;
+		private transient ByteBuffer                     directByteBuffer        ;
+		private transient byte[]                         stringReadBuffer        ;
+		private final transient VarString                vs                      ;
+		private final transient AFileSystem              fileSystem              ;
+		private final transient ScheduledExecutorService executor                ;
 		
 		
 		///////////////////////////////////////////////////////////////////////////

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
@@ -17,19 +17,15 @@ package org.eclipse.store.storage.types;
 import static org.eclipse.serializer.util.X.notNull;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.ExecutionException;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.eclipse.serializer.afs.types.AFile;
 import org.eclipse.serializer.afs.types.AFileSystem;
 import org.eclipse.serializer.chars.VarString;
-import org.eclipse.serializer.chars.XChars;
 import org.eclipse.serializer.collections.ArrayView;
-import org.eclipse.serializer.collections.XArrays;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.util.X;
 import org.eclipse.serializer.util.logging.Logging;
@@ -108,11 +104,11 @@ public interface StorageLockFileManager extends Runnable
 		// cached values
 		private transient StorageLockFile       lockFile                ;
 		private transient LockFileData          lockFileData            ;
+		private transient String                sessionNonce            ;
 		private transient ByteBuffer[]          wrappedByteBuffer       ;
 		private transient ArrayView<ByteBuffer> wrappedWrappedByteBuffer;
 		private transient ByteBuffer            directByteBuffer        ;
 		private transient byte[]                stringReadBuffer        ;
-		private transient byte[]                stringWriteBuffer       ;
 		private transient VarString vs                                  ;
 		private transient AFileSystem fileSystem                        ;
 		private transient ScheduledExecutorService executor             ;
@@ -138,7 +134,6 @@ public interface StorageLockFileManager extends Runnable
 			this.wrappedWrappedByteBuffer = X.ArrayView(this.wrappedByteBuffer);
 
 			this.stringReadBuffer = new byte[64];
-			this.stringWriteBuffer = this.stringReadBuffer.clone();
 			this.allocateBuffer(this.stringReadBuffer.length);
 			
 			this.executor = Executors.newSingleThreadScheduledExecutor(threadProvider);
@@ -241,56 +236,83 @@ public interface StorageLockFileManager extends Runnable
 		public void initialize()
 		{
 			logger.info("initializing lock file manager for storage {}", this.setup.processIdentity());
-			
+
 			final StorageLiveFileProvider fileProvider = this.setup.lockFileProvider();
 			final AFile lockFile     = fileProvider.provideLockFile();
 			this.lockFile = StorageLockFile.New(lockFile);
-			
-			
-			LockFileData initialFileData = null;
-			if(this.lockFileHasContent()) {
-				
-				initialFileData = this.readLockFileData();
-				if(!this.validateExistingLockFileData(initialFileData))
-				{
-					// wait one interval and try a second time
-					logger.warn("Non expired storage lock found! Retrying once");
-					
-					ScheduledFuture<Boolean> future = this.executor.schedule(() ->
-						this.validateExistingLockFileData(this.readLockFileData()),
-						initialFileData.updateInterval,
-						TimeUnit.MILLISECONDS);
-									
-					try {
-						if(!future.get(initialFileData.updateInterval *2, TimeUnit.MILLISECONDS)) {
-							this.executor.shutdownNow();
-							throw new StorageException("Storage already in use by: " + initialFileData.identifier);
-						}
-					} catch(InterruptedException | ExecutionException | TimeoutException e) {
-						this.executor.shutdownNow();
-						throw new StorageException("failed to validate lock file", e);
-					}
-				}
-				
-				
+
+			// Absent lock file => legitimate fresh start. Present but unreadable => fail closed (see
+			// #readExistingLockFileDataOrNull): an existing-but-unparseable lock (another process' truncate
+			// window, a torn write) must not be treated as free, or two writers could both claim.
+			final LockFileData existing = this.readExistingLockFileDataOrNull();
+			if(existing != null && !this.validateExistingLockFileData(existing))
+			{
+				throw new StorageException("Storage already in use by: " + existing.identifier);
 			}
-			
+
 			if(this.isReadOnlyMode())
 			{
-				if(initialFileData != null)
-				{
-					// write buffer must be filled with the file's current content so the check will be successful.
-					this.setToWriteBuffer(initialFileData);
-				}
-				
-				// abort, since neither lockFileData nor writing is required/allowed in read-only mode.
+				// read-only never claims; only remember the current owner (if any) to detect a later takeover.
+				this.sessionNonce = existing != null ? existing.nonce : null;
 				return;
 			}
 
-			this.lockFileData = new LockFileData(this.setup.processIdentity(), this.setup.updateInterval());
-			
+			// Claim with a fresh per-session nonce, then verify the claim survived a concurrent claimer
+			// before the caller runs recovery writes (initialize() completes before startup recovery).
+			this.sessionNonce = newNonce();
+			this.lockFileData = new LockFileData(this.setup.processIdentity(), this.sessionNonce, this.setup.updateInterval());
+
 			this.lockFile.file().ensureExists();
 			this.writeLockFileData();
+			this.verifyClaim();
+		}
+
+		/**
+		 * Reads the current lock file content. Returns {@code null} only if the lock file does not exist
+		 * (a legitimate fresh start). If the file exists but cannot be parsed (empty, torn or partial
+		 * write), it fails closed rather than treating the storage as free.
+		 */
+		private LockFileData readExistingLockFileDataOrNull()
+		{
+			if(!this.lockFile.exists())
+			{
+				return null;
+			}
+
+			try
+			{
+				return this.readLockFileData();
+			}
+			catch(final StorageException e)
+			{
+				throw new StorageException(
+					"Storage lock file is present but unreadable; refusing to start to avoid split-brain.",
+					e
+				);
+			}
+		}
+
+		/**
+		 * Confirms our just-written claim is still on disk before any recovery write happens. If a
+		 * concurrent process overwrote it, the nonce differs and startup is aborted.
+		 */
+		private void verifyClaim()
+		{
+			final LockFileData current = this.readLockFileData();
+			if(!this.sessionNonce.equals(current.nonce))
+			{
+				throw new StorageException(
+					"Storage already in use: lock claim was overwritten by a concurrent process ("
+					+ current.identifier + ")."
+				);
+			}
+		}
+
+		private static String newNonce()
+		{
+			// Fresh per-session identity: distinguishes our writes from a foreign takeover and from a
+			// previous session that reused the same process identity.
+			return UUID.randomUUID().toString();
 		}
 		
 		
@@ -337,9 +359,7 @@ public interface StorageLockFileManager extends Runnable
 		{
 			this.ensureBufferCapacity(bytes.length);
 			this.directByteBuffer.clear();
-			
-			this.stringWriteBuffer = bytes;
-			
+
 			return this.wrappedWrappedByteBuffer;
 		}
 		
@@ -383,51 +403,51 @@ public interface StorageLockFileManager extends Runnable
 		
 		private LockFileData readLockFileData()
 		{
-			final String currentFileData = this.readString();
-			
-			// since JDK 9's String change, there's even one more copying required.
-			final char[] chars = currentFileData.toCharArray();
-			
-			final int sep1Index = indexOfFirstNonNumberCharacter(chars, 0);
-			final int sep2Index = indexOfFirstNonNumberCharacter(chars, sep1Index + 1);
-			
-			final long   currentTime    = XChars.parse_longDecimal(chars, 0, sep1Index);
-			final long   expirationTime = XChars.parse_longDecimal(chars, sep1Index + 1, sep2Index - sep1Index - 1);
-			final String identifier     = String.valueOf(chars, sep2Index + 1, chars.length - sep2Index - 1);
-			
-			return new LockFileData(currentTime, expirationTime, identifier);
-		}
-		
-		static final int indexOfFirstNonNumberCharacter(final char[] data, final int offset)
-		{
-			for(int i = offset; i < data.length; i++)
+			// format: lastWriteTime;expirationTime;nonce;identifier
+			final String s = this.readString();
+
+			final int i1 = s.indexOf(';');
+			final int i2 = i1 < 0 ? -1 : s.indexOf(';', i1 + 1);
+			final int i3 = i2 < 0 ? -1 : s.indexOf(';', i2 + 1);
+			if(i1 < 0 || i2 < 0 || i3 < 0)
 			{
-				if(data[i] < '0' || data[i] > '9')
-				{
-					return i;
-				}
+				throw new StorageException("Malformed storage lock file content.");
 			}
-			
-			throw new StorageException("No separator found in lock file string.");
+
+			try
+			{
+				final long   lastWriteTime  = Long.parseLong(s.substring(0, i1));
+				final long   expirationTime = Long.parseLong(s.substring(i1 + 1, i2));
+				final String nonce          = s.substring(i2 + 1, i3);
+				final String identifier     = s.substring(i3 + 1);
+
+				return new LockFileData(lastWriteTime, expirationTime, nonce, identifier);
+			}
+			catch(final NumberFormatException e)
+			{
+				throw new StorageException("Malformed storage lock file timestamps.", e);
+			}
 		}
 		
 		static final class LockFileData
 		{
 			      long   lastWriteTime ;
 			      long   expirationTime;
+			final String nonce         ;
 			final String identifier    ;
 			final long   updateInterval;
-			
-			LockFileData(final String identifier, final long updateInterval)
+
+			LockFileData(final String identifier, final String nonce, final long updateInterval)
 			{
 				super();
 				this.identifier     = identifier    ;
-				this.updateInterval = updateInterval;
+				this.nonce          = nonce          ;
+				this.updateInterval = updateInterval ;
 			}
-			
-			LockFileData(final long lastWriteTime, final long expirationTime, final String identifier)
+
+			LockFileData(final long lastWriteTime, final long expirationTime, final String nonce, final String identifier)
 			{
-				this(identifier, deriveUpdateInterval(lastWriteTime, expirationTime));
+				this(identifier, nonce, deriveUpdateInterval(lastWriteTime, expirationTime));
 				this.lastWriteTime  = lastWriteTime ;
 				this.expirationTime = expirationTime;
 			}
@@ -477,15 +497,17 @@ public interface StorageLockFileManager extends Runnable
 				return;
 			}
 			
-			this.fillReadBufferFromFile();
-			
-			// performance-optimized JDK method
-			if(XArrays.equals(this.stringReadBuffer, this.stringWriteBuffer, this.stringWriteBuffer.length))
+			// Self-fence: the on-disk nonce must still be the one this session claimed. Our own heartbeats
+			// keep the nonce stable (only timestamps change), so a mismatch means a foreign process took over.
+			final LockFileData current = this.readLockFileData();
+			if(this.sessionNonce != null && this.sessionNonce.equals(current.nonce))
 			{
 				return;
 			}
 
-			throw new StorageException("Concurrent lock file modification detected.");
+			throw new StorageException(
+				"Concurrent lock file modification detected (foreign owner: " + current.identifier + ")."
+			);
 		}
 		
 		private boolean isReadOnlyMode()
@@ -518,6 +540,7 @@ public interface StorageLockFileManager extends Runnable
 			this.vs.reset()
 			.add(lockFileData.lastWriteTime).add(';')
 			.add(lockFileData.expirationTime).add(';')
+			.add(lockFileData.nonce).add(';')
 			.add(lockFileData.identifier)
 			;
 			

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
@@ -33,28 +33,28 @@ import org.eclipse.store.storage.exceptions.StorageException;
 import org.slf4j.Logger;
 
 /**
- * The StorageLockFileManager purpose is to provide a mechanism that prevents
+ * The StorageLockFileManager's purpose is to provide a mechanism that prevents
  * other storage instances running in different processes from accessing the
  * storage data.
  */
 public interface StorageLockFileManager extends Runnable
 {
 	/**
-	 * Start periodical lock file checks.
-	 * 
+	 * Start periodic lock file checks.
+	 *
 	 * @return this
 	 */
 	public StorageLockFileManager start();
-	
+
 	/**
-	 * Stop periodical lock file checks
-	 * 
+	 * Stop periodic lock file checks.
+	 *
 	 * @return this
 	 */
 	public StorageLockFileManager stop();
 	
 	/**
-	 * Initialize the lock file manager without starting any periodical actions.
+	 * Initialize the lock file manager without starting any periodic actions.
 	 */
 	public void initialize();
 	
@@ -80,15 +80,15 @@ public interface StorageLockFileManager extends Runnable
 	}
 	
 	/**
-	 * Default implementation of the #StorageLockFileManager.
+	 * Default implementation of {@link StorageLockFileManager}.
 	 * This implementation uses a file to indicate if the storage data
 	 * is already in use by a storage instance.
-	 * The file contains a process depended ID and time-stamps of the last modification
-	 * and expiring time.
+	 * The file contains a process-dependent ID and timestamps of the last modification
+	 * and the expiration time.
 	 * A storage is accessible if:
 	 * - no lock file exists
 	 * - a lock file exists and the process id matches
-	 * - a lock file exists and the current system time is greater than the expiring time + update interval
+	 * - a lock file exists and the current system time is greater than the expiration time + update interval
 	 */
 	public final class Default implements StorageLockFileManager
 	{
@@ -129,7 +129,7 @@ public interface StorageLockFileManager extends Runnable
 			this.fileSystem          = setup.lockFileProvider().fileSystem();
 			this.operationController = operationController;
 			this.vs                  = VarString.New()    ;
-			// 2 timestamps with separators and an identifier. Should suffice.
+			// timestamps, nonce and identifier with separators; the buffer grows on demand if needed.
 			this.wrappedByteBuffer = new ByteBuffer[1];
 			this.wrappedWrappedByteBuffer = X.ArrayView(this.wrappedByteBuffer);
 
@@ -154,7 +154,7 @@ public interface StorageLockFileManager extends Runnable
 		
 		private synchronized boolean isReady()
 		{
-			boolean result = this.isInitialized() && this.operationController.checkProcessingEnabled();
+			final boolean result = this.isInitialized() && this.operationController.checkProcessingEnabled();
 			logger.trace("Storage LockFile Manager isReady: {}" , result);
 			return result;
 		}
@@ -162,7 +162,7 @@ public interface StorageLockFileManager extends Runnable
 		@Override
 		public StorageLockFileManager.Default start()
 		{
-			logger.info("Starting log file manager thread ");
+			logger.info("Starting lock file manager thread");
 			this.executor.scheduleWithFixedDelay(this, 0, this.setup.updateInterval(), TimeUnit.MILLISECONDS);
 			return this;
 		}
@@ -213,7 +213,7 @@ public interface StorageLockFileManager extends Runnable
 					}
 				}
 			}
-			catch(InterruptedException e)
+			catch(final InterruptedException e)
 			{
 				this.executor.shutdownNow();
 				Thread.currentThread().interrupt();
@@ -229,7 +229,7 @@ public interface StorageLockFileManager extends Runnable
 		}
 		
 		/**
-		 * Initialize the storage lock file manager without starting the periodical
+		 * Initialize the storage lock file manager without starting the periodic
 		 * lock file check.
 		 */
 		@Override
@@ -322,7 +322,7 @@ public interface StorageLockFileManager extends Runnable
 			final String identifier = this.setup.processIdentity();
 			if(identifier.equals(lockFileData.identifier))
 			{
-				// database is already owned by "this" process (e.g. crash shorty before), so just continue and reuse.
+				// database is already owned by "this" process (e.g. crash shortly before), so just continue and reuse.
 				logger.info("Storage already owned by process!");
 				return true;
 			}
@@ -333,7 +333,7 @@ public interface StorageLockFileManager extends Runnable
 				 * The lock file is no longer updated, meaning the database is not used anymore
 				 * and the lockfile is just a zombie, probably left by a crash.
 				 */
-				logger.info("Storage lock file outdated, aquiring storage!");
+				logger.info("Storage lock file outdated, acquiring storage!");
 				return true;
 			}
 			
@@ -489,7 +489,8 @@ public interface StorageLockFileManager extends Runnable
 			
 			/**
 			 * "long" meaning the expiration time has been passed by another interval.
-			 * This is a tolerance / grace time strategy to exclude
+			 * This is a tolerance / grace time strategy to avoid mistaking a merely delayed
+			 * heartbeat (e.g. a brief pause or scheduling lag) for a dead owner.
 			 */
 			final boolean isLongExpired()
 			{
@@ -508,7 +509,7 @@ public interface StorageLockFileManager extends Runnable
 		{
 			if(this.isReadOnlyMode() && !this.lockFileHasContent())
 			{
-				// no existing lock file can be ignored in read-only mode.
+				// an absent lock file can be ignored in read-only mode.
 				return;
 			}
 			
@@ -542,7 +543,7 @@ public interface StorageLockFileManager extends Runnable
 						
 			final ArrayView<ByteBuffer> bb = this.setToWriteBuffer(this.lockFileData);
 			
-			// no need for the writer detour (for now) since it makes no sense to backup lock files.
+			// no need for the writer detour (for now) since it makes no sense to back up lock files.
 			
 			//don't delete file!
 			this.lockFile.truncate(0);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
@@ -183,10 +183,13 @@ public interface StorageLockFileManager extends Runnable
 				}
 				else
 				{
-					// controller deactivated (teardown) without a disruption: nothing to recover, so stop
-					// instead of ticking (and logging) forever on a leaked non-daemon thread.
+					// controller deactivated (teardown) without a disruption: nothing to recover. Shut the
+					// executor down and release the lock file here rather than ticking forever. Done inline
+					// instead of via stop() because this runs on the executor's own worker thread, which
+					// cannot join itself in awaitTermination.
 					logger.info("Lock file manager no longer ready, stopping.");
-					this.stop();
+					this.executor.shutdown();
+					this.ensureClosedLockFile(null);
 				}
 			}
 			catch(final Exception e)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageLockFileManager.java
@@ -189,7 +189,11 @@ public interface StorageLockFileManager extends Runnable
 			}
 			catch(final Exception e)
 			{
-				this.stop();
+				// Same rationale as the else-branch above: this runs on the executor's own worker thread, so
+				// shut the executor down and close the lock file inline (stop()'s awaitTermination would
+				// self-join), then register the disruption and rethrow.
+				this.executor.shutdown();
+				this.ensureClosedLockFile(null);
 				this.operationController.registerDisruption(e);
 				throw e;
 			}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
@@ -749,8 +749,8 @@ public interface StorageSystem extends StorageController
 		}
 		
 		/**
-		 * Best-effort teardown after a failed startup. A failure in any step is attached as suppressed
-		 * to the primary startup exception instead of replacing it, and each step is still attempted.
+		 * Best-effort teardown after a failed startup: each fallible step is attempted independently and
+		 * any failure is attached as suppressed to the primary startup exception instead of replacing it.
 		 */
 		private void cleanupFailedStartup(final Throwable primary)
 		{

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageSystem.java
@@ -730,14 +730,13 @@ public interface StorageSystem extends StorageController
 				}
 				catch(final InterruptedException e)
 				{
-					this.operationController.deactivate();
-					this.monitorManager.shutdown();
-					throw new StorageExceptionInitialization(e);
+					final StorageExceptionInitialization ex = new StorageExceptionInitialization(e);
+					this.cleanupFailedStartup(ex);
+					throw ex;
 				}
 				catch(final Throwable t)
 				{
-					this.operationController.deactivate();
-					this.monitorManager.shutdown();
+					this.cleanupFailedStartup(t);
 					throw t;
 				}
 				finally
@@ -749,6 +748,34 @@ public interface StorageSystem extends StorageController
 			return this;
 		}
 		
+		/**
+		 * Best-effort teardown after a failed startup. A failure in any step is attached as suppressed
+		 * to the primary startup exception instead of replacing it, and each step is still attempted.
+		 */
+		private void cleanupFailedStartup(final Throwable primary)
+		{
+			this.operationController.deactivate();
+
+			try
+			{
+				// lock-file executor does not self-terminate on deactivation; stop it or its non-daemon thread leaks.
+				this.stopLockFileManagerThread();
+			}
+			catch(final Throwable cleanupError)
+			{
+				primary.addSuppressed(cleanupError);
+			}
+
+			try
+			{
+				this.monitorManager.shutdown();
+			}
+			catch(final Throwable cleanupError)
+			{
+				primary.addSuppressed(cleanupError);
+			}
+		}
+
 		@Override
 		public final StorageIdAnalysis initializationIdAnalysis()
 		{
@@ -849,14 +876,14 @@ public interface StorageSystem extends StorageController
 		{
 			/*
 			 * Immediately deactivates all activities without waiting for currently existing work items to be
-			 * completed.
-			 * 
-			 * Deactivates all threads (Channel threads, lock file thread, backup thread).
-			 * All terminating threads cleanup their resources (e.g. opened files).
-			 * So this is all that must be necessary
+			 * completed. Channel threads self-terminate on the deactivated controller; the lock-file executor
+			 * and backup handler do not, so they are stopped explicitly.
 			 */
 			this.operationController.deactivate();
-			
+
+			// lock-file executor does not self-terminate on deactivation; stop it or its non-daemon thread leaks.
+			this.stopLockFileManagerThread();
+
 			// backup handler must be treated specially since it is normally intended to finish its items on its own.
 			if(this.backupHandler != null)
 			{


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                   
  Reworks the storage-directory lock file to fix a thread/handle lifecycle leak, correct its heartbeat scheduling, and harden it against admitting a second writer. All product changes are contained in StorageLockFileManager and the lock-file  
  teardown paths of StorageSystem; a new integration-test suite covers the behavior.                                                                                                                                                               
                                                                                                                                                                                                                                                   
  Problems addressed                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                   
  1. The lock-file worker thread (and its open handle) leaked on non-graceful teardown.                                                                                                                                                            
  The lock-file manager runs a non-daemon scheduled executor. It was shut down only on the graceful shutdown path — a killStorage teardown and every failed start() left it scheduled forever, so the JVM could not exit, and the still-open       
  lock-file handle was never released.                                                                                                                                                                                                             
                                                                                                                                                                                                                                                   
  2. The heartbeat ran ~1000× too often.                                                                                                                                                                                                           
  The periodic check was scheduled with a microsecond time unit while the configured interval is defined in milliseconds, producing constant read/write/compare traffic instead of the configured cadence.                                         
                                                                                                                                                                                                                                                   
  3. The lock could admit a second writer.                                                                                                                                                                                                         
  An empty or unreadable lock file was treated as a free directory, so a second process could claim a directory already in use; and detection of a concurrent claimer only began after start-up recovery writes had already run.                   
                                                                                                                                                                                                                                                   
  Changes                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                   
  Lifecycle                                                                                                                                                                                                                                        
  - killStorage and both start() failure paths now stop the lock-file manager, so the non-daemon thread and the lock-file handle are always released on any teardown.                                                                              
  - The periodic task self-terminates if it ever runs after the controller has been deactivated, so the executor cannot outlive a teardown that forgot to stop it. Because it runs on its own worker thread, it shuts the executor down inline     
  rather than awaiting itself.                                                                                                                                                                                                                     
  - stop() always releases the lock file, even when the executor was already shut down (e.g. after a start-up refusal), joining any in-flight task first to avoid a close-vs-read race.                                                            
  - Failed-start cleanup is best-effort: each teardown step is attempted independently and any cleanup failure is attached as a suppressed exception to the original start-up failure instead of replacing it.                                     
                                                                                                                                                                                                                                                   
  Scheduling                                                                                                                                                                                                                                       
  - The heartbeat is scheduled in milliseconds, matching the configured interval and the timestamp arithmetic used everywhere else.                                                                                                                
                                                                                                                                                                                                                                                   
  Exclusion / claim                                                                                                                                                                                                                                
  - Fail closed at claim time: an absent lock file is a legitimate fresh start, but a present-but-unparseable one (empty, torn, or partially written) now refuses start-up instead of claiming the directory.                                      
  - Verify before recovery: after writing its claim the manager reads the file back and confirms ownership before start-up proceeds to any recovery write, so a concurrent claimer is detected before data is touched.                             
  - Per-session marker: each session writes a fresh marker that stays stable across its own heartbeats, so the periodic self-check reliably distinguishes this session's own writes from a foreign takeover (replacing a byte comparison that also 
  mis-tripped on a writer's heartbeats in read-only mode).                                                                                                                                                                                         
  - A live foreign lock is now refused immediately rather than after a one-interval retry.                                                                                                                                                         
                                                                                                                                                                                                                                                   
  Compatibility                                                                                                                                                                                                                                    
  - A lock file written in the previous on-disk format (without the session marker) is accepted and rewritten in the current format on the next claim, so an upgrade never fails to start on a leftover lock file.                                 
  - Same-process restart reuse and read-only behavior are unchanged. The write idiom and the time-to-live heartbeat are unchanged.