### PR TITLE
GigaMap: widen store(Persister) to store(PersistenceStoring) so a Storer can be passed

### DIFF
--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -70,6 +70,32 @@ synchronized (gigaMap) {
 
 This is the same principle as the classic problem with synchronized JDK collections like `Vector`: synchronizing individual methods is not sufficient when multiple operations need to be atomic. In this case, the entire store traversal must be protected from concurrent modifications.
 
+== Storing several instances in one commit
+
+`gigaMap.store()` is one commit per call. A change that spans two GigaMaps — or a GigaMap plus the root object that references it — is therefore *two* commits, and nothing makes them atomic: a crash in between leaves one applied and the other not.
+
+`store(...)` accepts any `PersistenceStoring`. Pass a `Persister` (e.g. the storage manager) and it stores and commits immediately; pass a `Storer` and it only registers the changes, leaving the commit to you:
+
+[source, java]
+----
+final Storer storer = storageManager.createStorer();
+gigaMapA.store(storer);
+gigaMapB.store(storer);
+storer.store(root);
+storer.commit();          // one commit, atomic across all of the above
+----
+
+`Storer.commit()` is all-or-nothing, so either every registered change is persisted or none of it is.
+
+What `store(storer)` covers is exactly what `store()` covers: the entities, the indices, the segments, the constraints, and entities mutated through `update` / `apply`. Entities mutated directly are still not covered and still leave the indices stale, as described above.
+
+[IMPORTANT]
+====
+Register *through the GigaMap* (`gigaMap.store(storer)`), not through the storer (`storer.store(gigaMap)`). The latter is the external path warned about above and does not acquire the GigaMap's internal lock.
+
+Note that with a `Storer` the lock `gigaMap.store(storer)` holds spans its own registration only — *not* the later `commit()`. The calling context is therefore responsible for a lock that spans mutation through `commit()`. Registering with a `Storer` and committing it from different threads, or mutating a registered GigaMap before the commit, is not safe.
+====
+
 == Class evolution and indexed fields
 
 GigaMap's indices (bitmap, Lucene, vector) are a *derived cache*: their keys are computed from your entities by the indexers and are then persisted alongside the entities. On load the index keys are restored *verbatim from storage* — they are **not** recomputed from, or revalidated against, the entities.

--- a/docs/modules/intro/pages/changelog.adoc
+++ b/docs/modules/intro/pages/changelog.adoc
@@ -18,7 +18,6 @@
 ** Entity-id based `update()` / `apply()`, so Lucene-only and JVector-only maps can be reindexed without a bitmap index https://github.com/eclipse-store/store/issues/713[[713]] https://github.com/eclipse-store/store/pull/722[[722]]
 ** External-directory Lucene index commits are now coupled to `store()` instead of committing eagerly https://github.com/eclipse-store/store/issues/715[[715]] https://github.com/eclipse-store/store/pull/719[[719]]
 ** Opt-in null embeddings for the vector index, and `BitmapIndices.addWithoutInitialization` for lazy registration without back-fill https://github.com/eclipse-store/store/pull/748[[748]] https://github.com/eclipse-store/store/pull/759[[759]]
-** `store(Persister)` widened to `store(PersistenceStoring)`, so a `Storer` can be passed to register a GigaMap's changes without committing - letting several GigaMaps (or a GigaMap and its root) share one atomic commit
 * Binary type handler for `EqConstList` https://github.com/eclipse-serializer/serializer/pull/304[[304]] https://github.com/eclipse-serializer/serializer/pull/306[[306]]
 * `PersistenceShutdownReleasable`, an opt-in contract to release resources of persisted instances on storage shutdown https://github.com/eclipse-serializer/serializer/pull/305[[305]]
 

--- a/docs/modules/intro/pages/changelog.adoc
+++ b/docs/modules/intro/pages/changelog.adoc
@@ -18,6 +18,7 @@
 ** Entity-id based `update()` / `apply()`, so Lucene-only and JVector-only maps can be reindexed without a bitmap index https://github.com/eclipse-store/store/issues/713[[713]] https://github.com/eclipse-store/store/pull/722[[722]]
 ** External-directory Lucene index commits are now coupled to `store()` instead of committing eagerly https://github.com/eclipse-store/store/issues/715[[715]] https://github.com/eclipse-store/store/pull/719[[719]]
 ** Opt-in null embeddings for the vector index, and `BitmapIndices.addWithoutInitialization` for lazy registration without back-fill https://github.com/eclipse-store/store/pull/748[[748]] https://github.com/eclipse-store/store/pull/759[[759]]
+** `store(Persister)` widened to `store(PersistenceStoring)`, so a `Storer` can be passed to register a GigaMap's changes without committing - letting several GigaMaps (or a GigaMap and its root) share one atomic commit
 * Binary type handler for `EqConstList` https://github.com/eclipse-serializer/serializer/pull/304[[304]] https://github.com/eclipse-serializer/serializer/pull/306[[306]]
 * `PersistenceShutdownReleasable`, an opt-in contract to release resources of persisted instances on storage shutdown https://github.com/eclipse-serializer/serializer/pull/305[[305]]
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -934,8 +934,9 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * storer.commit();      // one commit, atomic across all of the above
 	 * }</pre>
 	 * What is covered is exactly what {@link #store()} covers - the indices, the segments, the constraints,
-	 * and entities mutated through {@link #update} or {@link #apply}. Entities mutated directly are NOT
-	 * covered and leave the indices stale, as described on {@link #store()}.
+	 * and entities mutated through {@link #update(long, Consumer)} or {@link #apply(long, Function)}.
+	 * Entities mutated directly are NOT covered and leave the indices stale, as described on
+	 * {@link #store()}.
 	 * <p>
 	 * <b>Note on concurrency:</b><br>
 	 * The lock this method holds spans its own work only. With a {@link Persister} that is the whole store, as

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -911,17 +911,46 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 
 	/**
-	 * Stores this {@link GigaMap} instance and all its modified data using the provided {@link Persister}.
+	 * Stores this {@link GigaMap} instance and all its modified data through the passed
+	 * {@link PersistenceStoring}. Unlike {@link #store()}, no previously linked storing context is required.
 	 * <p>
-	 * Unlike {@link #store()}, which requires a previously linked storing context,
-	 * this method allows explicitly passing the {@link Persister} to use for storing.
+	 * <b>Whether this commits depends on what you pass</b>, which is the whole point of accepting the common
+	 * supertype:
+	 * <ul>
+	 *   <li>a {@link Persister} - e.g. an {@code EmbeddedStorageManager} - stores and commits immediately,
+	 *       exactly like {@link #store()};</li>
+	 *   <li>a {@link Storer} only <em>registers</em> the changes, and the caller decides the commit boundary
+	 *       by calling {@link Storer#commit()}.</li>
+	 * </ul>
+	 * The second form is how several instances go into a <b>single atomic commit</b> - two {@link GigaMap}s
+	 * that one logical change spans, or a {@link GigaMap} together with the root object referencing it.
+	 * {@link Storer#commit()} is all-or-nothing, so either every registered change is persisted or none is;
+	 * calling {@link #store()} per instance produces one commit each, with no atomicity between them.
+	 * <pre>{@code
+	 * final Storer storer = storageManager.createStorer();
+	 * gigaMapA.store(storer);
+	 * gigaMapB.store(storer);
+	 * storer.store(root);
+	 * storer.commit();      // one commit, atomic across all of the above
+	 * }</pre>
+	 * What is covered is exactly what {@link #store()} covers - the indices, the segments, the constraints,
+	 * and entities mutated through {@link #update} or {@link #apply}. Entities mutated directly are NOT
+	 * covered and leave the indices stale, as described on {@link #store()}.
+	 * <p>
+	 * <b>Note on concurrency:</b><br>
+	 * The lock this method holds spans its own work only. With a {@link Persister} that is the whole store, as
+	 * for {@link #store()}. With a {@link Storer} it is the registration alone and NOT the commit that happens
+	 * later, so the calling context is responsible for a lock spanning mutation through
+	 * {@link Storer#commit()} - see the concurrency notes on {@link #store()}, which apply with that added
+	 * span. Registering with a {@link Storer} and committing it from a different thread, or mutating this
+	 * instance in between, is not safe.
 	 *
-	 * @param persister the {@link Persister} to use for storing this instance
+	 * @param storing the {@link Persister} or {@link Storer} to store this instance through
 	 * @return the objectId of this instance
 	 * @see #store()
-	 * @see Persister#store(Object)
+	 * @see Storer#commit()
 	 */
-	public long store(Persister persister);
+	public long store(PersistenceStoring storing);
 
 	/**
 	 * Provides this set {@link Equalator} instance of this {@link GigaMap}.
@@ -3221,9 +3250,14 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		}
 
 		@Override
-		public final synchronized long store(final Persister persister)
+		public final synchronized long store(final PersistenceStoring storing)
 		{
-			return persister.store(this);
+			// One call for both kinds of storing context, because the type handler is what registers this
+			// instance's changes (see BinaryHandlerGigaMapDefault#store -> #internalRegisterChangeStores) and
+			// that fires for anything that traverses the map. Whether the changes are also committed is the
+			// storing context's own behaviour: a Persister commits, a Storer waits for its commit() - which is
+			// what lets a caller group several instances into one atomic commit.
+			return storing.store(this);
 		}
 
 		private Persister storeContext()

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/SharedStorerCommitAtomicityTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/SharedStorerCommitAtomicityTest.java
@@ -1,0 +1,210 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A change spanning two {@link GigaMap}s, registered with one {@link Storer} and committed once, must
+ * survive a power loss as a unit: either both halves are there or neither is. This is the property
+ * that makes a single commit an alternative to an application-level write-ahead log for a model whose
+ * logical writes span more than one map.
+ * <p>
+ * The power loss is staged the way the other tests here stage it - commit cleanly, then cut the log
+ * back to the state a crash before the commit's log entry reached the medium would leave, and restart.
+ * <p>
+ * Each case is paired with a positive control that runs the same sequence without the surgery.
+ * Without it, a commit that persisted nothing at all would satisfy the "neither half survived"
+ * assertion just as well as correct all-or-nothing behaviour.
+ */
+@Timeout(120)
+class SharedStorerCommitAtomicityTest
+{
+	private static final int MAX_FILE_SIZE = 50_000_000;
+
+	@TempDir
+	Path directory;
+
+	private EmbeddedStorageManager storage ;
+	private EmbeddedStorageManager reloaded;
+
+	@AfterEach
+	void shutdown()
+	{
+		for(final EmbeddedStorageManager manager : new EmbeddedStorageManager[]{this.reloaded, this.storage})
+		{
+			if(manager != null && manager.isRunning())
+			{
+				try
+				{
+					manager.shutdown();
+				}
+				catch(final RuntimeException ignored)
+				{
+					// best effort
+				}
+			}
+		}
+	}
+
+	@Test
+	void aCommitSpanningTwoMapsIsLostAsAUnit()
+	{
+		this.stageBaseline();
+		this.stageSpanningCommit();
+		RecoverySimulation.cutLastStore(this.directory, 0);
+
+		final Root root = this.reload();
+		assertEquals(1L, root.left .size(), "the left half of the lost commit must be gone" );
+		assertEquals(1L, root.right.size(), "the right half of the lost commit must be gone");
+		assertEquals(1L, root.left .query(LEFT_NAME , "base-l").count(), "left index back at the baseline" );
+		assertEquals(1L, root.right.query(RIGHT_NAME, "base-r").count(), "right index back at the baseline");
+		assertEquals(0L, root.left .query(LEFT_NAME , "span-l").count(), "no trace of the lost commit");
+		assertEquals(0L, root.right.query(RIGHT_NAME, "span-r").count(), "no trace of the lost commit");
+	}
+
+	/** Positive control for {@link #aCommitSpanningTwoMapsIsLostAsAUnit()}: no surgery, both halves survive. */
+	@Test
+	void aCommitSpanningTwoMapsSurvivesWhenItsLogEntryDoes()
+	{
+		this.stageBaseline();
+		this.stageSpanningCommit();
+
+		final Root root = this.reload();
+		assertEquals(2L, root.left .size(), "the left half must survive" );
+		assertEquals(2L, root.right.size(), "the right half must survive");
+		assertEquals(1L, root.left .query(LEFT_NAME , "span-l").count(), "left index carries the commit" );
+		assertEquals(1L, root.right.query(RIGHT_NAME, "span-r").count(), "right index carries the commit");
+	}
+
+	/**
+	 * The mixed shape: a removal in one map and an addition in the other. A partial recovery here would
+	 * be visible as the removal surviving without the addition, or the reverse - a torn logical change
+	 * rather than merely a lost one.
+	 */
+	@Test
+	void aRemovalAndAnAdditionAreLostTogether()
+	{
+		this.stageBaseline();
+
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+		final Root root = (Root)this.storage.root();
+		root.left.removeById(0L);
+		root.right.add(new Item("span-r"));
+
+		final Storer storer = this.storage.createStorer();
+		root.left .store(storer);
+		root.right.store(storer);
+		storer.commit();
+		this.storage.shutdown();
+		this.storage = null;
+
+		RecoverySimulation.cutLastStore(this.directory, 0);
+
+		final Root recovered = this.reload();
+		assertEquals(1L, recovered.left .size(), "the removal must be rolled back with its commit");
+		assertEquals(1L, recovered.right.size(), "the addition must be rolled back with its commit");
+		assertNotNull(recovered.left.get(0L), "the removed entity is back");
+		assertEquals(1L, recovered.left .query(LEFT_NAME , "base-l").count(), "left index back at the baseline");
+		assertEquals(0L, recovered.right.query(RIGHT_NAME, "span-r").count(), "the addition left no index entry");
+	}
+
+
+	private void stageBaseline()
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+		final Root root = new Root();
+		this.storage.setRoot(root);
+		this.storage.storeRoot();
+
+		root.left .add(new Item("base-l"));
+		root.right.add(new Item("base-r"));
+
+		final Storer storer = this.storage.createStorer();
+		root.left .store(storer);
+		root.right.store(storer);
+		storer.commit();
+
+		this.storage.shutdown();
+		this.storage = null;
+	}
+
+	private void stageSpanningCommit()
+	{
+		this.storage = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+		final Root root = (Root)this.storage.root();
+
+		root.left .add(new Item("span-l"));
+		root.right.add(new Item("span-r"));
+
+		final Storer storer = this.storage.createStorer();
+		root.left .store(storer);
+		root.right.store(storer);
+		storer.commit();
+
+		this.storage.shutdown();
+		this.storage = null;
+	}
+
+	private Root reload()
+	{
+		this.reloaded = EmbeddedStorage.start(RecoverySimulation.quietConfig(this.directory, 1, MAX_FILE_SIZE));
+		final Root root = (Root)this.reloaded.root();
+		assertNotNull(root, "root gone after recovery");
+		return root;
+	}
+
+
+	public static class Item
+	{
+		String name;
+
+		Item(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	public static class NameIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.name;
+		}
+	}
+
+	static final NameIndexer LEFT_NAME  = new NameIndexer();
+	static final NameIndexer RIGHT_NAME = new NameIndexer();
+
+	public static class Root
+	{
+		final GigaMap<Item> left  = GigaMap.<Item>Builder().withBitmapIndex(LEFT_NAME ).build();
+		final GigaMap<Item> right = GigaMap.<Item>Builder().withBitmapIndex(RIGHT_NAME).build();
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/storer/SharedStorerMultiGigaMapTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/storer/SharedStorerMultiGigaMapTest.java
@@ -1,0 +1,254 @@
+package test.eclipse.store.storer;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.file.Path;
+
+import org.eclipse.serializer.persistence.types.Storer;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Coverage for {@link GigaMap#store(Storer)}: several {@link GigaMap}s registered with one
+ * {@link Storer} and committed once, which is the only way to make a change spanning more than one
+ * {@link GigaMap} atomic - {@link GigaMap#store()} produces one commit per map, with no atomicity
+ * between them.
+ * <p>
+ * The properties held here are what a caller grouping maps into one commit depends on: that
+ * registration covers the entities, the indices, {@link GigaMap#set(long, Object)} replacements and
+ * {@link GigaMap#update(long, java.util.function.Consumer)} mutations alike, and that nothing at all
+ * reaches disk before {@link Storer#commit()}.
+ */
+public class SharedStorerMultiGigaMapTest
+{
+    static class Item
+    {
+        String name;
+
+        Item(final String name)
+        {
+            this.name = name;
+        }
+    }
+
+    static class NameIndexer extends IndexerString.Abstract<Item>
+    {
+        @Override
+        protected String getString(final Item entity)
+        {
+            return entity.name;
+        }
+    }
+
+    /**
+     * Two maps under one root, the shape a caller collapsing several maps into one storage instance
+     * ends up with.
+     */
+    static class Root
+    {
+        final GigaMap<Item> left  = GigaMap.<Item>Builder().withBitmapIndex(LEFT_NAME ).build();
+        final GigaMap<Item> right = GigaMap.<Item>Builder().withBitmapIndex(RIGHT_NAME).build();
+    }
+
+    // One indexer instance per map: an indexer belongs to the index it was registered with.
+    private static final NameIndexer LEFT_NAME  = new NameIndexer();
+    private static final NameIndexer RIGHT_NAME = new NameIndexer();
+
+    private static Root startAndEnsureRoot(final EmbeddedStorageManager storage)
+    {
+        Root root = (Root)storage.root();
+        if (root == null)
+        {
+            root = new Root();
+            storage.setRoot(root);
+            storage.storeRoot();
+        }
+        return root;
+    }
+
+    @Test
+    public void oneCommitCoversEveryRegisteredGigaMap(@TempDir final Path dir)
+    {
+        final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+        final Root                   root    = startAndEnsureRoot(storage);
+
+        final long leftId  = root.left .add(new Item("l1"));
+        final long rightId = root.right.add(new Item("r1"));
+
+        final Storer storer = storage.createStorer();
+        root.left .store(storer);
+        root.right.store(storer);
+        storer.commit();
+
+        storage.shutdown();
+
+        final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
+        final Root                   fromDisk = (Root)reopened.root();
+
+        assertEquals(1L, fromDisk.left .size(), "left map persisted");
+        assertEquals(1L, fromDisk.right.size(), "right map persisted");
+        assertEquals("l1", fromDisk.left .get(leftId ).name);
+        assertEquals("r1", fromDisk.right.get(rightId).name);
+
+        // the bitmap indices rode the same commit, not just the entities
+        assertEquals(1L, fromDisk.left .query(LEFT_NAME , "l1").count(), "left index persisted" );
+        assertEquals(1L, fromDisk.right.query(RIGHT_NAME, "r1").count(), "right index persisted");
+
+        reopened.shutdown();
+    }
+
+    /**
+     * The negative case, and the one that distinguishes this overload from {@link GigaMap#store()}:
+     * registration alone must persist nothing. Asserted after a shutdown and a reopen from a fresh
+     * manager, so it is disk state being read and not the live in-memory graph.
+     */
+    @Test
+    public void registrationWithoutCommitPersistsNothing(@TempDir final Path dir)
+    {
+        final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+        final Root                   root    = startAndEnsureRoot(storage);
+
+        root.left .add(new Item("l1"));
+        root.right.add(new Item("r1"));
+
+        final Storer storer = storage.createStorer();
+        root.left .store(storer);
+        root.right.store(storer);
+        // deliberately no storer.commit()
+
+        storage.shutdown();
+
+        final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
+        final Root                   fromDisk = (Root)reopened.root();
+
+        assertEquals(0L, fromDisk.left .size(), "an uncommitted registration must not reach disk");
+        assertEquals(0L, fromDisk.right.size(), "an uncommitted registration must not reach disk");
+
+        reopened.shutdown();
+    }
+
+    /**
+     * A {@code set} replacement has to persist at the id it replaced, with the index re-keyed to the
+     * replacement. Both halves matter: an entity that survives at the right id but keeps the old index
+     * entry is reachable by {@code get} and invisible - or wrongly visible - to a query.
+     */
+    @Test
+    public void setReplacementIsPersistedAtItsIdWithARefreshedIndex(@TempDir final Path dir)
+    {
+        final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+        final Root                   root    = startAndEnsureRoot(storage);
+
+        final long id = root.left.add(new Item("before"));
+        final Storer initial = storage.createStorer();
+        root.left.store(initial);
+        initial.commit();
+
+        root.left.set(id, new Item("after"));
+
+        final Storer storer = storage.createStorer();
+        root.left.store(storer);
+        storer.commit();
+
+        storage.shutdown();
+
+        final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
+        final Root                   fromDisk = (Root)reopened.root();
+
+        assertEquals(1L, fromDisk.left.size(), "a replacement must not add an entity");
+        assertNotNull(fromDisk.left.get(id), "the replacement kept the id it replaced");
+        assertEquals("after", fromDisk.left.get(id).name, "the replacement was persisted");
+        assertEquals(1L, fromDisk.left.query(LEFT_NAME, "after" ).count(), "index re-keyed to the replacement");
+        assertEquals(0L, fromDisk.left.query(LEFT_NAME, "before").count(), "the replaced key is gone");
+
+        reopened.shutdown();
+    }
+
+    /**
+     * {@code update} mutates in place, so the entity keeps its object identity and only the map's
+     * pending-store bookkeeping knows it changed. Registration has to carry that across.
+     */
+    @Test
+    public void updateMutatedEntityIsPersistedWithARefreshedIndex(@TempDir final Path dir)
+    {
+        final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+        final Root                   root    = startAndEnsureRoot(storage);
+
+        final long id = root.left.add(new Item("before"));
+        final Storer initial = storage.createStorer();
+        root.left.store(initial);
+        initial.commit();
+
+        root.left.update(id, item -> item.name = "after");
+
+        final Storer storer = storage.createStorer();
+        root.left.store(storer);
+        storer.commit();
+
+        storage.shutdown();
+
+        final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
+        final Root                   fromDisk = (Root)reopened.root();
+
+        assertEquals("after", fromDisk.left.get(id).name, "the in-place mutation was persisted");
+        assertEquals(1L, fromDisk.left.query(LEFT_NAME, "after" ).count(), "index re-keyed after update");
+        assertEquals(0L, fromDisk.left.query(LEFT_NAME, "before").count(), "the stale key is gone");
+
+        reopened.shutdown();
+    }
+
+    /**
+     * A removal in one map and an addition in the other, committed together - the shape of a change
+     * that spans maps, which is the reason the overload exists.
+     */
+    @Test
+    public void aChangeSpanningTwoMapsCommitsAsAUnit(@TempDir final Path dir)
+    {
+        final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+        final Root                   root    = startAndEnsureRoot(storage);
+
+        final long doomed = root.left.add(new Item("doomed"));
+        final Storer initial = storage.createStorer();
+        root.left.store(initial);
+        initial.commit();
+
+        root.left.removeById(doomed);
+        final long added = root.right.add(new Item("added"));
+
+        final Storer storer = storage.createStorer();
+        root.left .store(storer);
+        root.right.store(storer);
+        storer.commit();
+
+        storage.shutdown();
+
+        final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
+        final Root                   fromDisk = (Root)reopened.root();
+
+        assertEquals(0L, fromDisk.left.size(), "the removal persisted");
+        assertNull(fromDisk.left.get(doomed), "the removed entity is gone");
+        assertEquals(0L, fromDisk.left.query(LEFT_NAME, "doomed").count(), "index reflects the removal");
+        assertEquals("added", fromDisk.right.get(added).name, "the addition persisted");
+
+        reopened.shutdown();
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/storer/SharedStorerMultiGigaMapTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/storer/SharedStorerMultiGigaMapTest.java
@@ -108,8 +108,12 @@ public class SharedStorerMultiGigaMapTest
 
         assertEquals(1L, fromDisk.left .size(), "left map persisted");
         assertEquals(1L, fromDisk.right.size(), "right map persisted");
-        assertEquals("l1", fromDisk.left .get(leftId ).name);
-        assertEquals("r1", fromDisk.right.get(rightId).name);
+        final Item leftItem  = fromDisk.left .get(leftId );
+        final Item rightItem = fromDisk.right.get(rightId);
+        assertNotNull(leftItem , "the left entity is present after reload" );
+        assertNotNull(rightItem, "the right entity is present after reload");
+        assertEquals("l1", leftItem .name);
+        assertEquals("r1", rightItem.name);
 
         // the bitmap indices rode the same commit, not just the entities
         assertEquals(1L, fromDisk.left .query(LEFT_NAME , "l1").count(), "left index persisted" );
@@ -176,8 +180,9 @@ public class SharedStorerMultiGigaMapTest
         final Root                   fromDisk = (Root)reopened.root();
 
         assertEquals(1L, fromDisk.left.size(), "a replacement must not add an entity");
-        assertNotNull(fromDisk.left.get(id), "the replacement kept the id it replaced");
-        assertEquals("after", fromDisk.left.get(id).name, "the replacement was persisted");
+        final Item replaced = fromDisk.left.get(id);
+        assertNotNull(replaced, "the replacement kept the id it replaced");
+        assertEquals("after", replaced.name, "the replacement was persisted");
         assertEquals(1L, fromDisk.left.query(LEFT_NAME, "after" ).count(), "index re-keyed to the replacement");
         assertEquals(0L, fromDisk.left.query(LEFT_NAME, "before").count(), "the replaced key is gone");
 
@@ -210,7 +215,9 @@ public class SharedStorerMultiGigaMapTest
         final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
         final Root                   fromDisk = (Root)reopened.root();
 
-        assertEquals("after", fromDisk.left.get(id).name, "the in-place mutation was persisted");
+        final Item mutated = fromDisk.left.get(id);
+        assertNotNull(mutated, "the mutated entity is present after reload");
+        assertEquals("after", mutated.name, "the in-place mutation was persisted");
         assertEquals(1L, fromDisk.left.query(LEFT_NAME, "after" ).count(), "index re-keyed after update");
         assertEquals(0L, fromDisk.left.query(LEFT_NAME, "before").count(), "the stale key is gone");
 
@@ -248,7 +255,9 @@ public class SharedStorerMultiGigaMapTest
         assertEquals(0L, fromDisk.left.size(), "the removal persisted");
         assertNull(fromDisk.left.get(doomed), "the removed entity is gone");
         assertEquals(0L, fromDisk.left.query(LEFT_NAME, "doomed").count(), "index reflects the removal");
-        assertEquals("added", fromDisk.right.get(added).name, "the addition persisted");
+        final Item addedItem = fromDisk.right.get(added);
+        assertNotNull(addedItem, "the added entity is present after reload");
+        assertEquals("added", addedItem.name, "the addition persisted");
 
         reopened.shutdown();
     }

--- a/integration-tests/src/test/java/test/eclipse/store/storer/SharedStorerMultiGigaMapTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/storer/SharedStorerMultiGigaMapTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.file.Path;
 
+import org.eclipse.serializer.persistence.types.PersistenceStoring;
 import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.eclipse.store.gigamap.types.IndexerString;
@@ -29,10 +30,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Coverage for {@link GigaMap#store(Storer)}: several {@link GigaMap}s registered with one
- * {@link Storer} and committed once, which is the only way to make a change spanning more than one
- * {@link GigaMap} atomic - {@link GigaMap#store()} produces one commit per map, with no atomicity
- * between them.
+ * Coverage for {@link GigaMap#store(PersistenceStoring)} when a {@link Storer} is passed: several
+ * {@link GigaMap}s registered with one {@link Storer} and committed once, which is the only way to make a
+ * change spanning more than one {@link GigaMap} atomic - {@link GigaMap#store()} produces one commit per
+ * map, with no atomicity between them.
  * <p>
  * The properties held here are what a caller grouping maps into one commit depends on: that
  * registration covers the entities, the indices, {@link GigaMap#set(long, Object)} replacements and
@@ -118,7 +119,7 @@ public class SharedStorerMultiGigaMapTest
     }
 
     /**
-     * The negative case, and the one that distinguishes this overload from {@link GigaMap#store()}:
+     * The negative case, and what distinguishes passing a {@link Storer} from {@link GigaMap#store()}:
      * registration alone must persist nothing. Asserted after a shutdown and a reopen from a fresh
      * manager, so it is disk state being read and not the live in-memory graph.
      */


### PR DESCRIPTION
## What

`GigaMap.store()` is one commit per call. A change spanning two GigaMaps - or a GigaMap and the root object that references it - is therefore two commits with no atomicity between them, and a crash in between leaves one applied and the other not. There was no way to express the grouping: `store(Persister)` commits on its own, and `Storer` does not extend `Persister`, so `gigaMap.store(storer)` did not compile.

`PersistenceStoring` is the common supertype of both, so widening the parameter covers the new case without adding an overload:

- a `Persister` (e.g. an `EmbeddedStorageManager`) stores **and commits** immediately, exactly as before;
- a `Storer` only **registers** the changes, and the caller decides the commit boundary.

```java
final Storer storer = storageManager.createStorer();
gigaMapA.store(storer);
gigaMapB.store(storer);
storer.store(root);
storer.commit();          // one commit, atomic across all of the above
```

## Why it covers what `store()` covers

The dirty-tracking is in the type handler, not in `store()`: `BinaryHandlerGigaMapDefault#store` calls `internalRegisterChangeStores`, which fires for any storer that traverses the map. So indices, level3 segments, constraints and entities mutated through `update()` / `apply()` are all collected regardless of which storing context is passed. Entities mutated directly are still not covered and still leave the indices stale - unchanged from the existing contract.

## Compatibility

Widening a parameter type keeps existing **source** compiling, and no caller in this repository passes an argument to it. It is **not binary compatible** - the method descriptor changes - which is the reason to do it in a major version rather than add a second overload alongside.

## Why registration stays on the map

Deliberately `gigaMap.store(storer)` rather than leaving callers to write `storer.store(gigaMap)`. The latter is the external path the docs already warn about, which does not acquire the map's internal lock. Keeping the entry point on the map leaves registration and locking owned by the map and reduces the caller to deciding the commit boundary.

With a `Storer`, the lock held spans the registration only and **not** the later `commit()`, so the javadoc states that the caller is responsible for a lock spanning mutation through `commit()`. Registering with a `Storer` and committing it from a different thread, or mutating a registered map before the commit, is not safe.

## Tests

`SharedStorerMultiGigaMapTest` - coverage properties: one commit covers every registered map including its bitmap indices; `set()` replacements persist at the id they replaced with a re-keyed index; `update()` in-place mutations persist; a change spanning two maps commits as a unit; and registration without `commit()` persists nothing.

Each of those was checked against a variant with the registration call omitted, to confirm the assertions fail without the mechanism rather than passing over it.

`SharedStorerCommitAtomicityTest` - the crash property, in `test.eclipse.store.recovery` so it can reuse `RecoverySimulation`, and staged the way the other recovery tests stage power loss: commit cleanly, cut the commit's store entry out of the transactions log, restart. A commit spanning two maps is lost as a unit, and a removal in one map with an addition in the other rolls back together. Both are paired with a positive control that runs the same sequence without the surgery, since "neither half survived" would otherwise also be satisfied by a commit that persisted nothing.

Full `gigamap` suite: 999 tests, 0 failures, 0 errors, 1 skipped.

## Docs

New section in `gigamap/persistence.adoc` after the existing "Why not `storageManager.store(gigaMap)`?" warning - which is where a reader looking for multi-instance atomicity currently lands - plus a changelog entry.