### PR TITLE
GigaMap Lucene: query(Query) on an empty map returns empty instead of throwing "numHits must be > 0"

### DIFF
--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -94,7 +94,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	 *
 	 * @param <A> the type of the {@code SearchResultAcceptor} that will process the search results
 	 * @param query the {@code Query} object representing the search criteria to be executed
-	 * @param maxResults the maximum number of search results that should be processed
+	 * @param maxResults the maximum number of search results that should be processed;
+	 *                   a non-positive value processes no results at all
 	 * @param searchResultAcceptor an instance of {@code SearchResultAcceptor} to handle each search result
 	 *                             returned by the query execution
 	 * @return the {@code SearchResultAcceptor} instance provided as a parameter, potentially modified
@@ -124,7 +125,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	 *
 	 * @param <A> the type of the {@code SearchResultAcceptor} that will process the search results
 	 * @param queryText the text representation of the query to be executed
-	 * @param maxResults the maximum number of search results that should be processed
+	 * @param maxResults the maximum number of search results that should be processed;
+	 *                   a non-positive value processes no results at all
 	 * @param searchResultAcceptor an instance of {@code SearchResultAcceptor} to handle each search result
 	 *                              returned by the query execution
 	 * @return the {@code SearchResultAcceptor} instance provided as a parameter, potentially modified
@@ -134,7 +136,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	
 	/**
 	 * Executes a query against the Lucene index and returns a list of entities
-	 * that match the provided search criteria.
+	 * that match the provided search criteria. Uses the current {@link GigaMap} size as the
+	 * default result limit, so an empty {@link GigaMap} yields an empty list.
 	 *
 	 * @param query the {@code Query} object representing the search criteria to be executed
 	 * @return a {@code List} of entities of type {@code E} that match the query
@@ -151,7 +154,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	 * that match the provided search criteria, with a limit on the maximum number of results.
 	 *
 	 * @param query the {@code Query} object representing the search criteria to be executed
-	 * @param maxResults the maximum number of search results to be returned
+	 * @param maxResults the maximum number of search results to be returned;
+	 *                   a non-positive value returns no results at all
 	 * @return a {@code List} of entities of type {@code E} that match the query
 	 */
 	public default List<E> query(final Query query, final int maxResults)
@@ -163,7 +167,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	
 	/**
 	 * Executes a query against the Lucene index using the specified query text
-	 * and returns a list of entities that match the query.
+	 * and returns a list of entities that match the query. Uses the current {@link GigaMap} size
+	 * as the default result limit, so an empty {@link GigaMap} yields an empty list.
 	 *
 	 * @param queryText the text representation of the query to be executed
 	 * @return a list of entities of type {@code E} that match the query
@@ -180,7 +185,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	 * a list of entities matching the query, with a limit on the maximum number of results.
 	 *
 	 * @param queryText the text representation of the query to be executed
-	 * @param maxResults the maximum number of search results to be returned
+	 * @param maxResults the maximum number of search results to be returned;
+	 *                   a non-positive value returns no results at all
 	 * @return a list of entities of type {@code E} that match the query
 	 */
 	public default List<E> query(final String queryText, final int maxResults)
@@ -198,7 +204,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	 * with other {@link GigaQuery} conditions via {@link GigaQuery#and(GigaMap.SubQuery)}.
 	 *
 	 * @param query the {@link Query} representing the search criteria
-	 * @param maxResults the maximum number of search results to be returned
+	 * @param maxResults the maximum number of search results to be returned;
+	 *                   a non-positive value returns no results at all
 	 * @return a {@link LuceneSearchResult} with the matching entries
 	 */
 	public LuceneSearchResult<E> search(Query query, int maxResults);
@@ -211,7 +218,8 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 	 * with other {@link GigaQuery} conditions via {@link GigaQuery#and(GigaMap.SubQuery)}.
 	 *
 	 * @param queryText the text representation of the query to be executed
-	 * @param maxResults the maximum number of search results to be returned
+	 * @param maxResults the maximum number of search results to be returned;
+	 *                   a non-positive value returns no results at all
 	 * @return a {@link LuceneSearchResult} with the matching entries
 	 */
 	public LuceneSearchResult<E> search(String queryText, int maxResults);
@@ -614,6 +622,15 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 			final A     searchResultAcceptor
 		)
 		{
+			// Lucene's IndexSearcher.search(query, numHits) rejects numHits <= 0. A non-positive limit
+			// simply means "no results wanted", which most notably happens for the default-maxResults
+			// overloads on an empty map (defaultMaxResults() derives from gigaMap.size()), so return the
+			// unmodified acceptor instead of throwing - just like the sibling overloads do.
+			if(maxResults <= 0)
+			{
+				return searchResultAcceptor;
+			}
+
 			try
 			{
 				synchronized(this.gigaMap)

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneEmptyMapQueryTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneEmptyMapQueryTest.java
@@ -1,0 +1,166 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that querying a {@link LuceneIndex} whose {@link GigaMap} is currently empty returns an
+ * empty result instead of throwing.
+ * <p>
+ * The convenience overloads without an explicit {@code maxResults} derive that limit from the map
+ * size, which is 0 for an empty map, while Lucene's {@code IndexSearcher.search(query, numHits)}
+ * rejects {@code numHits <= 0} with {@code IllegalArgumentException: numHits must be > 0}. All
+ * search entry points must therefore treat a non-positive limit as "no results wanted".
+ */
+public class LuceneEmptyMapQueryTest
+{
+	// ── shared entity ─────────────────────────────────────────────────────────
+
+	private static class Article
+	{
+		final String title;
+		final String content;
+
+		Article(final String title, final String content)
+		{
+			this.title   = title;
+			this.content = content;
+		}
+	}
+
+	private static class ArticlePopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			document.add(createTextField("title",     entity.title));
+			document.add(createStringField("exact",   entity.title));
+			document.add(createTextField("content",   entity.content));
+		}
+	}
+
+	private static LuceneContext<Article> standardContext()
+	{
+		return LuceneContext.New(DirectoryCreator.ByteBuffers(), new ArticlePopulator());
+	}
+
+
+	// ── freshly created, still empty map ──────────────────────────────────────
+
+	@Test
+	void queryOnEmptyMapReturnsEmpty()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(standardContext())))
+		{
+			final Query query = new TermQuery(new Term("exact", "nothing"));
+
+			assertTrue(idx.query("title:anything").isEmpty(),
+				"query(String) on an empty map must return empty");
+			assertTrue(idx.query(query).isEmpty(),
+				"query(Query) on an empty map must return empty, not throw \"numHits must be > 0\"");
+			assertTrue(idx.search("title:anything").isEmpty(),
+				"search(String) on an empty map must return empty");
+			assertTrue(idx.search(query).isEmpty(),
+				"search(Query) on an empty map must return empty");
+		}
+	}
+
+	@Test
+	void queryWithAcceptorOnEmptyMapReturnsUnmodifiedAcceptor()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(standardContext())))
+		{
+			final List<Article> collected = new ArrayList<>();
+
+			idx.query(new TermQuery(new Term("exact", "nothing")),
+				(entityId, entity, score) -> collected.add(entity));
+
+			assertTrue(collected.isEmpty(), "the acceptor must not be called for an empty map");
+		}
+	}
+
+	@Test
+	void nonPositiveMaxResultsReturnsEmpty()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(standardContext())))
+		{
+			map.add(new Article("eclipse store", "content"));
+
+			final Query query = new TermQuery(new Term("exact", "eclipse store"));
+			assertEquals(1, idx.query(query).size(), "sanity: findable with the default maxResults");
+
+			// an explicitly non-positive limit means "no results wanted" on every overload
+			assertTrue(idx.query(query, 0).isEmpty(),  "query(Query, 0) must return empty");
+			assertTrue(idx.query(query, -1).isEmpty(), "query(Query, -1) must return empty");
+			assertTrue(idx.query("title:eclipse", 0).isEmpty(), "query(String, 0) must return empty");
+			assertTrue(idx.search(query, 0).isEmpty(), "search(Query, 0) must return empty");
+			assertTrue(idx.search("title:eclipse", 0).isEmpty(), "search(String, 0) must return empty");
+		}
+	}
+
+
+	// ── map emptied again after having held entities ──────────────────────────
+
+	@Test
+	void queryAfterRemoveByIdEmptiedTheMapReturnsEmpty()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(standardContext())))
+		{
+			final long entityId = map.add(new Article("solo", "content"));
+			assertEquals(1, idx.query("title:solo").size(), "sanity: findable while present");
+
+			map.removeById(entityId);
+
+			// the map size is back to 0, so the default maxResults is derived from 0 again
+			assertTrue(idx.query("title:solo").isEmpty(),
+				"query(String) after the map emptied must return empty");
+			assertTrue(idx.query(new TermQuery(new Term("exact", "solo"))).isEmpty(),
+				"query(Query) after the map emptied must return empty, not throw");
+		}
+	}
+
+	@Test
+	void queryAfterRemoveAllReturnsEmpty()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(standardContext())))
+		{
+			map.add(new Article("first",  "content"));
+			map.add(new Article("second", "content"));
+			assertEquals(2, idx.query("content:content").size(), "sanity: findable while present");
+
+			map.removeAll();
+
+			assertTrue(idx.query(new TermQuery(new Term("exact", "first"))).isEmpty(),
+				"query(Query) after removeAll must return empty, not throw");
+		}
+	}
+}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneEmptyMapQueryTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneEmptyMapQueryTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -98,9 +99,13 @@ public class LuceneEmptyMapQueryTest
 		{
 			final List<Article> collected = new ArrayList<>();
 
-			idx.query(new TermQuery(new Term("exact", "nothing")),
-				(entityId, entity, score) -> collected.add(entity));
+			final LuceneIndex.SearchResultAcceptor<Article> acceptor =
+				(entityId, entity, score) -> collected.add(entity);
 
+			final LuceneIndex.SearchResultAcceptor<Article> returned =
+				idx.query(new TermQuery(new Term("exact", "nothing")), acceptor);
+
+			assertSame(acceptor, returned, "the very acceptor that was passed in must be returned");
 			assertTrue(collected.isEmpty(), "the acceptor must not be called for an empty map");
 		}
 	}
@@ -122,6 +127,20 @@ public class LuceneEmptyMapQueryTest
 			assertTrue(idx.query("title:eclipse", 0).isEmpty(), "query(String, 0) must return empty");
 			assertTrue(idx.search(query, 0).isEmpty(), "search(Query, 0) must return empty");
 			assertTrue(idx.search("title:eclipse", 0).isEmpty(), "search(String, 0) must return empty");
+
+			// including the two acceptor overloads that carry the limit - the actual defect site
+			final List<Article> collected = new ArrayList<>();
+			final LuceneIndex.SearchResultAcceptor<Article> acceptor =
+				(entityId, entity, score) -> collected.add(entity);
+
+			assertSame(acceptor, idx.query(query, 0, acceptor),
+				"query(Query, 0, acceptor) must return the acceptor it was passed");
+			assertSame(acceptor, idx.query(query, -1, acceptor),
+				"query(Query, -1, acceptor) must return the acceptor it was passed");
+			assertSame(acceptor, idx.query("title:eclipse", 0, acceptor),
+				"query(String, 0, acceptor) must return the acceptor it was passed");
+
+			assertTrue(collected.isEmpty(), "no acceptor call may happen for a non-positive limit");
 		}
 	}
 


### PR DESCRIPTION
## The bug

Searching a Lucene index whose `GigaMap` is currently empty throws instead of returning nothing:

```java
final GigaMap<Article> map = GigaMap.New();
try(final LuceneIndex<Article> idx = map.index().register(LuceneIndex.Category(ctx())))
{
    idx.query("title:anything");                             // empty list, fine
    idx.query(new TermQuery(new Term("exact", "nothing")));  // IllegalArgumentException: numHits must be > 0
}
```

A zero-result query is the most ordinary thing to do against a fresh index, and three of the four overloads that could be asked it already answer with an empty result.

## Why

The overloads that take no explicit `maxResults` derive the limit from the map size:

```java
private int defaultMaxResults() { return XMath.cap_int(this.gigaMap.size()); }   // 0 on an empty map
```

Lucene's `IndexSearcher.search(query, numHits)` rejects `numHits <= 0`. Four internal entry points receive that derived value, and three guard it:

| entry point | guarded `maxResults <= 0`? |
|---|---|
| `query(String, maxResults, acceptor)` | ✅ returns the acceptor |
| `search(Query, maxResults)` | ✅ returns an empty result |
| `search(String, maxResults)` | ✅ returns an empty result |
| **`query(Query, maxResults, acceptor)`** | ❌ **forwards 0 to Lucene** |

So `query(Query)` was the one path that reached `IndexSearcher.search(query, 0)`.

The trigger is not "a freshly created index" - it is "a map that is currently empty", which is a state any map can return to. The same throw lands right after `removeById` empties the last slot, and after `removeAll`.

## The fix

The missing guard, returning the unmodified acceptor exactly as the `String` sibling does.

The behaviour is now documented rather than incidental: every `maxResults` parameter states that a non-positive value yields no results, and the default-limit overloads `query(Query)` / `query(String)` state that they use the current `GigaMap` size as the limit - so an empty map yields an empty list. The `search(...)` overloads already documented the size-derived default; the `query(...)` ones did not.

Deliberately not changed: the derived default itself. Capping at the map size is a sensible upper bound for a full-text hit count, and changing it would alter results for non-empty maps; only the degenerate `size() == 0` case was ever broken.

## Test

`LuceneEmptyMapQueryTest`, five cases:

- all four default-limit entry points (`query`/`search` × `String`/`Query`) on a fresh empty map
- the acceptor overload directly - the acceptor must not be called
- explicit limits of `0` and `-1` on a **non-empty** map, across all five limit-taking overloads, with a sanity assertion that the default limit does find the entity
- a map emptied again, once via `removeById` and once via `removeAll`

Every one of the five errors with `numHits must be > 0` when the guard is stashed.

Full `gigamap/lucene` suite green: 74 tests.

## How it turned up

While probing the integration seams of the GigaMap-Lucene binding rather than Lucene itself. Two other seams were exercised by the same hunt and came back clean, so they are not part of this PR: the `GraphDirectory` index persisted inside the map's `fileEntries` stays consistent across repeated `store()` + restart rounds (added entities stay findable, an id-based removal stays removed), and content carrying Lucene query-syntax metacharacters (`AND`, `a+b`, `wild*card`, `"quoted"`, `back\slash`, `emoji-😀`, ...) is exactly matchable through the programmatic `TermQuery` path with no cross-matching.
