### PR TITLE
GigaMap/jvector: populate a newly registered vector index exactly once

### DIFF
--- a/gigamap/jvector/ARCHITECTURE.md
+++ b/gigamap/jvector/ARCHITECTURE.md
@@ -383,7 +383,7 @@ The two ways a graph gets populated are deliberately disjoint, so no entity is e
 
 | Origin | Populated by |
 |---|---|
-| Newly created via `VectorIndices#add` / `#ensure` | The back-fill in `VectorIndices.Default#internalAddVectorIndex` (`parent.iterateIndexed(index::internalAdd)`). The standard `VectorIndex.Default` constructor runs `initializeIndex()` only and publishes `graphRebuilt = true` — a brand-new index has no store to rebuild from. |
+| Newly created via `VectorIndices#add` / `#ensure` | The back-fill in `VectorIndices.Default#internalAddVectorIndex` (`parent.iterateIndexed(index::internalAdd)`). The standard `VectorIndex.Default` constructor runs `initializeIndex()` only and publishes `graphRebuilt = true`, so the deferred rebuild cannot also populate this index. Rebuilding from the store is meaningful only for an index that *has* a store to rebuild, i.e. after a load — in embedded mode `rebuildGraphFromStore()` reads the parent map, so for a fresh index it would duplicate every entity the back-fill adds rather than being a harmless no-op. |
 | Deserialized | The deferred `ensureGraphRebuilt()` on first search / mutation / optimize. `internalAddVectorIndex` is not on the load path. |
 
 The disk-load branch flips `incrementalMode = true` only after `diskDeletedOrdinals` is initialized (safe-publication ordering). Search and mutation paths read `incrementalMode` as a `volatile` and rely on this ordering to never see a `null` `diskDeletedOrdinals`.
@@ -932,7 +932,7 @@ PQ "trained" is restored implicitly: the codebook lives inside the `FusedPQ` fea
 | Background indexing op throws | `processAllPendingIndexingOps` logs `error`, drops the op, continues. | Graph desync until next manual `optimize()`/`persistToDisk()` rebuilds. Exposed by `VectorIndexConcurrentStressTest`. |
 | PQ training throws | `trainPQ` logs and leaves `pqTrained=false`. | Next persist falls back to non-compressed `OnDiskGraphIndex.write()`. Will retry on the persist after that. |
 | Disk write IOException mid-`writeIndex` | Wrapped as `IORuntimeException` and propagated out of `doPersistToDisk`. The `.graph` may be partially written and `.meta` may be missing. | On next load, `verifyMetadata` fails (missing or mismatched .meta) → rebuild from source. |
-| Disk load IOException | Caught in `tryLoad`, logs warning, calls `close()`, returns `false`. | `initializeIndex` leaves `incrementalMode` false, so the deferred `ensureGraphRebuilt()` rebuilds from source on first access. |
+| Disk load IOException | Caught in `tryLoad`, logs warning, calls `close()`, returns `false`. | `initializeIndex` leaves `incrementalMode` false. On a loaded index the deferred `ensureGraphRebuilt()` then rebuilds from source on first access; a freshly created one is populated by the registration back-fill instead (see §6). |
 | Count-collision corruption | v2 metadata mismatch on load. | Rebuild from source via `rebuildGraphFromStore`. |
 | `persistOnShutdown=true` with no background features | Pre-`fa189228`: changes silently dropped. Post-fix: `close()` falls through to direct `doPersistToDisk()` call. | None needed — change is durable. |
 | `Vectorizer` returns `null` | `IllegalStateException` at insertion. | Hard fail — fix the vectorizer. |

--- a/gigamap/jvector/ARCHITECTURE.md
+++ b/gigamap/jvector/ARCHITECTURE.md
@@ -302,7 +302,7 @@ Layout: 40 bytes, five object-id references.
 | 24 | `vectorizer` (`Vectorizer`) | User class; must be persistable by EclipseStore. |
 | 32 | `vectorStore` (`GigaMap<VectorEntry>`) | `null` if `vectorizer.isEmbedded()`. |
 
-Empty-instance creation: `new VectorIndex.Default<>()`. After `updateState` patches the five persistent fields, **`complete()` calls `instance.ensureIndexInitialized()`** — this is the seam where all transient state (builder, in-memory graph, disk manager, PQ manager, background task manager, searcher pools) is rebuilt or re-loaded.
+Empty-instance creation: `new VectorIndex.Default<>()`. After `updateState` patches the five persistent fields, **`complete()` calls `instance.initializeAfterLoad()`** — this is the seam where all transient state (builder, in-memory graph, disk manager, PQ manager, background task manager, searcher pools) is rebuilt or re-loaded. It deliberately does **not** rebuild the in-memory graph, because that rebuild iterates the parent GigaMap / vector store (a nested object-graph load) and must not run inside the enclosing load's `completeInstances` phase; the rebuild is deferred to the first search / mutation via `ensureGraphRebuilt()`.
 
 ### Persistent vs transient fields of `VectorIndex.Default`
 
@@ -350,7 +350,7 @@ sequenceDiagram
     ES->>H: updateState(data, instance, handler)
     H->>VI: XMemory.setObject(parent / name / configuration / vectorizer / vectorStore)
     ES->>H: complete(data, instance, handler)
-    H->>VI: ensureIndexInitialized()
+    H->>VI: initializeAfterLoad()
     VI->>VI: initializeIndex()
     alt PQ enabled
         VI->>PQM: new PQCompressionManager.Default(this, ...)
@@ -367,19 +367,24 @@ sequenceDiagram
             VI->>VI: incrementalMode = true<br/>diskDeletedOrdinals = newKeySet()
         else metadata mismatch / files missing
             DIM-->>VI: false
-            VI->>VI: rebuildGraphFromStore()
         end
-    else
-        VI->>VI: rebuildGraphFromStore()
     end
 
     VI->>VI: initializeSearcherPool()
     opt eventualIndexing or backgroundOptimization or backgroundPersistence
         VI->>BTM: new BackgroundTaskManager(this, ...)
     end
+    Note over VI: graph rebuild NOT done here —<br/>deferred to first access via<br/>ensureGraphRebuilt() → rebuildGraphFromStore()
 ```
 
-`ensureIndexInitialized()` is idempotent and guarded — it skips work when `builder != null` or when the disk graph is already loaded. It is called both from the binary handler `complete()` and from every method that needs the in-memory builder available.
+`ensureIndexInitialized()` is idempotent and guarded — it skips the transient setup when `builder != null` or when the disk graph is already loaded, and the graph rebuild when `graphRebuilt` or `incrementalMode` is already set. Every method that needs the in-memory builder available calls it; the binary handler `complete()` instead calls the rebuild-free `initializeAfterLoad()`.
+
+The two ways a graph gets populated are deliberately disjoint, so no entity is ever indexed twice (internal #123):
+
+| Origin | Populated by |
+|---|---|
+| Newly created via `VectorIndices#add` / `#ensure` | The back-fill in `VectorIndices.Default#internalAddVectorIndex` (`parent.iterateIndexed(index::internalAdd)`). The standard `VectorIndex.Default` constructor runs `initializeIndex()` only and publishes `graphRebuilt = true` — a brand-new index has no store to rebuild from. |
+| Deserialized | The deferred `ensureGraphRebuilt()` on first search / mutation / optimize. `internalAddVectorIndex` is not on the load path. |
 
 The disk-load branch flips `incrementalMode = true` only after `diskDeletedOrdinals` is initialized (safe-publication ordering). Search and mutation paths read `incrementalMode` as a `volatile` and rely on this ordering to never see a `null` `diskDeletedOrdinals`.
 
@@ -878,7 +883,7 @@ sequenceDiagram
     participant FS as filesystem
 
     ES->>H: create() / updateState() / complete()
-    H->>VI: ensureIndexInitialized()
+    H->>VI: initializeAfterLoad()
     VI->>VI: initializeIndex()<br/>(builder, in-memory graph, pqManager)
     alt configuration.onDisk()
         VI->>DIM: tryLoad()
@@ -908,12 +913,12 @@ sequenceDiagram
     alt tryLoad returned true
         VI->>VI: initializeSearcherPool()<br/>(disk pool + in-memory pool)
     else
-        VI->>VI: rebuildGraphFromStore()<br/>(iterate vectorStore or parentMap)
         VI->>VI: initializeSearcherPool()<br/>(in-memory pool only)
     end
     opt eventualIndexing OR backgroundOptimization OR backgroundPersistence
         VI->>VI: new BackgroundTaskManager
     end
+    Note over VI: first search / mutation / optimize:<br/>ensureGraphRebuilt() → rebuildGraphFromStore()<br/>(iterate vectorStore or parentMap);<br/>skipped while incrementalMode
 ```
 
 PQ "trained" is restored implicitly: the codebook lives inside the `FusedPQ` feature in the `.graph` file, so once the on-disk graph loads successfully, the PQ manager is marked trained without re-running training. If the disk load fails, the next `persistToDisk()` will re-train (assuming ≥ 256 vectors).
@@ -927,7 +932,7 @@ PQ "trained" is restored implicitly: the codebook lives inside the `FusedPQ` fea
 | Background indexing op throws | `processAllPendingIndexingOps` logs `error`, drops the op, continues. | Graph desync until next manual `optimize()`/`persistToDisk()` rebuilds. Exposed by `VectorIndexConcurrentStressTest`. |
 | PQ training throws | `trainPQ` logs and leaves `pqTrained=false`. | Next persist falls back to non-compressed `OnDiskGraphIndex.write()`. Will retry on the persist after that. |
 | Disk write IOException mid-`writeIndex` | Wrapped as `IORuntimeException` and propagated out of `doPersistToDisk`. The `.graph` may be partially written and `.meta` may be missing. | On next load, `verifyMetadata` fails (missing or mismatched .meta) → rebuild from source. |
-| Disk load IOException | Caught in `tryLoad`, logs warning, calls `close()`, returns `false`. | Caller (`initializeIndex`) falls through to `rebuildGraphFromStore`. |
+| Disk load IOException | Caught in `tryLoad`, logs warning, calls `close()`, returns `false`. | `initializeIndex` leaves `incrementalMode` false, so the deferred `ensureGraphRebuilt()` rebuilds from source on first access. |
 | Count-collision corruption | v2 metadata mismatch on load. | Rebuild from source via `rebuildGraphFromStore`. |
 | `persistOnShutdown=true` with no background features | Pre-`fa189228`: changes silently dropped. Post-fix: `close()` falls through to direct `doPersistToDisk()` call. | None needed — change is durable. |
 | `Vectorizer` returns `null` | `IllegalStateException` at insertion. | Hard fail — fix the vectorizer. |

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -809,8 +809,9 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // to the first search/mutation/optimize via ensureGraphRebuilt(), which runs it exactly once
         // under the parent GigaMap monitor (see there). Volatile: fast-path read lock-free; the actual
         // rebuild + set happens under synchronized(parentMap()). Also set true by the runtime rebuild
-        // in exitIncrementalMode() so it is not repeated, and by the standard constructor, where a
-        // brand-new index has nothing to rebuild from (see there).
+        // in exitIncrementalMode() so it is not repeated, and by the standard constructor, to keep the
+        // deferred rebuild from racing the one-time registration back-fill that populates a newly
+        // created index (see there).
         private transient volatile boolean                   graphRebuilt       ;
 
         // Incremental on-disk mode: after disk reload, use disk index for search
@@ -877,13 +878,16 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             this.builderLock         = new ReentrantReadWriteLock();
             this.deferredBuilderOps  = new ConcurrentLinkedQueue<>();
 
-            // A brand-new index has nothing to rebuild from, so publish the one-shot rebuild guard right
-            // away: in embedded mode rebuildGraphFromStore() would iterate the *parent map* and create a
-            // node per existing entity, which the back-fill in VectorIndices.Default#internalAddVectorIndex
-            // then adds a second time - jvector rejects the duplicate with "Node 0 already exists"
-            // (internal #123). That back-fill is the single population path for a newly created index,
-            // embedded and computed alike. Set before initializeIndex() so a background task started there
-            // cannot observe a false flag and rebuild behind the back-fill.
+            // Publish the one-shot rebuild guard right away, so the deferred rebuild never runs for an
+            // index created here: this one is populated by the back-fill in
+            // VectorIndices.Default#internalAddVectorIndex, immediately after construction, and that is
+            // its single population path - embedded and computed alike. A rebuild would not find an empty
+            // source and stay a no-op: in embedded mode rebuildGraphFromStore() reads the *parent map*, so
+            // it would create a node per existing entity and the back-fill would then add each one a second
+            // time - jvector rejects the duplicate with "Node 0 already exists" (internal #123). Rebuilding
+            // from the store is meaningful only for an index that has a store to rebuild, i.e. after a load.
+            // Set before initializeIndex() so a background task started there cannot observe a false flag
+            // and rebuild behind the back-fill.
             this.graphRebuilt = true;
 
             // Transient setup only - deliberately NOT ensureIndexInitialized(), see above.

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -809,7 +809,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // to the first search/mutation/optimize via ensureGraphRebuilt(), which runs it exactly once
         // under the parent GigaMap monitor (see there). Volatile: fast-path read lock-free; the actual
         // rebuild + set happens under synchronized(parentMap()). Also set true by the runtime rebuild
-        // in exitIncrementalMode() so it is not repeated.
+        // in exitIncrementalMode() so it is not repeated, and by the standard constructor, where a
+        // brand-new index has nothing to rebuild from (see there).
         private transient volatile boolean                   graphRebuilt       ;
 
         // Incremental on-disk mode: after disk reload, use disk index for search
@@ -846,7 +847,9 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         /////////////////
 
         /**
-         * Standard constructor for creating a new index.
+         * Standard constructor for creating a new index. Sets up the transient state but leaves the graph
+         * empty: populating it with the entities the parent map already holds is the caller's job, done
+         * exactly once by {@code VectorIndices.Default#internalAddVectorIndex}.
          */
         Default(
             final VectorIndices<E>         parent       ,
@@ -870,11 +873,21 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     .build()
             ;
 
-            // Initialize builder lock early (before ensureIndexInitialized)
+            // Initialize builder lock early (before initializeIndex)
             this.builderLock         = new ReentrantReadWriteLock();
             this.deferredBuilderOps  = new ConcurrentLinkedQueue<>();
 
-            this.ensureIndexInitialized();
+            // A brand-new index has nothing to rebuild from, so publish the one-shot rebuild guard right
+            // away: in embedded mode rebuildGraphFromStore() would iterate the *parent map* and create a
+            // node per existing entity, which the back-fill in VectorIndices.Default#internalAddVectorIndex
+            // then adds a second time - jvector rejects the duplicate with "Node 0 already exists"
+            // (internal #123). That back-fill is the single population path for a newly created index,
+            // embedded and computed alike. Set before initializeIndex() so a background task started there
+            // cannot observe a false flag and rebuild behind the back-fill.
+            this.graphRebuilt = true;
+
+            // Transient setup only - deliberately NOT ensureIndexInitialized(), see above.
+            this.initializeIndex();
         }
 
         /**

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
@@ -449,7 +449,10 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
 
             this.markStateChangeInstance();
 
-            // Index existing entities
+            // Index the entities the map already contains. This is the single population path for a newly
+            // created index: VectorIndex.Default's constructor deliberately does not rebuild its graph, so
+            // adding a second population here (or reinstating the constructor's rebuild) would double-index
+            // every existing entity - which jvector rejects as a duplicate node (internal #123).
             this.parent.iterateIndexed(index::internalAdd);
             this.parent.internalReportIndexGroupStateChange(this);
         }

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexLifecycleTest.java
@@ -174,30 +174,30 @@ class VectorIndexLifecycleTest
 	@Test
 	void addIndex_fromOtherThread_waitsForOpenReader()
 	{
-		// The map is deliberately left empty: registering a vector index on a map that already contains
-		// entities trips an unrelated defect in the back-fill (the index is populated both by
-		// VectorIndex.Default's graph rebuild and by VectorIndices#internalAddVectorIndex, which fails with
-		// "Node 0 already exists"). The mutability guard under test runs before any of that.
 		final GigaMap<Doc> map = GigaMap.New();
 		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+		addDocs(map);
 
 		// Registering a vector index is a structural write, so it must wait for a reader open on another
 		// thread instead of failing - exactly like an entity write does.
 		assertWaitsForForeignReader(map, () -> vi.add("emb", config(), new EmbeddingVectorizer()));
 
 		assertNotNull(vi.get("emb"));
+		// The entities that were already there must be back-filled exactly once (internal #123).
+		assertEquals(3, vi.get("emb").search(new float[]{1.0f, 0.0f, 0.0f}, 3).size());
 	}
 
 	@Test
 	void ensureIndex_fromOtherThread_waitsForOpenReader()
 	{
-		// see #addIndex_fromOtherThread_waitsForOpenReader on why the map stays empty
 		final GigaMap<Doc> map = GigaMap.New();
 		final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+		addDocs(map);
 
 		assertWaitsForForeignReader(map, () -> vi.ensure("emb", config(), new EmbeddingVectorizer()));
 
 		assertNotNull(vi.get("emb"));
+		assertEquals(3, vi.get("emb").search(new float[]{1.0f, 0.0f, 0.0f}, 3).size());
 	}
 
 	@Test
@@ -336,6 +336,37 @@ class VectorIndexLifecycleTest
 			final VectorIndices<Doc> vi = map.index().get(VectorIndices.Category());
 			assertNull(vi.get("emb"));   // removal persisted
 			assertEquals(3, map.size()); // entity data intact
+		}
+	}
+
+	/**
+	 * Registering the index <b>after</b> the entities exist - the natural ordering when a vector index is
+	 * added to an existing dataset - and then reloading: the back-filled graph has to survive persistence,
+	 * and the deferred post-load rebuild must not index the entities a second time (internal #123).
+	 */
+	@Test
+	void addIndex_onPopulatedMap_survivesReload(@TempDir final Path dir)
+	{
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Doc> map = GigaMap.New();
+			storage.setRoot(map);
+			addDocs(map);
+
+			final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
+			final VectorIndex<Doc> index = vi.add("emb", config(), new EmbeddingVectorizer());
+
+			assertEquals(3, index.search(new float[]{1.0f, 0.0f, 0.0f}, 3).size());
+			storage.storeRoot();
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Doc> map = storage.root();
+			final VectorIndices<Doc> vi = map.index().get(VectorIndices.Category());
+
+			assertEquals(3, map.size());
+			assertEquals(3, vi.get("emb").search(new float[]{1.0f, 0.0f, 0.0f}, 3).size());
 		}
 	}
 }

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndicesTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndicesTest.java
@@ -16,6 +16,9 @@ package org.eclipse.store.gigamap.jvector;
 
 import org.eclipse.store.gigamap.types.GigaMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,6 +41,43 @@ class VectorIndicesTest
         {
             return entity.embedding();
         }
+    }
+
+    /**
+     * Embedded-mode counterpart of {@link DocumentVectorizer}: the vector lives inside the entity, so
+     * the index has no vector store of its own and reads through to the parent map.
+     */
+    static class EmbeddedDocumentVectorizer extends Vectorizer<Document>
+    {
+        @Override
+        public float[] vectorize(final Document entity)
+        {
+            return entity.embedding();
+        }
+
+        @Override
+        public boolean isEmbedded()
+        {
+            return true;
+        }
+    }
+
+    private static VectorIndexConfiguration config()
+    {
+        return VectorIndexConfiguration.builder()
+            .dimension(3)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .build();
+    }
+
+    private static GigaMap<Document> populatedMap()
+    {
+        final GigaMap<Document> gigaMap = GigaMap.New();
+
+        gigaMap.add(new Document("doc1", new float[]{1.0f, 0.0f, 0.0f}));
+        gigaMap.add(new Document("doc2", new float[]{0.0f, 1.0f, 0.0f}));
+
+        return gigaMap;
     }
 
     @Test
@@ -374,6 +414,85 @@ class VectorIndicesTest
         final VectorSearchResult<Document> result = index.search(new float[]{1.0f, 0.0f, 0.0f}, 10);
 
         assertEquals(2, result.size(), "Index should auto-populate with existing entities");
+    }
+
+    /**
+     * Embedded-mode counterpart of {@link #testIndexAutoPopulatesExistingEntities()}: registering the index
+     * after the entities exist used to index each of them twice - once by the constructor's graph rebuild
+     * (which iterates the parent map in embedded mode) and once by the registration back-fill - and jvector
+     * rejected the second node with {@code IllegalStateException: Node 0 already exists}.
+     */
+    @Test
+    void addIndex_onPopulatedMap_embedded_indexesEachEntityOnce()
+    {
+        final GigaMap<Document> gigaMap = populatedMap();
+        final VectorIndices<Document> vectorIndices = gigaMap.index().register(VectorIndices.Category());
+
+        final VectorIndex<Document> index = vectorIndices.add(
+            "emb", config(), new EmbeddedDocumentVectorizer());
+
+        assertEquals(2, index.search(new float[]{1.0f, 0.0f, 0.0f}, 10).size());
+        assertEquals(
+            "doc1",
+            gigaMap.get(index.search(new float[]{1.0f, 0.0f, 0.0f}, 1).stream()
+                .findFirst().orElseThrow().entityId()).content()
+        );
+    }
+
+    /**
+     * Same as {@link #addIndex_onPopulatedMap_embedded_indexesEachEntityOnce()} through {@code ensure(...)},
+     * which is the entry point used by annotation-driven registration.
+     */
+    @Test
+    void ensureIndex_onPopulatedMap_embedded_indexesEachEntityOnce()
+    {
+        final GigaMap<Document> gigaMap = populatedMap();
+        final VectorIndices<Document> vectorIndices = gigaMap.index().register(VectorIndices.Category());
+
+        final VectorIndex<Document> index = vectorIndices.ensure(
+            "emb", config(), new EmbeddedDocumentVectorizer());
+
+        assertEquals(2, index.search(new float[]{1.0f, 0.0f, 0.0f}, 10).size());
+    }
+
+    /**
+     * On-disk variant: with no index files present yet, {@code tryLoad()} fails and the index stays in
+     * plain in-memory mode - the branch that previously reached the constructor's graph rebuild.
+     */
+    @Test
+    void addIndex_onPopulatedMap_embeddedOnDisk_indexesEachEntityOnce(@TempDir final Path indexDir)
+    {
+        final GigaMap<Document> gigaMap = populatedMap();
+        final VectorIndices<Document> vectorIndices = gigaMap.index().register(VectorIndices.Category());
+
+        final VectorIndexConfiguration diskConfig = VectorIndexConfiguration.builder()
+            .dimension(3)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .build();
+
+        final VectorIndex<Document> index = vectorIndices.add(
+            "emb", diskConfig, new EmbeddedDocumentVectorizer());
+
+        assertEquals(2, index.search(new float[]{1.0f, 0.0f, 0.0f}, 10).size());
+    }
+
+    /**
+     * The back-filled index must keep accepting entities added after registration.
+     */
+    @Test
+    void addIndex_onPopulatedMap_embedded_thenAddMoreEntities()
+    {
+        final GigaMap<Document> gigaMap = populatedMap();
+        final VectorIndices<Document> vectorIndices = gigaMap.index().register(VectorIndices.Category());
+
+        final VectorIndex<Document> index = vectorIndices.add(
+            "emb", config(), new EmbeddedDocumentVectorizer());
+
+        gigaMap.add(new Document("doc3", new float[]{0.0f, 0.0f, 1.0f}));
+
+        assertEquals(3, index.search(new float[]{1.0f, 0.0f, 0.0f}, 10).size());
     }
 }
 


### PR DESCRIPTION
## The bug

Registering an **embedded-mode** vector index on a `GigaMap` that already holds entities fails outright:

```java
final GigaMap<Doc> map = GigaMap.New();
map.add(new Doc(new float[]{1.0f, 0.0f, 0.0f}));
map.add(new Doc(new float[]{0.0f, 1.0f, 0.0f}));

final VectorIndices<Doc> vi = map.index().register(VectorIndices.Category());
vi.add("emb", config, new EmbeddedVectorizer());   // IllegalStateException: Node 0 already exists
```

```
java.lang.IllegalStateException: Node 0 already exists
	at io.github.jbellis.jvector.graph.ConcurrentNeighborMap.addNode(ConcurrentNeighborMap.java:129)
	at io.github.jbellis.jvector.graph.OnHeapGraphIndex.addNode(OnHeapGraphIndex.java:167)
	at io.github.jbellis.jvector.graph.GraphIndexBuilder.addGraphNode(GraphIndexBuilder.java:612)
	at org.eclipse.store.gigamap.jvector.VectorIndex$Default.executeOrDeferBuilderOp(VectorIndex.java:3143)
```

The existing entities were pushed into the HNSW graph twice, and both populations happen inside one `add(...)` call.

**1. The constructor rebuilt the graph.** `new VectorIndex.Default<>(...)` ended with `ensureIndexInitialized()`, whose `ensureGraphRebuilt()` -> `rebuildGraphFromStore()` -> `collectStoredVectors()` iterates the **parent GigaMap** in embedded mode and creates a node per entity. It then published `graphRebuilt = true`.

**2. Registration back-filled again.** `VectorIndices.Default#internalAddVectorIndex` closes with `this.parent.iterateIndexed(index::internalAdd)`. `internalAdd` re-enters `ensureIndexInitialized()`, sees `graphRebuilt == true`, skips the rebuild, and adds the node - which jvector rejects, because entity id 0 is already a node.

Verified single-threaded, no concurrency involved:

| vectorizer | index registered | before this PR |
|---|---|---|
| `isEmbedded() == true` | **after** entities exist | **`IllegalStateException: Node 0 already exists`** |
| `isEmbedded() == true` | before entities exist | works |
| `isEmbedded() == false` (computed) | after entities exist | works |

Computed mode escapes it because `collectStoredVectors()` reads `this.vectorStore` instead of the parent map, and that store is a brand-new empty `GigaMap<VectorEntry>` for a fresh index - so step 1 contributes nothing and only the back-fill runs.

`ensure(name, config, vectorizer)` is affected identically (it delegates to the same `internalAddIndex`), and therefore so is annotation-driven registration: `VectorAnnotationHandler` calls `ensure(...)` with an `AnnotationVectorizer`, which is embedded.

## The fix

The two back-fills are redundant by construction, so one has to go - and it has to be the constructor's.

Dropping the *registration* back-fill instead looks tempting, since `ensureGraphRebuilt()` is the path that already handles the embedded/computed split. But in computed mode `collectStoredVectors()` reads the still-empty vector store, and `iterateIndexed(index::internalAdd)` is exactly what fills that store at registration time. Removing it would silently leave a computed index empty - breaking behaviour that works today, and which `VectorIndicesTest#testIndexAutoPopulatesExistingEntities` covers.

So the constructor now runs `initializeIndex()` alone and publishes `graphRebuilt = true`. That is not a suppression flag bolted on: at construction time the index is not registered in `vectorIndices` yet and has no store to rebuild *from*, so the honest value of a one-shot "the deferred post-load rebuild is done or unnecessary" guard is `true`. `exitIncrementalMode()` already does the same thing after its own rebuild. The flag is set *before* `initializeIndex()`, so a background task started there cannot observe a false flag and rebuild behind the back-fill.

Making `addGraphNode` tolerate duplicates was deliberately not the fix - a duplicate-tolerant add would also mask genuine double-indexing bugs.

## What is unchanged

**Deserialization.** `initializeAfterLoad()` already defers the rebuild out of the enclosing load's `completeInstances` phase (internal #87), and `internalAddVectorIndex` is not on the load path. So the two population paths are now disjoint, which is what makes double-indexing structurally impossible rather than merely absent:

| Origin | Populated by |
|---|---|
| Newly created via `add` / `ensure` | the registration back-fill in `internalAddVectorIndex` |
| Deserialized | the deferred `ensureGraphRebuilt()` on first search / mutation / optimize |

**On-disk mode.** A successful `tryLoad()` in `initializeIndex()` flips `incrementalMode`, which already short-circuited `ensureGraphRebuilt()`, so that case behaved this way before the change; `exitIncrementalMode()` still rebuilds from a fresh builder on the first persist.

## Why it went unnoticed

Every existing test in `gigamap/jvector` registers the vector index *before* adding entities - `VectorIndexLifecycleTest`, `VectorAnnotationTest` and the rest all follow `register(...)` -> `add("emb", ...)` -> `addDocs(map)`. The populated-map ordering was never exercised, even though it is the natural one for adding a vector index to an existing dataset - the whole reason the back-fill in `internalAddVectorIndex` exists.

## Tests

`VectorIndicesTest`, 4 new tests, the embedded-mode counterparts of `testIndexAutoPopulatesExistingEntities` (which stays untouched as the computed-mode guard against the rejected alternative):

- `add(...)` on a populated map: the reproducer above, asserting both entities searchable and the nearest neighbour correct
- `ensure(...)` on a populated map - the entry point annotation-driven registration uses
- an on-disk configuration, covering the `tryLoad() == false` branch of `initializeIndex()` that previously reached `rebuildGraphFromStore()`
- entities added *after* registration, so the back-filled index is pinned to keep accepting mutations

`VectorIndexLifecycleTest`: the two mutability-guard tests added in #787 had to use an empty map because of this defect, with a comment pointing at it. They now use a populated map, the comments are gone, and they assert the back-fill count - so they double as the regression test. `addIndex_onPopulatedMap_survivesReload` pins the store/load round trip: the back-filled graph survives persistence and the deferred post-load rebuild does not index the entities a second time.

All seven fail against the unfixed constructor with the reported `IllegalStateException: Node 0 already exists`.

`gigamap/jvector` green in both profiles: 234 tests by default, 121 with `-Pslow-tests`. Full `gigamap` reactor green.

## Docs

`ARCHITECTURE.md` claimed `complete()` calls `ensureIndexInitialized()`; it has called `initializeAfterLoad()` since internal #87. Corrected, along with the two initialization diagrams that still showed `rebuildGraphFromStore()` running inside `initializeIndex()`, plus the population-path table above.
