### PR TITLE
GigaMap: clear the composite index key carrier before every indexer invocation (internal#137)

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -410,7 +410,7 @@ implements BitmapIndex.TopLevel<E, KS>
 					continue;
 				}
 
-				// #query is guaranteed to no return a NO_RESULT, since that would have caused a return in the loop above.
+				// #query is guaranteed not to return an EMPTY_RESULT, since that would have caused a return in the loop above.
 				results[r++] = this.subIndices[i].internalQueryForKeys(keys);
 			}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -93,8 +93,25 @@ implements BitmapIndex.TopLevel<E, KS>
 	protected abstract void ensureSubIndices(KS keys);
 	
 	protected abstract void clearCarrier();
-	
+
 	protected abstract KS carrier();
+
+	/**
+	 * Returns the shared carrier in a guaranteed cleared state.
+	 * <p>
+	 * The carrier may still hold positions from a previous use (e.g. the previous element of an
+	 * addAll batch, or a preceding contains check). An indexer is allowed to leave empty positions
+	 * unwritten - the "unwritten position = empty" contract - so it must always receive a cleared
+	 * carrier. Every {@code indexer.index(entity, carrier)} invocation must use this method
+	 * instead of {@link #carrier()}.
+	 *
+	 * @return the cleared carrier
+	 */
+	private KS cleanCarrier()
+	{
+		this.clearCarrier();
+		return this.carrier();
+	}
 	
 	protected abstract boolean isEmpty(KS keys, int i);
 	
@@ -133,7 +150,7 @@ implements BitmapIndex.TopLevel<E, KS>
 	@Override
 	protected KS indexEntity(final E entity)
 	{
-		return this.indexer().index(entity, this.carrier());
+		return this.indexer().index(entity, this.cleanCarrier());
 	}
 	
 	@Override
@@ -212,7 +229,7 @@ implements BitmapIndex.TopLevel<E, KS>
 	@Override
 	public final void internalRemove(final long entityId, final E entity)
 	{
-		final KS keys = this.indexer.index(entity, this.carrier());
+		final KS keys = this.indexer.index(entity, this.cleanCarrier());
 		this.internalRemoveForKeys(entityId, keys);
 	}
 	
@@ -259,7 +276,11 @@ implements BitmapIndex.TopLevel<E, KS>
 	@Override
 	protected final void internalAddToEntry(final long entityId, final E entity)
 	{
-		final KS keys = this.indexer.index(entity, this.carrier());
+		// cleanCarrier (not carrier) is essential here: this method is invoked per element by the
+		// inherited addAll loops, whose enclosing clearCarrier() runs only AFTER the whole batch.
+		// Without the per-element clear, an indexer that leaves absent positions unwritten would
+		// inherit the previous element's positions, silently corrupting the index keys.
+		final KS keys = this.indexer.index(entity, this.cleanCarrier());
 		this.ensureSubIndices(keys);
 		
 		for(int i = 0; i < this.subIndices.length; i++)
@@ -355,7 +376,7 @@ implements BitmapIndex.TopLevel<E, KS>
 
 	private boolean internalContains(final E entity, final EntityResolver<E> containsBreaker)
 	{
-		final KS keys = this.indexer.index(entity, this.carrier());
+		final KS keys = this.indexer.index(entity, this.cleanCarrier());
 		if(this.isOversized(keys))
 		{
 			// if the keys contains more key values than there currently are sub indices, the entity cannot possibly be contained.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -376,58 +376,67 @@ implements BitmapIndex.TopLevel<E, KS>
 
 	private boolean internalContains(final E entity, final EntityResolver<E> containsBreaker)
 	{
-		final KS keys = this.indexer.index(entity, this.cleanCarrier());
-		if(this.isOversized(keys))
-		{
-			// if the keys contains more key values than there currently are sub indices, the entity cannot possibly be contained.
-			return false;
-		}
-		
-		for(int i = 0; i < this.subIndices.length; i++)
-		{
-			// a null key value means it is irrelevant for the query
-			if(this.isEmpty(keys, i))
-			{
-				continue;
-			}
-			
-			if(!this.subIndices[i].internalContains(keys))
-			{
-				// if at least one sub index does not contain a non-null key, the whole entity cannot be contained.
-				return false;
-			}
-		}
-		
-		final BitmapResult[] results = new BitmapResult[this.subIndices.length];
-		int r = 0;
-		
-		for(int i = 0; i < this.subIndices.length; i++)
-		{
-			if(this.isEmpty(keys, i))
-			{
-				continue;
-			}
-			
-			// #query is guaranteed to no return a NO_RESULT, since that would have caused a return in the loop above.
-			results[r++] = this.subIndices[i].internalQueryForKeys(keys);
-		}
-		
-		final GigaMap<E> parentMap = this.parent().parentMap();
-		
-		// if the entity might be contained, a full query result evaluation has to be performed. But without loading entities.
 		try
 		{
-			// contains function throws a Break on the first encounter of a (non-excluded) match
-			GigaMap.Default.execute(EntityIdMatcher.NoOp(), containsBreaker, results, 0, parentMap.highestUsedId() + 1, null);
+			final KS keys = this.indexer.index(entity, this.cleanCarrier());
+			if(this.isOversized(keys))
+			{
+				// if the keys contains more key values than there currently are sub indices, the entity cannot possibly be contained.
+				return false;
+			}
+
+			for(int i = 0; i < this.subIndices.length; i++)
+			{
+				// a null key value means it is irrelevant for the query
+				if(this.isEmpty(keys, i))
+				{
+					continue;
+				}
+
+				if(!this.subIndices[i].internalContains(keys))
+				{
+					// if at least one sub index does not contain a non-null key, the whole entity cannot be contained.
+					return false;
+				}
+			}
+
+			final BitmapResult[] results = new BitmapResult[this.subIndices.length];
+			int r = 0;
+
+			for(int i = 0; i < this.subIndices.length; i++)
+			{
+				if(this.isEmpty(keys, i))
+				{
+					continue;
+				}
+
+				// #query is guaranteed to no return a NO_RESULT, since that would have caused a return in the loop above.
+				results[r++] = this.subIndices[i].internalQueryForKeys(keys);
+			}
+
+			final GigaMap<E> parentMap = this.parent().parentMap();
+
+			// if the entity might be contained, a full query result evaluation has to be performed. But without loading entities.
+			try
+			{
+				// contains function throws a Break on the first encounter of a (non-excluded) match
+				GigaMap.Default.execute(EntityIdMatcher.NoOp(), containsBreaker, results, 0, parentMap.highestUsedId() + 1, null);
+			}
+			catch(final ThrowBreak b)
+			{
+				// contains function aborted the execution because of a match, aka the entity is contained, so return true.
+				return true;
+			}
+
+			// execution ran through until the end without finding any match. So the entity is not contained, return false.
+			return false;
 		}
-		catch(final ThrowBreak b)
+		finally
 		{
-			// contains function aborted the execution because of a match, aka the entity is contained, so return true.
-			return true;
+			// consistent with the other operations: do not leave the shared carrier populated
+			// (for the hashing variant this would retain stale object references).
+			this.clearCarrier();
 		}
-		
-		// execution ran through until the end without finding any match. So the entity is not contained, return false.
-		return false;
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeBatchCarrierClearingTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeBatchCarrierClearingTest.java
@@ -1,4 +1,3 @@
-
 package org.eclipse.store.gigamap.indexer;
 
 /*-

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeBatchCarrierClearingTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/CompositeBatchCarrierClearingTest.java
@@ -1,0 +1,179 @@
+
+package org.eclipse.store.gigamap.indexer;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+
+import org.eclipse.store.gigamap.types.BinaryCompositeIndexer;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.HashingCompositeIndexer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for GitHub issue: the composite index key carrier is not cleared BETWEEN the elements
+ * of an {@code addAll} batch.
+ * <p>
+ * Root cause: {@code AbstractCompositeBitmapIndex.internalAddAll} cleared the shared carrier
+ * only <strong>after</strong> the whole batch, while the inherited loop invoked
+ * {@code indexer.index(entity, carrier())} per element on the SAME array. A composite indexer
+ * that writes a position only when its component is present - the "unwritten position = empty"
+ * pattern that the per-single-add {@code clearCarrier()} calls exist to support - therefore
+ * inherited the carrier positions of its batch predecessor: the same entities got different
+ * index keys via {@code add()} vs {@code addAll()}.
+ * <p>
+ * Fix: the carrier is cleared before every {@code indexer.index(entity, carrier)} invocation,
+ * making batch semantics identical to per-element single adds by construction.
+ */
+public class CompositeBatchCarrierClearingTest
+{
+	static final class Rec
+	{
+		final long a;
+		final long b; // 0 means "absent" (optional component)
+
+		Rec(final long a, final long b)
+		{
+			this.a = a;
+			this.b = b;
+		}
+	}
+
+	/**
+	 * Optional-component binary composite: writes carrier[1] only when the component is present -
+	 * the pattern the framework's per-single-add clearCarrier() calls exist to support.
+	 */
+	static final class BinaryOptIdx extends BinaryCompositeIndexer.Abstract<Rec>
+	{
+		@Override
+		public String name()
+		{
+			return "binaryOpt";
+		}
+
+		@Override
+		public long[] index(final Rec entity, final long[] carrier)
+		{
+			final long[] result = carrier != null && carrier.length >= 2 ? carrier : new long[2];
+			result[0] = entity.a;
+			if(entity.b != 0L)
+			{
+				result[1] = entity.b;
+			}
+			return result;
+		}
+	}
+
+	/**
+	 * Same optional-component pattern for the hashing composite family ({@code Object[]} carrier,
+	 * empty position = null).
+	 */
+	static final class HashingOptIdx extends HashingCompositeIndexer.Abstract<Rec>
+	{
+		@Override
+		public String name()
+		{
+			return "hashingOpt";
+		}
+
+		@Override
+		public Object[] index(final Rec entity, final Object[] carrier)
+		{
+			final Object[] result = carrier != null && carrier.length >= 2 ? carrier : new Object[2];
+			result[0] = entity.a;
+			if(entity.b != 0L)
+			{
+				result[1] = entity.b;
+			}
+			return result;
+		}
+	}
+
+	@Test
+	@Timeout(60)
+	void binary_batchAddMustKeyElementsExactlyLikeSingleAdds()
+	{
+		final BinaryOptIdx idx = new BinaryOptIdx();
+
+		// reference: single adds - correct keys
+		final GigaMap<Rec> single = GigaMap.New();
+		single.index().bitmap().add(idx);
+		single.add(new Rec(1, 7));
+		single.add(new Rec(2, 0));
+		assertEquals(1, single.query(idx.is(new long[]{2, 0})).count(), "single add: true key");
+		assertEquals(0, single.query(idx.is(new long[]{2, 7})).count(), "single add: no alias");
+
+		// the SAME entities as a batch
+		final GigaMap<Rec> batch = GigaMap.New();
+		batch.index().bitmap().add(idx);
+		batch.addAll(List.of(new Rec(1, 7), new Rec(2, 0)));
+
+		assertEquals(1, batch.query(idx.is(new long[]{2, 0})).count(),
+			"CARRIER LEAK: the optional-absent batch element must be keyed [2,<empty>] exactly like "
+			+ "a single add - the shared carrier must be cleared per batch element, otherwise "
+			+ "the element inherits its predecessor's component");
+		assertEquals(0, batch.query(idx.is(new long[]{2, 7})).count(),
+			"CARRIER LEAK: entity (2,absent) must not be findable under the predecessor's b=7");
+	}
+
+	@Test
+	@Timeout(60)
+	void binary_varargsBatchAddMustKeyElementsExactlyLikeSingleAdds()
+	{
+		final BinaryOptIdx idx = new BinaryOptIdx();
+
+		final GigaMap<Rec> batch = GigaMap.New();
+		batch.index().bitmap().add(idx);
+		batch.addAll(new Rec(1, 7), new Rec(2, 0));
+
+		assertEquals(1, batch.query(idx.is(new long[]{2, 0})).count(),
+			"CARRIER LEAK (varargs addAll): the optional-absent batch element must be keyed [2,<empty>]");
+		assertEquals(0, batch.query(idx.is(new long[]{2, 7})).count(),
+			"CARRIER LEAK (varargs addAll): entity (2,absent) must not be findable under the predecessor's b=7");
+	}
+
+	@Test
+	@Timeout(60)
+	void hashing_batchAddMustKeyElementsExactlyLikeSingleAdds()
+	{
+		// note: for the hashing family a null sample position is a WILDCARD (ObjectSampleBased),
+		// so the discriminating assertion is the alias check on the predecessor's component value.
+		final HashingOptIdx idx = new HashingOptIdx();
+
+		// reference: single adds - correct keys
+		final GigaMap<Rec> single = GigaMap.New();
+		single.index().bitmap().add(idx);
+		single.add(new Rec(1, 7));
+		single.add(new Rec(2, 0));
+		assertEquals(1, single.query(idx.is(new Object[]{2L, null})).count(), "single add: found by first component");
+		assertEquals(0, single.query(idx.is(new Object[]{2L, 7L})).count(), "single add: no alias");
+
+		// the SAME entities as a batch
+		final GigaMap<Rec> batch = GigaMap.New();
+		batch.index().bitmap().add(idx);
+		batch.addAll(List.of(new Rec(1, 7), new Rec(2, 0)));
+
+		assertEquals(1, batch.query(idx.is(new Object[]{2L, null})).count(),
+			"batch element must be findable by its first component");
+		assertEquals(0, batch.query(idx.is(new Object[]{2L, 7L})).count(),
+			"CARRIER LEAK: entity (2,absent) must not be findable under the predecessor's b=7 - "
+			+ "the shared carrier must be cleared per batch element, otherwise the element "
+			+ "inherits its predecessor's component");
+	}
+}


### PR DESCRIPTION
## Summary

`AbstractCompositeBitmapIndex` cleared its shared key carrier only after a whole `addAll` batch, while the inherited loop handed the same array to `indexer.index(entity, carrier)` per element. A composite indexer that leaves absent positions unwritten - the "unwritten position = empty" pattern the per-single-add `clearCarrier()` calls exist to support - inherited its batch predecessor's positions: the same entities got different index keys via `add()` vs `addAll()`, silent corruption that is durable once stored.

## Fix

A private `cleanCarrier()` helper in `AbstractCompositeBitmapIndex` clears the carrier before returning it, and all four `indexer.index(entity, carrier)` call sites use it, making "the indexer always receives a clean carrier" true by construction:

- `internalAddToEntry` - the reported bug: per-element clear on the batch path
- `internalContains` - same defect class: it left the carrier dirty with no clear at all, so e.g. a unique-constraint check could poison a subsequent operation
- `internalRemove`, `indexEntity` - contract consistency

The existing `finally { clearCarrier(); }` blocks are kept (they also release stale object references in the `Object[]` hashing carrier). Since the fix lives in the shared abstract class, both composite families are covered at once: `CompositeBitmapIndexBinary` (`long[]`) and `CompositeBitmapIndexHashing` (`Object[]`).

## Test

New `CompositeBatchCarrierClearingTest` with the issue's reproducer plus two extensions: varargs `addAll` and the hashing family. All three tests are RED on main and GREEN with the fix. Note for the hashing variant: a `null` sample position in `is(...)` is a wildcard (`ObjectSampleBased`), unlike the binary family's exact-empty semantics, so that test discriminates via the alias assertion (the entity must not be findable under the predecessor's component value).

Full gigamap module suite: 1124 tests, 0 failures.
