### PR TITLE
GigaMap: materialize the Iterable in addAll / addUniqueConstraints / addConstraints

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -20,6 +20,7 @@ import org.eclipse.serializer.chars.VarString;
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.ConstHashEnum;
 import org.eclipse.serializer.collections.EqHashTable;
+import org.eclipse.serializer.collections.types.XGettingCollection;
 import org.eclipse.serializer.collections.types.XGettingEnum;
 import org.eclipse.serializer.collections.types.XGettingTable;
 import org.eclipse.serializer.collections.types.XImmutableEnum;
@@ -108,6 +109,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * Adds all indexers to this group.
 	 * <p>
 	 * For details see {@link #add(Indexer)}.
+	 * <p>
+	 * The passed iterable is traversed exactly once, so a single-use iterable (e.g. stream-backed) is fine.
+	 * Passing no indexer at all is a no-op. Two indexers with the same {@link Indexer#name() name} within the
+	 * same call are rejected, just like an indexer whose name is already registered.
 	 *
 	 * @param indexers the new indexing logic
 	 * @return this
@@ -1179,15 +1184,33 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public final BitmapIndices<E> addAll(final Iterable<? extends Indexer<? super E, ?>> indexers)
 		{
+			// The indexers are traversed twice below, so the passed Iterable must be materialized: a single-use
+			// one (e.g. stream-backed) would come up empty on the second pass and silently register no index at
+			// all. Materializing outside the monitor also keeps arbitrary caller code (a lazily evaluated
+			// Iterable) from running while the parent map is locked.
+			final XGettingCollection<? extends Indexer<? super E, ?>> requested = BulkList.New(indexers);
+
 			synchronized(this.parentMap())
 			{
 				this.ensureMutable("add indices");
-				for(final Indexer<? super E, ?> indexer : indexers)
+
+				// Validation before changing any state, including name conflicts within the batch itself:
+				// #validateIndexToAdd only sees the already registered names, so a duplicate inside the batch
+				// would pass validation and then be dropped silently while registering.
+				final EqHashTable<String, Indexer<? super E, ?>> byName = EqHashTable.New();
+				for(final Indexer<? super E, ?> indexer : requested)
 				{
 					this.validateIndexToAdd(indexer);
+					if(!byName.add(indexer.name(), indexer))
+					{
+						throw new BitmapIndicesException(
+							"Conflicted index name: \"" + indexer.name() + "\".",
+							this
+						);
+					}
 				}
 
-				for(final Indexer<? super E, ?> indexer : indexers)
+				for(final Indexer<? super E, ?> indexer : requested)
 				{
 					final BitmapIndex.Internal<E, ?> index = indexer.createFor(this);
 					this.internalAddBitmapIndex(index);
@@ -1635,11 +1658,17 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		@Override
 		public final UniqueConstraints<E> addUniqueConstraints(final Iterable<? extends Indexer<? super E, ?>> indexers)
 		{
+			// #internalAddUniqueConstraints traverses the indexers twice, so the passed Iterable must be
+			// materialized: a single-use one (e.g. stream-backed) would come up empty on the second pass and
+			// silently register neither index nor unique constraint. Materializing outside the monitor also
+			// keeps arbitrary caller code (a lazily evaluated Iterable) from running while the map is locked.
+			final XGettingCollection<? extends Indexer<? super E, ?>> requested = BulkList.New(indexers);
+
 			synchronized(this.parentMap())
 			{
 				this.ensureMutable("add unique constraints");
 
-				this.internalAddUniqueConstraints(indexers);
+				this.internalAddUniqueConstraints(requested);
 			}
 
 			return this;
@@ -1648,8 +1677,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		/**
 		 * Registers the given indexers as unique constraints without checking mutability. Callers must have
 		 * passed {@link #ensureMutable(String)} and must still hold the parent-map monitor.
+		 * <p>
+		 * Takes a re-traversable collection on purpose: the indexers are traversed twice.
 		 */
-		private void internalAddUniqueConstraints(final Iterable<? extends Indexer<? super E, ?>> indexers)
+		private void internalAddUniqueConstraints(final XGettingCollection<? extends Indexer<? super E, ?>> indexers)
 		{
 			// Basic validation before changing any state.
 			for(final Indexer<? super E, ?> indexer : indexers)
@@ -1710,7 +1741,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		}
 
 		private void buildUniqueIndices(
-			final Iterable<? extends Indexer<? super E, ?>> indexers,
+			final XGettingCollection<? extends Indexer<? super E, ?>> indexers,
 			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices
 		)
 		{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CustomConstraints.java
@@ -59,6 +59,9 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 	
 	/**
 	 * Adds multiple custom constraints to the current set of constraints.
+	 * <p>
+	 * The passed iterable is traversed exactly once, so a single-use iterable (e.g. stream-backed) is fine.
+	 * Passing no constraint at all is a no-op.
 	 *
 	 * @param constraints an iterable collection of custom constraints to be added, each of type CustomConstraint
 	 *                    that can be applied to elements of type E or its superclasses
@@ -261,11 +264,17 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		@Override
 		public final CustomConstraints<E> addConstraints(final Iterable<? extends CustomConstraint<? super E>> constraints)
 		{
+			// #internalAddConstraints traverses the constraints repeatedly, so the passed Iterable must be
+			// materialized: a single-use one (e.g. stream-backed) would come up empty on the second pass and
+			// silently register nothing at all. Materializing outside the monitor also keeps arbitrary caller
+			// code (a lazily evaluated Iterable) from running while the parent map is locked.
+			final BulkList<CustomConstraint<? super E>> requested = BulkList.New(constraints);
+
 			synchronized(this.parentMap())
 			{
 				this.ensureMutable("add custom constraint(s)");
 
-				this.internalAddConstraints(constraints);
+				this.internalAddConstraints(requested);
 			}
 
 			return this;
@@ -274,8 +283,11 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 		/**
 		 * Registers the given constraints without checking mutability. Callers must have passed
 		 * {@link #ensureMutable(String)} and must still hold the parent-map monitor.
+		 * <p>
+		 * Takes a re-traversable collection on purpose: the constraints are traversed several times, including
+		 * once per already present entity in {@link #validateForExistingEntities(XGettingCollection)}.
 		 */
-		private void internalAddConstraints(final Iterable<? extends CustomConstraint<? super E>> constraints)
+		private void internalAddConstraints(final XGettingCollection<? extends CustomConstraint<? super E>> constraints)
 		{
 			for(final CustomConstraint<? super E> constraint : constraints)
 			{
@@ -305,11 +317,7 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 			// once: a single-use one (e.g. stream-backed) would come up empty on the second pass and silently
 			// skip the constraints. Materializing outside the monitor also keeps arbitrary caller code (a
 			// lazily evaluated Iterable) from running while the parent map is locked.
-			final BulkList<CustomConstraint<? super E>> requested = BulkList.New();
-			for(final CustomConstraint<? super E> constraint : constraints)
-			{
-				requested.add(constraint);
-			}
+			final BulkList<CustomConstraint<? super E>> requested = BulkList.New(constraints);
 
 			synchronized(this.parentMap())
 			{
@@ -375,7 +383,15 @@ public interface CustomConstraints<E> extends GigaConstraints.Category<E>
 			}
 		}
 
-		private void validateForExistingEntities(final Iterable<? extends CustomConstraint<? super E>> constraints)
+		/**
+		 * Note on the loop nesting: the entities are the outer loop on purpose. Iterating the entities may
+		 * load data from storage, so traversing them once per constraint instead would multiply that cost by
+		 * the number of constraints. The constraints are a re-traversable in-memory collection by contract,
+		 * which makes the inner loop cheap.
+		 */
+		private void validateForExistingEntities(
+			final XGettingCollection<? extends CustomConstraint<? super E>> constraints
+		)
 		{
 			this.parent.iterateIndexed((final long entityId, final E entity) ->
 			{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
@@ -72,6 +72,9 @@ public interface UniqueConstraints<E> extends GigaConstraints.Category<E>
 	 * Adds multiple unique constraints to the current set of constraints using the provided indexers.
 	 * Each unique constraint ensures that the indexed values for the specified properties
 	 * are unique across all elements in the context of the implementing category.
+	 * <p>
+	 * The passed iterable is traversed exactly once, so a single-use iterable (e.g. stream-backed) is fine.
+	 * Passing no indexer at all is a no-op.
 	 *
 	 * @param indexers an iterable of indexers used to extract properties from elements for indexing
 	 * @return the updated instance of {@code UniqueConstraints<E>} with the new unique constraints applied

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SingleUseIterableRegistrationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SingleUseIterableRegistrationTest.java
@@ -418,6 +418,24 @@ public class SingleUseIterableRegistrationTest
 
 		map.index().bitmap().addAll(sameIteratorEachTime(List.<Indexer<? super Item, ?>>of()));
 
+		assertNull(map.index().bitmap().get(String.class, "label"));
 		assertEquals(2, map.size());
+	}
+
+	@Test
+	void addUniqueConstraints_emptyIterable_isSilentNoOp()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		map.constraints().unique().addUniqueConstraints(sameIteratorEachTime(
+			List.<Indexer<? super Item, ?>>of()
+		));
+
+		assertTrue(map.index().bitmap().uniqueConstraints() == null
+			|| map.index().bitmap().uniqueConstraints().isEmpty());
+
+		// no constraint was registered, so a duplicate code is still accepted
+		map.add(new Item("c", "c1"));
+		assertEquals(3, map.size());
 	}
 }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SingleUseIterableRegistrationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SingleUseIterableRegistrationTest.java
@@ -1,0 +1,423 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.exceptions.BitmapIndicesException;
+import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.CustomConstraint;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.Indexer;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The structural bulk-registration entry points used to traverse their {@link Iterable} parameter more than
+ * once ({@code addConstraints} even once per already present entity). An iterable that cannot be traversed
+ * twice was therefore exhausted after the first (validation) pass, so the registration pass found nothing
+ * left and the method returned normally having registered nothing at all - leaving a custom constraint the
+ * application believed it had installed silently unenforced.
+ * <p>
+ * These tests pin that each entry point traverses its input exactly once.
+ */
+public class SingleUseIterableRegistrationTest
+{
+	///////////////////////////////////////////////////////////////////////////
+	// shared domain //
+	//////////////////
+
+	static class Item
+	{
+		String label;
+		String code;
+
+		Item(final String label, final String code)
+		{
+			super();
+			this.label = label;
+			this.code  = code;
+		}
+	}
+
+	static final IndexerString<Item> LABEL = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "label";
+		}
+
+		@Override
+		protected String getString(final Item item)
+		{
+			return item.label;
+		}
+	};
+
+	static final IndexerString<Item> CODE = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "code";
+		}
+
+		@Override
+		protected String getString(final Item item)
+		{
+			return item.code;
+		}
+	};
+
+	static final BinaryIndexerString<Item> UNIQUE_CODE = new BinaryIndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "uniqueCode";
+		}
+
+		@Override
+		protected String getString(final Item item)
+		{
+			return item.code;
+		}
+	};
+
+	/**
+	 * An indexer with a caller-supplied name, to provoke a name conflict within a single batch.
+	 */
+	static final class FixedNameIndexer extends IndexerString.Abstract<Item>
+	{
+		private final String fixedName;
+
+		FixedNameIndexer(final String fixedName)
+		{
+			super();
+			this.fixedName = fixedName;
+		}
+
+		@Override
+		public String name()
+		{
+			return this.fixedName;
+		}
+
+		@Override
+		protected String getString(final Item item)
+		{
+			return item.label;
+		}
+	}
+
+	static final class NoBad extends CustomConstraint.AbstractSimple<Item>
+	{
+		@Override
+		public boolean isViolated(final Item item)
+		{
+			return item.label.contains("BAD");
+		}
+	}
+
+	static final class NoUgly extends CustomConstraint.AbstractSimple<Item>
+	{
+		@Override
+		public boolean isViolated(final Item item)
+		{
+			return item.label.contains("UGLY");
+		}
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// helpers //
+	////////////
+
+	/**
+	 * An {@link Iterable} that hands out the <b>same</b> iterator every time, i.e. it is exhausted after the
+	 * first traversal. This is the silent variant of the defect: no exception, simply nothing left to register.
+	 */
+	static <T> Iterable<T> sameIteratorEachTime(final List<T> elements)
+	{
+		final Iterator<T> shared = elements.iterator();
+
+		return () -> shared;
+	}
+
+	/**
+	 * An {@link Iterable} counting how often a traversal was started.
+	 */
+	static final class CountingIterable<T> implements Iterable<T>
+	{
+		private final List<T> elements;
+		private       int     iteratorRequests;
+
+		CountingIterable(final List<T> elements)
+		{
+			super();
+			this.elements = elements;
+		}
+
+		@Override
+		public Iterator<T> iterator()
+		{
+			this.iteratorRequests++;
+
+			return this.elements.iterator();
+		}
+
+		int iteratorRequests()
+		{
+			return this.iteratorRequests;
+		}
+	}
+
+	private static GigaMap<Item> populatedMap()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.add(new Item("a", "c1"));
+		map.add(new Item("b", "c2"));
+
+		return map;
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// an iterable handing out the same iterator every time //
+	/////////////////////////////////////////////////////////
+
+	@Test
+	void addConstraints_singleUseIterable_registersAndEnforces()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		map.constraints().custom().addConstraints(sameIteratorEachTime(
+			List.<CustomConstraint<? super Item>>of(new NoBad())
+		));
+
+		// the constraint must actually be enforced
+		assertThrows(
+			ConstraintViolationException.class,
+			() -> map.add(new Item("this is BAD", "c3"))
+		);
+		assertEquals(2, map.size());
+
+		// ... and it must actually be registered
+		assertTrue(map.constraints().custom().removeConstraint("NoBad"));
+	}
+
+	@Test
+	void addAll_singleUseIterable_registersIndices()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		map.index().bitmap().addAll(sameIteratorEachTime(
+			List.<Indexer<? super Item, ?>>of(LABEL, CODE)
+		));
+
+		assertNotNull(map.index().bitmap().get(String.class, "label"));
+		assertNotNull(map.index().bitmap().get(String.class, "code"));
+
+		// the back-fill over the already present entities must have run, too
+		assertEquals(1, map.query(LABEL.is("a")).count());
+		assertEquals(1, map.query(CODE.is("c2")).count());
+	}
+
+	@Test
+	void addUniqueConstraints_singleUseIterable_registersAndEnforces()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		map.constraints().unique().addUniqueConstraints(sameIteratorEachTime(
+			List.<Indexer<? super Item, ?>>of(UNIQUE_CODE)
+		));
+
+		assertNotNull(map.index().bitmap().uniqueConstraints());
+		assertEquals(1, map.index().bitmap().uniqueConstraints().size());
+
+		assertThrows(
+			ConstraintViolationException.class,
+			() -> map.add(new Item("c", "c1"))
+		);
+		assertEquals(2, map.size());
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// a stream-backed iterable (the loud variant) //
+	////////////////////////////////////////////////
+
+	@Test
+	void addConstraints_streamBackedIterable_registersAndEnforces()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		final Stream<CustomConstraint<? super Item>> constraints = Stream.of(new NoBad(), new NoUgly());
+		map.constraints().custom().addConstraints(constraints::iterator);
+
+		assertTrue(map.constraints().custom().removeConstraint("NoBad"));
+		assertTrue(map.constraints().custom().removeConstraint("NoUgly"));
+	}
+
+	@Test
+	void addAll_streamBackedIterable_registersIndices()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		final Stream<Indexer<? super Item, ?>> indexers = Stream.of(LABEL, CODE);
+		map.index().bitmap().addAll(indexers::iterator);
+
+		assertNotNull(map.index().bitmap().get(String.class, "label"));
+		assertNotNull(map.index().bitmap().get(String.class, "code"));
+	}
+
+	@Test
+	void addUniqueConstraints_streamBackedIterable_registersConstraint()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		final Stream<Indexer<? super Item, ?>> indexers = Stream.of(UNIQUE_CODE);
+		map.constraints().unique().addUniqueConstraints(indexers::iterator);
+
+		assertNotNull(map.index().bitmap().uniqueConstraints());
+		assertEquals(1, map.index().bitmap().uniqueConstraints().size());
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// traversal count //
+	////////////////////
+
+	/**
+	 * The constraint validation against the already present entities used to sit inside the entity iteration,
+	 * so the constraints were re-traversed once per entity - {@code n + 2} passes in total. This test fails on
+	 * any such regression, independently of whether the passed iterable happens to tolerate it.
+	 */
+	@Test
+	void addConstraints_traversesIterableExactlyOnce()
+	{
+		final GigaMap<Item> map = populatedMap();
+		map.add(new Item("c", "c3"));
+		map.add(new Item("d", "c4"));
+
+		final CountingIterable<CustomConstraint<? super Item>> constraints = new CountingIterable<>(
+			List.of(new NoBad(), new NoUgly())
+		);
+
+		map.constraints().custom().addConstraints(constraints);
+
+		assertEquals(1, constraints.iteratorRequests());
+	}
+
+	@Test
+	void addAll_traversesIterableExactlyOnce()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		final CountingIterable<Indexer<? super Item, ?>> indexers = new CountingIterable<>(
+			List.of(LABEL, CODE)
+		);
+
+		map.index().bitmap().addAll(indexers);
+
+		assertEquals(1, indexers.iteratorRequests());
+	}
+
+	@Test
+	void addUniqueConstraints_traversesIterableExactlyOnce()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		final CountingIterable<Indexer<? super Item, ?>> indexers = new CountingIterable<>(
+			List.of(UNIQUE_CODE)
+		);
+
+		map.constraints().unique().addUniqueConstraints(indexers);
+
+		assertEquals(1, indexers.iteratorRequests());
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// name conflicts within a single batch //
+	/////////////////////////////////////////
+
+	/**
+	 * Two indexers of the same name within one batch both pass the validation pass (which only knows the
+	 * already registered names), so the second one used to be dropped silently while registering - after its
+	 * data had already been built up over all existing entities.
+	 */
+	@Test
+	void addAll_duplicateNamesInBatch_throwsAndRegistersNothing()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		assertThrows(
+			BitmapIndicesException.class,
+			() -> map.index().bitmap().addAll(
+				List.<Indexer<? super Item, ?>>of(new FixedNameIndexer("dup"), new FixedNameIndexer("dup"))
+			)
+		);
+
+		assertNull(map.index().bitmap().get(String.class, "dup"));
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// empty input //
+	////////////////
+
+	/**
+	 * An empty batch is a legitimate no-op, which is why the defect stayed invisible for so long.
+	 */
+	@Test
+	void addConstraints_emptyIterable_isSilentNoOp()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		map.constraints().custom().addConstraints(sameIteratorEachTime(
+			List.<CustomConstraint<? super Item>>of()
+		));
+
+		map.add(new Item("nothing is enforced here", "c3"));
+		assertEquals(3, map.size());
+	}
+
+	@Test
+	void addAll_emptyIterable_isSilentNoOp()
+	{
+		final GigaMap<Item> map = populatedMap();
+
+		map.index().bitmap().addAll(sameIteratorEachTime(List.<Indexer<? super Item, ?>>of()));
+
+		assertEquals(2, map.size());
+	}
+}


### PR DESCRIPTION
## The defect

`BitmapIndices#addAll`, `BitmapIndices#addUniqueConstraints` and `CustomConstraints#addConstraints` all accept an `Iterable` and traverse it more than once - once to validate, then again to register. `addConstraints` is the worst of them, because `validateForExistingEntities` re-traverses the constraints *inside* `parent.iterateIndexed(...)`, making `n + 2` passes over a map with `n` entities.

Passed an `Iterable` that cannot be traversed twice, all three registered nothing and reported no error. Two symptoms, depending on how the iterable behaves on re-traversal:

- **Loud** - a stream-backed iterable (`someStream::iterator`) throws `IllegalStateException: stream has already been operated upon or closed` on the second pass.
- **Silent** - an iterable returning the *same* iterator each time (`() -> someIterator`, a cursor adapter) is simply exhausted. The first pass validates everything, the second finds nothing to register, and the method returns normally having done nothing.

The custom-constraint case is the one with teeth: an application that installs `addConstraints(...)` at startup and relies on it to reject bad data got no constraint and no warning, so violating entities were accepted.

## The fix

All three entry points materialize their input into a `BulkList` exactly once, **before** entering the parent-map monitor, and the internal workers now take an `XGettingCollection` so the single-traversal requirement is visible in their signatures.

This is the same treatment #787 gave `ensureConstraints`, extended to the `add*` methods that PR deliberately left alone. Public parameter types stay `Iterable`, so this is **not a breaking change** - callers passing a `java.util.List` keep compiling, and callers passing a stream-backed iterable simply start working.

Materializing outside the monitor is deliberate: a lazily evaluated `Iterable` runs arbitrary caller code, and the traversal touches no map state, so there is no reason to hold the lock across it. This matters more since #787, where `ensureMutable` may release the monitor while waiting for open readers.

### Loop nesting in `validateForExistingEntities`

The linked issue suggests the loops there are "nested the expensive way round". They are not, and this PR keeps entities as the outer loop: `iterateIndexed` may load segments from storage, so inverting to constraints-outer would multiply the entity traversal by the constraint count. The real cost was re-traversing the caller's `Iterable` per entity, which materializing removes - the inner loop now walks an array-backed `BulkList`. Added a comment saying so, since the nesting looks accidental otherwise.

### Adjacent fix: duplicate index names within one `addAll` batch

Found while verifying. Two indexers with the same name in one batch both passed `validateIndexToAdd` (it only checks *already registered* names, and the validation loop completes before any registration), then `EqHashTable#add` silently dropped the second - after `internalAddBitmapIndex` had already back-filled every existing entity into the dropped index. `buildUniqueIndices` already rejected this case; `addAll` now matches it, which is cheap once the batch is materialized.

### Deliberately unchanged

A zero-element batch stays a silent no-op. It is legitimate for idempotent startup declaration, and throwing would break it. Documented in the Javadoc instead.

## Scope

A sweep of every `Iterable`-typed parameter across `gigamap/`, `lucene/` and `jvector/` found no further instances. Ruled out: `GigaMap.Builder#withBitmapIndices` / `withBitmapUniqueIndices` (single `forEach` into the builder's own collection), `GigaMap.Default#lookupEntityIdPeeking`, `BitmapIndex.Category.Default#createIndexGroup`, and the `ensureAll` / `ensureUniqueConstraints` defaults (one pass, delegating per element).

## Tests

New `SingleUseIterableRegistrationTest` (12 cases): same-iterator-each-time and stream-backed variants for all three entry points, explicit traversal-count assertions via a counting `Iterable`, the duplicate-name batch, and the empty-input no-op.

Verified these actually catch the defect by reverting the three main-source files and re-running: **10 of 12 failed**, reproducing every reported symptom - the `IllegalStateException`, the unenforced constraint, and traversal counts of `2`, `2` and **`6` for a 4-entity map** (the issue's `n + 2`). The 2 that passed are the empty-input no-op tests, which pin behaviour that must not change.

The traversal-count assertions are the ones that matter long-term: they fail on any reintroduction of the `n + 2` shape regardless of whether the passed iterable happens to tolerate it.

Full suites green: gigamap 1111, lucene 68, jvector 229 (9 skipped, `@Tag("slow")`), codegen-test 20.
