### PR TITLE
GigaMap: make index registration wait for open readers, like entity mutation does

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -932,9 +932,11 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public <K> BitmapIndex<E, K> add(final Indexer<? super E, K> indexer)
 		{
+			final String indexName = validateIndexerIdentity(indexer);
+
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable("add index \"" + indexerName(indexer) + "\"");
+				this.ensureMutable("add index \"" + indexName + "\"");
 
 				return this.internalAddIndex(indexer, true);
 			}
@@ -943,9 +945,11 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public <K> BitmapIndex<E, K> addWithoutInitialization(final Indexer<? super E, K> indexer)
 		{
+			final String indexName = validateIndexerIdentity(indexer);
+
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable("add index \"" + indexerName(indexer) + "\"");
+				this.ensureMutable("add index \"" + indexName + "\"");
 
 				return this.internalAddIndex(indexer, false);
 			}
@@ -994,12 +998,6 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					this
 				);
 			}
-		}
-
-		private static String indexerName(final Indexer<?, ?> indexer)
-		{
-			// the guard runs before #validateIndexToAdd, so the indexer may still be null here.
-			return indexer == null ? "<null>" : indexer.name();
 		}
 
 		@Override
@@ -1108,11 +1106,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public <K> BitmapIndex<E, K> update(final Indexer<? super E, K> indexer)
 		{
+			final String name = validateIndexerIdentity(indexer);
+
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable("update indexer \"" + indexerName(indexer) + "\"");
+				this.ensureMutable("update indexer \"" + name + "\"");
 
-				final String                     name     = indexer.name();
 				final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(name);
 				if(existing == null)
 				{
@@ -1509,9 +1508,11 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		
 		final <I> BitmapIndex<E, I> ensureBitmapIndex(final Indexer<? super E, I> indexer)
 		{
+			final String indexName = validateIndexerIdentity(indexer);
+
 			synchronized(this.parentMap())
 			{
-				BitmapIndex<E, I> index = this.get(indexer.keyType(), indexer.name());
+				BitmapIndex<E, I> index = this.get(indexer.keyType(), indexName);
 				if(index != null)
 				{
 					// Already present: no structural change, so the mutability guard is deliberately not
@@ -1520,12 +1521,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					return index;
 				}
 
-				this.ensureMutable("add index \"" + indexerName(indexer) + "\"");
+				this.ensureMutable("add index \"" + indexName + "\"");
 
 				// The guard may have released the parent-map monitor while waiting for foreign readers, so
 				// another thread may have registered the index meanwhile. Re-check instead of letting
 				// #validateIndexToAdd turn an idempotent ensure() into a "name already taken" failure.
-				index = this.get(indexer.keyType(), indexer.name());
+				index = this.get(indexer.keyType(), indexName);
 
 				return index != null
 					? index
@@ -1562,24 +1563,40 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		
 		private void validateIndexToAdd(final Indexer<? super E, ?> indexer)
 		{
-			if(indexer == null)
-			{
-				throw new IllegalArgumentException("Indexer may not be null.");
-			}
-			
-			final String indexName = indexer.name();
-			if(indexName == null)
-			{
-				throw new IllegalArgumentException("Index name may not be null.");
-			}
-			
-			
+			final String indexName = validateIndexerIdentity(indexer);
+
 			// Index name may not be taken, yet.
 			final BitmapIndex<E, ?> index = this.bitmapIndices.get(indexName);
 			if(index != null)
 			{
 				throw new RuntimeException(BitmapIndex.class.getSimpleName() + " already registered for name \"" + index.name() + "\".");
 			}
+		}
+
+		/**
+		 * Validates that the indexer and its registry key exist at all, independent of whether that key is
+		 * still free. Called by every entry point before the indexer is dereferenced - both to build the
+		 * mutability guard's message and to look the index up - so that a {@code null} indexer or name yields
+		 * the same {@link IllegalArgumentException} everywhere instead of a {@link NullPointerException} from
+		 * whichever dereference happens to come first.
+		 *
+		 * @param indexer the indexer to validate
+		 * @return the indexer's non-null name
+		 */
+		private static String validateIndexerIdentity(final Indexer<?, ?> indexer)
+		{
+			if(indexer == null)
+			{
+				throw new IllegalArgumentException("Indexer may not be null.");
+			}
+
+			final String indexName = indexer.name();
+			if(indexName == null)
+			{
+				throw new IllegalArgumentException("Index name may not be null.");
+			}
+
+			return indexName;
 		}
 		
 		private void internalAddUniqueConstraint(final BitmapIndex.Internal<E, ?> index)
@@ -1657,20 +1674,22 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public final UniqueConstraints<E> ensureUniqueConstraint(final Indexer<? super E, ?> indexer)
 		{
+			final String indexName = validateIndexerIdentity(indexer);
+
 			synchronized(this.parentMap())
 			{
-				if(this.isRegisteredUniqueConstraint(indexer))
+				if(this.isRegisteredUniqueConstraint(indexName))
 				{
 					// Already registered as a unique constraint -> idempotent no-op. No structural change, so
 					// the mutability guard is deliberately not reached (see #ensureBitmapIndex).
 					return this;
 				}
 
-				this.ensureMutable("add unique constraint \"" + indexerName(indexer) + "\"");
+				this.ensureMutable("add unique constraint \"" + indexName + "\"");
 
 				// The guard may have released the parent-map monitor while waiting for foreign readers, so
 				// re-check before creating the constraint (see #ensureBitmapIndex).
-				if(this.isRegisteredUniqueConstraint(indexer))
+				if(this.isRegisteredUniqueConstraint(indexName))
 				{
 					return this;
 				}
@@ -1682,10 +1701,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 		}
 
-		private boolean isRegisteredUniqueConstraint(final Indexer<? super E, ?> indexer)
+		private boolean isRegisteredUniqueConstraint(final String indexName)
 		{
 			// registry key is the indexer's name (a unique constraint is registered under index.name())
-			final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(indexer.name());
+			final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(indexName);
 
 			return existing != null && this.uniqueConstraints != null && this.uniqueConstraints.contains(existing);
 		}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -934,14 +934,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable();
-				this.validateIndexToAdd(indexer);
+				this.ensureMutable("add index \"" + indexerName(indexer) + "\"");
 
-				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
-				this.internalAddBitmapIndex(index);
-				this.rebuildCache();
-
-				return index;
+				return this.internalAddIndex(indexer, true);
 			}
 		}
 
@@ -950,27 +945,61 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable();
-				this.validateIndexToAdd(indexer);
+				this.ensureMutable("add index \"" + indexerName(indexer) + "\"");
 
-				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
-				this.internalAddBitmapIndex(index, false);
-				this.rebuildCache();
-
-				return index;
+				return this.internalAddIndex(indexer, false);
 			}
 		}
 
 		/**
-		 * Guards structural mutations against a read-only parent {@link GigaMap}. Must be called while
-		 * holding the parent-map lock.
+		 * Registers a single index without checking mutability. Callers must have passed
+		 * {@link #ensureMutable(String)} and must still hold the parent-map monitor.
+		 *
+		 * @param initialize whether to back-fill the new index from the already-present entities
+		 *        (see {@link #addWithoutInitialization(Indexer)})
 		 */
-		private void ensureMutable()
+		private <K> BitmapIndex<E, K> internalAddIndex(final Indexer<? super E, K> indexer, final boolean initialize)
 		{
-			if(this.parentMap().isReadOnly())
+			this.validateIndexToAdd(indexer);
+
+			final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
+			this.internalAddBitmapIndex(index, initialize);
+			this.rebuildCache();
+
+			return index;
+		}
+
+		/**
+		 * Guards structural mutations against a parent {@link GigaMap} that is currently not mutable, applying
+		 * the same classification an entity write applies (see {@link GigaMap.Internal#internalEnsureMutability()}):
+		 * an explicit read-only mark, an in-progress iteration and a self-held reader fail fast, while readers
+		 * open on other threads are waited out.
+		 * <p>
+		 * Must be called while holding the parent-map monitor. <b>The call may release that monitor while
+		 * waiting</b>, so state read before it must be re-checked afterwards.
+		 *
+		 * @param operation description of the attempted change, used to build the error message
+		 */
+		private void ensureMutable(final String operation)
+		{
+			try
 			{
-				throw new BitmapIndicesException("Cannot modify indices: the parent GigaMap is read-only.", this);
+				this.parentMap().internalEnsureMutability();
 			}
+			catch(final IllegalStateException e)
+			{
+				throw new BitmapIndicesException(
+					"Cannot " + operation + ": the parent GigaMap is not mutable.",
+					e,
+					this
+				);
+			}
+		}
+
+		private static String indexerName(final Indexer<?, ?> indexer)
+		{
+			// the guard runs before #validateIndexToAdd, so the indexer may still be null here.
+			return indexer == null ? "<null>" : indexer.name();
 		}
 
 		@Override
@@ -978,13 +1007,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				if(this.parentMap().isReadOnly())
-				{
-					throw new BitmapIndicesException(
-						"Cannot remove index \"" + name + "\": the parent GigaMap is read-only.",
-						this
-					);
-				}
+				this.ensureMutable("remove index \"" + name + "\"");
+
 				return this.internalRemoveIndex(name, false, true) != null;
 			}
 		}
@@ -1032,13 +1056,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				if(this.parentMap().isReadOnly())
-				{
-					throw new BitmapIndicesException(
-						"Cannot remove unique constraint \"" + name + "\": the parent GigaMap is read-only.",
-						this
-					);
-				}
+				this.ensureMutable("remove unique constraint \"" + name + "\"");
+
 				final BitmapIndex.Internal<E, ?> index = this.bitmapIndices.get(name);
 				if(index == null || this.uniqueConstraints == null || !this.uniqueConstraints.contains(index))
 				{
@@ -1091,13 +1110,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				if(this.parentMap().isReadOnly())
-				{
-					throw new BitmapIndicesException(
-						"Cannot update indexer \"" + indexer.name() + "\": the parent GigaMap is read-only.",
-						this
-					);
-				}
+				this.ensureMutable("update indexer \"" + indexerName(indexer) + "\"");
+
 				final String                     name     = indexer.name();
 				final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(name);
 				if(existing == null)
@@ -1168,12 +1182,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable();
+				this.ensureMutable("add indices");
 				for(final Indexer<? super E, ?> indexer : indexers)
 				{
 					this.validateIndexToAdd(indexer);
 				}
-				
+
 				for(final Indexer<? super E, ?> indexer : indexers)
 				{
 					final BitmapIndex.Internal<E, ?> index = indexer.createFor(this);
@@ -1181,7 +1195,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				}
 				this.rebuildCache();
 			}
-			
+
 			return this;
 		}
 		
@@ -1444,7 +1458,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable();
+				this.ensureMutable("set identity indices");
 				for(final IndexIdentifier<? super E, ?> i : identityIndices)
 				{
 					final BitmapIndex<E, ?> index = i.resolveFor(this);
@@ -1495,12 +1509,29 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		
 		final <I> BitmapIndex<E, I> ensureBitmapIndex(final Indexer<? super E, I> indexer)
 		{
-			BitmapIndex<E, I> index = this.get(indexer.keyType(), indexer.name());
-			if(index == null)
+			synchronized(this.parentMap())
 			{
-				index = this.add(indexer);
+				BitmapIndex<E, I> index = this.get(indexer.keyType(), indexer.name());
+				if(index != null)
+				{
+					// Already present: no structural change, so the mutability guard is deliberately not
+					// reached. This keeps ensure() a no-op on a read-only map, letting a read-only replica run
+					// the identical startup schema declaration.
+					return index;
+				}
+
+				this.ensureMutable("add index \"" + indexerName(indexer) + "\"");
+
+				// The guard may have released the parent-map monitor while waiting for foreign readers, so
+				// another thread may have registered the index meanwhile. Re-check instead of letting
+				// #validateIndexToAdd turn an idempotent ensure() into a "name already taken" failure.
+				index = this.get(indexer.keyType(), indexer.name());
+
+				return index != null
+					? index
+					: this.internalAddIndex(indexer, true)
+				;
 			}
-			return index;
 		}
 		
 		@Override
@@ -1589,28 +1620,38 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				this.ensureMutable();
-				// Basic validation before changing any state.
-				for(final Indexer<? super E, ?> indexer : indexers)
-				{
-					this.validateIndexToAdd(indexer);
-				}
+				this.ensureMutable("add unique constraints");
 
-				// Building unique indices, their data and data-related validation.
-				final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
-				this.buildUniqueIndices(indexers, indices);
-				this.buildIndexDataAndValidateUniqueness(indices);
-				
-				// When everything is guaranteed to be valid and consistent, the indices are actually added.
-				for(final BitmapIndex.Internal<E, ?> index : indices.values())
-				{
-					this.internalAddUniqueConstraint(index);
-					this.internalAddBitmapIndex(index);
-				}
-				this.rebuildCache();
+				this.internalAddUniqueConstraints(indexers);
 			}
 
 			return this;
+		}
+
+		/**
+		 * Registers the given indexers as unique constraints without checking mutability. Callers must have
+		 * passed {@link #ensureMutable(String)} and must still hold the parent-map monitor.
+		 */
+		private void internalAddUniqueConstraints(final Iterable<? extends Indexer<? super E, ?>> indexers)
+		{
+			// Basic validation before changing any state.
+			for(final Indexer<? super E, ?> indexer : indexers)
+			{
+				this.validateIndexToAdd(indexer);
+			}
+
+			// Building unique indices, their data and data-related validation.
+			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
+			this.buildUniqueIndices(indexers, indices);
+			this.buildIndexDataAndValidateUniqueness(indices);
+
+			// When everything is guaranteed to be valid and consistent, the indices are actually added.
+			for(final BitmapIndex.Internal<E, ?> index : indices.values())
+			{
+				this.internalAddUniqueConstraint(index);
+				this.internalAddBitmapIndex(index);
+			}
+			this.rebuildCache();
 		}
 
 		@Override
@@ -1618,16 +1659,35 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		{
 			synchronized(this.parentMap())
 			{
-				// registry key is the indexer's name (a unique constraint is registered under index.name())
-				final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(indexer.name());
-				if(existing != null && this.uniqueConstraints != null && this.uniqueConstraints.contains(existing))
+				if(this.isRegisteredUniqueConstraint(indexer))
 				{
-					// already registered as a unique constraint -> idempotent no-op
+					// Already registered as a unique constraint -> idempotent no-op. No structural change, so
+					// the mutability guard is deliberately not reached (see #ensureBitmapIndex).
 					return this;
 				}
+
+				this.ensureMutable("add unique constraint \"" + indexerName(indexer) + "\"");
+
+				// The guard may have released the parent-map monitor while waiting for foreign readers, so
+				// re-check before creating the constraint (see #ensureBitmapIndex).
+				if(this.isRegisteredUniqueConstraint(indexer))
+				{
+					return this;
+				}
+
 				// create + validate against existing data (throws if the name is taken by a non-unique index)
-				return this.addUniqueConstraint(indexer);
+				this.internalAddUniqueConstraints(X.Constant(indexer));
+
+				return this;
 			}
+		}
+
+		private boolean isRegisteredUniqueConstraint(final Indexer<? super E, ?> indexer)
+		{
+			// registry key is the indexer's name (a unique constraint is registered under index.name())
+			final BitmapIndex.Internal<E, ?> existing = this.bitmapIndices.get(indexer.name());
+
+			return existing != null && this.uniqueConstraints != null && this.uniqueConstraints.contains(existing);
 		}
 
 		private void buildUniqueIndices(

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
@@ -16,6 +16,7 @@ package org.eclipse.store.gigamap.types;
 
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.EqHashTable;
+import org.eclipse.serializer.collections.types.XGettingCollection;
 import org.eclipse.serializer.persistence.binary.types.BinaryTypeHandler;
 import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.serializer.util.X;
@@ -299,9 +300,20 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		@Override
 		public final CustomConstraints<E> ensureConstraints(final Iterable<? extends CustomConstraint<? super E>> constraints)
 		{
+			// The absent set is collected twice (once before the mutability guard and once after, since the
+			// guard may release the monitor while waiting), so the passed Iterable must be traversed exactly
+			// once: a single-use one (e.g. stream-backed) would come up empty on the second pass and silently
+			// skip the constraints. Materializing outside the monitor also keeps arbitrary caller code (a
+			// lazily evaluated Iterable) from running while the parent map is locked.
+			final BulkList<CustomConstraint<? super E>> requested = BulkList.New();
+			for(final CustomConstraint<? super E> constraint : constraints)
+			{
+				requested.add(constraint);
+			}
+
 			synchronized(this.parentMap())
 			{
-				BulkList<CustomConstraint<? super E>> toAdd = this.collectAbsentConstraints(constraints);
+				BulkList<CustomConstraint<? super E>> toAdd = this.collectAbsentConstraints(requested);
 				if(toAdd.isEmpty())
 				{
 					// Nothing to create: no structural change, so the mutability guard is deliberately not
@@ -315,7 +327,7 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 				// The guard may have released the parent-map monitor while waiting for foreign readers, so
 				// another thread may have registered some of them meanwhile. Re-collect instead of letting
 				// #validateConstraintToAdd turn an idempotent ensure() into a "name already taken" failure.
-				toAdd = this.collectAbsentConstraints(constraints);
+				toAdd = this.collectAbsentConstraints(requested);
 				if(!toAdd.isEmpty())
 				{
 					this.internalAddConstraints(toAdd);  // validates only the new constraints against existing entities
@@ -326,7 +338,7 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		}
 
 		private BulkList<CustomConstraint<? super E>> collectAbsentConstraints(
-			final Iterable<? extends CustomConstraint<? super E>> constraints
+			final XGettingCollection<CustomConstraint<? super E>> constraints
 		)
 		{
 			final BulkList<CustomConstraint<? super E>> absent = BulkList.New();

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
@@ -231,36 +231,69 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 			throw new IllegalArgumentException(CustomConstraint.class.getSimpleName() + " already registered for name \"" + index.name() + "\".");
 		}
 		
+		/**
+		 * Guards structural mutations against a parent {@link GigaMap} that is currently not mutable, applying
+		 * the same classification an entity write applies (see
+		 * {@link GigaMap.Internal#internalEnsureMutability()}): an explicit read-only mark, an in-progress
+		 * iteration and a self-held reader fail fast, while readers open on other threads are waited out.
+		 * <p>
+		 * Must be called while holding the parent-map monitor. <b>The call may release that monitor while
+		 * waiting</b>, so state read before it must be re-checked afterwards.
+		 *
+		 * @param operation description of the attempted change, used to build the error message
+		 */
+		private void ensureMutable(final String operation)
+		{
+			try
+			{
+				this.parentMap().internalEnsureMutability();
+			}
+			catch(final IllegalStateException e)
+			{
+				throw new IllegalStateException(
+					"Cannot " + operation + ": the parent GigaMap is not mutable.",
+					e
+				);
+			}
+		}
+
 		@Override
 		public final CustomConstraints<E> addConstraints(final Iterable<? extends CustomConstraint<? super E>> constraints)
 		{
 			synchronized(this.parentMap())
 			{
-				if(this.parentMap().isReadOnly())
-				{
-					throw new IllegalStateException("Cannot add custom constraint(s): the parent GigaMap is read-only.");
-				}
-				for(final CustomConstraint<? super E> constraint : constraints)
-				{
-					this.validateConstraintToAdd(constraint.name(), constraint);
-				}
-				
-				this.validateForExistingEntities(constraints);
-				
-				if(this.elements == null)
-				{
-					this.elements = EqHashTable.New();
-				}
-				for(final CustomConstraint<? super E> constraint : constraints)
-				{
-					Default.addConstraintChecked(this.elements, constraint);
-				}
+				this.ensureMutable("add custom constraint(s)");
 
-				this.markStateChangeInstance();
-				this.parent.internalReportConstraintsStateChange();
+				this.internalAddConstraints(constraints);
 			}
 
 			return this;
+		}
+
+		/**
+		 * Registers the given constraints without checking mutability. Callers must have passed
+		 * {@link #ensureMutable(String)} and must still hold the parent-map monitor.
+		 */
+		private void internalAddConstraints(final Iterable<? extends CustomConstraint<? super E>> constraints)
+		{
+			for(final CustomConstraint<? super E> constraint : constraints)
+			{
+				this.validateConstraintToAdd(constraint.name(), constraint);
+			}
+
+			this.validateForExistingEntities(constraints);
+
+			if(this.elements == null)
+			{
+				this.elements = EqHashTable.New();
+			}
+			for(final CustomConstraint<? super E> constraint : constraints)
+			{
+				Default.addConstraintChecked(this.elements, constraint);
+			}
+
+			this.markStateChangeInstance();
+			this.parent.internalReportConstraintsStateChange();
 		}
 
 		@Override
@@ -268,22 +301,45 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		{
 			synchronized(this.parentMap())
 			{
-				final BulkList<CustomConstraint<? super E>> toAdd = BulkList.New();
-				for(final CustomConstraint<? super E> constraint : constraints)
+				BulkList<CustomConstraint<? super E>> toAdd = this.collectAbsentConstraints(constraints);
+				if(toAdd.isEmpty())
 				{
-					if(this.elements == null || this.elements.get(constraint.name()) == null)
-					{
-						toAdd.add(constraint);  // absent -> create
-					}
-					// else: already registered under that name -> idempotent no-op
+					// Nothing to create: no structural change, so the mutability guard is deliberately not
+					// reached. This keeps ensure() a no-op on a read-only map, letting a read-only replica run
+					// the identical startup schema declaration.
+					return this;
 				}
+
+				this.ensureMutable("add custom constraint(s)");
+
+				// The guard may have released the parent-map monitor while waiting for foreign readers, so
+				// another thread may have registered some of them meanwhile. Re-collect instead of letting
+				// #validateConstraintToAdd turn an idempotent ensure() into a "name already taken" failure.
+				toAdd = this.collectAbsentConstraints(constraints);
 				if(!toAdd.isEmpty())
 				{
-					this.addConstraints(toAdd);  // validates only the new constraints against existing entities
+					this.internalAddConstraints(toAdd);  // validates only the new constraints against existing entities
 				}
 			}
 
 			return this;
+		}
+
+		private BulkList<CustomConstraint<? super E>> collectAbsentConstraints(
+			final Iterable<? extends CustomConstraint<? super E>> constraints
+		)
+		{
+			final BulkList<CustomConstraint<? super E>> absent = BulkList.New();
+			for(final CustomConstraint<? super E> constraint : constraints)
+			{
+				if(this.elements == null || this.elements.get(constraint.name()) == null)
+				{
+					absent.add(constraint);  // absent -> create
+				}
+				// else: already registered under that name -> idempotent no-op
+			}
+
+			return absent;
 		}
 
 		@Override
@@ -291,12 +347,8 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		{
 			synchronized(this.parentMap())
 			{
-				if(this.parentMap().isReadOnly())
-				{
-					throw new IllegalStateException(
-						"Cannot remove custom constraint \"" + name + "\": the parent GigaMap is read-only."
-					);
-				}
+				this.ensureMutable("remove custom constraint \"" + name + "\"");
+
 				if(this.elements == null)
 				{
 					return false;

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -208,7 +208,30 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 		{
 			return this.parent;
 		}
-		
+
+		/**
+		 * Guards structural mutations against a parent {@link GigaMap} that is currently not mutable, applying
+		 * the same classification an entity write applies (see
+		 * {@link GigaMap.Internal#internalEnsureMutability()}): an explicit read-only mark, an in-progress
+		 * iteration and a self-held reader fail fast, while readers open on other threads are waited out.
+		 * <p>
+		 * Must be called while holding the parent-map monitor. <b>The call may release that monitor while
+		 * waiting</b>, so state read before it must be re-checked afterwards.
+		 *
+		 * @param operation description of the attempted change, used to build the error message
+		 */
+		private void ensureMutable(final String operation)
+		{
+			try
+			{
+				this.parent.internalEnsureMutability();
+			}
+			catch(final IllegalStateException e)
+			{
+				throw new IllegalStateException("Cannot " + operation + ": the GigaMap is not mutable.", e);
+			}
+		}
+
 		protected final void internalAdd(final long entityId, final E entity)
 		{
 			notNull(entity);
@@ -571,12 +594,8 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 		{
 			synchronized(this.parentMap())
 			{
-				if(this.parent.isReadOnly())
-				{
-					throw new IllegalStateException(
-						"Cannot register an index group: the GigaMap is read-only."
-					);
-				}
+				this.ensureMutable("register an index group");
+
 				final IndexGroup.Internal<E> indexGroup = category.createIndexGroup(this.parent);
 				
 				@SuppressWarnings("unchecked")
@@ -638,12 +657,7 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 			final IndexGroup.Internal<E> found;
 			synchronized(this.parentMap())
 			{
-				if(this.parent.isReadOnly())
-				{
-					throw new IllegalStateException(
-						"Cannot remove index group \"" + categoryType.getName() + "\": the GigaMap is read-only."
-					);
-				}
+				this.ensureMutable("remove index group \"" + categoryType.getName() + "\"");
 
 				IndexGroup.Internal<E> match = null;
 				// exact class match is checked first, then the general (e.g. interface) type, mirroring #get.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2318,8 +2318,16 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				}
 				catch(final InterruptedException e)
 				{
+					// Restore the interrupt status the catch consumed: the caller aborts with an exception
+					// either way, but code further up (an executor's task loop, a shutdown handler) must
+					// still be able to observe that this thread was interrupted.
+					Thread.currentThread().interrupt();
+
+					// Distinct from the read-only messages above: the map may well be mutable: this thread
+					// just stopped waiting for it. Index groups reach this via #internalEnsureMutability.
 					throw new IllegalStateException(
-						XChars.systemString(this) + " is not mutable. (readOnlyCount " + this.readOnlyCount + ")",
+						"Interrupted while waiting for " + XChars.systemString(this)
+						+ " to become mutable. (readOnlyCount " + this.readOnlyCount + ")",
 						e
 					);
 				}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2298,6 +2298,15 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			level2.markChanged(level2Index);
 		}
 
+		@Override
+		public final synchronized void internalEnsureMutability()
+		{
+			// Index groups perform structural changes on this map's behalf, so they must use the very same
+			// check (including the wait for foreign readers) that an entity write uses. See the interface
+			// declaration for the contract, especially the monitor-release-while-waiting part.
+			this.ensureMutability();
+		}
+
 		private void ensureMutability()
 		{
 			while(this.checkingIsReadOnly())
@@ -3315,8 +3324,41 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public interface Internal<E> extends GigaMap<E>
 	{
 		public void internalReportIndexGroupStateChange(IndexGroup<E> indexGroup);
-		
+
 		public void internalReportConstraintsStateChange();
+
+		/**
+		 * Ensures that this {@link GigaMap} may currently be modified structurally, applying exactly the same
+		 * classification of a read-only hold that entity mutation applies. Intended for index groups, which
+		 * perform structural changes on the map's behalf and must not have different concurrency semantics
+		 * than an entity write.
+		 * <p>
+		 * A read-only hold is classified as follows:
+		 * <ul>
+		 * <li>an explicit {@link #markReadOnly()} throws immediately;</li>
+		 * <li>an in-progress {@link #iterate(Consumer)} / {@link #iterateIndexed(EntryConsumer)} or query
+		 *     execution throws immediately, because structural modification during iteration is not
+		 *     supported;</li>
+		 * <li>an open reader held by the <i>calling</i> thread throws immediately, because waiting for it
+		 *     would deadlock (the blocked thread is the only one that could close it);</li>
+		 * <li>open readers held only by <i>other</i> threads make this method <b>block</b> until they are
+		 *     closed.</li>
+		 * </ul>
+		 * <p>
+		 * <b>Must be called while holding this instance's monitor</b>, and the caller must keep holding it
+		 * until the structural change is complete: the monitor is what keeps new readers out (reader
+		 * registration is {@code synchronized} on this instance), so releasing it in between would let a
+		 * reader slip in before the mutation.
+		 * <p>
+		 * <b>While blocking, this method releases the caller's monitor hold entirely</b> - including
+		 * re-entrant holds, as {@link Object#wait()} performs as many unlock actions as the thread has
+		 * matching lock actions. Any state the caller read before calling this method may therefore be stale
+		 * once it returns, and must be re-checked.
+		 *
+		 * @throws IllegalStateException if the map is explicitly read-only, is being iterated, or the calling
+		 *         thread itself holds an open reader
+		 */
+		public void internalEnsureMutability();
 	}
 
 	

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/IndexRegistrationReadOnlyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/IndexRegistrationReadOnlyTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -438,6 +439,42 @@ public class IndexRegistrationReadOnlyTest
 		assertEquals(threadCount, results.size());
 		final BitmapIndex<Item, String> registered = map.index().bitmap().get("other");
 		results.forEach(index -> assertSame(registered, index));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// argument validation across the guard //
+	/////////////////////////////////////////
+
+	@Test
+	void nullIndexerIsRejectedConsistently()
+	{
+		final GigaMap<Item> map = newMap();
+
+		// The guard builds its message from the indexer's name, so every entry point has to validate the
+		// indexer before dereferencing it - otherwise the caller gets a NullPointerException from whichever
+		// dereference happens to come first instead of the documented IllegalArgumentException.
+		assertThrows(IllegalArgumentException.class, () -> map.index().bitmap().add(null));
+		assertThrows(IllegalArgumentException.class, () -> map.index().bitmap().addWithoutInitialization(null));
+		assertThrows(IllegalArgumentException.class, () -> map.index().bitmap().ensure(null));
+		assertThrows(IllegalArgumentException.class, () -> map.index().bitmap().update(null));
+		assertThrows(IllegalArgumentException.class, () -> map.constraints().unique().ensureUniqueConstraint(null));
+	}
+
+	@Test
+	void ensureConstraintsAcceptsASingleUseIterable()
+	{
+		final GigaMap<Item> map = newMap();
+
+		// ensureConstraints collects the absent set twice (before and after the mutability guard, which may
+		// release the monitor), so it must traverse the passed Iterable exactly once: a single-use one would
+		// come up empty on the second pass and the constraint would be silently skipped.
+		final Iterable<CustomConstraint<? super Item>> singleUse =
+			Stream.<CustomConstraint<? super Item>>of(new NoEmptyLabel())::iterator;
+
+		map.constraints().custom().ensureConstraints(singleUse);
+
+		assertTrue(map.constraints().custom().removeConstraint("NoEmptyLabel"));
 	}
 
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/IndexRegistrationReadOnlyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/IndexRegistrationReadOnlyTest.java
@@ -1,0 +1,579 @@
+package org.eclipse.store.gigamap.indexer.edge;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.BitmapIndicesException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.BitmapIndex;
+import org.eclipse.store.gigamap.types.CustomConstraint;
+import org.eclipse.store.gigamap.types.GigaIterator;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.serializer.util.X;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the mutability guard of the index side ({@code BitmapIndices}, {@code CustomConstraints},
+ * {@code GigaIndices}).
+ * <p>
+ * A structural index change must apply exactly the same classification of a read-only hold that an entity
+ * write applies: an explicit {@code markReadOnly()}, a structural change during an in-progress iteration and a
+ * self-held reader fail fast, while readers that are open on <i>other</i> threads are waited out instead of
+ * being reported as an error. Before that was the case, {@code ensure(indexer)} failed unpredictably: it only
+ * touches index structure on the first use of a key, so the same logical write succeeded many times and then
+ * threw once, the first time a new key coincided with a reader open somewhere else.
+ */
+public class IndexRegistrationReadOnlyTest
+{
+	static class Item
+	{
+		String label;
+
+		Item()
+		{
+			// required for deserialization
+		}
+
+		Item(final String label)
+		{
+			this.label = label;
+		}
+	}
+
+	static final IndexerString<Item> LABEL = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "label";
+		}
+
+		@Override
+		protected String getString(final Item e)
+		{
+			return e.label;
+		}
+	};
+
+	static final IndexerString<Item> OTHER = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "other";
+		}
+
+		@Override
+		protected String getString(final Item e)
+		{
+			return e.label;
+		}
+	};
+
+	static final BinaryIndexerString<Item> UNIQUE_LABEL = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "uniqueLabel";
+		}
+
+		@Override
+		protected String getString(final Item e)
+		{
+			return e.label;
+		}
+	};
+
+	// same name as LABEL but different logic, for BitmapIndices#update
+	static final IndexerString<Item> LABEL_FIRST_LETTER = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "label";
+		}
+
+		@Override
+		protected String getString(final Item e)
+		{
+			return e.label.substring(0, 1);
+		}
+	};
+
+	// CustomConstraint.AbstractBase#name() is final -> registered under the simple class name
+	static class NoEmptyLabel extends CustomConstraint.AbstractSimple<Item>
+	{
+		@Override
+		public boolean isViolated(final Item entity)
+		{
+			return entity.label.isEmpty();
+		}
+	}
+
+	static class NoBlankLabel extends CustomConstraint.AbstractSimple<Item>
+	{
+		@Override
+		public boolean isViolated(final Item entity)
+		{
+			return entity.label.isBlank();
+		}
+	}
+
+	private static GigaMap<Item> newMap()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().ensure(LABEL);
+		map.addAll(new Item("a1"), new Item("a2"), new Item("a3"));
+
+		return map;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// the reported bug //
+	/////////////////////
+
+	@Test
+	void ensureIndexFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		// Both statements are structural writes against the same GigaMap under the same read-only hold.
+		// Before the fix only the second one failed, with
+		// "BitmapIndicesException: Cannot modify indices: the parent GigaMap is read-only."
+		assertWaitsForForeignReader(map, () -> map.add(new Item("b1")));
+		assertWaitsForForeignReader(map, () -> map.index().bitmap().ensure(OTHER));
+
+		assertNotNull(map.index().bitmap().get("other"));
+		assertEquals(4, map.size());
+		assertEquals(1, map.query(OTHER.is("b1")).count());
+	}
+
+	@Test
+	void ensureAlreadyPresentIndexDoesNotWaitForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		// The fast path performs no structural change, so it must not even reach the guard - a read-only
+		// replica has to be able to run the identical startup schema declaration while readers are open.
+		final BitmapIndex<Item, String> index = assertCompletesWithForeignReader(
+			map,
+			() -> map.index().bitmap().ensure(LABEL)
+		);
+		assertSame(map.index().bitmap().get("label"), index);
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// the other index-side guards //
+	////////////////////////////////
+
+	@Test
+	void addIndexFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertWaitsForForeignReader(map, () -> map.index().bitmap().add(OTHER));
+
+		// the new index must have been back-filled from the entities that were already present
+		assertEquals(1, map.query(OTHER.is("a1")).count());
+	}
+
+	@Test
+	void removeIndexFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+		map.index().bitmap().add(OTHER);
+
+		assertWaitsForForeignReader(map, () -> map.index().bitmap().removeIndex("other"));
+
+		assertNull(map.index().bitmap().get("other"));
+	}
+
+	@Test
+	void updateIndexerFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertWaitsForForeignReader(map, () -> map.index().bitmap().update(LABEL_FIRST_LETTER));
+
+		assertEquals(3, map.query(LABEL_FIRST_LETTER.is("a")).count());
+	}
+
+	@Test
+	void addUniqueConstraintFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertWaitsForForeignReader(map, () -> map.constraints().unique().addUniqueConstraint(UNIQUE_LABEL));
+
+		assertEquals(1, map.index().bitmap().uniqueConstraints().size());
+	}
+
+	@Test
+	void removeUniqueConstraintFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+		map.constraints().unique().addUniqueConstraint(UNIQUE_LABEL);
+
+		assertWaitsForForeignReader(
+			map,
+			() -> assertTrue(map.index().bitmap().removeUniqueConstraint("uniqueLabel"))
+		);
+
+		assertTrue(map.index().bitmap().uniqueConstraints() == null
+			|| map.index().bitmap().uniqueConstraints().isEmpty());
+	}
+
+	@Test
+	void setIdentityIndicesFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertWaitsForForeignReader(map, () -> map.index().bitmap().setIdentityIndices(X.Enum(LABEL)));
+
+		assertEquals(1, map.index().bitmap().identityIndices().size());
+	}
+
+	@Test
+	void addCustomConstraintFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertWaitsForForeignReader(map, () -> map.constraints().custom().addConstraint(new NoEmptyLabel()));
+
+		// CustomConstraints has no getter; a successful remove proves the constraint was registered.
+		assertTrue(map.constraints().custom().removeConstraint("NoEmptyLabel"));
+	}
+
+	@Test
+	void ensureCustomConstraintFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertWaitsForForeignReader(map, () -> map.constraints().custom().ensureConstraint(new NoBlankLabel()));
+
+		assertTrue(map.constraints().custom().removeConstraint("NoBlankLabel"));
+	}
+
+	@Test
+	void removeCustomConstraintFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+		map.constraints().custom().addConstraint(new NoEmptyLabel());
+
+		assertWaitsForForeignReader(
+			map,
+			() -> assertTrue(map.constraints().custom().removeConstraint("NoEmptyLabel"))
+		);
+
+		assertFalse(map.constraints().custom().removeConstraint("NoEmptyLabel"));
+	}
+
+	@Test
+	void registerIndexGroupFromOtherThreadWaitsForOpenReader()
+	{
+		final GigaMap<Item> map = newMap();
+
+		// The bitmap group is already registered, so register(...) is a no-op returning null - but the
+		// mutability guard sits in front of that check and must wait rather than throw.
+		assertWaitsForForeignReader(
+			map,
+			() -> assertNull(map.index().register(BitmapIndex.Category()))
+		);
+
+		assertNotNull(map.index().bitmap());
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// the fail-fast cases, which must stay fail-fast //
+	//////////////////////////////////////////////////
+
+	@Test
+	void ensureIndexWhileHoldingOwnReaderThrows()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+		{
+			final GigaIterator<Item> reader = map.iterator();
+			reader.hasNext();
+
+			// Waiting for a reader the calling thread holds itself would block forever, so this must fail
+			// fast - exactly like an entity write does.
+			final BitmapIndicesException thrown = assertThrows(
+				BitmapIndicesException.class,
+				() -> map.index().bitmap().ensure(OTHER)
+			);
+			assertInstanceOf(IllegalStateException.class, thrown.getCause());
+			assertTrue(thrown.getCause().getMessage().contains("Self-deadlock"));
+
+			reader.close();
+		});
+
+		assertNull(map.index().bitmap().get("other"));
+	}
+
+	@Test
+	void ensureIndexDuringIterationThrows()
+	{
+		final GigaMap<Item> map = newMap();
+
+		// A structural change while an iteration walks the map is not supported and must fail fast, not
+		// wait: the iteration's read-only hold is never released by another thread.
+		assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+		{
+			final BitmapIndicesException thrown = assertThrows(
+				BitmapIndicesException.class,
+				() -> map.iterate(e -> map.index().bitmap().ensure(OTHER))
+			);
+			assertInstanceOf(IllegalStateException.class, thrown.getCause());
+		});
+
+		assertNull(map.index().bitmap().get("other"));
+	}
+
+	@Test
+	void ensureIndexOnExplicitlyReadOnlyMapThrows()
+	{
+		final GigaMap<Item> map = newMap();
+		map.markReadOnly();
+
+		// An explicit read-only mark is a deliberate, open-ended state - waiting for it would block until
+		// some other thread happens to unmark it, so it must fail fast.
+		assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+		{
+			final BitmapIndicesException thrown = assertThrows(
+				BitmapIndicesException.class,
+				() -> map.index().bitmap().ensure(OTHER)
+			);
+			assertInstanceOf(IllegalStateException.class, thrown.getCause());
+			assertTrue(thrown.getCause().getMessage().contains("read only mode"));
+		});
+
+		map.unmarkReadOnly();
+		assertNull(map.index().bitmap().get("other"));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// idempotency of ensure() across the wait //
+	////////////////////////////////////////////
+
+	@Test
+	void concurrentEnsureOfSameIndexerReturnsTheSameIndex()
+	{
+		final GigaMap<Item> map = newMap();
+
+		final int                              threadCount = 8;
+		final CountDownLatch                   start       = new CountDownLatch(1);
+		final CountDownLatch                   done        = new CountDownLatch(threadCount);
+		final List<BitmapIndex<Item, String>>  results     = new ArrayList<>();
+		final AtomicReference<Throwable>       error       = new AtomicReference<>();
+
+		assertTimeoutPreemptively(Duration.ofSeconds(15), () ->
+		{
+			for(int i = 0; i < threadCount; i++)
+			{
+				new Thread(() ->
+				{
+					try
+					{
+						start.await(5, TimeUnit.SECONDS);
+						final BitmapIndex<Item, String> index = map.index().bitmap().ensure(OTHER);
+						synchronized(results)
+						{
+							results.add(index);
+						}
+					}
+					catch(final Throwable t)
+					{
+						error.compareAndSet(null, t);
+					}
+					finally
+					{
+						done.countDown();
+					}
+				}, "ensure-" + i).start();
+			}
+
+			start.countDown();
+			assertTrue(done.await(10, TimeUnit.SECONDS), "all ensure() calls must finish");
+		});
+
+		assertNull(error.get(), () -> "concurrent ensure() must not fail: " + error.get());
+		assertEquals(threadCount, results.size());
+		final BitmapIndex<Item, String> registered = map.index().bitmap().get("other");
+		results.forEach(index -> assertSame(registered, index));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// harness //
+	////////////
+
+	/**
+	 * Runs {@code operation} on a dedicated thread while another thread holds an open reader on {@code map},
+	 * and asserts that it neither throws nor completes: it has to block until the foreign reader is closed,
+	 * which is what an entity write does in the same situation.
+	 */
+	private static void assertWaitsForForeignReader(final GigaMap<Item> map, final Executable operation)
+	{
+		assertWithForeignReader(map, operation, true);
+	}
+
+	/**
+	 * Same setup as {@link #assertWaitsForForeignReader}, but asserts the opposite: the operation performs no
+	 * structural change and must therefore complete while the foreign reader is still open.
+	 */
+	private static <T> T assertCompletesWithForeignReader(
+		final GigaMap<Item>            map      ,
+		final ThrowingSupplier<T>      operation
+	)
+	{
+		final AtomicReference<T> result = new AtomicReference<>();
+		assertWithForeignReader(map, () -> result.set(operation.get()), false);
+
+		return result.get();
+	}
+
+	private static void assertWithForeignReader(
+		final GigaMap<Item> map           ,
+		final Executable    operation     ,
+		final boolean       expectBlocking
+	)
+	{
+		final CountDownLatch             readerOpened = new CountDownLatch(1);
+		final CountDownLatch             releaseReader = new CountDownLatch(1);
+		final CountDownLatch             operationDone = new CountDownLatch(1);
+		final AtomicReference<Throwable> holderError   = new AtomicReference<>();
+		final AtomicReference<Throwable> writerError   = new AtomicReference<>();
+
+		// A different thread holds an open reader, then releases it on signal.
+		final Thread holder = new Thread(() ->
+		{
+			try(final GigaIterator<Item> reader = map.iterator())
+			{
+				reader.hasNext();
+				readerOpened.countDown();
+				releaseReader.await(30, TimeUnit.SECONDS);
+			}
+			catch(final Throwable t)
+			{
+				holderError.set(t);
+			}
+		}, "reader-holder");
+
+		final Thread writer = new Thread(() ->
+		{
+			try
+			{
+				operation.execute();
+			}
+			catch(final Throwable t)
+			{
+				writerError.set(t);
+			}
+			finally
+			{
+				operationDone.countDown();
+			}
+		}, "index-writer");
+
+		assertTimeoutPreemptively(Duration.ofSeconds(30), () ->
+		{
+			holder.start();
+			assertTrue(readerOpened.await(10, TimeUnit.SECONDS), "the foreign reader must be open");
+
+			writer.start();
+			if(expectBlocking)
+			{
+				// The operation can only get here if it did NOT wait: either it threw (the reported bug) or
+				// it went through while a reader was open. Both are wrong, and #writerError names which one.
+				assertFalse(
+					operationDone.await(500, TimeUnit.MILLISECONDS),
+					() -> "the operation must wait for the foreign reader to close, but it finished"
+						+ (writerError.get() == null ? " immediately." : " by throwing " + writerError.get())
+				);
+			}
+			else
+			{
+				assertTrue(
+					operationDone.await(5, TimeUnit.SECONDS),
+					"the operation performs no structural change and must not wait for the foreign reader"
+				);
+			}
+
+			releaseReader.countDown();
+			assertTrue(
+				operationDone.await(10, TimeUnit.SECONDS),
+				"the operation must proceed once the foreign reader is closed"
+			);
+
+			holder.join(10_000);
+		});
+
+		assertNull(holderError.get(), () -> "the reader holder failed: " + holderError.get());
+		assertNull(writerError.get(), () -> "the operation failed: " + writerError.get());
+	}
+
+	private interface ThrowingSupplier<T>
+	{
+		T get() throws Throwable;
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// sanity check of the fixture itself //
+	///////////////////////////////////////
+
+	@Test
+	void openReaderIsActuallyDetectedAsReadOnly()
+	{
+		final GigaMap<Item> map = newMap();
+
+		assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+		{
+			try(final GigaIterator<Item> reader = map.iterator())
+			{
+				reader.hasNext();
+				assertTrue(map.isReadOnly(), "an open reader must put the map into a read-only hold");
+			}
+			assertFalse(map.isReadOnly());
+			assertDoesNotThrow(() -> map.index().bitmap().ensure(OTHER));
+		});
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/IndexRegistrationReadOnlyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/IndexRegistrationReadOnlyTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -439,6 +440,83 @@ public class IndexRegistrationReadOnlyTest
 		assertEquals(threadCount, results.size());
 		final BitmapIndex<Item, String> registered = map.index().bitmap().get("other");
 		results.forEach(index -> assertSame(registered, index));
+	}
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// interruption of the new wait //
+	/////////////////////////////////
+
+	@Test
+	void interruptingAWaitingIndexRegistrationPreservesInterruptStatus()
+	{
+		final GigaMap<Item> map = newMap();
+
+		final CountDownLatch             readerOpened = new CountDownLatch(1);
+		final CountDownLatch             releaseReader = new CountDownLatch(1);
+		final CountDownLatch             writerDone   = new CountDownLatch(1);
+		final AtomicReference<Throwable> writerError  = new AtomicReference<>();
+		final AtomicBoolean              stillInterrupted = new AtomicBoolean();
+
+		final Thread holder = new Thread(() ->
+		{
+			try(final GigaIterator<Item> reader = map.iterator())
+			{
+				reader.hasNext();
+				readerOpened.countDown();
+				releaseReader.await(30, TimeUnit.SECONDS);
+			}
+			catch(final Throwable t)
+			{
+				// ignored: the holder is only a vehicle for the read-only hold
+			}
+		}, "reader-holder");
+
+		final Thread writer = new Thread(() ->
+		{
+			try
+			{
+				map.index().bitmap().ensure(OTHER);
+			}
+			catch(final Throwable t)
+			{
+				writerError.set(t);
+				// Interrupting a blocked writer must not swallow the interrupt status: code further up
+				// (an executor task loop, a shutdown handler) still has to be able to see it.
+				stillInterrupted.set(Thread.currentThread().isInterrupted());
+			}
+			finally
+			{
+				writerDone.countDown();
+			}
+		}, "index-writer");
+
+		assertTimeoutPreemptively(Duration.ofSeconds(30), () ->
+		{
+			holder.start();
+			assertTrue(readerOpened.await(10, TimeUnit.SECONDS));
+
+			writer.start();
+			// Registration is now blocked in the guard's wait(); interrupt it there.
+			assertFalse(writerDone.await(500, TimeUnit.MILLISECONDS), "the registration must be waiting");
+			writer.interrupt();
+			assertTrue(writerDone.await(10, TimeUnit.SECONDS), "the interrupt must break the wait");
+
+			releaseReader.countDown();
+			holder.join(10_000);
+		});
+
+		assertInstanceOf(BitmapIndicesException.class, writerError.get());
+		assertInstanceOf(IllegalStateException.class, writerError.get().getCause());
+		assertTrue(
+			writerError.get().getCause().getMessage().contains("Interrupted"),
+			() -> "the cause must name the interrupt, not claim the map is read-only: "
+				+ writerError.get().getCause().getMessage()
+		);
+		assertTrue(stillInterrupted.get(), "the interrupt status must be restored before throwing");
+
+		// The aborted registration left no half-registered index behind.
+		assertNull(map.index().bitmap().get("other"));
 	}
 
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
@@ -198,6 +198,29 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
             return this.vectorIndices;
         }
 
+        /**
+         * Guards structural mutations against a parent {@link GigaMap} that is currently not mutable, applying
+         * the same classification an entity write applies (see
+         * {@link GigaMap.Internal#internalEnsureMutability()}): an explicit read-only mark, an in-progress
+         * iteration and a self-held reader fail fast, while readers open on other threads are waited out.
+         * <p>
+         * Must be called while holding the parent-map monitor. <b>The call may release that monitor while
+         * waiting</b>, so state read before it must be re-checked afterwards.
+         *
+         * @param operation description of the attempted change, used to build the error message
+         */
+        private void ensureMutable(final String operation)
+        {
+            try
+            {
+                this.parent.internalEnsureMutability();
+            }
+            catch(final IllegalStateException e)
+            {
+                throw new IllegalStateException("Cannot " + operation + ": the GigaMap is not mutable.", e);
+            }
+        }
+
         @Override
         public final void internalAdd(final long entityId, final E entity)
         {
@@ -284,25 +307,34 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
         {
             synchronized(this.parentMap())
             {
-                if(this.parent.isReadOnly())
-                {
-                    throw new IllegalStateException(
-                        "Cannot add vector index \"" + name + "\": the GigaMap is read-only."
-                    );
-                }
-                this.validateIndexToAdd(name);
+                this.ensureMutable("add vector index \"" + name + "\"");
 
-                final VectorIndex.Internal<E> index = new VectorIndex.Default<>(
-                    this,
-                    name,
-                    true,
-                    configuration,
-                    vectorizer
-                );
-                this.internalAddVectorIndex(index);
-
-                return index;
+                return this.internalAddIndex(name, configuration, vectorizer);
             }
+        }
+
+        /**
+         * Registers a single vector index without checking mutability. Callers must have passed
+         * {@link #ensureMutable(String)} and must still hold the parent-map monitor.
+         */
+        private VectorIndex<E> internalAddIndex(
+            final String name,
+            final VectorIndexConfiguration configuration,
+            final Vectorizer<? super E> vectorizer
+        )
+        {
+            this.validateIndexToAdd(name);
+
+            final VectorIndex.Internal<E> index = new VectorIndex.Default<>(
+                this,
+                name,
+                true,
+                configuration,
+                vectorizer
+            );
+            this.internalAddVectorIndex(index);
+
+            return index;
         }
 
         @Override
@@ -312,12 +344,28 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
             final Vectorizer<? super E> vectorizer
         )
         {
-            VectorIndex<E> index = this.get(name);
-            if(index == null)
+            synchronized(this.parentMap())
             {
-                index = this.add(name, configuration, vectorizer);
+                VectorIndex<E> index = this.internalGet(name);
+                if(index != null)
+                {
+                    // Already present: no structural change, so the mutability guard is deliberately not
+                    // reached. This keeps ensure() a no-op on a read-only map.
+                    return index;
+                }
+
+                this.ensureMutable("add vector index \"" + name + "\"");
+
+                // The guard may have released the parent-map monitor while waiting for foreign readers, so
+                // another thread may have registered the index meanwhile. Re-check instead of letting
+                // #validateIndexToAdd turn an idempotent ensure() into a "name already taken" failure.
+                index = this.internalGet(name);
+
+                return index != null
+                    ? index
+                    : this.internalAddIndex(name, configuration, vectorizer)
+                ;
             }
-            return index;
         }
 
         @Override
@@ -335,12 +383,8 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
             final VectorIndex.Internal<E> index;
             synchronized(this.parentMap())
             {
-                if(this.parent.isReadOnly())
-                {
-                    throw new IllegalStateException(
-                        "Cannot remove vector index \"" + name + "\": the GigaMap is read-only."
-                    );
-                }
+                this.ensureMutable("remove vector index \"" + name + "\"");
+
                 index = this.vectorIndices.get(name);
                 if(index == null)
                 {

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
@@ -15,21 +15,28 @@ package org.eclipse.store.gigamap.jvector;
  */
 
 import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.GigaIterator;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexGroup;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -162,6 +169,144 @@ class VectorIndexLifecycleTest
 			(Class<? extends IndexGroup<Doc>>)(Class<?>)BitmapIndices.class;
 
 		assertThrows(IllegalArgumentException.class, () -> map.index().remove(bitmapType));
+	}
+
+	@Test
+	void addIndex_fromOtherThread_waitsForOpenReader()
+	{
+		// The map is deliberately left empty: registering a vector index on a map that already contains
+		// entities trips an unrelated defect in the back-fill (the index is populated both by
+		// VectorIndex.Default's graph rebuild and by VectorIndices#internalAddVectorIndex, which fails with
+		// "Node 0 already exists"). The mutability guard under test runs before any of that.
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+
+		// Registering a vector index is a structural write, so it must wait for a reader open on another
+		// thread instead of failing - exactly like an entity write does.
+		assertWaitsForForeignReader(map, () -> vi.add("emb", config(), new EmbeddingVectorizer()));
+
+		assertNotNull(vi.get("emb"));
+	}
+
+	@Test
+	void ensureIndex_fromOtherThread_waitsForOpenReader()
+	{
+		// see #addIndex_fromOtherThread_waitsForOpenReader on why the map stays empty
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+
+		assertWaitsForForeignReader(map, () -> vi.ensure("emb", config(), new EmbeddingVectorizer()));
+
+		assertNotNull(vi.get("emb"));
+	}
+
+	@Test
+	void removeIndex_fromOtherThread_waitsForOpenReader()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+		vi.add("emb", config(), new EmbeddingVectorizer());
+		addDocs(map);
+
+		assertWaitsForForeignReader(map, () -> assertTrue(vi.removeIndex("emb")));
+
+		assertNull(vi.get("emb"));
+	}
+
+	@Test
+	void registerIndexGroup_fromOtherThread_waitsForOpenReader()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		addDocs(map);
+
+		assertWaitsForForeignReader(map, () -> assertNotNull(map.index().register(VectorIndices.Category())));
+
+		assertNotNull(map.index().get(VectorIndices.Category()));
+	}
+
+	@Test
+	void removeIndexGroup_fromOtherThread_waitsForOpenReader()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		map.index().register(VectorIndices.Category());
+		addDocs(map);
+
+		assertWaitsForForeignReader(map, () -> assertTrue(map.index().remove(VectorIndices.Category())));
+
+		assertNull(map.index().get(VectorIndices.Category()));
+	}
+
+	/**
+	 * Runs {@code operation} on a dedicated thread while another thread holds an open reader on {@code map},
+	 * and asserts that it neither throws nor completes early: it has to block until the foreign reader is
+	 * closed, which is what an entity write does in the same situation.
+	 */
+	private static void assertWaitsForForeignReader(final GigaMap<Doc> map, final Executable operation)
+	{
+		final CountDownLatch             readerOpened  = new CountDownLatch(1);
+		final CountDownLatch             releaseReader = new CountDownLatch(1);
+		final CountDownLatch             operationDone = new CountDownLatch(1);
+		final AtomicReference<Throwable> holderError   = new AtomicReference<>();
+		final AtomicReference<Throwable> writerError   = new AtomicReference<>();
+
+		final Thread holder = new Thread(() ->
+		{
+			// #iterator() registers the reader right away; hasNext() is deliberately NOT called, because it
+			// closes the iterator as soon as there is no next element - which would release the hold again
+			// on an empty map.
+			try(final GigaIterator<Doc> reader = map.iterator())
+			{
+				assertNotNull(reader);
+				readerOpened.countDown();
+				releaseReader.await(30, TimeUnit.SECONDS);
+			}
+			catch(final Throwable t)
+			{
+				holderError.set(t);
+			}
+		}, "reader-holder");
+
+		final Thread writer = new Thread(() ->
+		{
+			try
+			{
+				operation.execute();
+			}
+			catch(final Throwable t)
+			{
+				writerError.set(t);
+			}
+			finally
+			{
+				operationDone.countDown();
+			}
+		}, "index-writer");
+
+		assertTimeoutPreemptively(Duration.ofSeconds(60), () ->
+		{
+			holder.start();
+			assertTrue(readerOpened.await(10, TimeUnit.SECONDS), "the foreign reader must be open");
+
+			writer.start();
+			// The operation can only get here if it did NOT wait: either it threw or it went through while a
+			// reader was open. Both are wrong, and #writerError names which one.
+			assertFalse(
+				operationDone.await(500, TimeUnit.MILLISECONDS),
+				() -> "the operation must wait for the foreign reader to close, but it finished"
+					+ (writerError.get() == null ? " immediately." : " by throwing " + writerError.get())
+			);
+
+			releaseReader.countDown();
+			assertTrue(
+				operationDone.await(30, TimeUnit.SECONDS),
+				"the operation must proceed once the foreign reader is closed"
+			);
+
+			holder.join(10_000);
+		});
+
+		assertNull(holderError.get(), () -> "the reader holder failed: " + holderError.get());
+		assertNull(writerError.get(), () -> "the operation failed: " + writerError.get());
 	}
 
 	@Test


### PR DESCRIPTION
## The problem

`GigaMap` had two structurally identical kinds of write guarded in two different ways.

Entity mutation goes through `GigaMap.Default#ensureMutability`, which classifies the read-only hold via `#checkingIsReadOnly`: an explicit `markReadOnly()` throws, an in-progress `iterate()`/query (`readOnlyCount > activeReaderCount`) throws, a self-held reader fails fast via `#checkSelfHeldReader`, and a reader open on *another* thread makes the writer `wait()` until `#exitReadOnly` calls `notifyAll()`.

Index registration had none of that. `BitmapIndices.Default#ensureMutable` and its inlined siblings only asked `parentMap().isReadOnly()`, which is `explicitReadOnlyCount != 0 || readOnlyCount != 0` - true for *every* open reader, including one driven by an unrelated thread. So the ordinary "a reader is open somewhere" case, which entity writes handle by waiting, was a hard `BitmapIndicesException` for index registration.

That made `ensure(indexer)` non-deterministic for open key spaces. An application that maps an ad-hoc key space onto one bitmap index per key registers an index only on *first* use of a new key; every later write with that key takes the `ensureBitmapIndex` fast path and touches no index structure. So the same logical write succeeded thousands of times and then threw once, the first time a genuinely new key coincided with an open reader on another thread. There was no application-side workaround short of serialising all reads against all writes, which throws away exactly the read concurrency the wait-based path was built to allow.

## The fix

`GigaMap.Internal` now exposes `internalEnsureMutability()`, implemented by `GigaMap.Default` as a `synchronized` delegate to the existing private `#ensureMutability`. Every index-side guard routes through it, keeping its operation-specific message and chaining the `IllegalStateException` as cause:

- `BitmapIndices` - `add`, `addWithoutInitialization`, `addAll`, `setIdentityIndices`, `addUniqueConstraints`, plus the three previously inlined guards in `removeIndex`, `removeUniqueConstraint` and `update`, all folded into one parameterised `ensureMutable(String)`
- `CustomConstraints` - `addConstraints`, `removeConstraint`
- `GigaIndices` - `register`, `internalRemoveGroup`
- jvector `VectorIndices` - `add`, `removeIndex`

No new lock and no new ordering: the two sides already agreed on the monitor. `GigaMap.Default`'s mutators are `synchronized` on the map and `#ensureMutability` waits/notifies on that monitor, while every index-side mutator already runs inside `synchronized(this.parentMap())`, so a `wait()` there releases exactly the monitor `#exitReadOnly` needs to `notifyAll()` on.

All three fail-fast cases stay fail-fast. Only "a reader is open on another thread" changed, from throw to wait.

### Consequence for the `ensure*` paths

Because the guard can now release the parent-map monitor while waiting (`Object#wait` unlocks a re-entrantly held monitor completely, JLS 17.2.1), a presence check taken before it may be stale afterwards. Each `ensure*` therefore checks presence *before* the guard - preserving the documented "already present -> no-op even on a read-only map" behaviour that `ConstraintEnsureTest#ensure_onReadOnlyMap_noOpWhenAlreadyPresent` asserts, so a read-only replica can still run the identical startup schema declaration - and *again after* it, delegating to non-guarding `internalAdd...` variants so the guard is evaluated exactly once per operation.

`ensureBitmapIndex` and `VectorIndices#ensure` additionally gained the `synchronized(this.parentMap())` they were missing, making their check-then-add atomic. Previously two threads could both see `null` and the loser failed with `"already registered for name ..."`.

`GigaIndices#register` keeps its guard where it was, in front of `category.createIndexGroup(...)`: moving it after the already-registered check would allocate index-group resources (Lucene directory, jvector builder) before the guard, for a call that then returns `null`.

## Tests

New `IndexRegistrationReadOnlyTest` (17 tests), reusing the `CountDownLatch` + `assertTimeoutPreemptively` harness pattern from `QueryIteratorCloseTest#mutationFromOtherThreadStillWaits`. The harness runs the operation on a dedicated thread while another thread holds an open reader, and asserts the operation neither throws nor completes until the reader closes - a non-waiting implementation is caught either way, and the failure message names which of the two happened.

Covered: the reported reproducer (`map.add(...)` *and* `bitmap().ensure(...)` both wait under the same hold); foreign-reader waiting for `add`, `removeIndex`, `update`, `addUniqueConstraint`, `removeUniqueConstraint`, `setIdentityIndices`, custom-constraint add/ensure/remove and index-group `register`; the three fail-fast cases with their causes asserted; the `ensure` fast path completing *without* waiting; and concurrent `ensure` of the same indexer from 8 threads returning the same index.

**14 of the 17 fail on the unpatched tree** - verified by stashing only `src/main` and re-running.

`VectorIndexLifecycleTest` gains 5 foreign-reader tests for `add`, `ensure`, `removeIndex` and index-group `register`/`remove`.

Existing read-only coverage stays green and pins the fail-fast paths: `crud/ReadOnlyTest`, `IndexRemovalTest#removeIndex_readOnly_throws`, `IndexerRedefinitionTest#update_readOnly_throws`, both `ConstraintEnsureTest` read-only tests, `VectorIndexLifecycleTest#removeIndex_readOnly_throws`, `LuceneLifecycleRemovalTest#removeLuceneGroup_readOnly_throws`.

Full `gigamap` reactor with `-Pslow-tests`: green. Javadoc build: clean.

## Unrelated defect found while testing

Registering a vector index on a `GigaMap` that **already contains entities** is broken independently of this change: `VectorIndex.Default`'s constructor back-fills the graph via `ensureGraphRebuilt()`, and `VectorIndices#internalAddVectorIndex` then back-fills again via `iterateIndexed`, failing with `IllegalStateException: Node 0 already exists`. Reproduced single-threaded on the unpatched tree; every pre-existing jvector test happens to register the index before adding documents, which is why it was never hit. The two new `add`/`ensure` jvector tests therefore use an empty map, with a comment naming the defect. Worth a separate issue.
