### PR TITLE
GigaMap: fix set() into a slot that removeById emptied - size drift and ClassCastException

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
@@ -635,7 +635,27 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 		@Override
 		public void changeInIndex(final long entityId, final ChangeHandler prevEntityHandler)
 		{
-			this.index.internalHandleChanged(((BinaryChangeHandler<?>)prevEntityHandler).keys, entityId, this.keys);
+			if(!(prevEntityHandler instanceof final BinaryChangeHandler<?> prevHandler))
+			{
+				/*
+				 * There is no previous state to read keys from: #getChangeHandler yields the
+				 * NullChangeChandler for a null previous entity, which is what GigaMap#set is handed when it
+				 * fills a slot that #removeById emptied (restoring an entity at its own id). Every other
+				 * ChangeHandler implementation copes with a foreign previous handler by routing the
+				 * de-indexing through #removeFromIndex instead of reading keys off it, so this does the same:
+				 * de-index whatever the previous handler stands for (nothing, for the null handler), then
+				 * treat the new keys as a plain addition. Formerly the cast below was unguarded and threw a
+				 * ClassCastException here.
+				 */
+				prevEntityHandler.removeFromIndex(entityId);
+
+				// no previous keys means no dispensable entries, so every 1 bit of the new keys is added.
+				this.index.internalHandleChanged(0L, entityId, this.keys);
+
+				return;
+			}
+
+			this.index.internalHandleChanged(prevHandler.keys, entityId, this.keys);
 		}
 		
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -553,6 +553,14 @@ implements BitmapIndex.TopLevel<E, KS>
 		subResultAnds.add(new BitmapResult.ChainOr(subResults.toArray(BitmapResult.class)));
 	}
 
+	/**
+	 * Applies a key change for one entity to all sub indices.
+	 *
+	 * @param oldKeys the keys the entity was indexed under, or {@code null} if it had no previous state in
+	 *        this index at all (e.g. a slot that a removal emptied), which makes every new key an addition
+	 * @param entityId the id of the entity whose keys changed
+	 * @param newKeys the keys the entity must be indexed under from now on
+	 */
 	final void internalHandleChanged(final KS oldKeys, final long entityId, final KS newKeys)
 	{
 		// Ensure sub-indices array is large enough for newKeys
@@ -564,8 +572,9 @@ implements BitmapIndex.TopLevel<E, KS>
 			// Check if old/new keys are empty at this sub-index position
 			// This guard is critical: when oldKeys is shorter than subIndices (e.g. NULL() = Object[1]
 			// vs decomposed Instant = Object[6]), positions beyond oldKeys.length must be treated as
-			// "new additions" not "changes" to avoid ArrayIndexOutOfBoundsException.
-			final boolean oldEmpty = this.isEmpty(oldKeys, i);
+			// "new additions" not "changes" to avoid ArrayIndexOutOfBoundsException. Absent oldKeys are
+			// the same case for every position: #isEmpty reads the keys, so it may not be passed null.
+			final boolean oldEmpty = oldKeys == null || this.isEmpty(oldKeys, i);
 			final boolean newEmpty = this.isEmpty(newKeys, i);
 
 			if(oldEmpty && newEmpty)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositeChangeToken.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/CompositeChangeToken.java
@@ -63,6 +63,24 @@ public final class CompositeChangeToken<E, KS, K> implements ChangeHandler
 	@Override
 	public void changeInIndex(final long entityId, final ChangeHandler prevEntityHandler)
 	{
+		if(!(prevEntityHandler instanceof CompositeChangeToken))
+		{
+			/*
+			 * There is no previous state to read keys from: AbstractCompositeBitmapIndex#getChangeHandler
+			 * yields the NullChangeChandler for a null previous entity, which is what GigaMap#set is handed
+			 * when it fills a slot that #removeById emptied (restoring an entity at its own id). Every other
+			 * ChangeHandler implementation copes with a foreign previous handler by routing the de-indexing
+			 * through #removeFromIndex instead of reading keys off it, so this does the same: de-index
+			 * whatever the previous handler stands for (nothing, for the null handler), then let the index
+			 * add the new keys, which is what it does for absent old keys. Formerly the cast below was
+			 * unguarded and threw a ClassCastException here.
+			 */
+			prevEntityHandler.removeFromIndex(entityId);
+			this.index.internalHandleChanged(null, entityId, this.keys);
+
+			return;
+		}
+
 		this.index.internalHandleChanged(((CompositeChangeToken<?, KS, K>)prevEntityHandler).keys, entityId, this.keys);
 	}
 	

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2130,6 +2130,18 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			// only change state if there is an actual change in the entity data.
 			if(!this.equalator.equal(replacedEntity, entity))
 			{
+				if(replacedEntity == null)
+				{
+					/*
+					 * The slot is empty, so this id was removed: #removeById decremented the size and this
+					 * fills the slot again, which has to restore it. Without this the size stays one too low
+					 * for the rest of the map's life - and it is persisted state, so the drift survives a
+					 * restart. Every valid id below nextFreeId was handed out by #add, so an empty slot can
+					 * only mean a removal.
+					 */
+					this.baseSize++;
+				}
+
 				this.constraints.check(entityId, replacedEntity, entity);
 
 				/*

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2130,18 +2130,6 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			// only change state if there is an actual change in the entity data.
 			if(!this.equalator.equal(replacedEntity, entity))
 			{
-				if(replacedEntity == null)
-				{
-					/*
-					 * The slot is empty, so this id was removed: #removeById decremented the size and this
-					 * fills the slot again, which has to restore it. Without this the size stays one too low
-					 * for the rest of the map's life - and it is persisted state, so the drift survives a
-					 * restart. Every valid id below nextFreeId was handed out by #add, so an empty slot can
-					 * only mean a removal.
-					 */
-					this.baseSize++;
-				}
-
 				this.constraints.check(entityId, replacedEntity, entity);
 
 				/*
@@ -2151,6 +2139,23 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				 * whose keys the indices do not reflect.
 				 */
 				this.indices.internalUpdateIndices(entityId, replacedEntity, entity, this.constraints.custom());
+
+				if(replacedEntity == null)
+				{
+					/*
+					 * The slot is empty, so this id was removed: #removeById decremented the size and this
+					 * fills the slot again, which has to restore it. Without this the size stays one too low
+					 * for the rest of the map's life - and it is persisted state, so the drift survives a
+					 * restart. Every valid id below nextFreeId was handed out by #add, so an empty slot can
+					 * only mean a removal.
+					 *
+					 * Counted here rather than earlier, with the rest of the state changes and after everything
+					 * that can throw: the checks above and the index update are ordered so a throw leaves the
+					 * map observably unchanged, and a size that had already been incremented would break
+					 * exactly that.
+					 */
+					this.baseSize++;
+				}
 
 				level1.entities[level1Index] = entity;
 				level3.markChanged(level3Index);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -305,21 +305,31 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	public void unmarkReadOnly();
 	
 	/**
-	 * Replaces an entity if present in this collection, updates the indices accordingly,
-	 * and returns the old entity mapped to the specified id.
+	 * Writes the specified entity to the specified id, updates the indices accordingly, and returns the
+	 * entity that was mapped to that id before.
+	 * <p>
+	 * If the id currently holds an entity, that entity is replaced and returned. If the id is one whose
+	 * entity {@link #removeById(long)} has removed, its now empty slot is filled: the entity is restored
+	 * at its original id, becomes queryable under it, the size is incremented again, and {@code null} is
+	 * returned because nothing was replaced. Since the map offers no {@code add(long, Object)}, this is
+	 * the only id-addressed write and therefore the way to undo a removal at the id it was removed from.
+	 * <p>
+	 * Ids that this map never handed out are rejected: the id must be non-negative and must not exceed
+	 * {@link #highestUsedId()}.
 	 * <p>
 	 * <b>Behavior on failure:</b> constraints are checked and the bitmap indices are updated
 	 * <em>before</em> the entity is replaced in the map's storage. If a constraint is violated or
 	 * an {@link Indexer} throws an exception while deriving the new entity's keys, the map is left
-	 * unchanged: the old entity stays in place and remains indexed. (On maps with additional,
-	 * non-bitmap index groups such as Lucene or vector indices, a failure in a group that is
-	 * processed after another group already updated can leave the groups diverged; such states are
-	 * repaired by {@link #reindex()}.)
+	 * unchanged: the old entity stays in place and remains indexed, and an empty slot stays empty and
+	 * uncounted. (On maps with additional, non-bitmap index groups such as Lucene or vector indices, a
+	 * failure in a group that is processed after another group already updated can leave the groups
+	 * diverged; such states are repaired by {@link #reindex()}.)
 	 *
-	 * @param entityId the entity id to replace
+	 * @param entityId the entity id to write to
 	 * @param entity the new entity
-	 * @return the old entity
-	 * @throws IllegalArgumentException if the entityId is not found
+	 * @return the entity previously mapped to the id, or {@code null} if its slot was empty
+	 * @throws IllegalArgumentException if the entityId was never handed out by this map, i.e. it is
+	 *         negative or greater than {@link #highestUsedId()}
 	 */
 	public E set(long entityId, E entity);
 	

--- a/integration-tests/src/test/java/test/eclipse/store/storer/SetAfterRemoveSizeTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/storer/SetAfterRemoveSizeTest.java
@@ -20,8 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.ToLongFunction;
 
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.BinaryIndexerUUID;
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.Indexer;
+import org.eclipse.store.gigamap.types.IndexerInstant;
 import org.eclipse.store.gigamap.types.IndexerString;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -43,11 +50,27 @@ public class SetAfterRemoveSizeTest
 {
 	static class Item
 	{
-		String name;
+		String  name     ;
+		long    code     ;
+		UUID    uuid     ;
+		Instant timestamp;
 
 		Item(final String name)
 		{
-			this.name = name;
+			this(name, 0L, new UUID(0L, 0L), Instant.EPOCH);
+		}
+
+		Item(
+			final String  name     ,
+			final long    code     ,
+			final UUID    uuid     ,
+			final Instant timestamp
+		)
+		{
+			this.name      = name     ;
+			this.code      = code     ;
+			this.uuid      = uuid     ;
+			this.timestamp = timestamp;
 		}
 	}
 
@@ -61,6 +84,49 @@ public class SetAfterRemoveSizeTest
 	}
 
 	private static final NameIndexer NAME = new NameIndexer();
+
+	/** Plain binary index: one bitmap entry per bit position of the indexed long. */
+	private static final BinaryIndexerLong<Item> CODE = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Item entity)
+		{
+			return entity.code;
+		}
+	};
+
+	/** Composite binary index: a UUID does not fit into one long, so it is split across sub indices. */
+	private static final BinaryIndexerUUID<Item> UUID_CODE = new BinaryIndexerUUID.Abstract<>()
+	{
+		@Override
+		protected UUID getUUID(final Item entity)
+		{
+			return entity.uuid;
+		}
+	};
+
+	/** Composite hashing index: an Instant is decomposed into year, month, day, ... sub indices. */
+	private static final IndexerInstant<Item> TIMESTAMP = new IndexerInstant.Abstract<>()
+	{
+		@Override
+		protected Instant getInstant(final Item entity)
+		{
+			return entity.timestamp;
+		}
+	};
+
+	private static final UUID    UUID_A      = new UUID(1L, 1L);
+	private static final Instant TIMESTAMP_A = Instant.parse("2026-01-01T10:15:30Z");
+
+	private static Item itemA()
+	{
+		return new Item("a", 1L, UUID_A, TIMESTAMP_A);
+	}
+
+	private static Item itemB()
+	{
+		return new Item("b", 2L, new UUID(2L, 2L), Instant.parse("2026-02-02T20:25:35Z"));
+	}
 
 	@Test
 	public void settingAnEntityBackIntoARemovedSlotRestoresTheSize(@TempDir final Path dir)
@@ -145,6 +211,75 @@ public class SetAfterRemoveSizeTest
 			}
 			return entity.name;
 		}
+	}
+
+	/**
+	 * The same restore on a map with a <em>binary</em> index. Its change handler read the previous entity's
+	 * keys straight off the handler it was handed, casting it without a check - and the handler for an empty
+	 * slot is the no-op one every other implementation tolerates, so the restore threw a
+	 * {@code ClassCastException} instead of indexing the entity.
+	 */
+	@Test
+	public void settingAnEntityBackIntoARemovedSlotWorksWithABinaryIndex(@TempDir final Path dir)
+	{
+		this.assertRestoreIntoEmptiedSlot(dir, CODE, map -> map.query(CODE.is(1L)).count());
+	}
+
+	/** Composite binary index (a UUID spread over sub indices): same unguarded cast, same throw. */
+	@Test
+	public void settingAnEntityBackIntoARemovedSlotWorksWithACompositeBinaryIndex(@TempDir final Path dir)
+	{
+		this.assertRestoreIntoEmptiedSlot(dir, UUID_CODE, map -> map.query(UUID_CODE.is(UUID_A)).count());
+	}
+
+	/** Composite hashing index (an Instant decomposed into date/time parts): likewise. */
+	@Test
+	public void settingAnEntityBackIntoARemovedSlotWorksWithACompositeHashingIndex(@TempDir final Path dir)
+	{
+		this.assertRestoreIntoEmptiedSlot(dir, TIMESTAMP, map -> map.query(TIMESTAMP.is(TIMESTAMP_A)).count());
+	}
+
+	/**
+	 * Removes the entity at one id and puts an equal one back at that same id, then checks that the map is
+	 * coherent about it: counted, reachable by id, findable through the index - before and after a restart.
+	 *
+	 * @param dir the storage directory for this test
+	 * @param indexer the single index the map is built with
+	 * @param restoredCount counts the entities the index reports for the restored entity's key
+	 */
+	private void assertRestoreIntoEmptiedSlot(
+		final Path                          dir          ,
+		final Indexer<? super Item, ?>      indexer      ,
+		final ToLongFunction<GigaMap<Item>> restoredCount
+	)
+	{
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		final GigaMap<Item> map = storage.ensureRoot(
+			() -> GigaMap.<Item>Builder().withBitmapIndex(indexer).build());
+
+		final long a = map.add(itemA());
+		map.add(itemB());
+		map.store();
+		assertEquals(1L, restoredCount.applyAsLong(map), "the entity is indexed to start with");
+
+		map.removeById(a);
+		assertEquals(1L, map.size(), "the removal is accounted for");
+		assertEquals(0L, restoredCount.applyAsLong(map), "and de-indexed the entity");
+
+		map.set(a, itemA());
+		assertEquals(2L, map.size(), "filling the removed slot again must restore the size");
+		assertNotNull(map.get(a), "the entity is back at its own id");
+		assertEquals(1L, restoredCount.applyAsLong(map), "and is indexed under its key again");
+
+		map.store();
+		storage.shutdown();
+
+		final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
+		final GigaMap<Item> fromDisk = reopened.root();
+		assertEquals(2L, fromDisk.size(), "the size is persisted correctly, not one too low");
+		assertNotNull(fromDisk.get(a), "the restored entity survived");
+		assertEquals(1L, restoredCount.applyAsLong(fromDisk), "and is still indexed");
+		reopened.shutdown();
 	}
 
 	/** A plain replacement must not change the size - the slot was occupied, so nothing was restored. */

--- a/integration-tests/src/test/java/test/eclipse/store/storer/SetAfterRemoveSizeTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/storer/SetAfterRemoveSizeTest.java
@@ -1,0 +1,115 @@
+package test.eclipse.store.storer;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.file.Path;
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Putting an entity back at an id that was removed has to restore the size too.
+ *
+ * <p>{@link GigaMap#removeById(long)} decrements the size and empties the slot;
+ * {@link GigaMap#set(long, Object)} fills a slot again. Filling a slot that a removal emptied left the size
+ * one too low, permanently and persistently - the entity was present and queryable, so the map disagreed with
+ * itself about how much it held, and a restart preserved the disagreement.
+ *
+ * <p>This is the shape an undo log needs: restoring an entity a rolled-back operation removed is
+ * {@code set(id, snapshot)}, because it is the only id-addressed write.
+ */
+public class SetAfterRemoveSizeTest
+{
+	static class Item
+	{
+		String name;
+
+		Item(final String name)
+		{
+			this.name = name;
+		}
+	}
+
+	static class NameIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.name;
+		}
+	}
+
+	private static final NameIndexer NAME = new NameIndexer();
+
+	@Test
+	public void settingAnEntityBackIntoARemovedSlotRestoresTheSize(@TempDir final Path dir)
+	{
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		final GigaMap<Item> map = storage.ensureRoot(
+			() -> GigaMap.<Item>Builder().withBitmapIndex(NAME).build());
+
+		final long a = map.add(new Item("a"));
+		map.add(new Item("b"));
+		map.store();
+		assertEquals(2L, map.size(), "two entities to start with");
+
+		map.removeById(a);
+		assertEquals(1L, map.size(), "the removal is accounted for");
+		assertNull(map.get(a), "and the slot is empty");
+
+		map.set(a, new Item("a"));
+		assertEquals(2L, map.size(), "filling the removed slot again must restore the size");
+		assertNotNull(map.get(a), "the entity is back at its own id");
+		assertEquals(1L, map.query(NAME, "a").count(), "and is indexed");
+
+		map.store();
+		storage.shutdown();
+
+		final EmbeddedStorageManager reopened = EmbeddedStorage.start(dir);
+		final GigaMap<Item> fromDisk = reopened.root();
+		assertEquals(2L, fromDisk.size(), "the size is persisted correctly, not one too low");
+		assertNotNull(fromDisk.get(a), "the restored entity survived");
+		assertEquals(1L, fromDisk.query(NAME, "a").count(), "and is still indexed");
+		reopened.shutdown();
+	}
+
+	/** A plain replacement must not change the size - the slot was occupied, so nothing was restored. */
+	@Test
+	public void replacingAnOccupiedSlotLeavesTheSizeAlone(@TempDir final Path dir)
+	{
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		final GigaMap<Item> map = storage.ensureRoot(
+			() -> GigaMap.<Item>Builder().withBitmapIndex(NAME).build());
+
+		final long a = map.add(new Item("a"));
+		map.add(new Item("b"));
+		map.store();
+
+		map.set(a, new Item("a2"));
+		assertEquals(2L, map.size(), "a replacement is not an addition");
+		assertEquals(1L, map.query(NAME, "a2").count(), "the replacement is indexed");
+		assertEquals(0L, map.query(NAME, "a" ).count(), "the replaced key is gone");
+
+		storage.shutdown();
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/storer/SetAfterRemoveSizeTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/storer/SetAfterRemoveSizeTest.java
@@ -17,6 +17,7 @@ package test.eclipse.store.storer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 
@@ -91,6 +92,59 @@ public class SetAfterRemoveSizeTest
 		assertNotNull(fromDisk.get(a), "the restored entity survived");
 		assertEquals(1L, fromDisk.query(NAME, "a").count(), "and is still indexed");
 		reopened.shutdown();
+	}
+
+	/**
+	 * A failed restore must not count. {@code internalSet} orders its work so that a throw leaves the map
+	 * observably unchanged, and the size is part of that: incrementing it before the index update would leave
+	 * the count raised while the slot and the indices were untouched - trading a size that was too low for one
+	 * that is too high, on a path that already reports failure.
+	 *
+	 * <p>The failure comes from an indexer that throws while deriving the new entity's keys, which is the last
+	 * user code {@code internalSet} runs before it commits to the change.
+	 */
+	@Test
+	public void aRestoreThatThrowsDoesNotChangeTheSize(@TempDir final Path dir)
+	{
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		final GigaMap<Item> map = storage.ensureRoot(
+			() -> GigaMap.<Item>Builder().withBitmapIndex(new ThrowingNameIndexer()).build());
+
+		final long a = map.add(new Item("a"));
+		map.add(new Item("b"));
+		map.store();
+		assertEquals(2L, map.size(), "two entities to start with");
+
+		map.removeById(a);
+		assertEquals(1L, map.size(), "the removal is accounted for");
+
+		assertThrows(RuntimeException.class, () -> map.set(a, new Item(POISON)),
+			"the indexer refuses this entity");
+
+		assertEquals(1L, map.size(), "a failed restore must leave the size as it was");
+		assertNull(map.get(a), "and the slot still empty");
+
+		// The map is still usable, and a successful restore still counts.
+		map.set(a, new Item("a"));
+		assertEquals(2L, map.size(), "a subsequent successful restore counts");
+
+		storage.shutdown();
+	}
+
+	private static final String POISON = "poison";
+
+	/** Refuses one particular value, to make the index update throw at the point that matters. */
+	static class ThrowingNameIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if (POISON.equals(entity.name))
+			{
+				throw new IllegalStateException("indexer refuses " + POISON);
+			}
+			return entity.name;
+		}
 	}
 
 	/** A plain replacement must not change the size - the slot was occupied, so nothing was restored. */


### PR DESCRIPTION
## The bug

`removeById` decrements the size and empties the slot. `set(id, entity)` fills a slot again - and when that slot was one a removal had emptied, the size was never restored. It stayed **one too low for the rest of the map's life**, and because the size is persisted, so did the drift.

```java
final long a = map.add(new Item("a"));
map.add(new Item("b"));            // size 2
map.removeById(a);                 // size 1, slot empty
map.set(a, new Item("a"));         // slot filled, entity queryable... size still 1
```

The entity is present, `get(a)` returns it and the index query finds it - so the map disagrees with itself about how much it holds, and a restart preserves the disagreement.

## The second bug: the same call throws on a binary or composite index

On a map whose index is binary or composite, that `set` did not merely miscount, it never got that far:

```
ClassCastException: NullChangeChandler cannot be cast to AbstractBitmapIndexBinary$BinaryChangeHandler
ClassCastException: NullChangeChandler cannot be cast to CompositeChangeToken
```

`BinaryChangeHandler.changeInIndex` and `CompositeChangeToken.changeInIndex` read the previous entity's keys straight off the handler they are given, casting it unguarded. The handler for an empty slot is `NullChangeChandler.SINGLETON` - which is what `getChangeHandler(null)` returns, and what the library itself passes in elsewhere (`AbstractBitmapIndexHashing:263`, `ChangeHandler:111,130`). Every other `ChangeHandler` implementation tolerates a foreign previous handler by routing the de-indexing through `removeFromIndex` instead of reading keys off it, which is why the plain hashing index was the only one where the restore worked at all.

## The fix

**The size.** `internalSet` increments `baseSize` when the slot it is filling was empty. Every valid id below `nextFreeId` was handed out by `add`, so an empty slot below that boundary can only be the result of a removal - the condition is unambiguous. The increment sits with the rest of the state changes, after everything that can throw: the checks and the index update are ordered so that a throw leaves the map observably unchanged, and a size that had already been incremented would break exactly that.

A replacement into an *occupied* slot is unaffected, and a test pins that, so the fix cannot later drift into counting replacements as additions.

**The throw.** Both change handlers now guard the cast and do what every other implementation does: de-index through `prevEntityHandler.removeFromIndex(entityId)` (a no-op for the null handler), then add the new keys.

- Binary: `internalHandleChanged(0L, entityId, keys)` - no previous keys means no dispensable entries, so every 1 bit of the new keys is an addition.
- Composite: `internalHandleChanged(null, entityId, keys)`. `AbstractCompositeBitmapIndex.internalHandleChanged` accepts absent old keys and treats every position as an addition, which is what its per-position dispatch already does for a position whose old key is empty. Absent keys are passed as null rather than as an empty key array because `isEmpty(KS, int)` reads the keys array and therefore cannot be handed one.

## The contract

`set(long, E)` declared `@throws IllegalArgumentException if the entityId is not found`, which the implementation never threw - it rejects ids outside `[0; highestUsedId]`, which is a different thing. Before this PR that was the implementation contradicting its documentation; after it, it would have been the documentation contradicting intended behaviour. The Javadoc now describes the fill-empty-slot semantics (the entity is restored at its id, the size is incremented, `null` is returned since nothing was replaced) and states the id range that is actually rejected.

## How it turned up

While building an undo log for a transactional store on top of GigaMap. Restoring an entity that a rolled-back operation removed is necessarily `set(id, snapshot)` - it is the only id-addressed write, since there is no `add(id, entity)`. So on a map with a plain hashing index every rolled-back removal cost one from the size, permanently and persistently; on a map with a binary or composite index the rollback threw instead.

## Tests

`SetAfterRemoveSizeTest`, 6 tests:

- the restore on a hashing index: size, presence, index, and all three again after a reopen
- the same restore on a plain binary (`BinaryIndexerLong`), a composite binary (`BinaryIndexerUUID`) and a composite hashing (`IndexerInstant`) index, each including the reopen
- a restore that throws (an indexer refusing the new entity) leaves size and slot as they were, and a subsequent successful restore still counts
- the plain-replacement control: replacing an occupied slot is not an addition

Against the unfixed code the first fails with `expected: <2> but was: <1>` and the three index variants error with the `ClassCastException` above.

Full `gigamap` suite: 1121 tests, 0 failures, 0 errors, 1 skipped. No existing test depended on either behaviour.
