### PR TITLE
disable UseCompactObjectHeaders profile

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -190,20 +190,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <!-- Eclipse Serializer's low-level memory access (sun.misc.Unsafe / native-memory accessor)
-             is incompatible with JDK Lilliput compact object headers, which are enabled by default
-             on some JDK 25+ builds (e.g. SapMachine) and corrupt object headers, crashing the forked
-             test JVM during G1 GC. Disable them there. The flag does not exist before JDK 24, so it
-             must only be applied on JDK 25+ (matches microstream-test). -->
-        <profile>
-            <id>jdk25-plus</id>
-            <activation>
-                <jdk>[25,)</jdk>
-            </activation>
-            <properties>
-                <extra.jvm.args>-XX:-UseCompactObjectHeaders</extra.jvm.args>
-            </properties>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Es sieht so aus, als ob diese Probleme mit den Compact Headers ausschließlich auf der SAP Machine JDK auftreten. Wir müssen das jedoch auch in der CI/CD-Pipeline auf anderen JDKs testen. Daher muss diese Einschränkung entfernt werden.
