### PR TITLE
GigaMap: release an entity segment when a removal empties it

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel1.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel1.java
@@ -85,9 +85,10 @@ public final class GigaLevel1<E> extends AbstractStateChangeFlagged implements U
 	 * makes a sequential drain, forward or backward, hit a surviving neighbour on the very first
 	 * comparison instead of walking the whole array.
 	 * <p>
-	 * Deliberately bound to the array's own length instead of the parent map's configured segment size:
-	 * the length of a reloaded array comes from the persisted binary form and may differ from what the
-	 * map is configured with now.
+	 * Bound to the array's own length rather than to the parent map's configured segment size, simply
+	 * because this class owns the array and needs no state of the map to walk it. The two always agree:
+	 * the length exponents are persisted with the map and a reloaded map is constructed from those, so
+	 * a reloaded array's length is the configured segment size.
 	 *
 	 * @param scanStartIndex the index to start scanning after, typically the slot that was cleared last
 	 * @return {@code true} if every slot is {@code null}, {@code false} otherwise

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel1.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel1.java
@@ -68,7 +68,49 @@ public final class GigaLevel1<E> extends AbstractStateChangeFlagged implements U
 		super(newInstance);
 		this.entities = this.createEntitiesArray(length);
 	}
-	
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+
+	/**
+	 * Whether this segment currently holds no entity at all, which makes it eligible for being released
+	 * from its parent {@link GigaLevel2}.
+	 * <p>
+	 * The scan starts right after {@code scanStartIndex} - the slot the caller just cleared - and wraps
+	 * around, so a sequential drain, forward or backward, hits a surviving neighbour on the very first
+	 * comparison instead of walking the whole array.
+	 * <p>
+	 * Deliberately bound to the array's own length instead of the parent map's configured segment size:
+	 * the length of a reloaded array comes from the persisted binary form and may differ from what the
+	 * map is configured with now.
+	 *
+	 * @param scanStartIndex the index of the slot that was cleared last
+	 * @return {@code true} if every slot is {@code null}, {@code false} otherwise
+	 */
+	final boolean isEmpty(final int scanStartIndex)
+	{
+		final E[] entities = this.entities;
+		final int length   = entities.length;
+
+		for(int i = 1; i <= length; i++)
+		{
+			int index = scanStartIndex + i;
+			if(index >= length)
+			{
+				index -= length;
+			}
+			if(entities[index] != null)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	@Override
 	protected void storeChangedChildren(final Storer storer)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel1.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel1.java
@@ -79,15 +79,17 @@ public final class GigaLevel1<E> extends AbstractStateChangeFlagged implements U
 	 * Whether this segment currently holds no entity at all, which makes it eligible for being released
 	 * from its parent {@link GigaLevel2}.
 	 * <p>
-	 * The scan starts right after {@code scanStartIndex} - the slot the caller just cleared - and wraps
-	 * around, so a sequential drain, forward or backward, hits a surviving neighbour on the very first
+	 * {@code scanStartIndex} only steers where the scan begins, it does not narrow what is examined:
+	 * every slot is checked, ending with {@code scanStartIndex} itself, so the answer never depends on
+	 * the caller having cleared that slot. Starting right after the slot a removal just cleared is what
+	 * makes a sequential drain, forward or backward, hit a surviving neighbour on the very first
 	 * comparison instead of walking the whole array.
 	 * <p>
 	 * Deliberately bound to the array's own length instead of the parent map's configured segment size:
 	 * the length of a reloaded array comes from the persisted binary form and may differ from what the
 	 * map is configured with now.
 	 *
-	 * @param scanStartIndex the index of the slot that was cleared last
+	 * @param scanStartIndex the index to start scanning after, typically the slot that was cleared last
 	 * @return {@code true} if every slot is {@code null}, {@code false} otherwise
 	 */
 	final boolean isEmpty(final int scanStartIndex)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel2.java
@@ -107,7 +107,67 @@ public final class GigaLevel2<E> extends AbstractStateChangeFlagged implements U
 		this.markUsedLevel1Entry(level1Entry);
 		this.markStateChangeInstance();
 	}
-	
+
+	/**
+	 * Releases the level1 segment at the passed index, the counterpart of
+	 * {@link #addLevel1(GigaLevel1, int)}, and reports whether this instance holds no segment at all
+	 * afterwards.
+	 * <p>
+	 * The slot is part of THIS instance's binary form, so the instance itself must be flagged for
+	 * re-storing: {@link #storeChangedChildren(Storer)} alone would never persist the removal, and the
+	 * dropped segment would come back on the next load.
+	 * <p>
+	 * The usage mark is removed explicitly although the dropped {@link Lazy} becomes garbage either way
+	 * (the lazy reference manager holds only weak references to it), so that no clearing or storing
+	 * logic can ever observe a pin for an unreachable child.
+	 *
+	 * @param level2Index the index of the level1 segment to release
+	 * @return {@code true} if this instance holds no level1 segment anymore, {@code false} otherwise
+	 */
+	final boolean removeLevel1(final int level2Index)
+	{
+		final Lazy<GigaLevel1<E>> level1Entry = this.segments[level2Index];
+		if(level1Entry != null)
+		{
+			this.unmarkUsedLevel1Entry(level1Entry);
+		}
+
+		this.segments[level2Index] = null;
+		this.markStateChangeInstance();
+
+		return this.isEmpty(level2Index);
+	}
+
+	/**
+	 * Whether every slot is {@code null}. Scans outward from the slot that was cleared last and wraps
+	 * around, for the same reason as {@link GigaLevel1#isEmpty(int)}: a sequential drain exits on the
+	 * first surviving neighbour. A non-null slot counts as occupied even when its segment is not
+	 * currently loaded, so no segment has to be loaded to answer this.
+	 *
+	 * @param scanStartIndex the index of the slot that was cleared last
+	 * @return {@code true} if every slot is {@code null}, {@code false} otherwise
+	 */
+	private boolean isEmpty(final int scanStartIndex)
+	{
+		final Lazy<GigaLevel1<E>>[] segments = this.segments;
+		final int                   length   = segments.length;
+
+		for(int i = 1; i <= length; i++)
+		{
+			int index = scanStartIndex + i;
+			if(index >= length)
+			{
+				index -= length;
+			}
+			if(segments[index] != null)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	@Override
 	protected void storeChangedChildren(final Storer storer)
 	{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel2.java
@@ -139,12 +139,12 @@ public final class GigaLevel2<E> extends AbstractStateChangeFlagged implements U
 	}
 
 	/**
-	 * Whether every slot is {@code null}. Scans outward from the slot that was cleared last and wraps
-	 * around, for the same reason as {@link GigaLevel1#isEmpty(int)}: a sequential drain exits on the
-	 * first surviving neighbour. A non-null slot counts as occupied even when its segment is not
+	 * Whether every slot is {@code null}. Starts scanning after the slot that was cleared last and wraps
+	 * around to it, for the same reason as {@link GigaLevel1#isEmpty(int)}: a sequential drain exits on
+	 * the first surviving neighbour. A non-null slot counts as occupied even when its segment is not
 	 * currently loaded, so no segment has to be loaded to answer this.
 	 *
-	 * @param scanStartIndex the index of the slot that was cleared last
+	 * @param scanStartIndex the index to start scanning after, typically the slot that was cleared last
 	 * @return {@code true} if every slot is {@code null}, {@code false} otherwise
 	 */
 	private boolean isEmpty(final int scanStartIndex)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel3.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaLevel3.java
@@ -121,7 +121,34 @@ public final class GigaLevel3<E> extends AbstractStateChangeFlagged implements U
 		this.markUsedLevel2Entry(level2Entry);
 		this.markStateChangeInstance();
 	}
-	
+
+	/**
+	 * Releases the level2 segment at the passed index, the counterpart of
+	 * {@link #addLevel2(GigaLevel2, int)}.
+	 * <p>
+	 * {@link #markStateChangeInstance()} is mandatory here and cannot be left to
+	 * {@link #markChanged(int)}: that one flags only this instance's <i>children</i>, so without the
+	 * instance flag the storing logic would skip this instance's own binary form and the released
+	 * segment would still be referenced on disk - resurrecting a whole subtree of removed entities on
+	 * the next load, while the persisted size and id counter would not know about them.
+	 * <p>
+	 * The segments array is deliberately not shrunk. Holes are the normal state of it, every reader
+	 * tolerates them, and the freed slot is a single reference per {@code level1Size * level2Size} ids.
+	 *
+	 * @param level3Index the index of the level2 segment to release
+	 */
+	final void removeLevel2(final int level3Index)
+	{
+		final Lazy<GigaLevel2<E>> level2Entry = this.segments[level3Index];
+		if(level2Entry != null)
+		{
+			this.unmarkUsedLevel2Entry(level2Entry);
+		}
+
+		this.segments[level3Index] = null;
+		this.markStateChangeInstance();
+	}
+
 	final void enlargeLevel3(final int minimumCapacity)
 	{
 		// add 10% capacity to avoid frequent rebuilding, but at the very least 1 more length.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2442,6 +2442,15 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		{
 			final GigaLevel3<E> level3      = this.level3();
 			final int           level3Index = this.toLevel3Index(entityId);
+
+			/*
+			 * Only the level3 index needs a bounds check, as everywhere else in this class: it addresses
+			 * an array that #enlargeLevel3 grows on demand, so it is not derived from a length exponent
+			 * and an id beyond the current capacity exceeds it. The level2 and level1 indices are masked
+			 * into their exponent's range by #toLevel2Index/#toLevel1Index, and since those exponents are
+			 * persisted with the map and a reloaded map is constructed from them, a segment array is
+			 * always exactly as long as its index range - reloaded ones included.
+			 */
 			if(level3Index >= level3.segments.length)
 			{
 				return;

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -186,6 +186,13 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	/**
 	 * Removes the entity mapped to the specified id.
 	 * <p>
+	 * The id is not recycled: it stays below {@link #highestUsedId()} and keeps reading as an empty
+	 * slot, and the next {@link #add(Object)} gets a fresh id. Removing the last entity of an internal
+	 * segment does release that segment, in memory and on disk, so a workload that keeps adding and
+	 * removing does not accumulate the storage of the ids it has churned through. That reclamation only
+	 * happens as a removal empties a segment, so segments left empty by an earlier version of this
+	 * library are not cleaned up retroactively; {@link #removeAll()} is the only full reset.
+	 * <p>
 	 * <b>Behavior on failure:</b> if an {@link Indexer} throws an exception while the entity's
 	 * index entries are being located for cleanup, the removal nevertheless completes: the entity
 	 * is removed from the map and {@link #size()} is decremented, the remaining indices are cleaned
@@ -313,6 +320,8 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * at its original id, becomes queryable under it, the size is incremented again, and {@code null} is
 	 * returned because nothing was replaced. Since the map offers no {@code add(long, Object)}, this is
 	 * the only id-addressed write and therefore the way to undo a removal at the id it was removed from.
+	 * That holds regardless of how much of the id's id range was removed: if the removals released the
+	 * internal segment the id lives in, writing to the id re-creates it.
 	 * <p>
 	 * Ids that this map never handed out are rejected: the id must be non-negative and must not exceed
 	 * {@link #highestUsedId()}.
@@ -1873,12 +1882,80 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 			level3.markChanged(level3Index);
 			level2.markChanged(level2Index);
-						
+
 			this.indices.internalRemove(entityId, current);
-			
+
+			/*
+			 * If that was the segment's last entity, the segment itself is released. Ids are never
+			 * recycled, so an emptied segment can only be reached again by #set(long, Object) or by
+			 * #internalAdd resuming in it, and both go through #ensureLevel2/#ensureLevel1, which
+			 * re-create a segment for a null slot. Without this the emptied segment would stay
+			 * referenced from the segment tree forever - not collectable, and persisted and reloaded
+			 * on every restart - so a workload that keeps adding and removing would accumulate one
+			 * dead segment per exhausted id range.
+			 *
+			 * Done as the last step, after the index removal: a throw from there then leaves the
+			 * segment tree untouched instead of having done structural work for a half-failed removal.
+			 */
+			if(level1.isEmpty(level1Index))
+			{
+				this.releaseEmptyLevel1(level3, level3Index, level2, level2Index);
+			}
+
 			return current;
 		}
-		
+
+		/**
+		 * Drops the emptied level1 segment at the passed coordinates from its level2 segment, and that
+		 * level2 segment from the level3 segment if it became empty as well.
+		 */
+		private void releaseEmptyLevel1(
+			final GigaLevel3<E> level3     ,
+			final int           level3Index,
+			final GigaLevel2<E> level2     ,
+			final int           level2Index
+		)
+		{
+			/*
+			 * The adding state caches the segment the next #internalAdd writes into. If that is the
+			 * segment being released, the cached state has to be folded into baseSize/baseAddingId
+			 * FIRST: otherwise the next add would write into a GigaLevel1 that is no longer reachable
+			 * from its level2 (a silently lost entity) and #ensureAddingStateSetup would fail on the
+			 * now-null slot. This is not an exotic case: #ensureClearedAddingState deliberately keeps a
+			 * live, non-exhausted adding segment, so any map that has not filled its first segment yet
+			 * removes entities with the adding state pointing right at them.
+			 *
+			 * size() and nextFreeId() are invariant under the fold, and the next add runs
+			 * #setupAddingState, which re-creates the segment and resumes at the very same level1 index.
+			 * Ids are still never recycled. #clearAddingState is idempotent, so the call is harmless on
+			 * the #rollbackToEntityId path, which has already cleared.
+			 *
+			 * Compared by coordinates, not by instance identity: addingLevel1 may be a stale instance
+			 * whose Lazy was evicted and reloaded in the meantime, in which case an identity comparison
+			 * would silently skip the fold. The addingLevel1 null-check is what makes the comparison
+			 * valid at all - a cleared adding state leaves both cached indices at 0, which would
+			 * otherwise match the segment at (0, 0).
+			 */
+			if(this.addingLevel1 != null
+				&& level3Index == this.addingLevel3Index
+				&& level2Index == this.addingLevel2Index
+			)
+			{
+				this.clearAddingState();
+			}
+
+			if(level2.removeLevel1(level2Index))
+			{
+				/*
+				 * This level2 cannot be the one the adding state points at: a live adding state keeps
+				 * its own level1 slot occupied, so either the released segment WAS the adding one - in
+				 * which case the state has just been cleared - or the adding segment's slot is still
+				 * occupied and this level2 is not empty.
+				 */
+				level3.removeLevel2(level3Index);
+			}
+		}
+
 
 		@Override
 		public final synchronized long remove(
@@ -2126,16 +2203,17 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		
 		private E internalSet(final long entityId, final E entity)
 		{
-			final GigaLevel3<E>       level3      = this.level3();
-			final int                 level3Index = this.toLevel3Index(entityId);
-			final Lazy<GigaLevel2<E>> lvl2Lazy    = level3.segments[level3Index];
-			final GigaLevel2<E>       level2      = lvl2Lazy.get();
-			final int                 level2Index = this.toLevel2Index(entityId);
-			final Lazy<GigaLevel1<E>> lvl1Lazy    = level2.segments[level2Index];
-			final GigaLevel1<E>       level1      = lvl1Lazy.get();
+			final GigaLevel3<E> level3      = this.level3();
+			final int           level3Index = this.toLevel3Index(entityId);
+			final int           level2Index = this.toLevel2Index(entityId);
+			final int           level1Index = this.toLevel1Index(entityId);
 
-			final int level1Index    = this.toLevel1Index(entityId);
-			final E   replacedEntity = level1.entities[level1Index];
+			/*
+			 * Resolved via #get instead of by walking the segments: emptying a segment releases it, so
+			 * the segments of an id whose entity was removed may well be gone. #get reports exactly that
+			 * as the empty slot it is, and the segments are re-created further down.
+			 */
+			final E replacedEntity = this.get(entityId);
 
 			// only change state if there is an actual change in the entity data.
 			if(!this.equalator.equal(replacedEntity, entity))
@@ -2167,11 +2245,22 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 					this.baseSize++;
 				}
 
+				/*
+				 * Re-created here if the removal of the last entity released them, and deliberately not
+				 * any earlier: materializing before the checks and the index update above would leave a
+				 * fresh empty segment (plus a pending re-store for it) behind on a failed set, breaking
+				 * the very "a throw leaves the map observably unchanged" guarantee they are ordered for.
+				 * Both methods return the existing segment when there is one, so this is a no-op for the
+				 * ordinary replacement.
+				 */
+				final GigaLevel2<E> level2 = this.ensureLevel2(level3, level3Index);
+				final GigaLevel1<E> level1 = this.ensureLevel1(level2, level2Index);
+
 				level1.entities[level1Index] = entity;
 				level3.markChanged(level3Index);
 				level2.markChanged(level2Index);
 			}
-			
+
 			return replacedEntity;
 		}
 				
@@ -2351,11 +2440,31 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 		private void markEntitySegmentChanged(final long entityId)
 		{
-			final GigaLevel3<E>       level3      = this.level3();
-			final int                 level3Index = this.toLevel3Index(entityId);
-			final Lazy<GigaLevel2<E>> lvl2Lazy    = level3.segments[level3Index];
-			final GigaLevel2<E>       level2      = lvl2Lazy.get();
-			final int                 level2Index = this.toLevel2Index(entityId);
+			final GigaLevel3<E> level3      = this.level3();
+			final int           level3Index = this.toLevel3Index(entityId);
+			if(level3Index >= level3.segments.length)
+			{
+				return;
+			}
+
+			/*
+			 * Tolerates released segments: the update logic passed to #apply runs while this map's
+			 * (reentrant) monitor is held, so it can remove the very entity it is applied to, and
+			 * emptying the segment that way releases it. A gone segment holds no entity, so there is
+			 * nothing left to mark for re-storing.
+			 */
+			final Lazy<GigaLevel2<E>> lvl2Lazy = level3.segments[level3Index];
+			if(lvl2Lazy == null)
+			{
+				return;
+			}
+
+			final GigaLevel2<E> level2      = lvl2Lazy.get();
+			final int           level2Index = this.toLevel2Index(entityId);
+			if(level2.segments[level2Index] == null)
+			{
+				return;
+			}
 
 			level3.markChanged(level3Index);
 			level2.markChanged(level2Index);
@@ -2508,10 +2617,17 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		{
 			if(this.addingLevel1Index < this.level1IndexBound)
 			{
-				// adding state already cleared.
+				/*
+				 * The adding segment is live and not yet exhausted, so it is deliberately kept: folding
+				 * it here would force the next add to set the adding state up again, for no gain. The
+				 * cached state stays consistent with size()/nextFreeId() either way. Note that removals
+				 * therefore do run with the adding state pointing at the segment they empty, which is
+				 * why #releaseEmptyLevel1 folds it itself before releasing that segment.
+				 */
 				return;
 			}
-			
+
+			// nothing to fold when the bound is 0 (already cleared); clearing again is a no-op then.
 			this.clearAddingState();
 		}
 		

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/EntitySegmentReclamationTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/EntitySegmentReclamationTest.java
@@ -1,0 +1,781 @@
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.serializer.reference.Lazy;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Emptying an entity segment has to release it (internal issue #120).
+ * <p>
+ * {@code GigaMap.Default#internalRemove} used to null only the entity slot, leaving the emptied
+ * {@link GigaLevel1} referenced from its {@link GigaLevel2} and that one from the {@link GigaLevel3}
+ * forever. Since ids are never recycled, an add/remove churn workload accumulated one dead segment per
+ * exhausted id range - not collectable (still reachable through the segment tree), not freed by a
+ * restart (persisted and reloaded), and not fixable by the application, because there is no
+ * {@code compact()} and {@code removeAll()} would discard the live data as well. The bitmap index tree
+ * has always self-cleaned ({@code BitmapLevel3#clearLevel2Segment}); the entity tree was the one place
+ * that skipped it.
+ * <p>
+ * This test lives in the {@code types} package so it can read {@link GigaLevel3#segments} and
+ * {@link GigaLevel2#segments} directly instead of reflectively.
+ * <p>
+ * Most cases use deliberately tiny segment dimensions: {@code GigaMap.New(1)} puts 2 entities into a
+ * level1 segment, and {@code GigaMap.New(0, 8)} puts 1 entity into a level1 segment and 256 level1
+ * segments into a level2 segment, so 256 ids empty a whole level2 - with 1 entity per level1 the adding
+ * state is always already folded when a removal arrives, which isolates the level3 drop from the
+ * adding-state handling.
+ */
+public class EntitySegmentReclamationTest
+{
+	static class Item
+	{
+		final String name;
+
+		Item(final String name)
+		{
+			super();
+			this.name = name;
+		}
+	}
+
+	static class NameIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.name;
+		}
+	}
+
+	private static final NameIndexer NAME = new NameIndexer();
+
+	private static final String POISON = "poison";
+
+	/** Refuses one particular value, to make an index update throw at the point that matters. */
+	static class ThrowingNameIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			if(POISON.equals(entity.name))
+			{
+				throw new IllegalStateException("indexer refuses " + POISON);
+			}
+			return entity.name;
+		}
+	}
+
+	/**
+	 * Refuses one particular value exactly once, so that the rollback triggered by the failure can still
+	 * clean the indices up (it re-runs the indexers to locate the entries to remove).
+	 */
+	static class FailOnceNameIndexer extends IndexerString.Abstract<Item>
+	{
+		private boolean refused;
+
+		@Override
+		protected String getString(final Item entity)
+		{
+			if(POISON.equals(entity.name) && !this.refused)
+			{
+				this.refused = true;
+				throw new IllegalStateException("indexer refuses " + POISON + " once");
+			}
+			return entity.name;
+		}
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// structural reclamation //
+	///////////////////////////
+
+	@Test
+	public void emptyingALevel1SegmentReleasesIt()
+	{
+		// 2 entities per level1 segment: ids 0+1 in segment 0, ids 2+3 in segment 1.
+		final GigaMap<Item> map = GigaMap.New(1);
+		for(int i = 0; i < 4; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+		assertEquals(2, nonNullLevel1Count(map), "two level1 segments to start with");
+
+		map.removeById(0);
+		assertNotNull(level1EntryOf(map, 0, 0), "one entity left, so the segment is still in use");
+
+		map.removeById(1);
+		assertNull(level1EntryOf(map, 0, 0), "the emptied level1 segment must be released");
+		assertNotNull(level2EntryOf(map, 0), "the level2 segment still holds the second level1 segment");
+		assertNotNull(level1EntryOf(map, 0, 1), "the untouched level1 segment stays");
+
+		assertEquals(2L, map.size(), "the size only counts the surviving entities");
+		assertEquals(3L, map.highestUsedId(), "ids are not recycled");
+		assertNull(map.get(0), "the released ids read as empty slots");
+		assertNull(map.get(1), "the released ids read as empty slots");
+		assertNotNull(map.get(2), "the surviving entities are untouched");
+		assertNotNull(map.get(3), "the surviving entities are untouched");
+		assertEquals(2, countIterated(map), "iteration agrees with the size");
+	}
+
+	@Test
+	public void emptyingTheLastLevel1ReleasesTheLevel2()
+	{
+		// 1 entity per level1 segment, 256 level1 segments per level2 segment: ids 0-255 in level2
+		// segment 0, id 256 in level2 segment 1.
+		final GigaMap<Item> map = GigaMap.New(0, 8);
+		for(int i = 0; i < 257; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+		assertEquals(2, nonNullLevel2Count(map), "two level2 segments to start with");
+
+		for(long id = 0; id < 255; id++)
+		{
+			map.removeById(id);
+		}
+		assertNotNull(level2EntryOf(map, 0), "one entity left, so the level2 segment is still in use");
+
+		map.removeById(255);
+		assertNull(level2EntryOf(map, 0), "the emptied level2 segment must be released as well");
+		assertNotNull(level2EntryOf(map, 1), "the untouched level2 segment stays");
+
+		assertEquals(1L, map.size(), "the size only counts the surviving entity");
+		assertEquals(256L, map.highestUsedId(), "ids are not recycled");
+		assertNotNull(map.get(256), "the surviving entity is untouched");
+		assertEquals(1, countIterated(map), "iteration agrees with the size");
+	}
+
+	/**
+	 * The segment the next add writes into is cached in the map's adding state. Releasing it without
+	 * folding that state first would make the next add write into a {@link GigaLevel1} no longer
+	 * reachable from its level2 - a silently lost entity - and fail on the now-null slot while marking
+	 * the segment changed. This is the ordinary case, not an exotic one: a map that has not filled its
+	 * first segment yet removes entities with the adding state pointing right at them.
+	 */
+	@Test
+	public void drainingTheAddingSegmentKeepsAddingConsistent()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.add(new Item("a"));
+		map.add(new Item("b"));
+		map.add(new Item("c"));
+
+		map.removeById(0);
+		map.removeById(1);
+		map.removeById(2);
+
+		assertEquals(0L, map.size(), "everything was removed");
+		assertEquals(0, nonNullLevel1Count(map), "the drained segment must be released");
+		assertEquals(0, nonNullLevel2Count(map), "and its now empty level2 segment too");
+
+		final Item d  = new Item("d");
+		final long id = map.add(d);
+
+		assertEquals(3L, id, "the next add gets a fresh id, the released ids are not recycled");
+		assertEquals(1L, map.size(), "the new entity is counted");
+		assertEquals(d, map.get(3), "the new entity is readable at its id, so the segment was re-created");
+		assertNull(map.get(0), "the released ids stay empty");
+		assertNull(map.get(1), "the released ids stay empty");
+		assertNull(map.get(2), "the released ids stay empty");
+		assertEquals(1, countIterated(map), "iteration agrees with the size");
+	}
+
+	/**
+	 * The counterpart: draining a segment that is not the one being added to must leave the adding state
+	 * alone, or every removal would cost a needless adding-state setup.
+	 */
+	@Test
+	public void drainingANonAddingSegmentLeavesTheAddingStateAlone()
+	{
+		// 4 entities per level1 segment: ids 0-3 in segment 0, id 4 in segment 1 (the adding one).
+		final GigaMap<Item> map = GigaMap.New(2);
+		for(int i = 0; i < 5; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+
+		for(long id = 0; id < 4; id++)
+		{
+			map.removeById(id);
+		}
+
+		assertNull(level1EntryOf(map, 0, 0), "the drained segment is released");
+		assertNotNull(level1EntryOf(map, 0, 1), "the adding segment is untouched");
+		assertEquals(1L, map.size(), "one entity left");
+		assertEquals(4L, map.highestUsedId(), "the adding state was not disturbed");
+
+		assertEquals(5L, map.add(new Item("item5")), "adding continues in the still live adding segment");
+		assertEquals(2L, map.size(), "both remaining entities are counted");
+	}
+
+	/**
+	 * The workload from the issue in its harshest form: a queue of depth one. Every removal empties the
+	 * segment the following add then resumes in, so nothing may accumulate at all.
+	 */
+	@Test
+	public void interleavedAddRemoveDoesNotAccumulateSegments()
+	{
+		this.assertInterleavedAddRemoveKeepsNothing(GigaMap.New(1) , 2000);
+		this.assertInterleavedAddRemoveKeepsNothing(GigaMap.New()  , 2000);
+		this.assertInterleavedAddRemoveKeepsNothing(GigaMap.New(0, 8), 2000);
+	}
+
+	private void assertInterleavedAddRemoveKeepsNothing(final GigaMap<Item> map, final int cycles)
+	{
+		for(int i = 0; i < cycles; i++)
+		{
+			map.removeById(map.add(new Item("item" + i)));
+		}
+
+		assertEquals(0L, map.size(), "nothing is left alive");
+		assertEquals(0, countIterated(map), "iteration agrees with the size");
+		assertTrue(nonNullLevel1Count(map) <= 1,
+			"emptied level1 segments must not accumulate, found " + nonNullLevel1Count(map));
+		assertTrue(nonNullLevel2Count(map) <= 1,
+			"emptied level2 segments must not accumulate, found " + nonNullLevel2Count(map));
+		assertEquals(cycles - 1, map.highestUsedId(), "ids are still not recycled");
+
+		final Item last = new Item("last");
+		final long id   = map.add(last);
+		assertEquals(cycles, id, "the map is still usable");
+		assertEquals(last, map.get(id), "and the entity is readable");
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// persistence //
+	////////////////
+
+	/**
+	 * The released slot has to reach the disk. A level2 slot is covered by the change marking a removal
+	 * already did, but the level3's own array is only rewritten when the level3 instance itself is
+	 * flagged - without that flag the drop would be in-memory only and a restart would resurrect a whole
+	 * subtree of removed entities, while the persisted size and id counter would know nothing about them.
+	 */
+	@Test
+	public void releasedLevel1StaysReleasedAcrossRestart(@TempDir final Path dir)
+	{
+		{
+			final GigaMap<Item> map = GigaMap.<Item>New(1);
+			map.index().bitmap().add(NAME);
+			final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir);
+			for(int i = 0; i < 4; i++)
+			{
+				map.add(new Item("item" + i));
+			}
+			storage.storeRoot();
+
+			map.removeById(0);
+			map.removeById(1);
+			assertNull(level1EntryOf(map, 0, 0), "the emptied level1 segment is released in memory");
+
+			map.store();
+			storage.shutdown();
+		}
+
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		try
+		{
+			final GigaMap<Item> map = storage.root();
+
+			assertNull(level1EntryOf(map, 0, 0), "the released level1 segment must not come back");
+			assertEquals(2L, map.size(), "the size survived");
+			assertEquals(2, countIterated(map), "iteration agrees with the size");
+			assertNull(map.get(0), "the removed entities stay removed");
+			assertNull(map.get(1), "the removed entities stay removed");
+			assertNotNull(map.get(2), "the surviving entities survived");
+			assertEquals(0L, map.query(NAME, "item0").count(), "and nothing resurrected into the index");
+			assertEquals(1L, map.query(NAME, "item2").count(), "the surviving entities are still indexed");
+			assertEquals(4L, map.add(new Item("item4")), "adding continues at the next fresh id");
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+	}
+
+	@Test
+	public void releasedLevel2StaysReleasedAcrossRestart(@TempDir final Path dir)
+	{
+		{
+			final GigaMap<Item> map = GigaMap.<Item>New(0, 8);
+			map.index().bitmap().add(NAME);
+			final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir);
+			for(int i = 0; i < 257; i++)
+			{
+				map.add(new Item("item" + i));
+			}
+			storage.storeRoot();
+
+			for(long id = 0; id < 256; id++)
+			{
+				map.removeById(id);
+			}
+			assertNull(level2EntryOf(map, 0), "the emptied level2 segment is released in memory");
+
+			map.store();
+			storage.shutdown();
+		}
+
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		try
+		{
+			final GigaMap<Item> map = storage.root();
+
+			assertNull(level2EntryOf(map, 0), "the released level2 segment must not come back");
+			assertEquals(1L, map.size(), "the size survived");
+			assertEquals(1, countIterated(map), "iteration agrees with the size");
+			assertNull(map.get(0), "the removed entities stay removed");
+			assertNotNull(map.get(256), "the surviving entity survived");
+			assertEquals(0L, map.query(NAME, "item0").count(), "and nothing resurrected into the index");
+			assertEquals(1L, map.query(NAME, "item256").count(), "the surviving entity is still indexed");
+			assertEquals(257L, map.add(new Item("item257")), "adding continues at the next fresh id");
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+	}
+
+	/**
+	 * A segment release is a structural change that is not stored yet, so the segment carrying it must
+	 * not be evicted before the store - otherwise the store would silently skip it while the index and
+	 * size updates commit anyway. Same guarantee as
+	 * {@code org.eclipse.store.gigamap.issues.DirtySegmentEvictionLostUpdateTest}, for the release.
+	 */
+	@Test
+	public void releasedSegmentSurvivesReleaseBeforeStore(@TempDir final Path dir)
+	{
+		{
+			final GigaMap<Item> map = GigaMap.<Item>New(1);
+			map.index().bitmap().add(NAME);
+			final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir);
+			for(int i = 0; i < 4; i++)
+			{
+				map.add(new Item("item" + i));
+			}
+			storage.storeRoot();
+
+			map.removeById(0);
+			map.removeById(1);
+
+			map.release();
+			map.store();
+			storage.shutdown();
+		}
+
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		try
+		{
+			final GigaMap<Item> map = storage.root();
+
+			assertNull(level1EntryOf(map, 0, 0), "the release must have been stored, not evicted");
+			assertEquals(2L, map.size(), "the size survived");
+			assertEquals(2, countIterated(map), "iteration agrees with the size");
+			assertNull(map.get(0), "no resurrection");
+			assertEquals(0L, map.query(NAME, "item0").count(), "and no index divergence");
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+	}
+
+	/**
+	 * The scenario reported in the issue: monotonic fill-one-segment / empty-it cycles with a store per
+	 * cycle. It used to leave one dead level1 segment per cycle behind, persisted, reloaded and immune
+	 * to a full garbage collection because the segments stayed reachable.
+	 */
+	@Test
+	public void monotonicFillEmptyCyclesDoNotRetainSegments(@TempDir final Path dir)
+	{
+		final int perSegment = 256; // exactly one level1 segment with the default dimensions
+		final int cycles     = 30 ;
+
+		{
+			final GigaMap<Item> map = GigaMap.New();
+			map.index().bitmap().add(NAME);
+			final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir);
+			storage.storeRoot();
+
+			for(int c = 0; c < cycles; c++)
+			{
+				final long[] ids = new long[perSegment];
+				for(int i = 0; i < perSegment; i++)
+				{
+					ids[i] = map.add(new Item("item" + (c * perSegment + i)));
+				}
+				for(final long id : ids)
+				{
+					map.removeById(id);
+				}
+				map.store();
+			}
+			storage.issueFullGarbageCollection();
+			storage.shutdown();
+		}
+
+		final EmbeddedStorageManager storage = EmbeddedStorage.start(dir);
+		try
+		{
+			final GigaMap<Item> map = storage.root();
+
+			assertEquals(0L, map.size(), "the workload leaves nothing alive");
+			assertEquals(0, countIterated(map), "iteration agrees with the size");
+			assertTrue(nonNullLevel1Count(map) <= 1,
+				"emptied level1 segments must not be persisted and reloaded, found "
+				+ nonNullLevel1Count(map) + " with 0 live entities");
+			assertEquals(cycles * perSegment - 1, map.highestUsedId(), "ids are still not recycled");
+		}
+		finally
+		{
+			storage.shutdown();
+		}
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// writing back into a released id //
+	////////////////////////////////////
+
+	/**
+	 * {@code set(id, entity)} into a slot a removal emptied is the supported way to undo a removal at its
+	 * own id (see {@code test.eclipse.store.storer.SetAfterRemoveSizeTest}). It has to keep working when
+	 * the removals released the whole segment, which means re-creating it.
+	 */
+	@Test
+	public void setIntoAReleasedLevel1RematerializesIt()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(1);
+		map.index().bitmap().add(NAME);
+		for(int i = 0; i < 4; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+
+		map.removeById(0);
+		map.removeById(1);
+		assertNull(level1EntryOf(map, 0, 0), "the segment is released");
+
+		final Item restored = new Item("item0");
+		assertNull(map.set(0, restored), "nothing was replaced, the slot was empty");
+
+		assertNotNull(level1EntryOf(map, 0, 0), "the segment was re-created");
+		assertEquals(3L, map.size(), "filling the released slot restores the size");
+		assertEquals(restored, map.get(0), "the entity is back at its own id");
+		assertEquals(1L, map.query(NAME, "item0").count(), "and is indexed");
+		assertEquals(4L, map.add(new Item("item4")), "adding still gets the next fresh id");
+	}
+
+	@Test
+	public void setIntoAReleasedLevel2RematerializesIt()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(0, 8);
+		map.index().bitmap().add(NAME);
+		for(int i = 0; i < 257; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+
+		for(long id = 0; id < 256; id++)
+		{
+			map.removeById(id);
+		}
+		assertNull(level2EntryOf(map, 0), "the level2 segment is released");
+
+		final Item restored = new Item("item0");
+		assertNull(map.set(0, restored), "nothing was replaced, the slot was empty");
+
+		assertNotNull(level2EntryOf(map, 0), "the level2 segment was re-created");
+		assertNotNull(level1EntryOf(map, 0, 0), "and so was the level1 segment");
+		assertEquals(2L, map.size(), "filling the released slot restores the size");
+		assertEquals(restored, map.get(0), "the entity is back at its own id");
+		assertEquals(1L, map.query(NAME, "item0").count(), "and is indexed");
+		assertEquals(257L, map.add(new Item("item257")), "adding still gets the next fresh id");
+	}
+
+	/**
+	 * A failed {@code set} must leave the map observably unchanged, which includes not leaving a freshly
+	 * created, empty segment (and a pending re-store for it) behind. So the segment is materialized only
+	 * after the last thing that can throw.
+	 */
+	@Test
+	public void aFailedSetIntoAReleasedSegmentCreatesNoSegment()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(1);
+		map.index().bitmap().add(new ThrowingNameIndexer());
+		for(int i = 0; i < 4; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+
+		map.removeById(0);
+		map.removeById(1);
+		assertNull(level1EntryOf(map, 0, 0), "the segment is released");
+
+		assertThrows(RuntimeException.class, () -> map.set(0, new Item(POISON)),
+			"the indexer refuses this entity");
+
+		assertNull(level1EntryOf(map, 0, 0), "a failed set must not re-create the segment");
+		assertEquals(2L, map.size(), "a failed set must leave the size as it was");
+		assertNull(map.get(0), "and the slot still empty");
+
+		// The map is still usable, and a successful restore still works.
+		final Item restored = new Item("item0");
+		assertNull(map.set(0, restored), "the slot was still empty");
+		assertEquals(3L, map.size(), "a subsequent successful restore counts");
+		assertEquals(restored, map.get(0), "and is readable");
+	}
+
+	/**
+	 * A rolled-back add releases the segment it had just created for its entity, and since the rollback
+	 * reclaims the id as well, the following add has to re-create that very segment.
+	 * <p>
+	 * The indexer fails only on its first call, because the rollback re-runs the indexers to locate the
+	 * entries to clean up: an indexer that keeps throwing aborts the cleanup, on which the rollback
+	 * deliberately keeps both the id and - since the reclamation is the last step of a removal - the
+	 * segment, so that the stale index entries can never alias a future entity.
+	 */
+	@Test
+	public void rollbackAfterAFailedAddReleasesTheFreshSegment()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(1);
+		map.index().bitmap().add(new FailOnceNameIndexer());
+		map.add(new Item("item0"));
+		map.add(new Item("item1"));
+		assertEquals(1, nonNullLevel1Count(map), "both entities are in the first level1 segment");
+
+		assertThrows(RuntimeException.class, () -> map.add(new Item(POISON)),
+			"the indexer refuses this entity once");
+
+		assertEquals(1, nonNullLevel1Count(map), "the segment the rolled back add created is released");
+		assertNull(level1EntryOf(map, 0, 1), "specifically the one for the rolled back id");
+		assertEquals(2L, map.size(), "the failed add is not counted");
+
+		final Item item2 = new Item("item2");
+		assertEquals(2L, map.add(item2), "the rolled back id is handed out again");
+		assertNotNull(level1EntryOf(map, 0, 1), "and its segment was re-created");
+		assertEquals(item2, map.get(2), "the entity is readable");
+		assertEquals(3L, map.size(), "and counted");
+	}
+
+	/**
+	 * An indexer that keeps throwing aborts the rollback's index cleanup, and the rollback then keeps
+	 * the id unreclaimed on purpose. The segment goes with it: a removal reclaims its segment only after
+	 * the index removal succeeded, so a half-failed removal leaves the segment tree untouched.
+	 */
+	@Test
+	public void rollbackWithAFailingCleanupKeepsTheFreshSegment()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(1);
+		map.index().bitmap().add(new ThrowingNameIndexer());
+		map.add(new Item("item0"));
+		map.add(new Item("item1"));
+
+		assertThrows(RuntimeException.class, () -> map.add(new Item(POISON)),
+			"the indexer refuses this entity");
+
+		assertNotNull(level1EntryOf(map, 0, 1), "the segment of the uncleaned id is kept");
+		assertEquals(2L, map.size(), "the failed add is not counted");
+		assertNull(map.get(2), "but its slot is empty");
+		assertEquals(3L, map.add(new Item("item3")), "and its id is not handed out again");
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// released ids on the other entity paths //
+	///////////////////////////////////////////
+
+	@Test
+	public void applyOnAReleasedIdFailsCleanly()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(1);
+		map.index().bitmap().add(NAME);
+		for(int i = 0; i < 4; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+
+		map.removeById(0);
+		map.removeById(1);
+
+		assertThrows(IllegalArgumentException.class, () -> map.apply(0L, e -> e),
+			"there is no entity at a released id");
+		assertNull(map.removeById(0), "removing a released id again is a no-op");
+		assertNull(map.peek(0), "peeking a released id yields nothing");
+		assertEquals(2L, map.size(), "none of that changed the size");
+	}
+
+	/**
+	 * The update logic runs while this map's (reentrant) monitor is held, so it can remove the very
+	 * entity it is applied to - and with a segment of 2 that removal can release the segment underneath
+	 * the running apply. Whatever else that reports, it must not be a {@link NullPointerException} from
+	 * the persistence bookkeeping dereferencing a segment that is gone.
+	 */
+	@Test
+	public void reentrantRemovalFromApplyLogicDoesNotHitAGoneSegment()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(1);
+		map.index().bitmap().add(NAME);
+		final long a = map.add(new Item("a"));
+		map.add(new Item("b"));
+		map.add(new Item("c"));
+		map.removeById(1); // leaves only id 0 in the first level1 segment
+
+		try
+		{
+			map.apply(a, e ->
+			{
+				map.removeById(a);
+				return e;
+			});
+		}
+		catch(final NullPointerException e)
+		{
+			fail("the released segment must not cause a NullPointerException", e);
+		}
+		catch(final RuntimeException e)
+		{
+			// Reentrant mutation from update logic is not a supported use, so any other report is fine.
+		}
+
+		assertNull(level1EntryOf(map, 0, 0), "the segment was released");
+		assertNull(map.get(a), "the entity is gone");
+		assertEquals(1L, map.size(), "only the untouched entity is left");
+		assertEquals(1, countIterated(map), "iteration agrees with the size");
+	}
+
+	@Test
+	public void removeAllAndReleaseTolerateReleasedSegments()
+	{
+		final GigaMap<Item> map = GigaMap.<Item>New(0, 8);
+		map.index().bitmap().add(NAME);
+		for(int i = 0; i < 257; i++)
+		{
+			map.add(new Item("item" + i));
+		}
+		for(long id = 0; id < 256; id++)
+		{
+			map.removeById(id);
+		}
+		assertNull(level2EntryOf(map, 0), "the level2 segment is released");
+
+		map.release();
+		map.removeAll();
+
+		assertEquals(0L, map.size(), "removeAll cleared the rest");
+		assertEquals(0, countIterated(map), "iteration agrees with the size");
+		assertEquals(0L, map.add(new Item("fresh")), "removeAll reset the id counter");
+		assertEquals(1L, map.size(), "and the map is usable again");
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// helpers //
+	////////////
+
+	private static <E> GigaLevel3<E> level3(final GigaMap<E> map)
+	{
+		return ((GigaMap.Default<E>)map).level3();
+	}
+
+	private static <E> Lazy<GigaLevel2<E>> level2EntryOf(final GigaMap<E> map, final int level3Index)
+	{
+		return level3(map).segments[level3Index];
+	}
+
+	private static <E> Lazy<GigaLevel1<E>> level1EntryOf(
+		final GigaMap<E> map        ,
+		final int        level3Index,
+		final int        level2Index
+	)
+	{
+		final Lazy<GigaLevel2<E>> level2Entry = level2EntryOf(map, level3Index);
+
+		return level2Entry == null
+			? null
+			: level2Entry.get().segments[level2Index]
+		;
+	}
+
+	/**
+	 * Counts the level1 segments the segment tree still holds. Deliberately counts non-null
+	 * {@link Lazy} slots, not loaded instances, so the count measures retention and is unaffected by
+	 * lazy eviction.
+	 */
+	private static <E> int nonNullLevel1Count(final GigaMap<E> map)
+	{
+		int count = 0;
+		for(final Lazy<GigaLevel2<E>> level2Entry : level3(map).segments)
+		{
+			if(level2Entry == null)
+			{
+				continue;
+			}
+			for(final Lazy<GigaLevel1<E>> level1Entry : level2Entry.get().segments)
+			{
+				if(level1Entry != null)
+				{
+					count++;
+				}
+			}
+		}
+
+		return count;
+	}
+
+	private static <E> int nonNullLevel2Count(final GigaMap<E> map)
+	{
+		int count = 0;
+		for(final Lazy<GigaLevel2<E>> level2Entry : level3(map).segments)
+		{
+			if(level2Entry != null)
+			{
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	private static <E> int countIterated(final GigaMap<E> map)
+	{
+		final AtomicLong count = new AtomicLong();
+		map.iterate(e -> count.incrementAndGet());
+
+		return (int)count.get();
+	}
+
+}


### PR DESCRIPTION
`internalRemove` nulled only the entity slot, so the emptied `GigaLevel1` stayed referenced from its `GigaLevel2` and that one from the `GigaLevel3` forever. Since ids are never recycled, an add/remove churn workload - a queue, a TTL cache, an event log, a staging store, the very use cases GigaMap targets - accumulated one dead segment per exhausted id range. The retained segments were not collectable (still reachable through the segment tree), not freed by a restart (persisted and reloaded), and not fixable by the application: there is no `compact()`, and `removeAll()` would have discarded the live data too. The leak scaled with the number of ever-used segments, not with the live size. The bitmap index tree has always self-cleaned on emptying (`BitmapLevel3.clearLevel2Segment`); the entity tree was the one place that skipped it.

A removal now checks whether it emptied the segment and, if so, drops it from its `GigaLevel2` - and drops that `GigaLevel2` from the `GigaLevel3` when it became empty as well. Nothing observable changes: `size()`, `nextFreeId()`, id assignment and query results are exactly as before, and every reader already treated a null segment slot as a lookup miss.

`GigaLevel3.removeLevel2` marks the level3 instance itself changed, which is mandatory and cannot be left to `markChanged`: that one flags only the children, so without the instance flag the drop would have been in-memory only and a restart would have resurrected a whole subtree of removed entities, while the persisted size and id counter knew nothing about them. Nulls in these reference arrays are already a round-trippable state, so there is no format change. The emptiness scan starts right after the slot just cleared and wraps around, so a sequential drain exits on the first surviving neighbour instead of walking the array, and it is bound to the array's own length rather than the map's configured segment size, which a reloaded array need not match.

## The three paths that were not null-tolerant

**The adding state.** It caches the segment the next add writes into, and `ensureClearedAddingState` deliberately keeps a live, non-exhausted adding segment - so removals normally run with that state pointing right at the segment they empty, which is the case for any map that has not filled its first segment yet. Releasing it without folding the state first would have made the next add write into a `GigaLevel1` no longer reachable from its level2, silently losing the entity, and would have failed on the now-null slot while marking it changed: `add(a), add(b), add(c), removeById(0..2), add(d)` is enough. The fold is `clearAddingState`, under which `size()` and `nextFreeId()` are invariant; the next add then re-creates the segment and resumes at the very same level1 index. It compares coordinates rather than instance identity, because `addingLevel1` may be a stale instance whose `Lazy` was evicted and reloaded, and an identity comparison would silently skip the fold. The misleading comment on the branch in `ensureClearedAddingState` that said the opposite of what it does is corrected; the condition itself is deliberately left alone, since inverting it would force an adding-state setup after every removal.

**`set(long, E)`.** Writing into a slot a removal emptied is the supported way to undo a removal at its own id (#793), and it walked the segments unguarded. It now resolves the replaced entity through `get(long)` and materializes the segments through the existing `ensureLevel2`/`ensureLevel1` - after the constraint check and the index update, not before, so a failed `set` still leaves the map observably unchanged instead of leaving a fresh empty segment and a pending re-store behind.

**`markEntitySegmentChanged`.** The update logic passed to `apply` runs while the map's reentrant monitor is held, so it can remove the very entity it is applied to and release the segment underneath the running apply; a gone segment holds no entity and there is nothing left to mark.

## Tests

`EntitySegmentReclamationTest` covers this from the `types` test package, so it reads the segment arrays directly instead of reflectively: the level1 and level2 drops, the adding-segment fold and its counterpart (draining a non-adding segment must not disturb the adding state), the interleaved add/remove queue of depth one, the issue's own 30x fill-and-empty cycles with a store per cycle and a restart, both releases surviving a restart and surviving a `release()` before the store, `set` into a released level1 and level2, a failed `set` creating no segment, the rollback of a failed add releasing the segment it had just created - and the contrast case where a still-throwing indexer aborts the cleanup and the segment is deliberately kept with the id - `apply` on a released id, a reentrant removal from apply logic, and `removeAll()`/`release()` over already-released slots.

Fifteen of the seventeen fail against the unfixed code; the two that pass pin unchanged behaviour. The three sub-guards were checked individually: without the fold, exactly the two adding-segment tests throw in `GigaLevel3.markChanged`; with `internalSet` reverted, exactly the three `set` tests throw; with the hardening reverted, exactly the reentrant-apply test throws.

## Known limitation

Reclamation happens as a removal empties a segment, so segments left empty by an earlier version are not cleaned up retroactively, and neither is the rare empty segment a rolled-back first add into a fresh segment leaves behind. Documented on `removeById` rather than papered over with a new `consolidate()` API.

## Verification

Full gigamap suite green: 1138 tests. `gigamap/lucene` 74, `gigamap/jvector` 121 with `-Pslow-tests`, `integration-tests` 1326 - including `SetAfterRemoveSizeTest`, the direct contract for the `internalSet` change, and `GigaMapDanglingReferenceTest`, which runs with `StorageReferenceValidationPolicy.FAIL` and would catch a segment persisted with a reference to a non-existent entity.
