### PR TITLE
fix/direct-buffer-reachability-fences

### DIFF
--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChunkChecksumCalculator.java
@@ -18,6 +18,7 @@ import static org.eclipse.serializer.util.X.checkArrayRange;
 import static org.eclipse.serializer.util.X.notNull;
 import static org.eclipse.serializer.util.X.toBytes;
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -226,31 +227,39 @@ public interface StorageChunkChecksumCalculator
 			final long                        chunkStart
 		)
 		{
-			// Hostile/corrupt-input guard: the full 46 B header must be resident before we read its
-			// payload (a truncated header would read past the buffer). Report-and-skip on overrun.
-			final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
-			if(address + StorageMetaRecord.LENGTH_FILEHEADERV1 > bufferBoundAddress)
+			try
 			{
-				this.reporter.onUnknownKind(file.number(), StorageMetaRecord.KIND_FileHeaderV1);
-				return chunkStart;
-			}
+				// Hostile/corrupt-input guard: the full 46 B header must be resident before we read its
+				// payload (a truncated header would read past the buffer). Report-and-skip on overrun.
+				final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
+				if(address + StorageMetaRecord.LENGTH_FILEHEADERV1 > bufferBoundAddress)
+				{
+					this.reporter.onUnknownKind(file.number(), StorageMetaRecord.KIND_FileHeaderV1);
+					return chunkStart;
+				}
 
-			// By format there is exactly one FileHeaderV1 per file, its first entry. A second/misplaced one
-			// (non-zero cached kind ⇒ a header was already parsed) is anomalous: do NOT let it silently
-			// re-seed the file's chunk-checksum kind / chain tip (which would rebase verification of every
-			// following chunk). Report it and skip past, accounting its bytes as meta.
-			if(file.chunkChecksumKind() != 0L)
-			{
-				this.reporter.onUnknownKind(file.number(), StorageMetaRecord.KIND_FileHeaderV1);
+				// By format there is exactly one FileHeaderV1 per file, its first entry. A second/misplaced one
+				// (non-zero cached kind ⇒ a header was already parsed) is anomalous: do NOT let it silently
+				// re-seed the file's chunk-checksum kind / chain tip (which would rebase verification of every
+				// following chunk). Report it and skip past, accounting its bytes as meta.
+				if(file.chunkChecksumKind() != 0L)
+				{
+					this.reporter.onUnknownKind(file.number(), StorageMetaRecord.KIND_FileHeaderV1);
+					file.registerMetaLength(StorageMetaRecord.LENGTH_FILEHEADERV1);
+					return address + StorageMetaRecord.LENGTH_FILEHEADERV1;
+				}
+
+				final FileHeaderV1Payload header = StorageMetaRecord.readFileHeaderV1(address);
+				file.setFileHeaderV1(header.chunkChecksumKind(), header.chainRoot());
+				// Account the header's bytes as meta (not gap) so dataFillRatio treats it as useful overhead.
 				file.registerMetaLength(StorageMetaRecord.LENGTH_FILEHEADERV1);
 				return address + StorageMetaRecord.LENGTH_FILEHEADERV1;
 			}
-
-			final FileHeaderV1Payload header = StorageMetaRecord.readFileHeaderV1(address);
-			file.setFileHeaderV1(header.chunkChecksumKind(), header.chainRoot());
-			// Account the header's bytes as meta (not gap) so dataFillRatio treats it as useful overhead.
-			file.registerMetaLength(StorageMetaRecord.LENGTH_FILEHEADERV1);
-			return address + StorageMetaRecord.LENGTH_FILEHEADERV1;
+			finally
+			{
+				// the buffer must stay strongly reachable while its raw memory is read via the passed address.
+				Reference.reachabilityFence(buffer);
+			}
 		}
 	}
 
@@ -290,48 +299,56 @@ public interface StorageChunkChecksumCalculator
 			final long                        chunkStart
 		)
 		{
-			final long      kind     = StorageMetaRecord.kindOf(address);
-			final Algorithm verifier = this.algorithmsByKind.get(kind);
-			if(verifier == null)
+			try
 			{
-				// This handler is registered for a KIND with no algorithm (registry/map drift) or the
-				// on-disk KIND is corrupt: cannot verify — report and skip (chunk boundary unchanged).
-				this.reporter.onUnknownKind(file.number(), kind);
-				return chunkStart;
-			}
-
-			// Hostile/corrupt-input guard: the full fixed-size record must be resident before we read the
-			// stored checksum (a truncated record would read past the buffer). Report-and-skip on overrun.
-			final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
-			if(address + verifier.recordLength() > bufferBoundAddress)
-			{
-				this.reporter.onUnknownKind(file.number(), kind);
-				return chunkStart;
-			}
-
-			final boolean chained = verifier.isChained();
-			if(this.policy.verify())
-			{
-				// shared verify core; on a chained kind the per-file running tip is the seed in and the tip out.
-				final byte[] tip = verifyChunk(
-					file.number(), buffer, address, chunkStart, verifier,
-					chained ? file.chainTip() : null, this.reporter
-				);
-				if(chained)
+				final long      kind     = StorageMetaRecord.kindOf(address);
+				final Algorithm verifier = this.algorithmsByKind.get(kind);
+				if(verifier == null)
 				{
-					file.setChainTip(tip);
+					// This handler is registered for a KIND with no algorithm (registry/map drift) or the
+					// on-disk KIND is corrupt: cannot verify — report and skip (chunk boundary unchanged).
+					this.reporter.onUnknownKind(file.number(), kind);
+					return chunkStart;
 				}
+
+				// Hostile/corrupt-input guard: the full fixed-size record must be resident before we read the
+				// stored checksum (a truncated record would read past the buffer). Report-and-skip on overrun.
+				final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
+				if(address + verifier.recordLength() > bufferBoundAddress)
+				{
+					this.reporter.onUnknownKind(file.number(), kind);
+					return chunkStart;
+				}
+
+				final boolean chained = verifier.isChained();
+				if(this.policy.verify())
+				{
+					// shared verify core; on a chained kind the per-file running tip is the seed in and the tip out.
+					final byte[] tip = verifyChunk(
+						file.number(), buffer, address, chunkStart, verifier,
+						chained ? file.chainTip() : null, this.reporter
+					);
+					if(chained)
+					{
+						file.setChainTip(tip);
+					}
+				}
+				else if(chained)
+				{
+					// Not verifying, but a chained file must still advance its per-file tip during the load
+					// walk so that writes appended to this (head) file after init continue the chain. The tip
+					// after chunk i is simply that chunk's stored hash — read it, no recompute needed.
+					file.setChainTip(verifier.readStoredChecksumBytes(address));
+				}
+				// Account the chunk-checksum record's bytes as meta (not gap).
+				file.registerMetaLength(verifier.recordLength());
+				return address + verifier.recordLength();
 			}
-			else if(chained)
+			finally
 			{
-				// Not verifying, but a chained file must still advance its per-file tip during the load
-				// walk so that writes appended to this (head) file after init continue the chain. The tip
-				// after chunk i is simply that chunk's stored hash — read it, no recompute needed.
-				file.setChainTip(verifier.readStoredChecksumBytes(address));
+				// the buffer must stay strongly reachable while its raw memory is read via the passed address.
+				Reference.reachabilityFence(buffer);
 			}
-			// Account the chunk-checksum record's bytes as meta (not gap).
-			file.registerMetaLength(verifier.recordLength());
-			return address + verifier.recordLength();
 		}
 	}
 
@@ -372,48 +389,56 @@ public interface StorageChunkChecksumCalculator
 		final StorageChecksumAnomalyReporter reporter
 	)
 	{
-		final boolean chained            = verifier.isChained();
-		final long    bufferStartAddress = XMemory.getDirectByteBufferAddress(buffer);
-
-		// Framing cross-check: the record's stored chunk start vs the boundary the walk reconstructed from entity
-		// LENGTH prefixes. A corrupted LENGTH leaves the stored start != cursor, or drives chunkStart past the
-		// record (negative chunk length). Either way [chunkStart, address) is wrong: report and re-anchor rather
-		// than hash it (and never slice a negative length).
-		final int  storedChunkStart = StorageMetaRecord.readChunkChecksumChunkStart(address);
-		final long walkerChunkStart = chunkStart - bufferStartAddress;
-		final long recordOffset     = address - bufferStartAddress;
-		if(!isChunkFramingConsistent(storedChunkStart, walkerChunkStart, recordOffset))
+		try
 		{
-			reporter.onChunkBoundaryMismatch(fileNumber, recordOffset, storedChunkStart, walkerChunkStart);
-			return chained ? verifier.readStoredChecksumBytes(address) : inboundTip;
-		}
+			final boolean chained            = verifier.isChained();
+			final long    bufferStartAddress = XMemory.getDirectByteBufferAddress(buffer);
 
-		// Checksum the chunk in place: it is already resident in `buffer`, so slice that view rather than copying
-		// [chunkStart, address) into a fresh array. Dispatch by on-disk KIND, not the primary.
-		final ByteBuffer chunk    = XMemory.slice(buffer, walkerChunkStart, address - chunkStart);
-		final byte[]     expected = verifier.readStoredChecksumBytes(address);
-		// chained kinds fold the running tip (seeded from the header chainRoot, advanced per verified chunk) into
-		// the recompute, so reorder/insert/delete/substitute breaks here.
-		if(chained)
-		{
-			byte[] seed = inboundTip;
-			if(seed == null)
+			// Framing cross-check: the record's stored chunk start vs the boundary the walk reconstructed from entity
+			// LENGTH prefixes. A corrupted LENGTH leaves the stored start != cursor, or drives chunkStart past the
+			// record (negative chunk length). Either way [chunkStart, address) is wrong: report and re-anchor rather
+			// than hash it (and never slice a negative length).
+			final int  storedChunkStart = StorageMetaRecord.readChunkChecksumChunkStart(address);
+			final long walkerChunkStart = chunkStart - bufferStartAddress;
+			final long recordOffset     = address - bufferStartAddress;
+			if(!isChunkFramingConsistent(storedChunkStart, walkerChunkStart, recordOffset))
 			{
-				// Chained covering record but no parsed FileHeaderV1: the engine never writes one to a header-less
-				// file, so the header was lost/corrupted. Report it and verify against the initial seed so a real
-				// defect still surfaces as a checksum mismatch.
-				reporter.onMissingHeader(fileNumber);
-				seed = verifier.initialSeed();
+				reporter.onChunkBoundaryMismatch(fileNumber, recordOffset, storedChunkStart, walkerChunkStart);
+				return chained ? verifier.readStoredChecksumBytes(address) : inboundTip;
 			}
-			verifier.setChainTip(seed);
+
+			// Checksum the chunk in place: it is already resident in `buffer`, so slice that view rather than copying
+			// [chunkStart, address) into a fresh array. Dispatch by on-disk KIND, not the primary.
+			final ByteBuffer chunk    = XMemory.slice(buffer, walkerChunkStart, address - chunkStart);
+			final byte[]     expected = verifier.readStoredChecksumBytes(address);
+			// chained kinds fold the running tip (seeded from the header chainRoot, advanced per verified chunk) into
+			// the recompute, so reorder/insert/delete/substitute breaks here.
+			if(chained)
+			{
+				byte[] seed = inboundTip;
+				if(seed == null)
+				{
+					// Chained covering record but no parsed FileHeaderV1: the engine never writes one to a header-less
+					// file, so the header was lost/corrupted. Report it and verify against the initial seed so a real
+					// defect still surfaces as a checksum mismatch.
+					reporter.onMissingHeader(fileNumber);
+					seed = verifier.initialSeed();
+				}
+				verifier.setChainTip(seed);
+			}
+			final byte[] actual = verifier.computeChecksumBytes(chunk);
+			if(!Arrays.equals(actual, expected))
+			{
+				reporter.onChecksumMismatch(fileNumber, walkerChunkStart, StorageMetaRecord.kindOf(address), expected, actual);
+			}
+			// chained: continue from the stored tip (== recomputed on match), the basis the writer chained from.
+			return chained ? expected : inboundTip;
 		}
-		final byte[] actual = verifier.computeChecksumBytes(chunk);
-		if(!Arrays.equals(actual, expected))
+		finally
 		{
-			reporter.onChecksumMismatch(fileNumber, walkerChunkStart, StorageMetaRecord.kindOf(address), expected, actual);
+			// the buffer must stay strongly reachable while its raw memory is read via the passed address.
+			Reference.reachabilityFence(buffer);
 		}
-		// chained: continue from the stored tip (== recomputed on match), the basis the writer chained from.
-		return chained ? expected : inboundTip;
 	}
 
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileItemIterator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileItemIterator.java
@@ -15,6 +15,7 @@ package org.eclipse.store.storage.types;
  */
 
 import java.io.IOException;
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 
 import org.eclipse.serializer.afs.types.AReadableFile;
@@ -253,6 +254,9 @@ public interface StorageDataFileItemIterator
 						itemProcessor
 					);
 					currentFilePosition += progress;
+
+					// the buffer must stay strongly reachable while its raw memory is read via the extracted address.
+					Reference.reachabilityFence(buffer);
 				}
 			}
 			catch(final Exception e)

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileItemIterator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageDataFileItemIterator.java
@@ -254,9 +254,6 @@ public interface StorageDataFileItemIterator
 						itemProcessor
 					);
 					currentFilePosition += progress;
-
-					// the buffer must stay strongly reachable while its raw memory is read via the extracted address.
-					Reference.reachabilityFence(buffer);
 				}
 			}
 			catch(final Exception e)
@@ -264,6 +261,11 @@ public interface StorageDataFileItemIterator
 				throw new StorageException(
 					"currentFilePosition = " + currentFilePosition + ". nextEntityLength = " + nextItemLength.value, e
 				);
+			}
+			finally
+			{
+				// the buffer must stay strongly reachable while its raw memory is read via the extracted address.
+				Reference.reachabilityFence(buffer);
 			}
 			
 			bufferProvider.cleanUp();

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -19,6 +19,7 @@ import static org.eclipse.serializer.math.XMath.positive;
 
 import static org.eclipse.serializer.util.X.notNull;
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 
 import org.eclipse.serializer.collections.EqHashEnum;
@@ -1551,16 +1552,24 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final long storageBackset    = chunkStoragePosition - chunkStartAddress;
 			final long chunkBoundAddress = chunkStartAddress    + chunkLength      ;
 
-			// chunk's entities are iterated, put into the cache and have their current storage positions set/updated
-			for(long adr = chunkStartAddress; adr < chunkBoundAddress; adr += Binary.getEntityLengthRawValue(adr))
+			try
 			{
-				final StorageEntity.Default entity = this.putEntity(adr);
-				this.markEntityForChangedData(entity);
-				entity.updateStorageInformation(
-						X.checkArrayRange(Binary.getEntityLengthRawValue(adr)),
-						validateStoragePosition(entity, storageBackset + adr)
-				);
-				file.appendEntry(entity);
+				// chunk's entities are iterated, put into the cache and have their current storage positions set/updated
+				for(long adr = chunkStartAddress; adr < chunkBoundAddress; adr += Binary.getEntityLengthRawValue(adr))
+				{
+					final StorageEntity.Default entity = this.putEntity(adr);
+					this.markEntityForChangedData(entity);
+					entity.updateStorageInformation(
+							X.checkArrayRange(Binary.getEntityLengthRawValue(adr)),
+							validateStoragePosition(entity, storageBackset + adr)
+					);
+					file.appendEntry(entity);
+				}
+			}
+			finally
+			{
+				// the buffer must stay strongly reachable while its raw memory is read via the extracted address.
+				Reference.reachabilityFence(chunk);
 			}
 		}
 

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileEntityDataIterator.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileEntityDataIterator.java
@@ -14,6 +14,7 @@ package org.eclipse.store.storage.types;
  * #L%
  */
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 
 import org.eclipse.store.storage.exceptions.StorageExceptionIoReading;
@@ -236,10 +237,21 @@ public interface StorageFileEntityDataIterator
 			final BinaryEntityRawDataAcceptor            dataAcceptor
 		)
 		{
-			final long bufferStartAddress = XMemory.getDirectByteBufferAddress(this.directByteBuffer);
-			final long bufferBoundAddress = bufferStartAddress + this.directByteBuffer.position();
-			
-			return dataIterator.iterateEntityRawData(bufferStartAddress, bufferBoundAddress, dataAcceptor);
+			final ByteBuffer buffer = this.directByteBuffer;
+			final long bufferStartAddress = XMemory.getDirectByteBufferAddress(buffer);
+			final long bufferBoundAddress = bufferStartAddress + buffer.position();
+
+			try
+			{
+				return dataIterator.iterateEntityRawData(bufferStartAddress, bufferBoundAddress, dataAcceptor);
+			}
+			finally
+			{
+				/* the buffer must stay strongly reachable while its raw memory is iterated via the
+				 * extracted address, or a GC may collect it and free the off-heap memory mid-iteration.
+				 */
+				Reference.reachabilityFence(buffer);
+			}
 		}
 		
 	}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordRegistry.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageMetaRecordRegistry.java
@@ -16,6 +16,7 @@ package org.eclipse.store.storage.types;
 
 import static org.eclipse.serializer.util.X.notNull;
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -178,55 +179,63 @@ public interface StorageMetaRecordRegistry
 			final long                        chunkStart
 		)
 		{
-			// Corrupt-input guard: the envelope (LENGTH 8B + META_MARKER 2B + KIND 2B = 12B) must be fully
-			// resident before we read the marker/KIND. An entry starting within fewer than 12 bytes of the
-			// buffer end cannot be a meta record (reading its marker would run past the buffer), so treat it
-			// as a legacy opaque gap. Only fires on a truncated/corrupted file.
-			final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
-			if(address + StorageMetaRecord.OFFSET_PAYLOAD > bufferBoundAddress)
+			try
 			{
-				return chunkStart;
-			}
+				// Corrupt-input guard: the envelope (LENGTH 8B + META_MARKER 2B + KIND 2B = 12B) must be fully
+				// resident before we read the marker/KIND. An entry starting within fewer than 12 bytes of the
+				// buffer end cannot be a meta record (reading its marker would run past the buffer), so treat it
+				// as a legacy opaque gap. Only fires on a truncated/corrupted file.
+				final long bufferBoundAddress = XMemory.getDirectByteBufferAddress(buffer) + buffer.limit();
+				if(address + StorageMetaRecord.OFFSET_PAYLOAD > bufferBoundAddress)
+				{
+					return chunkStart;
+				}
 
-			if(!StorageMetaRecord.isMetaRecord(address))
+				if(!StorageMetaRecord.isMetaRecord(address))
+				{
+					return chunkStart; // legacy gap — chunk boundary unchanged
+				}
+
+				final long                     kind    = StorageMetaRecord.kindOf(address);
+				final StorageMetaRecordHandler handler = this.handlersByKind.get(kind);
+				if(handler != null)
+				{
+					return handler.onLoad(file, buffer, address, chunkStart);
+				}
+
+				// unknown KIND — the reaction is applied (and gated) by the reporter; how the record is accounted
+				// then depends on whether the file's FileHeaderV1 has already been parsed (chunkChecksumKind != 0).
+				// FileHeaderV1 is by format the file's first entry, so once it is parsed every later meta record is
+				// reached with a non-zero kind, and a parsed header always carries a non-zero algorithm kind (the
+				// same invariant FileHeaderHandler and onFileComplete rely on).
+				this.reporter.onUnknownKind(file.number(), kind);
+				if(file.chunkChecksumKind() == 0L)
+				{
+					// No header parsed yet: an unknown record at the header position is a corrupted / lost
+					// FileHeaderV1 (its KIND garbled while the META_MARKER survived), NOT a forward-compat record.
+					// Leave the chunk boundary unadvanced so the following covering record's stored-chunk-start
+					// cross-check surfaces the drift (CHUNK_BOUNDARY_MISMATCH) instead of the corrupted file loading
+					// silently. (Header-less legacy / off files reach here too, but carry no covering records, so
+					// nothing is mis-flagged.)
+					return chunkStart;
+				}
+
+				// Header already parsed: this is a genuine forward-compat record in a checksummed file. Account it
+				// like every other meta record so the chunk bookkeeping stays consistent — advance the chunk boundary
+				// past the record (so a later covering record's stored start still matches the walker's cursor instead
+				// of raising a false CHUNK_BOUNDARY_MISMATCH / UNCOVERED_DATA) and register its bytes as meta overhead
+				// (so they are not mis-classified as reclaimable legacy gap by metaLength() / dataFillRatio()). The
+				// magnitude of the envelope LENGTH is the whole record size; the caller already validated it is fully
+				// resident (|LENGTH| <= remaining).
+				final long recordLength = -XMemory.get_long(address + StorageMetaRecord.OFFSET_LENGTH);
+				file.registerMetaLength(recordLength);
+				return address + recordLength;
+			}
+			finally
 			{
-				return chunkStart; // legacy gap — chunk boundary unchanged
+				// the buffer must stay strongly reachable while its raw memory is read via the passed address.
+				Reference.reachabilityFence(buffer);
 			}
-
-			final long                     kind    = StorageMetaRecord.kindOf(address);
-			final StorageMetaRecordHandler handler = this.handlersByKind.get(kind);
-			if(handler != null)
-			{
-				return handler.onLoad(file, buffer, address, chunkStart);
-			}
-
-			// unknown KIND — the reaction is applied (and gated) by the reporter; how the record is accounted
-			// then depends on whether the file's FileHeaderV1 has already been parsed (chunkChecksumKind != 0).
-			// FileHeaderV1 is by format the file's first entry, so once it is parsed every later meta record is
-			// reached with a non-zero kind, and a parsed header always carries a non-zero algorithm kind (the
-			// same invariant FileHeaderHandler and onFileComplete rely on).
-			this.reporter.onUnknownKind(file.number(), kind);
-			if(file.chunkChecksumKind() == 0L)
-			{
-				// No header parsed yet: an unknown record at the header position is a corrupted / lost
-				// FileHeaderV1 (its KIND garbled while the META_MARKER survived), NOT a forward-compat record.
-				// Leave the chunk boundary unadvanced so the following covering record's stored-chunk-start
-				// cross-check surfaces the drift (CHUNK_BOUNDARY_MISMATCH) instead of the corrupted file loading
-				// silently. (Header-less legacy / off files reach here too, but carry no covering records, so
-				// nothing is mis-flagged.)
-				return chunkStart;
-			}
-
-			// Header already parsed: this is a genuine forward-compat record in a checksummed file. Account it
-			// like every other meta record so the chunk bookkeeping stays consistent — advance the chunk boundary
-			// past the record (so a later covering record's stored start still matches the walker's cursor instead
-			// of raising a false CHUNK_BOUNDARY_MISMATCH / UNCOVERED_DATA) and register its bytes as meta overhead
-			// (so they are not mis-classified as reclaimable legacy gap by metaLength() / dataFillRatio()). The
-			// magnitude of the envelope LENGTH is the whole record size; the caller already validated it is fully
-			// resident (|LENGTH| <= remaining).
-			final long recordLength = -XMemory.get_long(address + StorageMetaRecord.OFFSET_LENGTH);
-			file.registerMetaLength(recordLength);
-			return address + recordLength;
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportDataByteBuffers.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportDataByteBuffers.java
@@ -14,6 +14,7 @@ package org.eclipse.store.storage.types;
  * #L%
  */
 
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 
 import org.eclipse.serializer.collections.types.XGettingEnum;
@@ -56,14 +57,22 @@ public interface StorageRequestTaskImportDataByteBuffers extends StorageRequestT
 		protected void iterateSource(final ByteBuffer buffer, final ItemAcceptor itemAcceptor)
 		{
 			final long address = XMemory.getDirectByteBufferAddress(buffer);
-	    	BinaryEntityRawDataIterator.New().iterateEntityRawData(
-	    		address,
-	    		address + buffer.limit(),
-	    		(entityStartAddress, dataBoundAddress) -> itemAcceptor.accept(
-	    			entityStartAddress                   , // start is the same
-	    			dataBoundAddress - entityStartAddress  // map to available item length
-	    		)
-	    	);
+			try
+			{
+				BinaryEntityRawDataIterator.New().iterateEntityRawData(
+					address,
+					address + buffer.limit(),
+					(entityStartAddress, dataBoundAddress) -> itemAcceptor.accept(
+						entityStartAddress                   , // start is the same
+						dataBoundAddress - entityStartAddress  // map to available item length
+					)
+				);
+			}
+			finally
+			{
+				// the buffer must stay strongly reachable while its raw memory is read via the extracted address.
+				Reference.reachabilityFence(buffer);
+			}
 		}
 
 	}


### PR DESCRIPTION
 Keep direct buffers reachable while using their raw addresses

  Extracting a direct ByteBuffer's address does not keep the buffer alive.
  The JIT may end the buffer's live range right after the extraction, so a
  GC can collect it and free the off-heap memory while the code still reads
  or writes through that address, causing garbage reads, silent corruption
  or JVM crashes.

  Add Reference.reachabilityFence for every affected site: the file entity
  data iterator, the entity cache chunk registration, the data file item
  iterator, the byte buffer import source, the chunk checksum handlers and
  verification, the meta record dispatch and Binary#copyMemory.