### PR TITLE
Fix outdated Lucene index code samples in the GigaMap docs

### DIFF
--- a/docs/modules/gigamap/pages/indexing/lucene/advanced.adoc
+++ b/docs/modules/gigamap/pages/indexing/lucene/advanced.adoc
@@ -104,36 +104,44 @@ builder.add(new Term("content", "machine"));
 builder.add(new Term("content", "learning"));
 Query phraseQuery = builder.build();
 
-// With slop (allows words in between)
-builder.setSlop(2);  // Allow up to 2 words between terms
+// With slop (allows words in between); set it before build()
+Query slopQuery = new PhraseQuery.Builder()
+    .add(new Term("content", "machine"))
+    .add(new Term("content", "learning"))
+    .setSlop(2)  // Allow up to 2 words between terms
+    .build();
 ----
 
 == Relevance Scoring
 
-Access relevance scores to rank or filter results.
+`search(...)` returns a `LuceneSearchResult` whose entries carry the relevance score. The entries are already ordered by decreasing relevance, so no manual sorting is required.
 
 [source, java]
 ----
-// Collect results with scores
-List<ScoredResult<Product>> scoredResults = new ArrayList<>();
+LuceneSearchResult<Product> hits = luceneIndex.search("name:wireless", 100);
 
-luceneIndex.query("name:wireless", (entityId, product, score) -> {
-    scoredResults.add(new ScoredResult<>(product, score));
-});
-
-// Sort by score descending
-scoredResults.sort((a, b) -> Float.compare(b.score(), a.score()));
+// Iterate in relevance order
+for(ScoredSearchResult.Entry<Product> entry : hits)
+{
+    System.out.println(entry.entity().getName() + " (" + entry.score() + ")");
+}
 
 // Filter by minimum score
-List<Product> highConfidence = scoredResults.stream()
-    .filter(r -> r.score() > 1.0f)
-    .map(ScoredResult::product)
+List<Product> highConfidence = hits.stream()
+    .filter(entry -> entry.score() > 1.0f)
+    .map(ScoredSearchResult.Entry::entity)
     .toList();
 ----
 
+Besides `entity()` and `score()`, every entry exposes the GigaMap entity id via `entityId()`.
+
+Alternatively, the callback-based `query(...)` overloads hand each hit to a `SearchResultAcceptor` without materializing a result object.
+
 [source, java]
 ----
-public record ScoredResult<E>(E product, float score) {}
+luceneIndex.query("name:wireless", (entityId, product, score) ->
+    System.out.println(product.getName() + " (" + score + ")")
+);
 ----
 
 == Boosting
@@ -195,11 +203,12 @@ For importing large amounts of data, disable auto-commit for better performance.
 [source, java]
 ----
 // Create context with auto-commit disabled
-LuceneContext<Product> context = LuceneContext.builder()
-    .directoryCreator(DirectoryCreator.MMap(indexPath))
-    .documentPopulator(new ProductDocumentPopulator())
-    .autoCommit(false)
-    .build();
+LuceneContext<Product> context = LuceneContext.New(
+    DirectoryCreator.MMap(indexPath),
+    AnalyzerCreator.Standard()      ,
+    new ProductDocumentPopulator()  ,
+    false                             // autoCommit
+);
 
 GigaMap<Product> products = GigaMap.New();
 LuceneIndex<Product> luceneIndex = products.index().register(LuceneIndex.Category(context));
@@ -226,7 +235,9 @@ luceneIndex.commit();
 
 == Custom Analyzers
 
-Create custom analyzers for specialized text processing.
+Create custom analyzers for specialized text processing by subclassing `AnalyzerCreator` and overriding `createAnalyzer()`.
+
+NOTE: `StandardAnalyzer` ships with `lucene-core`. The analyzers shown below live in `org.apache.lucene.analysis.core` and `org.apache.lucene.analysis.miscellaneous` and require the additional `lucene-analysis-common` dependency.
 
 === Keyword Analyzer
 
@@ -239,7 +250,7 @@ import org.apache.lucene.analysis.core.KeywordAnalyzer;
 public class KeywordAnalyzerCreator extends AnalyzerCreator
 {
     @Override
-    public Analyzer create()
+    public Analyzer createAnalyzer()
     {
         return new KeywordAnalyzer();
     }
@@ -257,7 +268,7 @@ import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 public class WhitespaceAnalyzerCreator extends AnalyzerCreator
 {
     @Override
-    public Analyzer create()
+    public Analyzer createAnalyzer()
     {
         return new WhitespaceAnalyzer();
     }
@@ -275,7 +286,7 @@ import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 public class CustomAnalyzerCreator extends AnalyzerCreator
 {
     @Override
-    public Analyzer create()
+    public Analyzer createAnalyzer()
     {
         Map<String, Analyzer> fieldAnalyzers = new HashMap<>();
         fieldAnalyzers.put("sku", new KeywordAnalyzer());
@@ -327,19 +338,17 @@ Count results by category using Lucene's faceting.
 // See Apache Lucene faceting documentation for details
 ----
 
-For simpler faceting, combine with GigaMap's bitmap indices:
+For simpler faceting, intersect the search result with a GigaMap query. Since `search(...)` returns a `LuceneSearchResult`, which is a xref:queries/defining.adoc#_sub_queries[`GigaMap.SubQuery`], no intermediate id set is needed.
 
 [source, java]
 ----
-// Get Lucene search results
-List<Product> searchResults = luceneIndex.query("name:wireless");
-Set<Long> resultIds = searchResults.stream()
-    .map(Product::getId)
-    .collect(Collectors.toSet());
+// Full-text hits, limited to the current map size
+LuceneSearchResult<Product> hits = luceneIndex.search("name:wireless");
 
-// Count by category using bitmap
-Map<String, Long> categoryCounts = products.query(Query.all())
-    .filter(p -> resultIds.contains(p.getId()))
+// Count the matching entities by category
+Map<String, Long> categoryCounts = products.query()
+    .and(hits)
+    .stream()
     .collect(Collectors.groupingBy(Product::getCategory, Collectors.counting()));
 ----
 

--- a/docs/modules/gigamap/pages/indexing/lucene/configuration.adoc
+++ b/docs/modules/gigamap/pages/indexing/lucene/configuration.adoc
@@ -17,6 +17,9 @@ LuceneContext<E> context = LuceneContext.New(directoryCreator, documentPopulator
 
 // Full customization
 LuceneContext<E> context = LuceneContext.New(directoryCreator, analyzerCreator, documentPopulator);
+
+// Full customization including the commit behavior
+LuceneContext<E> context = LuceneContext.New(directoryCreator, analyzerCreator, documentPopulator, autoCommit);
 ----
 
 == Directory Creators
@@ -106,14 +109,16 @@ LuceneContext<Article> context = LuceneContext.New(
 
 === Custom Analyzer
 
-For language-specific or domain-specific text processing, create a custom `AnalyzerCreator`.
+For language-specific or domain-specific text processing, subclass `AnalyzerCreator` and override `createAnalyzer()`.
+
+NOTE: `StandardAnalyzer` ships with `lucene-core`. Language-specific analyzers such as `GermanAnalyzer` live in `lucene-analysis-common`, which has to be added as an additional dependency.
 
 [source, java]
 ----
 public class GermanAnalyzerCreator extends AnalyzerCreator
 {
     @Override
-    public Analyzer create()
+    public Analyzer createAnalyzer()
     {
         return new GermanAnalyzer();
     }
@@ -128,15 +133,19 @@ LuceneContext<Article> context = LuceneContext.New(
 
 == Auto-Commit
 
-By default, changes are automatically committed after each operation. For bulk operations, you may want to disable auto-commit for better performance.
+By default, changes are automatically committed after each operation. For bulk operations, you may want to disable auto-commit for better performance. Pass the flag to the four-argument `LuceneContext.New(...)` factory.
+
+With `autoCommit` disabled, pending changes are still committed automatically at every `GigaMap.store()` boundary, so an explicit `LuceneIndex.commit()` is only needed to commit between stores.
 
 [source, java]
 ----
-// Manual commit for bulk operations
-LuceneContext<Article> context = LuceneContext.builder()
-    .documentPopulator(new ArticleDocumentPopulator())
-    .autoCommit(false)
-    .build();
+// Manual commit for bulk operations; null directory creator means embedded storage
+LuceneContext<Article> context = LuceneContext.New(
+    null                             ,
+    AnalyzerCreator.Standard()       ,
+    new ArticleDocumentPopulator()   ,
+    false                              // autoCommit
+);
 
 GigaMap<Article> articles = GigaMap.New();
 LuceneIndex<Article> luceneIndex = articles.index().register(LuceneIndex.Category(context));


### PR DESCRIPTION
## Problem

Several code samples on the GigaMap Lucene documentation pages referenced APIs that do not exist, so a reader copying them out would not get compiling code:

- `LuceneContext.builder()` with `.directoryCreator(...)`, `.documentPopulator(...)`, `.autoCommit(...)`, `.build()` - `LuceneContext` only offers static `New(...)` factories, there is no builder.
- Custom `AnalyzerCreator` subclasses overriding `create()` - the abstract method is `createAnalyzer()`, so the samples stayed abstract.
- A faceting sample using `products.query(Query.all())` and `GigaQuery.filter(...)` - neither exists; `GigaMap.query()` is the no-argument all-elements query and `GigaQuery` exposes `stream()`.

Two further samples compiled but were stale or misleading: the relevance-scoring section hand-rolled a `ScoredResult` record with manual sorting, which `search(...)` / `LuceneSearchResult` has made unnecessary, and the phrase-query sample called `setSlop(...)` after `build()`, so the slop silently had no effect on the built query.

## Changes

`docs/modules/gigamap/pages/indexing/lucene/advanced.adoc`

- Bulk Operations: use the four-argument `LuceneContext.New(directoryCreator, analyzerCreator, documentPopulator, autoCommit)`.
- Custom Analyzers: override `createAnalyzer()`, and add a note that the analyzers used there require the additional `lucene-analysis-common` dependency (the module itself only depends on `lucene-core` and `lucene-queryparser`).
- Faceted Search: intersect the `LuceneSearchResult` sub-query with `GigaMap.query()` instead of building an intermediate id set.
- Relevance Scoring: rewritten around `search(...)`, which already returns scored entries in relevance order; the callback-based `query(...)` form is kept as the alternative.
- Phrase Queries: set the slop before `build()`.

`docs/modules/gigamap/pages/indexing/lucene/configuration.adoc`

- Same `builder()` and `create()` defects fixed, the four-argument factory added to the factory-methods list, and a sentence added stating that with `autoCommit` disabled commits still happen at every `GigaMap.store()` boundary.

Sections that were already correct are untouched: term / boolean / range / prefix / wildcard / fuzzy queries, boosting, pagination, highlighting, reindexing, and the performance tips.

## Verification

Every corrected sample was extracted into a single Java file and compiled against the `gigamap-lucene` classpath; `javac` exits 0. The analyzer samples were compiled with `StandardAnalyzer` substituted, since `lucene-analysis-common` is not on the classpath - only the overridden method name was under test there.
