### PR TITLE
Harden binary import and export failure handling

### DIFF
--- a/integration-tests/src/test/java/test/eclipse/store/recovery/TornImportCommitFailureEscalationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/TornImportCommitFailureEscalationTest.java
@@ -1,0 +1,298 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import org.eclipse.serializer.afs.types.ADirectory;
+import org.eclipse.serializer.afs.types.AFile;
+import org.eclipse.serializer.collections.types.XEnum;
+import org.eclipse.serializer.util.X;
+import org.eclipse.store.afs.nio.types.NioFileSystem;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageConfiguration;
+import org.eclipse.store.storage.types.StorageFileWriter;
+import org.eclipse.store.storage.types.StorageLiveDataFile;
+import org.eclipse.store.storage.types.StorageLiveFileProvider;
+import org.eclipse.store.storage.types.StorageLiveTransactionsFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A commit-phase failure during {@code importFiles} must not leave a silently torn import behind.
+ * <p>
+ * Injected failure: channel 1's transactions-log store entry write throws inside its import
+ * commit. Depending on completion order, channel 0 may already have committed its part - the
+ * torn-import live window. Expected with the escalation + torn-import deferral fix:
+ * <ol>
+ * <li>{@code importFiles} throws, with the injected cause in the chain;</li>
+ * <li>the storage is DISRUPTED - further requests are refused, so no subsequent store can advance
+ *     the restart consensus past the torn commit, and no housekeeping can dissolve the files the
+ *     rollback needs (issuing a file check explicitly must fail too);</li>
+ * <li>a restart undoes the import completely via the cross-channel consensus: the root is the
+ *     pre-import state, and the storage is fully operational again.</li>
+ * </ol>
+ * Housekeeping is configured aggressively on purpose: without the fix, it may dissolve the
+ * pre-import head between the failed commit and the restart, making the torn import unrecoverable
+ * (rollback refusal) or leaving it half-applied.
+ */
+class TornImportCommitFailureEscalationTest
+{
+	private static final int CHANNELS = 2;
+
+	@Test
+	@Timeout(value = 180, unit = TimeUnit.SECONDS)
+	void commitFailureMustDisruptAndRestartMustUndoTheImport(@TempDir final Path tempDir) throws Exception
+	{
+		final NioFileSystem fs         = NioFileSystem.New();
+		final Path          storageDir = tempDir.resolve("storage");
+		final Path          exportDir  = tempDir.resolve("export");
+
+		// --- state v1, exported ---
+		EmbeddedStorageManager storage = start(storageDir, null);
+		try
+		{
+			@SuppressWarnings("unchecked")
+			final ArrayList<String> root = (ArrayList<String>)storage.root();
+			root.add("v1-a");
+			root.add("v1-b");
+			storage.storeRoot();
+
+			final ADirectory aExportDir = fs.ensureDirectoryPath(exportDir.toFile().getAbsolutePath());
+			storage.createConnection().exportChannels(StorageLiveFileProvider.New(aExportDir), true);
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+
+		// --- evolve to v2: this is the pre-import state a torn import must be undone to ---
+		storage = start(storageDir, null);
+		try
+		{
+			@SuppressWarnings("unchecked")
+			final ArrayList<String> root = (ArrayList<String>)storage.root();
+			root.clear();
+			root.add("v2-a");
+			root.add("v2-b");
+			storage.storeRoot();
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+
+		// --- import the v1 export; channel 1's commit entry write fails ---
+		final InjectingWriterProvider injectingProvider = new InjectingWriterProvider();
+		storage = start(storageDir, injectingProvider);
+		try
+		{
+			final XEnum<AFile> importFiles = X.Enum();
+			for(final Path p : listFiles(exportDir, ".dat"))
+			{
+				importFiles.add(fs.ensureFile(p));
+			}
+
+			final var connection = storage.createConnection();
+			injectingProvider.armed.set(true);
+			final Exception importFailure = assertThrows(
+				Exception.class,
+				() -> connection.importFiles(importFiles),
+				"importFiles must fail when a channel's commit entry write fails"
+			);
+			injectingProvider.armed.set(false);
+			assertTrue(
+				causeChainContains(importFailure, InjectingWriterProvider.INJECTED_MESSAGE),
+				"the injected failure must surface from importFiles: " + causeChain(importFailure)
+			);
+
+			// the commit-phase failure must have disrupted the storage: no further request may be
+			// served, or a later store would seal the torn state permanently
+			final EmbeddedStorageManager disrupted = storage;
+			assertThrows(
+				Exception.class,
+				() -> disrupted.createConnection().issueFullFileCheck(),
+				"a file check after a torn import commit must be refused (storage disrupted)"
+			);
+			assertThrows(
+				Exception.class,
+				disrupted::storeRoot,
+				"a store after a torn import commit must be refused (storage disrupted)"
+			);
+		}
+		finally
+		{
+			try
+			{
+				storage.shutdown();
+			}
+			catch(final Exception e)
+			{
+				// a disrupted storage may report its disruption once more on shutdown
+				System.out.println("shutdown after disruption reported: " + e);
+			}
+		}
+
+		// --- restart: the consensus must undo the torn import completely ---
+		try
+		{
+			storage = start(storageDir, null);
+		}
+		catch(final Exception e)
+		{
+			fail("storage did not start after a torn import commit: " + causeChain(e));
+			return;
+		}
+		try
+		{
+			@SuppressWarnings("unchecked")
+			final ArrayList<String> root = (ArrayList<String>)storage.root();
+			assertEquals(
+				List.of("v2-a", "v2-b"),
+				root,
+				"a torn import must be undone completely, leaving the pre-import state"
+			);
+
+			// the storage must be fully operational again
+			root.add("v3-after-recovery");
+			storage.storeRoot();
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+	}
+
+	/**
+	 * Housekeeping is deliberately aggressive (short interval, generous budget): the fix must hold
+	 * even when housekeeping gets every chance to run between the failed commit and the restart.
+	 */
+	private static EmbeddedStorageManager start(
+		final Path                       storageDir,
+		final StorageFileWriter.Provider writerProvider
+	)
+	{
+		final EmbeddedStorageFoundation<?> foundation = EmbeddedStorage.Foundation(
+			StorageConfiguration.Builder()
+				.setStorageFileProvider(Storage.FileProvider(storageDir))
+				.setChannelCountProvider(Storage.ChannelCountProvider(CHANNELS))
+				.setHousekeepingController(Storage.HousekeepingController(10, 100_000_000L))
+				.createConfiguration()
+		);
+		if(writerProvider != null)
+		{
+			foundation.setWriterProvider(writerProvider);
+		}
+		return foundation.start(new ArrayList<String>());
+	}
+
+	/**
+	 * Provides the default writer for every channel except channel 1, whose writer throws on the
+	 * next transactions-log store entry write while {@link #armed}. During {@code importFiles},
+	 * the only store entry written is the import commit's, so arming right before the call
+	 * injects the failure precisely into channel 1's commit phase.
+	 */
+	private static final class InjectingWriterProvider implements StorageFileWriter.Provider
+	{
+		static final String INJECTED_MESSAGE = "injected commit-phase failure (channel 1 entry-store write)";
+
+		final AtomicBoolean armed = new AtomicBoolean(false);
+
+		@Override
+		public StorageFileWriter provideWriter()
+		{
+			return new StorageFileWriter.Default();
+		}
+
+		@Override
+		public StorageFileWriter provideWriter(final int channelIndex)
+		{
+			if(channelIndex != 1)
+			{
+				return new StorageFileWriter.Default();
+			}
+			return new StorageFileWriter()
+			{
+				@Override
+				public long writeTransactionEntryStore(
+					final StorageLiveTransactionsFile    transactionFile,
+					final Iterable<? extends ByteBuffer> byteBuffers    ,
+					final StorageLiveDataFile            dataFile       ,
+					final long                           dataFileOffset ,
+					final long                           storeLength
+				)
+				{
+					if(InjectingWriterProvider.this.armed.get())
+					{
+						throw new RuntimeException(INJECTED_MESSAGE);
+					}
+					return StorageFileWriter.super.writeTransactionEntryStore(
+						transactionFile, byteBuffers, dataFile, dataFileOffset, storeLength
+					);
+				}
+			};
+		}
+	}
+
+	private static boolean causeChainContains(final Throwable t, final String message)
+	{
+		for(Throwable c = t; c != null; c = c.getCause())
+		{
+			if(c.getMessage() != null && c.getMessage().contains(message))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static String causeChain(final Throwable t)
+	{
+		final StringBuilder sb = new StringBuilder();
+		for(Throwable c = t; c != null; c = c.getCause())
+		{
+			sb.append("\n  <- ").append(c);
+		}
+		return sb.toString();
+	}
+
+	private static List<Path> listFiles(final Path dir, final String suffix) throws IOException
+	{
+		try(Stream<Path> walk = Files.walk(dir))
+		{
+			return walk.filter(Files::isRegularFile)
+				.filter(p -> p.getFileName().toString().endsWith(suffix))
+				.toList()
+			;
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/recovery/TornImportConsensusTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/recovery/TornImportConsensusTest.java
@@ -1,0 +1,320 @@
+package test.eclipse.store.recovery;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.serializer.afs.types.ADirectory;
+import org.eclipse.serializer.afs.types.AFile;
+import org.eclipse.serializer.collections.types.XEnum;
+import org.eclipse.serializer.util.X;
+import org.eclipse.store.afs.nio.types.NioFileSystem;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.types.Storage;
+import org.eclipse.store.storage.types.StorageConfiguration;
+import org.eclipse.store.storage.types.StorageDataFileEvaluator;
+import org.eclipse.store.storage.types.StorageLiveDataFile;
+import org.eclipse.store.storage.types.StorageLiveFileProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Does the cross-channel restart consensus undo a TORN import?
+ * <p>
+ * Every channel logs its import commit as a store entry carrying the same task timestamp, so the
+ * channels' timestamp sequences should remain prefixes of one global sequence and the consensus
+ * (StorageChannelTaskInitialize#determineConsistentStoreTimestamp = the minimum of the channels'
+ * latest timestamps) should roll every channel that is ahead back to the length its own log recorded
+ * for that timestamp - which for the import's head file is its creation length.
+ * <p>
+ * Simulated by surgery: run a complete import, then restore ONE channel's files from a snapshot taken
+ * before the import. That is the state a power loss between two channels' commits leaves behind - the
+ * restored channel never logged the import, the other did.
+ */
+class TornImportConsensusTest
+{
+	private static final int CHANNELS = 2;
+
+	/**
+	 * The tear happens immediately after the import, before anything could dissolve the old head.
+	 * That premise must be enforced, not hoped for: pinning the housekeeping interval alone does NOT
+	 * prevent in-session dissolution, because the eager-rollover-durability flush armed by the
+	 * import's own rollover carries an interval-independent maintenance pass that may dissolve the
+	 * undersized pre-import head right after the (fully confirmed) import - legitimately, and racing
+	 * the test's shutdown. The scenarios therefore disable dissolution outright.
+	 */
+	@Test
+	@Timeout(value = 180, unit = TimeUnit.SECONDS)
+	void tornImportMustBeUndoneOnRestart(@TempDir final Path tempDir) throws Exception
+	{
+		runTornImport(tempDir, "channel_1");
+	}
+
+	@Test
+	@Timeout(value = 180, unit = TimeUnit.SECONDS)
+	void tornImportMustBeUndoneOnRestartWhicheverChannelIsBehind(@TempDir final Path tempDir) throws Exception
+	{
+		runTornImport(tempDir, "channel_0");
+	}
+
+	private static void runTornImport(final Path tempDir, final String revertedChannel) throws Exception
+	{
+		final NioFileSystem fs         = NioFileSystem.New();
+		final Path          storageDir = tempDir.resolve("storage");
+		final Path          exportDir  = tempDir.resolve("export");
+		final Path          snapshot   = tempDir.resolve("snapshot");
+
+		// --- state v1, exported ---
+		EmbeddedStorageManager storage = start(storageDir);
+		try
+		{
+			@SuppressWarnings("unchecked")
+			final ArrayList<String> root = (ArrayList<String>)storage.root();
+			root.add("v1-a");
+			root.add("v1-b");
+			storage.storeRoot();
+
+			final ADirectory aExportDir = fs.ensureDirectoryPath(exportDir.toFile().getAbsolutePath());
+			storage.createConnection().exportChannels(StorageLiveFileProvider.New(aExportDir), true);
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+
+		// --- evolve to v2, then snapshot: this is the pre-import on-disk state ---
+		storage = start(storageDir);
+		try
+		{
+			@SuppressWarnings("unchecked")
+			final ArrayList<String> root = (ArrayList<String>)storage.root();
+			root.clear();
+			root.add("v2-a");
+			root.add("v2-b");
+			storage.storeRoot();
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+		copyDir(storageDir, snapshot);
+
+		// --- import the v1 export: reverts the root on every channel ---
+		storage = start(storageDir);
+		try
+		{
+			final XEnum<AFile> importFiles = X.Enum();
+			for(final Path p : listFiles(exportDir, ".dat"))
+			{
+				importFiles.add(fs.ensureFile(p));
+			}
+			storage.createConnection().importFiles(importFiles);
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+
+		/*
+		 * Verify the import took effect on a COPY, so the storage under test is not restarted and
+		 * housekeeping gets no chance to dissolve the pre-import head.
+		 */
+		final Path verifyCopy = tempDir.resolve("verify");
+		copyDir(storageDir, verifyCopy);
+		storage = start(verifyCopy);
+		try
+		{
+			@SuppressWarnings("unchecked")
+			final ArrayList<String> root = (ArrayList<String>)storage.root();
+			assertEquals(List.of("v1-a", "v1-b"), root, "precondition: the import must have been committed");
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+
+		// --- the tear: one channel never logged the import ---
+		deleteDir(storageDir.resolve(revertedChannel));
+		copyDir(snapshot.resolve(revertedChannel), storageDir.resolve(revertedChannel));
+		System.out.println("reverted " + revertedChannel + " to its pre-import state");
+
+		// --- restart: consensus should undo the import on the channel that is ahead ---
+		try
+		{
+			storage = start(storageDir);
+		}
+		catch(final Exception e)
+		{
+			fail("storage did not start after a torn import: " + causeChain(e));
+			return;
+		}
+		try
+		{
+			@SuppressWarnings("unchecked")
+			final ArrayList<String> root = (ArrayList<String>)storage.root();
+			System.out.println("root after restarting a torn import: " + root);
+			assertEquals(
+				List.of("v2-a", "v2-b"),
+				root,
+				"a torn import must be undone completely, leaving the pre-import state"
+			);
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+	}
+
+	/**
+	 * Housekeeping is pushed far out AND dissolution is disabled via the evaluator: the interval
+	 * alone does not prevent it, because the eager-rollover-durability flush armed by the import's
+	 * rollover runs an interval-independent maintenance pass that may dissolve the pre-import head
+	 * right after the import (see the first test method's javadoc).
+	 */
+	private static EmbeddedStorageManager start(final Path storageDir)
+	{
+		return EmbeddedStorage.start(
+			new ArrayList<String>(),
+			StorageConfiguration.Builder()
+				.setStorageFileProvider(Storage.FileProvider(storageDir))
+				.setChannelCountProvider(Storage.ChannelCountProvider(CHANNELS))
+				.setHousekeepingController(Storage.HousekeepingController(24 * 60 * 60 * 1000L, 1_000_000L))
+				.setDataFileEvaluator(neverDissolvingEvaluator())
+				.createConfiguration()
+		);
+	}
+
+	/** Delegates everything to the default evaluator except dissolution, which it forbids. */
+	private static StorageDataFileEvaluator neverDissolvingEvaluator()
+	{
+		final StorageDataFileEvaluator defaults = Storage.DataFileEvaluator();
+		return new StorageDataFileEvaluator()
+		{
+			@Override
+			public boolean needsDissolving(final StorageLiveDataFile storageFile)
+			{
+				return false;
+			}
+
+			@Override
+			public boolean needsRetirement(final long fileTotalLength)
+			{
+				return defaults.needsRetirement(fileTotalLength);
+			}
+
+			@Override
+			public int fileMinimumSize()
+			{
+				return defaults.fileMinimumSize();
+			}
+
+			@Override
+			public int fileMaximumSize()
+			{
+				return defaults.fileMaximumSize();
+			}
+
+			@Override
+			public int transactionFileMaximumSize()
+			{
+				return defaults.transactionFileMaximumSize();
+			}
+
+			@Override
+			public long coalesceChunkTargetBytes()
+			{
+				return defaults.coalesceChunkTargetBytes();
+			}
+		};
+	}
+
+	private static String causeChain(final Throwable t)
+	{
+		final StringBuilder sb = new StringBuilder();
+		for(Throwable c = t; c != null; c = c.getCause())
+		{
+			sb.append("\n  <- ").append(c);
+		}
+		return sb.toString();
+	}
+
+	private static List<Path> listFiles(final Path dir, final String suffix) throws IOException
+	{
+		try(Stream<Path> walk = Files.walk(dir))
+		{
+			return walk.filter(Files::isRegularFile)
+				.filter(p -> p.getFileName().toString().endsWith(suffix))
+				.toList()
+			;
+		}
+	}
+
+	private static void copyDir(final Path source, final Path target) throws IOException
+	{
+		Files.walkFileTree(source, new SimpleFileVisitor<Path>()
+		{
+			@Override
+			public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs)
+				throws IOException
+			{
+				Files.createDirectories(target.resolve(source.relativize(dir).toString()));
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs)
+				throws IOException
+			{
+				Files.copy(file, target.resolve(source.relativize(file).toString()));
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+	private static void deleteDir(final Path dir) throws IOException
+	{
+		Files.walkFileTree(dir, new SimpleFileVisitor<Path>()
+		{
+			@Override
+			public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs)
+				throws IOException
+			{
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(final Path d, final IOException e) throws IOException
+			{
+				Files.delete(d);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageChannel.java
@@ -373,6 +373,21 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 	public void commitImportData(long taskTimestamp);
 
 	/**
+	 * Confirms a {@link #commitImportData(long) committed} import: to be called only once the
+	 * import task completed on EVERY channel without problems ("no problems so far" does not
+	 * suffice), and never on a failed import. Until then, the channel defers file lifecycle events
+	 * (rollover, dissolution, deletion) that would render a restart's consensus rollback of a torn
+	 * import commit impossible.
+	 * <p>
+	 * The default implementation is a no-op for {@link StorageChannel} implementations without
+	 * such a deferral.
+	 */
+	public default void confirmImportData()
+	{
+		// no-op by default. To be overridden by implementations that defer file lifecycle events.
+	}
+
+	/**
 	 * Clears the garbage collection coordination state registered by
 	 * {@link #prepareImportData()}, releasing sweep initiation again. Must be called exactly once
 	 * per {@link #prepareImportData()} after the import task has ultimately completed, no matter
@@ -1288,6 +1303,12 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		public void commitImportData(final long taskTimestamp)
 		{
 			this.fileManager.commitImport(taskTimestamp);
+		}
+
+		@Override
+		public void confirmImportData()
+		{
+			this.fileManager.confirmImport();
 		}
 
 		@Override

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageConnection.java
@@ -372,13 +372,24 @@ public interface StorageConnection extends UsageMarkable, Persister
 	 * <p>
 	 * This is useful to extract the data contained in the storage in a structured way, for example to migrate it
 	 * into another storage system or to analyze it, like converting it into human readable form.
-	 * 
+	 * <p>
+	 * <b>A failed export is not rolled back.</b> The export files are written incrementally, so an export
+	 * that throws leaves whatever was written until then in the target directory: files of types already
+	 * exported are complete, the type being exported when the failure occurred is truncated at an arbitrary
+	 * point, and types not yet reached have no file at all. Only files that are still empty are removed.
+	 * <p>
+	 * Nothing marks such a directory as incomplete, and a truncated file that happens to end on an entity
+	 * boundary is indistinguishable from a complete one - including for
+	 * {@link #importFiles(XGettingEnum)}, which would import it as if it were the whole type. Treat the
+	 * target directory as unusable unless this method returned normally, and delete or set it aside
+	 * before retrying.
+	 *
 	 * @param exportFileProvider the {@link StorageEntityTypeExportFileProvider} logic to be used.
-	 * 
+	 *
 	 * @param isExportType a {@link Predicate} selecting which type's entity data to be exported.
-	 * 
+	 *
 	 * @return a {@link StorageEntityTypeExportStatistics} information instance about the completed export.
-	 * 
+	 *
 	 * @see #exportTypes(StorageEntityTypeExportFileProvider)
 	 */
 	public StorageEntityTypeExportStatistics exportTypes(
@@ -446,7 +457,12 @@ public interface StorageConnection extends UsageMarkable, Persister
 	 * (identified by their ObjectId), their current data will be replaced by the imported data.<br>
 	 * Note that importing data that is not reachable from any root entity will have no effect and will
 	 * eventually be deleted by the garbage collector.
-	 * 
+	 * <p>
+	 * Replacement happens on the storage level only: already loaded instances keep their in-memory
+	 * state, so heap and storage diverge for every replaced entity - observably mixed, and flipping
+	 * per entity as weakly referenced instances are collected and reloaded - until the application
+	 * discards its references and reloads from the root, typically by restarting.
+	 *
 	 * @param importFiles the files whose native binary content shall be imported.
 	 */
 	public void importFiles(XGettingEnum<AFile> importFiles);
@@ -458,7 +474,10 @@ public interface StorageConnection extends UsageMarkable, Persister
 	 * (identified by their ObjectId), their current data will be replaced by the imported data.<br>
 	 * Note that importing data that is not reachable from any root entity will have no effect and will
 	 * eventually be deleted by the garbage collector.
-	 * 
+	 * <p>
+	 * On heap/storage divergence after replacing existing entities, see
+	 * {@link #importFiles(XGettingEnum)} - the same applies here.
+	 *
 	 * @param importData the files whose native binary content shall be imported.
 	 */
 	public void importData(XGettingEnum<ByteBuffer> importData);

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageEntityCache.java
@@ -143,6 +143,9 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		private long    usedCacheSize;
 		private boolean hasUpdatePendingSweep;
 
+		// existing entities the current import replaced (see #reportImportConflicts)
+		private long importConflictCount;
+
 		// obsolete typeIds already warned about on a typeId change (see #handleTypeIdChange)
 		private final Set_long warnedObsoleteTypeIds = Set_long.New();
 		private boolean hasLoadPendingSweep  ;
@@ -286,6 +289,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 
 			this.usedCacheSize  = 0L;
 			this.warnedObsoleteTypeIds.clear();
+			this.importConflictCount = 0;
 
 			// create a new root type instance on every clear. Everything else is not worth the reset&register-hassle.
 			this.rootType       = this.getType(this.rootTypeId);
@@ -634,6 +638,36 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				this.markMonitor.resetCompletion();
 				this.hasUpdatePendingSweep = this.markMonitor.isPendingSweep(this);
 			}
+
+			// arm the conflict count for this import (see #reportImportConflicts)
+			this.importConflictCount = 0;
+		}
+
+		/**
+		 * Logs how many existing entities this channel's import replaced. An import always wins;
+		 * no staleness check is possible, as neither an entity nor an exported record carries a
+		 * timestamp or version. A stale re-import (reverting newer state) and a deliberate one
+		 * (the remedy for a torn import) are therefore indistinguishable - the overwrite can only
+		 * be reported, never rejected.
+		 * <p>
+		 * Aggregated per channel and import: a full re-import collides on every entity, so
+		 * per-entity warnings would bury the message.
+		 */
+		final void reportImportConflicts()
+		{
+			if(this.importConflictCount == 0)
+			{
+				return;
+			}
+
+			logger.warn(
+				"Channel {}: import replaced {} already existing entities. If this import was created "
+				+ "before the current state, those entities have been reverted to their exported state. "
+				+ "Already loaded instances keep their in-memory state - reload from the root "
+				+ "(typically: restart) before further use.",
+				this.channelIndex,
+				this.importConflictCount
+			);
 		}
 
 		final void clearPendingImportUpdate()
@@ -778,6 +812,8 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			{
 				if(entry.typeId() == type.typeId)
 				{
+					// counted for the once-per-import conflict report
+					this.importConflictCount++;
 					this.resetExistingEntityForUpdate(entry);
 					return entry;
 				}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageFileManager.java
@@ -30,7 +30,6 @@ import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.EqHashTable;
 import org.eclipse.serializer.collections.XSort;
 import org.eclipse.serializer.collections.types.XGettingSequence;
-import org.eclipse.serializer.exceptions.MultiCauseException;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.time.XTime;
 import org.eclipse.serializer.typing.Disposable;
@@ -278,6 +277,12 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		// completion barrier can make the sealed store durable on every channel (eager rollover
 		// durability - prevents a baseline collapse onto a not-yet-all-durable store).
 		private boolean rolloverOccurred;
+		// set by commitImport, cleared by confirmImport (problem-free import completion) or reset().
+		// While set, rollover/dissolution/deletion are deferred: a sibling may never have logged the
+		// import commit, and the restart's consensus rollback then needs the commit in the head file
+		// and every transferred byte's source alive. The durability gates cannot cover this - a store
+		// a sibling never wrote does not hold the all-durable watermark down.
+		private boolean unconfirmedImportCommit;
 		private final EqHashTable<Long, Long> durabilityDeferredDeletes = EqHashTable.New();
 		
 		
@@ -1047,6 +1052,15 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 		 */
 		final void createNextStorageFile()
 		{
+			// An unconfirmed import commit must stay in the head file: the head-file-only consensus
+			// recovery cannot roll it back out of a sealed file. Skipping is safe for every caller
+			// reachable here: size rollovers merely overshoot, the 2^31 pre-rollover falls through
+			// to its loud size check, prepareImport guards explicitly.
+			if(this.unconfirmedImportCommit)
+			{
+				return;
+			}
+
 			// Durability floor: the outgoing head is now complete and will not be appended again.
 			// Forcing it here means a power loss can strand at most the current head's tail, never a
 			// sealed (long-committed) file. Also covers a head that received transferred bytes and
@@ -2282,6 +2296,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			this.storageFlushRequested          = false;
 			this.unconditionalCompactionPending = false;
 			this.rolloverOccurred               = false;
+			this.unconfirmedImportCommit        = false;
 			this.durabilityDeferredDeletes.clear();
 		}
 		
@@ -2625,6 +2640,15 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				return true;
 			}
 
+			// An unconfirmed import commit defers all file cleanup: a FILE_DELETION logged now could
+			// destroy the last copy of bytes a torn import's consensus rollback must cut, making the
+			// storage unstartable. Reported as incomplete so the work is revisited; on a failed
+			// import the flag holds until the restart reconciles.
+			if(this.unconfirmedImportCommit)
+			{
+				return false;
+			}
+
 
 			StorageLiveDataFile.Default cycleAnchorFile = this.fileCleanupCursor;
 
@@ -2834,6 +2858,16 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 		final void prepareImport()
 		{
+			// A previous import commit is unconfirmed: its rollback protection is still active and
+			// the rollover below would be skipped. Unreachable past the disruption an unconfirmed
+			// commit comes with; guarded loudly anyway.
+			if(this.unconfirmedImportCommit)
+			{
+				throw new StorageException(
+					this.channelIndex() + " cannot prepare an import: a previous import commit is unconfirmed"
+				);
+			}
+
 			this.importHelper = new ImportHelper(this.headFile);
 			try
 			{
@@ -2857,6 +2891,10 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 
 		public void commitImport(final long taskTimestamp)
 		{
+			// From here until confirmImport, a restart may have to roll this commit back (a sibling
+			// channel's commit can still fail), so file lifecycle events are deferred (see the field).
+			// Set before any fallible work, so a throw anywhere in this method leaves it set.
+			this.unconfirmedImportCommit = true;
 
 			// caching variables
 			final StorageEntityCache.Default  entityCache = this.entityCache;
@@ -2919,6 +2957,9 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				taskTimestamp          ,
 				loopFileLength + metaLength
 			);
+
+			// reported only now, as only a durable import actually replaced anything
+			entityCache.reportImportConflicts();
 
 			/*
 			 * GC marking pass, deliberately AFTER the import became fully durable (transactions
@@ -3052,6 +3093,16 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 			this.importHelper = null;
 		}
 
+		/**
+		 * Lifts the {@link #unconfirmedImportCommit} deferral: the import task completed
+		 * problem-free, so every channel logged the import commit. Channel-thread only, like all
+		 * gate state.
+		 */
+		final void confirmImport()
+		{
+			this.unconfirmedImportCommit = false;
+		}
+
 		final void importBatch(final StorageImportSource source, final long position, final long length)
 		{
 			// ignore dummy batches (e.g. transfer file continuation head dummy) and no-op batches in general
@@ -3086,37 +3137,43 @@ public interface StorageFileManager extends StorageChannelResetablePart, Disposa
 				return;
 			}
 
-			final StorageLiveDataFile.Default first  = this.headFile.next;
-			StorageLiveDataFile.Default       doomed = this.importHelper.preImportHeadFile.next;
-			this.headFile.next = null;
-			(first.prev = this.headFile = this.importHelper.preImportHeadFile).next = first;
-
-			final BulkList<RuntimeException> exceptions = BulkList.New();
-			while(doomed != null)
+			/*
+			 * The import file is kept AS the head file and merely cut back to the length its own
+			 * file creation entry records. Deleting it instead is not representable: a deletion
+			 * entry only exists for files already closed by a successor's creation entry, so the
+			 * next store (which carries no file number) would be attributed to a missing file and
+			 * the following start fails validation. #totalLength is still the creation length here
+			 * (only #commitImport raises it), so truncating to it makes log and file agree again.
+			 */
+			try
 			{
-				try
-				{
-					this.terminateFile(doomed);
-				}
-				catch(final RuntimeException e)
-				{
-					exceptions.add(e);
-				}
-				doomed = doomed.next;
-			}
-			this.cleanupImportHelper();
+				final StorageLiveDataFile.Default importFile = this.headFile;
 
-			if(!exceptions.isEmpty())
-			{
-				throw new StorageException(new MultiCauseException(exceptions.toArray(RuntimeException.class)));
+				// an import always lands in a single file (see #importBatch): exactly one file to
+				// undo, guarded because truncating the wrong file would corrupt
+				if(this.importHelper.preImportHeadFile.next != importFile)
+				{
+					throw new StorageException(
+						this.channelIndex() + " cannot roll back an import spanning more than one storage file"
+					);
+				}
+
+				// a partially executed commitImport raises totalLength above the creation length this
+				// truncation relies on; no reachable path rolls back in that state, but truncating to
+				// a raised length would silently retain unlogged bytes - guarded, not relied upon
+				if(importFile.dataLength() != 0L)
+				{
+					throw new StorageException(
+						this.channelIndex() + " cannot roll back an import whose commit already registered entities"
+					);
+				}
+
+				this.writer.truncate(importFile, importFile.totalLength(), this.fileProvider);
 			}
-		}
-		
-		private void terminateFile(final StorageLiveDataFile.Default file)
-		{
-			// (12.08.2020 TM)FIXME: priv#351: where and how to check whether files may be deleted? Here? Weird!
-			file.close();
-			this.writer.delete(file, this.writeController, this.fileProvider);
+			finally
+			{
+				this.cleanupImportHelper();
+			}
 		}
 
 		final class ImportHelper implements Consumer<StorageChannelImportBatch>

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskExportEntitiesByType.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskExportEntitiesByType.java
@@ -25,6 +25,7 @@ import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.EqHashTable;
 import org.eclipse.serializer.collections.XUtilsCollection;
 import org.eclipse.serializer.typing.KeyValue;
+import org.eclipse.store.storage.exceptions.StorageException;
 import org.eclipse.store.storage.exceptions.StorageExceptionExportFailed;
 
 
@@ -38,6 +39,19 @@ public interface StorageRequestTaskExportEntitiesByType extends StorageRequestTa
 	extends StorageChannelSynchronizingTask.AbstractCompletingTask<StorageEntityTypeExportStatistics.ChannelStatistic>
 	implements StorageRequestTaskExportEntitiesByType
 	{
+		///////////////////////////////////////////////////////////////////////////
+		// constants //
+		//////////////
+
+		/*
+		 * The handoff notification can never arrive at all (a channel that fails does not increment the
+		 * item's progress), so a waiting channel must wake up periodically to notice that instead of
+		 * parking forever. Mirrors the wait time of the other cross-channel waits.
+		 */
+		private static final int HANDOFF_WAIT_TIME_MS = 100;
+
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
@@ -125,6 +139,25 @@ public interface StorageRequestTaskExportEntitiesByType extends StorageRequestTa
 			return this.exportTypes;
 		}
 
+		/**
+		 * A failing channel never reaches {@link ExportItem#incrementProgress()}, the only handoff
+		 * notification, so every higher-indexed channel would wait forever - never returning to its
+		 * work loop, stalling every subsequent synchronizing task including the shutdown. A task
+		 * problem or a storage disruption both mean this export cannot complete: abort the wait.
+		 */
+		private void checkExportHandoffAbort()
+		{
+			if(this.hasProblems())
+			{
+				throw new StorageException("Aborting export, another channel failed");
+			}
+
+			if(this.controller.hasDisruptions())
+			{
+				throw new StorageException("Aborting export after a storage disruption", this.controller.disruptions().first());
+			}
+		}
+
 		@Override
 		protected final StorageEntityTypeExportStatistics.ChannelStatistic internalProcessBy(final StorageChannel channel)
 		{
@@ -139,7 +172,8 @@ public interface StorageRequestTaskExportEntitiesByType extends StorageRequestTa
 					{
 						while(!exportItem.isCurrentChannel(channel))
 						{
-							exportItem.wait();
+							this.checkExportHandoffAbort();
+							exportItem.wait(HANDOFF_WAIT_TIME_MS);
 						}
 					}
 
@@ -281,21 +315,31 @@ public interface StorageRequestTaskExportEntitiesByType extends StorageRequestTa
 
 		final synchronized void cleanUp()
 		{
-			if(!this.file.isOpen())
+			try
 			{
-				return;
+				if(this.file.isOpen())
+				{
+					// only an empty file is removed; a partially written one is kept on purpose -
+					// see the contract of StorageConnection#exportTypes
+					if(this.file.isEmpty())
+					{
+						this.file.delete();
+					}
+					else
+					{
+						this.file.close();
+					}
+				}
 			}
-			
-			if(this.file.isEmpty())
+			finally
 			{
-				this.file.delete();
+				/*
+				 * Must run even for a never-opened file (types without entities on any channel) or
+				 * when delete/close threw: release(), not close(), deregisters the write lease from
+				 * provideExportFile. Idempotent - this runs again in the task's cleanUp.
+				 */
+				this.file.release();
 			}
-			else
-			{
-				this.file.close();
-			}
-			
-			this.file.release();
 		}
 
 	}

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
@@ -163,8 +163,9 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 		/**
 		 * The reader thread can fail, never start at all (a channel failing before registering its
 		 * entity cache leaves it unstarted, see {@link #ensureReaderThread()}), or a storage-wide
-		 * disruption can make waiting pointless. None of these set {@link #complete}, so a waiting
-		 * channel must observe them explicitly or it freezes the whole storage, shutdown included.
+		 * disruption can make waiting pointless. Only a failed reader sets {@link #complete} (its
+		 * finally); an unstarted reader or a disruption never does, so a waiting channel must
+		 * observe those explicitly or it freezes the whole storage, shutdown included.
 		 *
 		 * @return the cause to register as the waiting channel's problem, or {@code null}. Sibling
 		 *         problems are not reported here: those already route every channel into fail().

--- a/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
+++ b/storage/storage/src/main/java/org/eclipse/store/storage/types/StorageRequestTaskImportData.java
@@ -59,6 +59,10 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 		private final    AtomicBoolean complete  = new AtomicBoolean();
 		private volatile long          maxObjectId;
 		private          Thread        readThread ;
+		private volatile Throwable     readProblem;
+		// whether any channel entered the import commit phase; a channel taking fail() after that
+		// is a succeed/fail split the succeed() catch cannot see - it must disrupt (see fail()).
+		private volatile boolean       commitStarted;
 		Abstract(
 			final long                          timestamp             ,
 			final int                           channelCount          ,
@@ -122,24 +126,65 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 
 		final void readSources()
 		{
-			final ItemReader itemReader = new ItemReader(this.entityCaches, this.sourceHeads);
-
-			for(final S source : this.sources)
+			try
 			{
-				try
+				final ItemReader itemReader = new ItemReader(this.entityCaches, this.sourceHeads);
+
+				for(final S source : this.sources)
 				{
-					itemReader.setSource(source);
-					this.iterateSource(source, itemReader);
-					itemReader.completeCurrentSource();
-				}
-				catch(final Exception e)
-				{
-					throw new StorageExceptionImportFailed("Exception while reading import source " + source, e);
+					try
+					{
+						itemReader.setSource(source);
+						this.iterateSource(source, itemReader);
+						itemReader.completeCurrentSource();
+					}
+					catch(final Exception e)
+					{
+						throw new StorageExceptionImportFailed("Exception while reading import source " + source, e);
+					}
 				}
 			}
-			this.complete.set(true);
+			catch(final Throwable t)
+			{
+				// this thread has no uncaught exception handler, a failure escaping here would be
+				// swallowed; hand it to the channels, which must roll back instead of committing
+				// the batches published before the read failed
+				this.readProblem = t;
+			}
+			finally
+			{
+				// the only signal that no further source will arrive - left unset, every channel
+				// parks forever in #internalProcessBy. Written after #readProblem, so observing
+				// completion also observes the cause.
+				this.complete.set(true);
+			}
 		}
-		
+
+		/**
+		 * The reader thread can fail, never start at all (a channel failing before registering its
+		 * entity cache leaves it unstarted, see {@link #ensureReaderThread()}), or a storage-wide
+		 * disruption can make waiting pointless. None of these set {@link #complete}, so a waiting
+		 * channel must observe them explicitly or it freezes the whole storage, shutdown included.
+		 *
+		 * @return the cause to register as the waiting channel's problem, or {@code null}. Sibling
+		 *         problems are not reported here: those already route every channel into fail().
+		 */
+		private Throwable importAbortCause()
+		{
+			final Throwable readProblem = this.readProblem;
+			if(readProblem != null)
+			{
+				return readProblem;
+			}
+
+			if(this.controller.hasDisruptions())
+			{
+				return this.controller.disruptions().first();
+			}
+
+			return null;
+		}
+
 		protected abstract void iterateSource(S source, ItemAcceptor itemAcceptor);
 
 		@FunctionalInterface
@@ -352,6 +397,14 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 								// there will be no more next source, so abort (task is complete)
 								break importLoop;
 							}
+
+							// no source can arrive any more (see #importAbortCause, or a sibling
+							// already failed the task); the cause is registered after the loop
+							if(this.hasProblems() || this.importAbortCause() != null)
+							{
+								break importLoop;
+							}
+
 							// better check again after some time, indefinite wait caused a deadlock once
 							// (16.04.2016)TODO: isn't the above comment a bug? Test and change or comment better.
 							currentSource.wait(SOURCE_WAIT_TIME_MS);
@@ -376,34 +429,132 @@ public interface StorageRequestTaskImportData<S> extends StorageRequestTask
 				throw new StorageException(e);
 			}
 
+			/*
+			 * Registering the cause is what routes every channel into fail() (rollback). Merely
+			 * leaving the loop would let succeed() commit the batches published before the abort -
+			 * a partial import, silently reported as successful.
+			 */
+			final Throwable abortCause = this.importAbortCause();
+			if(abortCause != null)
+			{
+				this.addProblem(channel.channelIndex(), abortCause);
+			}
+
 			return null;
 		}
 
 		@Override
 		protected final void succeed(final StorageChannel channel, final Void result)
 		{
-			// evaluate (validate or update if possible) objectId before committing the import
-			this.objectIdRangeEvaluator.evaluateObjectIdRange(0, this.maxObjectId);
-
-			/* on success, signal the channel to commit the imported data (register entities in cache)
-			 * All channels use the same timestamp (this task's issuing timestamp) for consistency checks
+			/*
+			 * An aborted waitOnProcessing (async disruption) reaches succeed() WITHOUT the processing
+			 * barrier. Committing into a storage that is going down would only create a torn commit
+			 * for the restart to undo - abort; the throw registers as this channel's problem.
 			 */
-			channel.commitImportData(this.timestamp());
+			if(this.controller.hasDisruptions())
+			{
+				throw new StorageException(
+					"Aborting import commit: the storage is disrupted", this.controller.disruptions().first()
+				);
+			}
+
+			try
+			{
+				// evaluate (validate or update if possible) objectId before committing the import
+				this.objectIdRangeEvaluator.evaluateObjectIdRange(0, this.maxObjectId);
+
+				// from here on a fail() on any channel is a succeed/fail split, see fail()
+				this.commitStarted = true;
+
+				/* on success, signal the channel to commit the imported data (register entities in cache)
+				 * All channels use the same timestamp (this task's issuing timestamp) for consistency checks
+				 */
+				channel.commitImportData(this.timestamp());
+			}
+			catch(final Throwable t)
+			{
+				/*
+				 * A commit-phase throw can leave siblings committed but not this channel - a torn
+				 * import. Escalate so processing stops: further stores or housekeeping could make
+				 * the torn state permanent (consensus advanced past it, rollback files dissolved).
+				 * The restart's consensus then undoes it; the rethrow fails the task as before.
+				 */
+				this.controller.registerDisruption(t);
+				this.controller.setChannelProcessingEnabled(false);
+
+				// close the sources as fail() would - with the last-completing channel failing
+				// here, no sibling takes the fail() path. Safe: the disruption check above filtered
+				// the barrier-less path, so every channel passed the processing barrier.
+				try
+				{
+					this.cleanUpResources();
+				}
+				catch(final Throwable suppressed)
+				{
+					t.addSuppressed(suppressed);
+				}
+
+				throw t;
+			}
 		}
 
 		@Override
 		protected void postCompletionSuccess(final StorageChannel channel, final Void result)
 			throws InterruptedException
 		{
+			/*
+			 * hasProblems() was false when THIS channel completed, but a sibling can still fail in
+			 * its own succeed(). Problems are registered before the completion counter increments,
+			 * so the problem state is final once the task is complete - wait for that before lifting
+			 * the deferral, or a store queued behind the import could roll the head over and seal a
+			 * torn commit out of the head-file-only recovery.
+			 */
+			try
+			{
+				this.waitOnCompletion();
+			}
+			catch(final StorageException e)
+			{
+				// a sibling failed after this channel completed: the deferral must hold until the
+				// restart undoes the commit; the sibling disrupted the storage, closing the sources
+				return;
+			}
+
+			// every channel committed: lift this channel's torn-import deferral of file lifecycle events
+			channel.confirmImportData();
 			this.cleanUpResources();
 		}
 
 		@Override
 		protected final void fail(final StorageChannel channel, final Void result)
 		{
-			// on failure/abort, signal channel to rollback (delete newly created files and revert to last head file)
-			this.cleanUpResources();
-			channel.rollbackImportData(this.problemForChannel(channel));
+			/*
+			 * fail() after a sibling entered the commit phase is a succeed/fail split the succeed()
+			 * catch cannot see (e.g. a problem surfacing only in the completion phase). The lone
+			 * commit must not be buried by later stores advancing the restart consensus past it -
+			 * stop the storage; the next start undoes it.
+			 */
+			if(this.commitStarted)
+			{
+				final Throwable problem = this.problemForChannel(channel);
+				this.controller.registerDisruption(
+					problem != null
+						? problem
+						: new StorageException("Import failed after a channel already began its commit")
+				);
+				this.controller.setChannelProcessingEnabled(false);
+			}
+
+			try
+			{
+				this.cleanUpResources();
+			}
+			finally
+			{
+				// must run even when a source close throws; skipping the rollback leaves unlogged
+				// import bytes in the head file
+				channel.rollbackImportData(this.problemForChannel(channel));
+			}
 		}
 
 		@Override


### PR DESCRIPTION
Failures during binary import/export could freeze the whole storage, leave
it half-imported, or break the next start. This PR makes every failure path
end in one of two states: a clean rollback with the storage operational, or
a loud stop that the next start reconciles automatically.

### Import
- A failure while reading import sources no longer parks every channel
  forever; the import fails fast, rolls back, and the storage stays usable.
- A rollback truncates the import file and keeps it as head instead of
  deleting it, so a store after a failed import no longer breaks the next
  start.
- A failure while committing escalates to a storage disruption, and each
  channel defers rollover, dissolution and file deletion until every channel
  confirmed its commit: a torn import can neither become permanent nor
  destroy the state the restart's cross-channel consensus needs to undo it.
  **Behavior change:** the storage stops in this case instead of continuing
  in a diverged state; a restart heals it completely.
- Replacing existing entities is reported with one warning per channel, and
  the contract documents that already loaded instances keep their in-memory
  state until reloaded from the root.

### Export
- A failing channel aborts the per-type file handoff instead of parking all
  higher-indexed channels forever.
- Export file leases are always released, including for types without
  entities and when a delete or close throws.
- The contract documents that a failed export leaves an incomplete, unmarked
  target directory.

### Tests
`TornImportConsensusTest` (torn import undone by the restart consensus,
either channel behind) and `TornImportCommitFailureEscalationTest` (injected
commit failure → disruption → clean undo on restart) added to the
integration-test recovery suite. Full integration suite green.