### PR TITLE
GigaMap: traverse the entities Iterable exactly once in addAll

### DIFF
--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -43,6 +43,8 @@ gigaMap.addAll(newEntity1, newEntity2);
 gigaMap.addAll(collectionContainingNewEntities);
 ----
 
+`addAll` traverses the passed `Iterable` exactly once, so a lazily evaluated or single-use sequence - a stream (`stream::iterator`), a cursor adapter, or the weakly consistent view of a concurrent collection - is safe to pass. The entities are indexed exactly as they were added, so the indices can never diverge from the added entities, even if the passed sequence changes while it is being traversed.
+
 == Removing and Updating Entities
 
 When performing writing changes, first of all, the entities themselves have to be identified via the index. It is not a default lookup like a java.util.List does internally, by traversing all elements and comparing one by one, but a quick search via the index. The GigaMap is designed to contain vast amounts of data and uses lazy loading internally, so a one-by-one comparison could potentially take ages.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -142,11 +143,16 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * <p>
 	 * Null values are not allowed
 	 * <p>
+	 * The passed iterable is traversed exactly once, so a single-use iterable (e.g. stream-backed) is fine.
+	 * The elements are indexed exactly as they were added, so an iterable whose content may change while it is
+	 * being traversed (e.g. the weakly consistent view of a concurrent collection) can never make the indices
+	 * diverge from the added entities.
+	 * <p>
 	 * <b>Behavior on failure:</b> the operation is atomic in the same way as {@link #add(Object)}:
-	 * if a constraint is violated or an {@link Indexer} throws an exception for any of the
-	 * elements, all elements added so far by this call are rolled back and the exception is
-	 * rethrown; secondary cleanup failures are attached as suppressed exceptions and the affected
-	 * ids are skipped for future additions.
+	 * if an element is <code>null</code>, a constraint is violated or an {@link Indexer} throws an
+	 * exception for any of the elements, all elements added so far by this call are rolled back and
+	 * the exception is rethrown; secondary cleanup failures are attached as suppressed exceptions and
+	 * the affected ids are skipped for future additions.
 	 *
 	 * @param elements the elements to add
 	 * @return the last assigned id
@@ -2485,23 +2491,35 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		@Override
 		public final synchronized long addAll(final Iterable<? extends E> entities)
 		{
-			for(final E element : entities)
-			{
-				this.validateForCRUD(element);
-			}
 			this.ensureMutability();
 
 			final long currentId = this.nextFreeId();
 			try
 			{
+				/*
+				 * The only traversal of the passed Iterable: validation is fused into the adding loop so that
+				 * no element is ever seen twice. A single-use Iterable (stream-backed, or a cursor adapter
+				 * handing out the same iterator every time) is therefore perfectly valid input.
+				 * Validating inside the try block is intentional: a null element in the middle of the batch is
+				 * rolled back like any other mid-batch failure, leaving the map unchanged.
+				 */
 				for(final E element : entities)
 				{
+					this.validateForCRUD(element);
 					this.internalAdd(element);
 					this.addingLevel1Index++;
 				}
-				
-				this.indices.internalAddAll(currentId, entities);
-				
+
+				/*
+				 * The indices are fed from this map, not from the passed Iterable: the index fan-out traverses
+				 * its input once per index, so an Iterable whose content differs between traversals (e.g. the
+				 * weakly consistent view of a concurrent collection) would make the indices see a different
+				 * element sequence than the one added above. That would index entries at ids holding no entity
+				 * (aliasing a future entity once that id gets assigned) or leave added entities unindexed.
+				 * Reading the entities back by id makes the indexed sequence the added sequence by definition.
+				 */
+				this.indices.internalAddAll(currentId, this.viewEntities(currentId, this.nextFreeId()));
+
 				return this.nextFreeId() - 1;
 			}
 			catch(final Exception e)
@@ -2509,6 +2527,49 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				this.rollbackToEntityId(currentId, e);
 				throw e;
 			}
+		}
+
+		/**
+		 * Returns a re-traversable view of the entities in the id range [{@code firstEntityId}; {@code idBound}),
+		 * in id order. Every call to {@link Iterable#iterator()} yields the same element sequence, which is what
+		 * the index fan-out requires: it traverses its input once per index.
+		 * <p>
+		 * Deliberately resolves the entities via {@link #get(long)} instead of one of the iteration methods:
+		 * those enter the read-only state and register an active reader, which must not happen while a mutation
+		 * is in progress.
+		 */
+		private Iterable<E> viewEntities(final long firstEntityId, final long idBound)
+		{
+			return () -> new Iterator<>()
+			{
+				private long nextEntityId = firstEntityId;
+
+				@Override
+				public boolean hasNext()
+				{
+					return this.nextEntityId < idBound;
+				}
+
+				@Override
+				public E next()
+				{
+					if(this.nextEntityId >= idBound)
+					{
+						throw new NoSuchElementException();
+					}
+
+					final long entityId = this.nextEntityId++;
+					final E    entity   = GigaMap.Default.this.get(entityId);
+					if(entity == null)
+					{
+						// Unreachable unless the id accounting itself is broken. Reported instead of passed
+						// on, since a null entity would only surface as an obscure failure inside an indexer.
+						throw new IllegalStateException("Missing entity for id " + entityId + ".");
+					}
+
+					return entity;
+				}
+			};
 		}
 
 		private void rollbackToEntityId(final long requiredCurrentId, final Exception cause)

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/AddAllSingleTraversalTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/AddAllSingleTraversalTest.java
@@ -1,0 +1,370 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link GigaMap#addAll(Iterable)} used to traverse the passed {@link Iterable} once to validate, once to add
+ * and then once more per index during the index fan-out. That had three consequences:
+ * <ul>
+ * <li>an iterable that cannot be traversed repeatedly was exhausted by the validation pass, so the method
+ * added nothing, indexed nothing and returned normally - the caller had no indication at all;</li>
+ * <li>a stream-backed iterable failed loudly on the second pass;</li>
+ * <li>an iterable whose content changed between the passes made the adding pass and the indexing pass see
+ * different element sequences: index entries at ids holding no entity (aliasing the next added entity once
+ * that id got assigned), or added entities that were never indexed.</li>
+ * </ul>
+ * These tests pin that the passed iterable is traversed exactly once and that the indexed sequence is the
+ * added sequence.
+ */
+public class AddAllSingleTraversalTest
+{
+	///////////////////////////////////////////////////////////////////////////
+	// shared domain //
+	//////////////////
+
+	static class Item
+	{
+		final String label;
+
+		Item(final String label)
+		{
+			super();
+			this.label = label;
+		}
+	}
+
+	static final IndexerString<Item> LABEL = new IndexerString.Abstract<>()
+	{
+		@Override
+		public String name()
+		{
+			return "label";
+		}
+
+		@Override
+		protected String getString(final Item item)
+		{
+			return item.label;
+		}
+	};
+
+	/**
+	 * An indexer that throws for one specific label, to trigger the rollback of an otherwise valid batch.
+	 */
+	static final class FailingLabelIndexer extends IndexerString.Abstract<Item>
+	{
+		private final String failingLabel;
+
+		FailingLabelIndexer(final String failingLabel)
+		{
+			super();
+			this.failingLabel = failingLabel;
+		}
+
+		@Override
+		public String name()
+		{
+			return "failingLabel";
+		}
+
+		@Override
+		protected String getString(final Item item)
+		{
+			if(this.failingLabel.equals(item.label))
+			{
+				throw new RuntimeException("indexer failure for " + item.label);
+			}
+
+			return item.label;
+		}
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// helpers //
+	////////////
+
+	/**
+	 * An {@link Iterable} that hands out the <b>same</b> iterator every time, i.e. it is exhausted after the
+	 * first traversal. This is the silent variant of the defect: no exception, simply nothing left to add.
+	 */
+	static <T> Iterable<T> sameIteratorEachTime(final List<T> elements)
+	{
+		final Iterator<T> shared = elements.iterator();
+
+		return () -> shared;
+	}
+
+	/**
+	 * An {@link Iterable} counting how often a traversal was started. Each traversal is valid on its own, like
+	 * the weakly consistent view of a concurrent collection, but the content changes between traversals.
+	 */
+	static final class ChangingIterable<T> implements Iterable<T>
+	{
+		private final List<List<T>> traversals;
+		private       int           iteratorRequests;
+
+		@SafeVarargs
+		ChangingIterable(final List<T>... traversals)
+		{
+			super();
+			this.traversals = List.of(traversals);
+		}
+
+		@Override
+		public Iterator<T> iterator()
+		{
+			// the last defined traversal is repeated for any further request
+			final int index = Math.min(this.iteratorRequests++, this.traversals.size() - 1);
+
+			return this.traversals.get(index).iterator();
+		}
+
+		int iteratorRequests()
+		{
+			return this.iteratorRequests;
+		}
+	}
+
+	private static GigaMap<Item> indexedMap()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(LABEL);
+
+		return map;
+	}
+
+	private static List<Item> items(final String... labels)
+	{
+		return Arrays.stream(labels).map(Item::new).toList();
+	}
+
+	private static void assertIndexedOnce(final GigaMap<Item> map, final String... labels)
+	{
+		for(final String label : labels)
+		{
+			assertEquals(1, map.query(LABEL.is(label)).count(), "entity \"" + label + "\" must be indexed");
+		}
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// iterables that cannot be traversed repeatedly //
+	//////////////////////////////////////////////////
+
+	@Test
+	@Timeout(60)
+	void addAll_sameIteratorEachTime_addsAndIndexesEverything()
+	{
+		final GigaMap<Item> map = indexedMap();
+
+		final long lastId = map.addAll(sameIteratorEachTime(items("a", "b", "c")));
+
+		assertEquals(3, map.size(), "all entities of the batch must be added");
+		assertEquals(2, lastId, "the returned id must be the id of the last added entity");
+		assertIndexedOnce(map, "a", "b", "c");
+	}
+
+	@Test
+	@Timeout(60)
+	void addAll_streamBackedIterable_addsAndIndexesEverything()
+	{
+		final GigaMap<Item> map = indexedMap();
+
+		final Stream<Item> stream = items("a", "b", "c").stream();
+		map.addAll(stream::iterator);
+
+		assertEquals(3, map.size());
+		assertIndexedOnce(map, "a", "b", "c");
+	}
+
+	@Test
+	@Timeout(60)
+	void addAll_traversesThePassedIterableExactlyOnce()
+	{
+		final GigaMap<Item> map = indexedMap();
+
+		// two indices: the fan-out used to traverse the passed iterable once per index
+		map.index().bitmap().add(new FailingLabelIndexer("nothing fails here"));
+
+		final ChangingIterable<Item> entities = new ChangingIterable<>(items("a", "b", "c"));
+		map.addAll(entities);
+
+		assertEquals(1, entities.iteratorRequests(), "the passed iterable must be traversed exactly once");
+		assertEquals(3, map.size());
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// iterables whose content changes between traversals //
+	///////////////////////////////////////////////////////
+
+	@Test
+	@Timeout(60)
+	void addAll_iterableGrowingBetweenTraversals_leavesNoPhantomIndexEntry()
+	{
+		final GigaMap<Item> map = indexedMap();
+
+		// a later traversal would yield one more element than the adding pass saw
+		map.addAll(new ChangingIterable<>(items("a", "b", "c"), items("a", "b", "c", "d")));
+
+		assertEquals(3, map.size(), "only the added entities may count");
+		assertIndexedOnce(map, "a", "b", "c");
+		assertEquals(0, map.query(LABEL.is("d")).count(), "an entity that was never added must not be indexed");
+
+		// the phantom entry used to become visible only here: "x" gets the id the phantom bit was set for
+		final Item x = new Item("x");
+		map.add(x);
+
+		assertEquals(0, map.query(LABEL.is("d")).count(), "a phantom index entry must not alias a later entity");
+		assertEquals(1, map.query(LABEL.is("x")).count());
+		assertSame(x, map.query(LABEL.is("x")).toList().get(0));
+	}
+
+	@Test
+	@Timeout(60)
+	void addAll_iterableShrinkingBetweenTraversals_indexesEveryAddedEntity()
+	{
+		final GigaMap<Item> map = indexedMap();
+
+		// a later traversal would yield fewer elements than the adding pass saw
+		map.addAll(new ChangingIterable<>(items("a", "b", "c"), items("a", "b")));
+
+		assertEquals(3, map.size());
+		assertIndexedOnce(map, "a", "b", "c");
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// failure handling //
+	/////////////////////
+
+	@Test
+	@Timeout(60)
+	void addAll_nullElementInTheMiddle_rollsBackTheWholeBatch()
+	{
+		final GigaMap<Item> map = indexedMap();
+		map.add(new Item("existing"));
+
+		final List<Item> entities = new ArrayList<>(items("a", "b"));
+		entities.add(1, null);
+
+		assertThrows(IllegalArgumentException.class, () -> map.addAll(entities));
+
+		assertEquals(1, map.size(), "the map must be unchanged");
+		assertEquals(0, map.query(LABEL.is("a")).count(), "no entity of the batch may be indexed");
+		assertIndexedOnce(map, "existing");
+
+		// the map must still be usable afterwards
+		final Item next = new Item("next");
+		final long nextId = map.add(next);
+
+		assertSame(next, map.get(nextId));
+		assertIndexedOnce(map, "next");
+	}
+
+	@Test
+	@Timeout(60)
+	void addAll_throwingIndexer_rollsBackTheWholeBatch()
+	{
+		final GigaMap<Item> map = indexedMap();
+		map.index().bitmap().add(new FailingLabelIndexer("boom"));
+
+		assertThrows(RuntimeException.class, () -> map.addAll(items("a", "boom", "c")));
+
+		assertEquals(0, map.size(), "no entity of the batch may remain");
+		assertEquals(0, map.query(LABEL.is("a")).count(), "no index may refer to a rolled back entity");
+		assertEquals(0, map.query(LABEL.is("c")).count(), "no index may refer to a rolled back entity");
+
+		// the map must still be usable afterwards
+		final Item next = new Item("next");
+		assertNotNull(map.get(map.add(next)));
+		assertIndexedOnce(map, "next");
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// segment boundaries //
+	///////////////////////
+
+	@Test
+	@Timeout(60)
+	void addAll_batchSpanningMultipleSegments_indexesEveryEntityAtItsOwnId()
+	{
+		// tiny low level segments (4 entities each), so the batch spans several of them
+		final GigaMap<Item> map = GigaMap.New(2);
+		map.index().bitmap().add(LABEL);
+
+		final int        count  = 37;
+		final List<Item> batch  = new ArrayList<>(count);
+		for(int i = 0; i < count; i++)
+		{
+			batch.add(new Item("label" + i));
+		}
+
+		final long lastId = map.addAll(sameIteratorEachTime(batch));
+
+		assertEquals(count, map.size());
+		assertEquals(count - 1, lastId);
+
+		// every entity must be indexed at exactly its own id
+		for(int i = 0; i < count; i++)
+		{
+			final List<Item> found = map.query(LABEL.is("label" + i)).toList();
+			assertEquals(1, found.size(), "entity \"label" + i + "\" must be indexed exactly once");
+			assertSame(batch.get(i), found.get(0), "entity \"label" + i + "\" must be indexed at its own id");
+			assertSame(batch.get(i), map.get(i));
+		}
+	}
+
+	@Test
+	@Timeout(60)
+	void addAll_multipleBatches_keepIdAccountingIntact()
+	{
+		final GigaMap<Item> map = GigaMap.New(2);
+		map.index().bitmap().add(LABEL);
+
+		final List<Item> first  = items("a", "b", "c", "d", "e");
+		final List<Item> second = items("f", "g", "h");
+
+		assertEquals(4, map.addAll(sameIteratorEachTime(first)));
+		assertEquals(7, map.addAll(sameIteratorEachTime(second)));
+
+		assertEquals(8, map.size());
+		assertIndexedOnce(map, "a", "b", "c", "d", "e", "f", "g", "h");
+		assertSame(second.get(0), map.query(LABEL.is("f")).toList().get(0));
+	}
+}

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorAddAllSingleUseIterableTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorAddAllSingleUseIterableTest.java
@@ -1,0 +1,127 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link GigaMap#addAll(Iterable)} used to hand the caller's {@link Iterable} to the index fan-out, which
+ * traverses it once per index. An iterable that cannot be traversed repeatedly therefore left the entities
+ * unindexed, or indexed at ids holding no entity.
+ * <p>
+ * Pins that a single-use iterable is fully vector-indexed <b>and</b> that the batch still reaches the index as
+ * one batch, i.e. {@link Vectorizer#vectorizeAll(List)} is called once instead of {@code vectorize} per entity.
+ * The batch hand-off is what rules out fixing the traversal defect by indexing entity by entity.
+ */
+class VectorAddAllSingleUseIterableTest
+{
+	static final class Document
+	{
+		private final String  content;
+		private final float[] embedding;
+
+		Document(final String content, final float[] embedding)
+		{
+			super();
+			this.content   = content;
+			this.embedding = embedding;
+		}
+
+		String content()
+		{
+			return this.content;
+		}
+
+		float[] embedding()
+		{
+			return this.embedding;
+		}
+	}
+
+	/**
+	 * A vectorizer tracking how often the batch entry point was used.
+	 */
+	static final class BatchTrackingVectorizer extends Vectorizer<Document>
+	{
+		int vectorizeAllCallCount;
+
+		@Override
+		public float[] vectorize(final Document entity)
+		{
+			return entity.embedding();
+		}
+
+		@Override
+		public List<float[]> vectorizeAll(final List<? extends Document> entities)
+		{
+			this.vectorizeAllCallCount++;
+
+			return super.vectorizeAll(entities);
+		}
+	}
+
+	/**
+	 * An {@link Iterable} that hands out the <b>same</b> iterator every time, i.e. it is exhausted after the
+	 * first traversal.
+	 */
+	static <T> Iterable<T> sameIteratorEachTime(final List<T> elements)
+	{
+		final Iterator<T> shared = elements.iterator();
+
+		return () -> shared;
+	}
+
+	@Test
+	void addAll_singleUseIterable_indexesEveryEntityAsOneBatch()
+	{
+		final GigaMap<Document>       gigaMap    = GigaMap.New();
+		final BatchTrackingVectorizer vectorizer = new BatchTrackingVectorizer();
+
+		final VectorIndices<Document>  vectorIndices = gigaMap.index().register(VectorIndices.Category());
+		final VectorIndexConfiguration config        = VectorIndexConfiguration.builder()
+			.dimension(3)
+			.similarityFunction(VectorSimilarityFunction.COSINE)
+			.build()
+		;
+
+		final VectorIndex<Document> index = vectorIndices.add("embeddings", config, vectorizer);
+
+		final List<Document> docs = List.of(
+			new Document("Doc A", new float[]{1.0f, 0.0f, 0.0f}),
+			new Document("Doc B", new float[]{0.0f, 1.0f, 0.0f}),
+			new Document("Doc C", new float[]{0.0f, 0.0f, 1.0f})
+		);
+
+		gigaMap.addAll(sameIteratorEachTime(docs));
+
+		assertEquals(3, gigaMap.size(), "all entities of the batch must be added");
+		assertEquals(1, vectorizer.vectorizeAllCallCount, "the batch must still be vectorized as one batch");
+
+		// every entity must be searchable, i.e. the whole batch reached the graph
+		for(final Document doc : docs)
+		{
+			final VectorSearchResult<Document> result = index.search(doc.embedding(), 1);
+
+			assertEquals(1, result.size(), "entity \"" + doc.content() + "\" must be indexed");
+			assertEquals(doc.content(), result.toList().get(0).entity().content());
+		}
+	}
+}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneAddAllSingleUseIterableTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneAddAllSingleUseIterableTest.java
@@ -1,0 +1,128 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.apache.lucene.document.Document;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link GigaMap#addAll(Iterable)} used to hand the caller's {@link Iterable} to the index fan-out, which
+ * traverses it once per index. An iterable that cannot be traversed repeatedly therefore left the entities
+ * unindexed (or, in the worst case, indexed at ids holding no entity).
+ * <p>
+ * Pins that a single-use iterable is fully indexed by the Lucene index, which receives the batch via
+ * {@link LuceneIndex.Internal#internalAddAll(long, Iterable)} and turns it into one
+ * {@code IndexWriter#addDocuments} call.
+ */
+public class LuceneAddAllSingleUseIterableTest
+{
+	/**
+	 * An {@link Iterable} that hands out the <b>same</b> iterator every time, i.e. it is exhausted after the
+	 * first traversal.
+	 */
+	static <T> Iterable<T> sameIteratorEachTime(final List<T> elements)
+	{
+		final Iterator<T> shared = elements.iterator();
+
+		return () -> shared;
+	}
+
+	@Test
+	void addAll_singleUseIterable_indexesEveryEntity()
+	{
+		final LuceneContext<Article> luceneContext = LuceneContext.New(
+			DirectoryCreator.ByteBuffers(),
+			new ArticleDocumentPopulator()
+		);
+
+		final GigaMap<Article> gigaMap = GigaMap.New();
+		try(final LuceneIndex<Article> luceneIndex = gigaMap.index().register(LuceneIndex.Category(luceneContext)))
+		{
+			final List<Article> articles = List.of(
+				new Article("Title_1", "This is a first longer content text."),
+				new Article("Title_2", "This is a second longer Text"),
+				new Article("Title_3", "This is a third longer Text")
+			);
+
+			gigaMap.addAll(sameIteratorEachTime(articles));
+
+			assertEquals(3, gigaMap.size(), "all entities of the batch must be added");
+
+			// every entity must be findable, i.e. the whole batch reached the index
+			for(final Article article : articles)
+			{
+				final List<Article> result = new ArrayList<>();
+				luceneIndex.query("title:" + article.getTitle(), (id, entity, score) -> result.add(entity));
+
+				assertEquals(1, result.size(), "entity \"" + article.getTitle() + "\" must be indexed");
+				assertEquals(article.getTitle(), result.get(0).getTitle());
+			}
+
+			// and no phantom document may alias an entity added afterwards
+			final List<Article> result = new ArrayList<>();
+			gigaMap.add(new Article("Title_4", "This is a fourth longer Text"));
+			luceneIndex.query("title:Title_4", (id, entity, score) -> result.add(entity));
+
+			assertEquals(1, result.size());
+			assertEquals("Title_4", result.get(0).getTitle());
+		}
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// test domain //
+	////////////////
+
+	private static class ArticleDocumentPopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			document.add(createTextField("title", entity.getTitle()));
+			document.add(createTextField("content", entity.getContent()));
+		}
+	}
+
+	private static class Article
+	{
+		private final String title;
+		private final String content;
+
+		Article(final String title, final String content)
+		{
+			super();
+			this.title   = title;
+			this.content = content;
+		}
+
+		String getTitle()
+		{
+			return this.title;
+		}
+
+		String getContent()
+		{
+			return this.content;
+		}
+	}
+}


### PR DESCRIPTION
Fixes the entity-level variant of the repeated-traversal defect: `GigaMap#addAll(Iterable)` handed the caller's `Iterable` to a validation pass, an adding pass and the index fan-out. The fan-out alone traverses its input **once per index**, so the passed `Iterable` was actually consumed `2 + one-per-index` times.

## Symptoms

- **Silent data loss.** An `Iterable` that cannot be traversed repeatedly (a cursor adapter, `() -> someIterator`) was exhausted by the validation pass: nothing was added, nothing was indexed, and the method returned normally with a plausible-looking id. The caller had no indication that zero entities were persisted.
- **Loud failure.** A stream-backed iterable (`stream::iterator`) threw `IllegalStateException: stream has already been operated upon or closed` on the second pass.
- **Entity/index divergence.** Since the adding pass and the indexing pass traversed the caller's `Iterable` independently, an `Iterable` whose content changed in between - the weakly consistent view of a concurrent collection, which is a legal use of those collections and something the `addAll` contract never excluded - made the two passes see different element sequences. An element the index pass saw beyond the added ones got its index entry written at an id holding **no entity**: invisible at first, because queries clip at the current id bound, and then aliasing a foreign entity as soon as the next `add()` assigned that id. In the opposite direction entities were added but silently left unindexed.

## The fix

`addAll` now traverses the passed `Iterable` **exactly once**, with the null validation fused into the adding loop, and feeds the index fan-out from the map itself: a re-traversable view of the freshly added id range, resolved via `get(long)`.

That makes the indexed sequence the added sequence *by definition*, so no caller-side discipline is required. It also needs no snapshot of the batch, which would have been wasted memory on the documented bulk-insert path - the added entities are strongly reachable from the map's segments for the whole call anyway.

`ensureMutability()` moved ahead of the traversal; it previously ran after the validation pass, i.e. after arbitrary caller code had already executed against an immutable map.

## Why not index entity by entity

Collapsing the passes by calling `indices.internalAdd(id, entity)` per element would have removed two batch behaviours that exist on purpose:

- `LuceneIndex.Internal#internalAddAll` turns the batch into a single `IndexWriter#addDocuments` call;
- `VectorIndex` routes the batch through `Vectorizer#vectorizeAll`, the documented batch vectorization (`docs/modules/gigamap/pages/indexing/jvector/advanced.adoc`), pinned by `VectorIndexBatchTest`.

The `internalAddAll(long, Iterable)` contract is therefore untouched, and bitmap, Lucene and vector indices need no change at all.

## Behaviour change

A `null` element in the middle of a batch is now rolled back like any other mid-batch failure, instead of being rejected before any state change. The observable end state is the same - nothing added, `size()` unchanged, no index referring to the batch, map still usable - and the Javadoc of `addAll(Iterable)` documents it accordingly, alongside the single-traversal guarantee.

## Tests

`AddAllSingleTraversalTest` (gigamap): single-use iterable, stream-backed iterable, a direct assertion that the passed iterable is traversed exactly once, growing/shrinking iterables (no phantom entry, nothing left unindexed), null mid-batch, a batch spanning several level-1 segments, multiple consecutive batches, and two rollback anchors. **7 of the 9 cases fail without the fix**; the two rollback anchors pass in both states, on purpose.

`LuceneAddAllSingleUseIterableTest` and `VectorAddAllSingleUseIterableTest` pin the same input shape per index family, the vector one additionally asserting that `vectorizeAll` is still called once for the batch - the explicit guard for the batch hand-off that ruled out the per-entity alternative.

Suites run green on this branch: gigamap 1121 tests, lucene 69, jvector 120 (`-Pslow-tests`).
