### PR TITLE
GigaMap: stop the equalator from deciding whether set/replace writes at all

### DIFF
--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -108,3 +108,13 @@ gigaMap.apply(entityId, p -> {
 gigaMap.set(entityId, replacement);
 gigaMap.removeById(entityId);
 ----
+
+`set` and `replace` install a *different* instance in place of the current one and re-index that. They are therefore not a way to write back an entity you mutated yourself: passing the very instance the map already holds is rejected with an `IllegalArgumentException`, because re-indexing a mutation needs the keys the entity had *before* it was mutated, and those are gone once it has been mutated in place. That is exactly what `update` / `apply` derive up front, which is why they are the in-place path — and why `reindex()` is the repair for a mutation that already bypassed them.
+
+[source, java]
+----
+person.setLastName("Smith");
+
+gigaMap.set(entityId, person);                        // rejected - nothing to derive the old key from
+gigaMap.update(entityId, p -> p.setLastName("Smith")); // do this instead
+----

--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -71,16 +71,20 @@ Additionally, you have to use the `update` method of the GigaMap instead of just
 
 [source, java]
 ----
-// don't just update the entity
+// wrong: modifying the entity directly leaves the indices answering under the old values,
+// and there is no way back afterwards - the indexers can no longer derive what those were.
 person.setLastName("Smith");
 person.setAddress(newAddress);
 
-// use the update method, to automatically propagate the changes to the index
+// right: let update perform the modification, so the previous index keys are derived
+// before it applies - and the entity is scheduled for storing along the way.
 gigaMap.update(person, p -> {
-    p.setLastName("Smith"),
-    p.setAddress(newAddress)
+    p.setLastName("Smith");
+    p.setAddress(newAddress);
 });
 ----
+
+The two are alternatives, not steps: an `update` after a direct modification does not undo it. `update` derives the previous keys from the entity it is handed, and those are already the new values by then, so the stale entries stay. Once a direct modification has happened, only `reindex()` repairs the indices — it rebuilds them from the current entity state rather than trying to reconstruct the previous keys. It rebuilds index structures only, so the modified entity still has to be stored explicitly.
 
 Entities modified through `update` (or `apply`) are automatically persisted when calling `store()`. See xref:persistence.adoc[] for details.
 
@@ -113,14 +117,11 @@ gigaMap.removeById(entityId);
 
 [source, java]
 ----
-// wrong: the mutation has already happened, so nothing can derive the old key any more.
-// set rejects the instance it already holds - and update cannot repair it either, because it
-// would derive the "previous" keys from the mutated entity and find them unchanged.
+// wrong: set rejects the instance it already holds, and no method can repair the
+// modification afterwards - see above
 person.setLastName("Smith");
 gigaMap.set(entityId, person);
 
-// right: let update perform the mutation, so the old keys are derived before it applies.
+// right: let update perform the modification
 gigaMap.update(entityId, p -> p.setLastName("Smith"));
 ----
-
-If a direct mutation already happened, neither method repairs it — only `reindex()` does, since it rebuilds every index from the current entity state instead of trying to reconstruct the previous keys. Note that it rebuilds index structures only, so the mutated entity still has to be stored explicitly.

--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -113,8 +113,14 @@ gigaMap.removeById(entityId);
 
 [source, java]
 ----
+// wrong: the mutation has already happened, so nothing can derive the old key any more.
+// set rejects the instance it already holds - and update cannot repair it either, because it
+// would derive the "previous" keys from the mutated entity and find them unchanged.
 person.setLastName("Smith");
+gigaMap.set(entityId, person);
 
-gigaMap.set(entityId, person);                        // rejected - nothing to derive the old key from
-gigaMap.update(entityId, p -> p.setLastName("Smith")); // do this instead
+// right: let update perform the mutation, so the old keys are derived before it applies.
+gigaMap.update(entityId, p -> p.setLastName("Smith"));
 ----
+
+If a direct mutation already happened, neither method repairs it — only `reindex()` does, since it rebuilds every index from the current entity state instead of trying to reconstruct the previous keys. Note that it rebuilds index structures only, so the mutated entity still has to be stored explicitly.

--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -71,8 +71,9 @@ Additionally, you have to use the `update` method of the GigaMap instead of just
 
 [source, java]
 ----
-// wrong: modifying the entity directly leaves the indices answering under the old values,
-// and there is no way back afterwards - the indexers can no longer derive what those were.
+// wrong: modifying the entity directly leaves the indices answering under the old values.
+// The previous keys are gone once this runs, so no per-entity call can put them right
+// afterwards - it takes a full reindex(), see below.
 person.setLastName("Smith");
 person.setAddress(newAddress);
 
@@ -117,8 +118,8 @@ gigaMap.removeById(entityId);
 
 [source, java]
 ----
-// wrong: set rejects the instance it already holds, and no method can repair the
-// modification afterwards - see above
+// wrong: set rejects the instance it already holds, and recovering from the modification
+// then takes a full reindex() - see above
 person.setLastName("Smith");
 gigaMap.set(entityId, person);
 

--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -38,6 +38,8 @@ GigaMap has no automatic change tracking. Changes made to entities *directly* (o
 
 Mutating an indexed field directly leaves the indices stale: bitmap queries return wrong results, and Lucene searches fail *silently* (no error). A subsequent `gigaMap.store()` does not fix this — it neither re-runs the indexers nor implicitly persists the direct mutation.
 
+Note that `set` and `replace` cover a different case than `update` / `apply`: they install a *different* instance and re-index that, so they cannot write back an entity you mutated yourself — passing the instance the map already holds is rejected with an `IllegalArgumentException`.
+
 Always mutate indexed entities through `update` / `apply`, which update the indices and schedule the entity for storing. If a mutation already bypassed them, store the affected entities explicitly and call `reindex()` to rebuild all indices from the current entity state, then `store()` (note that `reindex()` rebuilds only the index structures — it does not store the entities):
 
 [source, java]

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2280,9 +2280,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				throw new IllegalArgumentException(
 					"The passed entity is already the one mapped to id " + entityId
 					+ ". An entity mutated in place cannot be re-indexed by set/replace, because its keys from"
-					+ " before the mutation are no longer derivable. Use update(long, Consumer) or"
-					+ " apply(long, Function) for in-place mutations (they also schedule the entity for"
-					+ " storing), or pass a different instance."
+					+ " before the mutation are no longer derivable. If it has already been mutated, call"
+					+ " reindex() to rebuild the indices from the current entity state, and store the entity"
+					+ " explicitly - update/apply cannot repair it either, for the same reason. To mutate in"
+					+ " place, use update(long, Consumer) or apply(long, Function), which derive the previous"
+					+ " keys up front and schedule the entity for storing. To replace it, pass a different"
+					+ " instance."
 				);
 			}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -70,7 +70,10 @@ import static org.eclipse.serializer.util.X.notNull;
  * <p>
  * Equality depends on the given {@link #equalator()}. By default, identity equality is used.
  * If you want value equality instead, you can use {@link XHashing#hashEqualityValue()} in the constructor methods,
- * or {@link Builder#withValueEquality()}.
+ * or {@link Builder#withValueEquality()}. It is used to resolve an entity <em>instance</em> to the id it is
+ * mapped to - in {@link #remove(Object) remove}, {@link #replace(Object, Object) replace},
+ * {@link #apply(Object, Function) apply} and {@link #update(Object, Consumer) update} - and never decides
+ * whether a mutation is carried out.
  * <p>
  * <b>Keeping indices in sync:</b> GigaMap has no automatic change tracking. Any mutation that affects an
  * indexed field must go through this collection's mutating methods ({@link #add(Object) add},
@@ -83,6 +86,12 @@ import static org.eclipse.serializer.util.X.notNull;
  * stored explicitly, as usual). To bring a single entity back in sync use {@link #update(long, Consumer)} /
  * {@link #apply(long, Function)} (which also schedule the entity for storing); to rebuild every index from the
  * current entity state use {@link #reindex()}.
+ * <p>
+ * Note the division of labour among those methods: {@code set} and {@code replace} install a <em>different</em>
+ * instance and re-index that, while {@code update} and {@code apply} mutate the contained instance in place.
+ * Writing an entity back through {@code set} / {@code replace} after mutating it directly cannot work and is
+ * rejected - the keys it had before the mutation are no longer derivable - so an in-place mutation is either
+ * done through {@code update} / {@code apply} from the start, or repaired afterwards with {@link #reindex()}.
  *
  * @param <E> the type of entities in this collection
  */
@@ -326,6 +335,19 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * Ids that this map never handed out are rejected: the id must be non-negative and must not exceed
 	 * {@link #highestUsedId()}.
 	 * <p>
+	 * <b>The entity must be a different instance than the one the id currently holds.</b> Passing the very
+	 * instance already mapped there - the "load it, mutate it, save it back" idiom - is rejected, because
+	 * this method cannot serve it: re-indexing a mutation needs the keys the entity had <em>before</em> it
+	 * was mutated, and once it has been mutated in place those are gone. Use
+	 * {@link #update(long, Consumer)} or {@link #apply(long, Function)} for in-place mutations - they derive
+	 * the previous keys before running the caller's logic, and additionally schedule the entity for storing.
+	 * For an entity that was already mutated directly, {@link #reindex()} is the recovery path.
+	 * <p>
+	 * A replacement that this map's {@link #equalator()} considers <em>equal</em> to the entity being
+	 * replaced is applied like any other: the equalator decides which id an entity instance resolves to, not
+	 * whether a write happens. On a map built with value equality this is the ordinary "store a new version
+	 * of the same record" case.
+	 * <p>
 	 * <b>Behavior on failure:</b> constraints are checked and the bitmap indices are updated
 	 * <em>before</em> the entity is replaced in the map's storage. If a constraint is violated or
 	 * an {@link Indexer} throws an exception while deriving the new entity's keys, the map is left
@@ -338,7 +360,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * @param entity the new entity
 	 * @return the entity previously mapped to the id, or {@code null} if its slot was empty
 	 * @throws IllegalArgumentException if the entityId was never handed out by this map, i.e. it is
-	 *         negative or greater than {@link #highestUsedId()}
+	 *         negative or greater than {@link #highestUsedId()}, or if the entity is the very instance
+	 *         already mapped to that id (use {@link #update(long, Consumer)} /
+	 *         {@link #apply(long, Function)} instead)
+	 * @see #update(long, Consumer)
+	 * @see #apply(long, Function)
 	 */
 	public E set(long entityId, E entity);
 	
@@ -353,8 +379,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * <p>
 	 * To get the best performance for this operation is the use of an identity index.
 	 * See {@link BitmapIndices#setIdentityIndices(IndexIdentifier...)}.
-	 * 
-	 * 
+	 * <p>
+	 * The {@link #equalator()} only selects <em>which</em> id is replaced; it does not decide whether the
+	 * write happens. A replacement it considers equal to {@code current} is therefore applied like any
+	 * other - on a map built with value equality that is the ordinary "store a new version of the same
+	 * record" case.
 	 * <p>
 	 * <b>Behavior on failure:</b> identical to {@link #set(long, Object)}: the map is left
 	 * unchanged if a constraint is violated or an {@link Indexer} throws while the indices are
@@ -364,7 +393,10 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * @param replacement the new entity instance
 	 * @return the mapped id of the entity
 	 * @throws IllegalStateException if no bitmap index is present
-	 * @throws IllegalArgumentException if current and replacement are the same object
+	 * @throws IllegalArgumentException if current and replacement are the same object, or if the
+	 *         replacement turns out to be the very instance mapped to the resolved id (which a value
+	 *         equalator can produce when several equal instances are contained); see
+	 *         {@link #set(long, Object)} for why an in-place mutation cannot be re-indexed
 	 */
 	public long replace(E current, E replacement);
 	
@@ -395,7 +427,8 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * leave the map unchanged on violation. The thrown exception carries the offending entity and its id
 	 * (via {@code violatingEntity} and {@code entityId}); callers that need to recover can re-add the
 	 * entity after correcting the violation, or use {@code set} / {@code replace} instead when
-	 * non-destructive semantics are required.
+	 * non-destructive semantics are required - passing a corrected, separate instance, since those methods
+	 * reject the instance the map already holds.
 	 * <p>
 	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
 	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
@@ -492,7 +525,8 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * leave the map unchanged on violation. The thrown exception carries the offending entity and its id
 	 * (via {@code violatingEntity} and {@code entityId}); callers that need to recover can re-add the
 	 * entity after correcting the violation, or use {@code set} / {@code replace} instead when
-	 * non-destructive semantics are required.
+	 * non-destructive semantics are required - passing a corrected, separate instance, since those methods
+	 * reject the instance the map already holds.
 	 * <p>
 	 * A <em>stale index</em> (persisted index keys no longer matching the entities, e.g. after a direct
 	 * mutation of an indexed field or entity class evolution) is treated as a special case so it can
@@ -542,7 +576,8 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * entry is the only way to keep the map consistent. The thrown exception carries the offending entity
 	 * and its id (via {@code violatingEntity} and {@code entityId}); callers that need to recover can
 	 * re-add the entity after correcting the violation, or use {@link #set(long, Object) set} when
-	 * non-destructive semantics are required.
+	 * non-destructive semantics are required - passing a corrected, separate instance, since {@code set}
+	 * rejects the instance the map already holds.
 	 * <p>
 	 * A <em>stale index</em> (persisted index keys no longer matching the entities, e.g. after a direct
 	 * mutation of an indexed field or entity class evolution) is treated as a special case so it can
@@ -583,7 +618,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * <p>
 	 * The rebuild drops each index' data and re-indexes every entity from its current state; a per-entity
 	 * update replay would be insufficient because the previous index key of a directly mutated entity is no
-	 * longer available.
+	 * longer available. For the same reason, writing a directly mutated entity back through
+	 * {@link #set(long, Object) set} / {@link #replace(Object, Object) replace} is rejected rather than
+	 * silently ignored: those methods install a <em>different</em> instance and re-index that, so they cannot
+	 * repair a mutation of the instance they already hold. This method - or, from the start,
+	 * {@code update} / {@code apply} - is the way.
 	 * <p>
 	 * This rebuilds only the index structures; it does <b>not</b> store the entities themselves. A directly
 	 * mutated entity must still be persisted explicitly (mutating via {@code update} / {@code apply} does this
@@ -980,6 +1019,14 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 
 	/**
 	 * Provides this set {@link Equalator} instance of this {@link GigaMap}.
+	 * <p>
+	 * It answers exactly one question: which id a given entity <em>instance</em> resolves to. That is what
+	 * {@link #remove(Object)}, {@link #replace(Object, Object)}, {@link #apply(Object, Function)} and
+	 * {@link #update(Object, Consumer)} need to turn the instance they are handed into an id. It has no say
+	 * in whether a mutation is carried out: a replacement it considers equal to the entity being replaced is
+	 * still written and re-indexed.
+	 * <p>
+	 * The default is identity equality; see {@link Builder#withValueEquality()} for value equality.
 	 *
 	 * @return the {@link Equalator} used by this {@link GigaMap}
 	 */
@@ -1089,6 +1136,8 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		
 		/**
 		 * Configures the builder to use value-based equality for comparing elements.
+		 * <p>
+		 * This affects only how an entity instance is resolved to its id; see {@link GigaMap#equalator()}.
 		 *
 		 * @return the builder instance for method chaining
 		 */
@@ -2215,51 +2264,69 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			 */
 			final E replacedEntity = this.get(entityId);
 
-			// only change state if there is an actual change in the entity data.
-			if(!this.equalator.equal(replacedEntity, entity))
+			if(replacedEntity == entity)
 			{
-				this.constraints.check(entityId, replacedEntity, entity);
-
 				/*
-				 * The indices are updated BEFORE the storage slot is overwritten: the index update is
-				 * the last operation that runs user code (indexers deriving the new entity's keys), so
-				 * a throw from it must leave the map observably unchanged instead of storing an entity
-				 * whose keys the indices do not reflect.
+				 * Writing back the very instance the id already holds is the "load it, mutate it, save it"
+				 * idiom - and this method cannot serve it. Re-indexing a mutation requires the keys the
+				 * entity had BEFORE it was mutated, and those are gone: the only thing left to derive keys
+				 * from is the mutated state. That is precisely why #update / #apply derive the previous keys
+				 * up front and only then let the caller's logic run.
+				 *
+				 * So the alternative to rejecting is doing nothing, which is what this used to do - silently,
+				 * losing both the index update and the mutation itself, since a slot whose reference does not
+				 * change gives the storer nothing to re-serialize either. Rejecting says so instead.
 				 */
-				this.indices.internalUpdateIndices(entityId, replacedEntity, entity, this.constraints.custom());
-
-				if(replacedEntity == null)
-				{
-					/*
-					 * The slot is empty, so this id was removed: #removeById decremented the size and this
-					 * fills the slot again, which has to restore it. Without this the size stays one too low
-					 * for the rest of the map's life - and it is persisted state, so the drift survives a
-					 * restart. Every valid id below nextFreeId was handed out by #add, so an empty slot can
-					 * only mean a removal.
-					 *
-					 * Counted here rather than earlier, with the rest of the state changes and after everything
-					 * that can throw: the checks above and the index update are ordered so a throw leaves the
-					 * map observably unchanged, and a size that had already been incremented would break
-					 * exactly that.
-					 */
-					this.baseSize++;
-				}
-
-				/*
-				 * Re-created here if the removal of the last entity released them, and deliberately not
-				 * any earlier: materializing before the checks and the index update above would leave a
-				 * fresh empty segment (plus a pending re-store for it) behind on a failed set, breaking
-				 * the very "a throw leaves the map observably unchanged" guarantee they are ordered for.
-				 * Both methods return the existing segment when there is one, so this is a no-op for the
-				 * ordinary replacement.
-				 */
-				final GigaLevel2<E> level2 = this.ensureLevel2(level3, level3Index);
-				final GigaLevel1<E> level1 = this.ensureLevel1(level2, level2Index);
-
-				level1.entities[level1Index] = entity;
-				level3.markChanged(level3Index);
-				level2.markChanged(level2Index);
+				throw new IllegalArgumentException(
+					"The passed entity is already the one mapped to id " + entityId
+					+ ". An entity mutated in place cannot be re-indexed by set/replace, because its keys from"
+					+ " before the mutation are no longer derivable. Use update(long, Consumer) or"
+					+ " apply(long, Function) for in-place mutations (they also schedule the entity for"
+					+ " storing), or pass a different instance."
+				);
 			}
+
+			this.constraints.check(entityId, replacedEntity, entity);
+
+			/*
+			 * The indices are updated BEFORE the storage slot is overwritten: the index update is
+			 * the last operation that runs user code (indexers deriving the new entity's keys), so
+			 * a throw from it must leave the map observably unchanged instead of storing an entity
+			 * whose keys the indices do not reflect.
+			 */
+			this.indices.internalUpdateIndices(entityId, replacedEntity, entity, this.constraints.custom());
+
+			if(replacedEntity == null)
+			{
+				/*
+				 * The slot is empty, so this id was removed: #removeById decremented the size and this
+				 * fills the slot again, which has to restore it. Without this the size stays one too low
+				 * for the rest of the map's life - and it is persisted state, so the drift survives a
+				 * restart. Every valid id below nextFreeId was handed out by #add, so an empty slot can
+				 * only mean a removal.
+				 *
+				 * Counted here rather than earlier, with the rest of the state changes and after everything
+				 * that can throw: the checks above and the index update are ordered so a throw leaves the
+				 * map observably unchanged, and a size that had already been incremented would break
+				 * exactly that.
+				 */
+				this.baseSize++;
+			}
+
+			/*
+			 * Re-created here if the removal of the last entity released them, and deliberately not
+			 * any earlier: materializing before the checks and the index update above would leave a
+			 * fresh empty segment (plus a pending re-store for it) behind on a failed set, breaking
+			 * the very "a throw leaves the map observably unchanged" guarantee they are ordered for.
+			 * Both methods return the existing segment when there is one, so this is a no-op for the
+			 * ordinary replacement.
+			 */
+			final GigaLevel2<E> level2 = this.ensureLevel2(level3, level3Index);
+			final GigaLevel1<E> level1 = this.ensureLevel1(level2, level2Index);
+
+			level1.entities[level1Index] = entity;
+			level3.markChanged(level3Index);
+			level2.markChanged(level2Index);
 
 			return replacedEntity;
 		}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -357,12 +357,12 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * diverged; such states are repaired by {@link #reindex()}.)
 	 *
 	 * @param entityId the entity id to write to
-	 * @param entity the new entity
+	 * @param entity the new entity, not <code>null</code>
 	 * @return the entity previously mapped to the id, or {@code null} if its slot was empty
-	 * @throws IllegalArgumentException if the entityId was never handed out by this map, i.e. it is
-	 *         negative or greater than {@link #highestUsedId()}, or if the entity is the very instance
-	 *         already mapped to that id (use {@link #update(long, Consumer)} /
-	 *         {@link #apply(long, Function)} instead)
+	 * @throws IllegalArgumentException if entity is <code>null</code>; if the entityId was never handed
+	 *         out by this map, i.e. it is negative or greater than {@link #highestUsedId()}; or if the
+	 *         entity is the very instance already mapped to that id (use
+	 *         {@link #update(long, Consumer)} / {@link #apply(long, Function)} instead)
 	 * @see #update(long, Consumer)
 	 * @see #apply(long, Function)
 	 */
@@ -389,14 +389,15 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * unchanged if a constraint is violated or an {@link Indexer} throws while the indices are
 	 * being updated.
 	 *
-	 * @param current the entity to be removed
-	 * @param replacement the new entity instance
+	 * @param current the entity to be removed, not <code>null</code>
+	 * @param replacement the new entity instance, not <code>null</code>
 	 * @return the mapped id of the entity
 	 * @throws IllegalStateException if no bitmap index is present
-	 * @throws IllegalArgumentException if current and replacement are the same object, or if the
-	 *         replacement turns out to be the very instance mapped to the resolved id (which a value
-	 *         equalator can produce when several equal instances are contained); see
-	 *         {@link #set(long, Object)} for why an in-place mutation cannot be re-indexed
+	 * @throws IllegalArgumentException if current or replacement is <code>null</code>; if they are the
+	 *         same object; or if the replacement turns out to be the very instance mapped to the
+	 *         resolved id (which a value equalator can produce when several equal instances are
+	 *         contained); see {@link #set(long, Object)} for why an in-place mutation cannot be
+	 *         re-indexed
 	 */
 	public long replace(E current, E replacement);
 	

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetIdenticalInstanceTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetIdenticalInstanceTest.java
@@ -242,7 +242,7 @@ public class SetIdenticalInstanceTest
 		@Override
 		public boolean equals(final Object other)
 		{
-			return other instanceof Item && ((Item)other).key.equals(this.key);
+			return other instanceof Item item && item.key.equals(this.key);
 		}
 
 		@Override

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetIdenticalInstanceTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetIdenticalInstanceTest.java
@@ -1,0 +1,260 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.hashing.XHashing;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for internal issue #131, symptom A: {@code set(id, theInstanceAlreadyMappedThere)}
+ * used to be a complete silent no-op.
+ * <p>
+ * The ordinary "load the entity, mutate an indexed field, write it back" idiom - which the class-level
+ * documentation of {@link GigaMap} and the Javadoc of {@link GigaMap#reindex()} both named as a
+ * sanctioned write path - hit an equality gate in {@code internalSet} that skipped the index update,
+ * the change marking, and any entry in the pending entity stores. The indices kept answering under the
+ * old key, {@code store()} persisted nothing, and a restart silently reverted the mutation - while
+ * {@code set} returned normally with no signal whatsoever.
+ * <p>
+ * A functional fix is impossible: an entity's pre-mutation index keys are no longer derivable once it
+ * has been mutated in place, which is exactly why {@link GigaMap#update(long, java.util.function.Consumer)}
+ * and {@link GigaMap#apply(long, java.util.function.Function)} capture them <em>before</em> running the
+ * caller's logic. So the call is now rejected with an {@link IllegalArgumentException} that names those
+ * two methods - symmetric with {@link GigaMap#replace(Object, Object)}, which has always rejected
+ * {@code current == replacement}.
+ * <p>
+ * Note the no-op was useless on <em>every</em> map configuration, indexed or not: the change marking it
+ * skipped would only have re-stored the owning segment, and that segment holds an already-persisted
+ * object id, so the storer never re-serializes the entity's changed content either.
+ *
+ * @see SetValueEqualInstanceTest the sibling symptom - a value-equal but distinct replacement was
+ *      discarded by the same gate
+ */
+public class SetIdenticalInstanceTest
+{
+	static final KeyIndexer KEY = new KeyIndexer();
+
+	/**
+	 * The call must be rejected rather than quietly doing nothing, and the map must be untouched.
+	 */
+	@Test
+	void setWithTheInstanceAlreadyMappedThrows()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(KEY);
+
+		final Item item = new Item("a");
+		final long id   = map.add(item);
+		map.add(new Item("b"));
+
+		final IllegalArgumentException e = assertThrows(
+			IllegalArgumentException.class,
+			() -> map.set(id, item)
+		);
+
+		// The message has to send the caller somewhere useful, since there is nothing set() can do.
+		assertTrue(e.getMessage().contains("update"),
+			"the message must point at update(long, Consumer) / apply(long, Function), was: " + e.getMessage());
+
+		assertEquals(2L, map.size()          , "a rejected set must not change the size");
+		assertSame  (item, map.get(id)       , "the entity must still be mapped to its id");
+		assertEquals(1L, map.query(KEY.is("a")).count(), "and must still be indexed exactly once");
+	}
+
+	/**
+	 * The exact idiom from the issue report: mutate an indexed field in place, then write the instance
+	 * back. Pre-fix this returned normally and lost both the index update and the mutation itself.
+	 * Post-fix it throws, and the documented remedies repair the state.
+	 */
+	@Test
+	void setAfterDirectMutationThrowsInsteadOfSilentlyDoingNothing(@TempDir final Path dir)
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(KEY);
+
+		final Item item = new Item("old");
+		final long id   = map.add(item);
+
+		item.key = "new";
+
+		assertThrows(
+			IllegalArgumentException.class,
+			() -> map.set(id, item),
+			"the direct mutation cannot be re-indexed by set(), so it must be rejected, not ignored"
+		);
+
+		// The rejection does not repair the staleness the direct mutation caused - it only stops the
+		// caller from believing it was repaired. The index still answers under the old key:
+		assertEquals(1L, map.query(KEY.is("old")).count(), "the index is stale, as documented");
+		assertEquals(0L, map.query(KEY.is("new")).count(), "and does not know the new key yet");
+
+		// reindex() is the documented repair for a direct mutation, and it must actually work here.
+		map.reindex();
+		assertEquals(0L, map.query(KEY.is("old")).count(), "reindex() must drop the stale key");
+		assertEquals(1L, map.query(KEY.is("new")).count(), "and index the current one");
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+		{
+			storage.storeRoot();
+		}
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Item> loaded = (GigaMap<Item>)storage.root();
+
+			assertEquals("new", loaded.get(id).key            , "the repaired mutation must be persisted");
+			assertEquals(1L, loaded.query(KEY.is("new")).count(), "and the repaired index with it");
+		}
+	}
+
+	/**
+	 * The interaction guard for the sibling fix (internal issue #130, {@code 6b7fb2fa}): restoring an
+	 * entity into a slot that {@code removeById} emptied is {@code set(id, theSameInstance)} - the only
+	 * id-addressed write there is - and must keep working.
+	 * <p>
+	 * It can never hit the new guard, because an emptied slot holds {@code null} while the entity passed
+	 * in is non-null; this pins that reasoning so the guard cannot later be widened into breaking the
+	 * restore.
+	 */
+	@Test
+	void setIntoAnEmptiedSlotWithTheSameInstanceIsAllowed(@TempDir final Path dir)
+	{
+		final GigaMap<Item> map = GigaMap.New();
+		map.index().bitmap().add(KEY);
+
+		final long id = map.add(new Item("a"));
+		map.add(new Item("b"));
+
+		final Item removed = map.get(id);
+		map.removeById(id);
+		assertEquals(1L, map.size(), "the removal is accounted for");
+
+		assertNull(map.set(id, removed), "nothing was replaced, so null is returned");
+
+		assertEquals(2L, map.size()                    , "the restore must count again");
+		assertSame  (removed, map.get(id)              , "and be reachable by its original id");
+		assertEquals(1L, map.query(KEY.is("a")).count(), "and be indexed again");
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+		{
+			storage.storeRoot();
+		}
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Item> loaded = (GigaMap<Item>)storage.root();
+
+			assertEquals(2L, loaded.size()                    , "the restored size is persisted");
+			assertNotNull(loaded.get(id)                      , "and the restored entity with it");
+			assertEquals(1L, loaded.query(KEY.is("a")).count(), "and it is still indexed");
+		}
+	}
+
+	/**
+	 * The guard lives in {@code internalSet} rather than in {@code set} for this case: on a value-equality
+	 * map holding two value-equal instances, {@code replace} resolves {@code current} to the lowest
+	 * matching id, which can be the <em>replacement's own</em> id. Guarding {@code set} alone would leave
+	 * that silently doing nothing while returning a plausible id.
+	 */
+	@Test
+	void replaceResolvingToTheReplacementsOwnIdThrows()
+	{
+		final GigaMap<Item> map = GigaMap.New(XHashing.hashEqualityValue());
+		map.index().bitmap().add(KEY);
+
+		// Value-equal per Item#equals (which compares the key only), distinct instances.
+		final Item first  = new Item("a");
+		final Item second = new Item("a");
+		map.add(second); // lower id, so the lookup below resolves to this one
+		map.add(first);
+
+		assertThrows(
+			IllegalArgumentException.class,
+			() -> map.replace(first, second),
+			"the lookup resolves to second's own id, so this is set(id, theInstanceAlreadyThere)"
+		);
+
+		assertEquals(2L, map.size(), "a rejected replace must not change the size");
+	}
+
+	/**
+	 * The contract must not depend on the index configuration: with no index at all there is nothing to
+	 * re-derive keys for, but the mutation would still go unpersisted, so the rejection stands.
+	 */
+	@Test
+	void setWithTheSameInstanceThrowsOnAMapWithoutIndices()
+	{
+		final GigaMap<Item> map = GigaMap.New();
+
+		final Item item = new Item("a");
+		final long id   = map.add(item);
+
+		assertThrows(
+			IllegalArgumentException.class,
+			() -> map.set(id, item)
+		);
+	}
+
+	static final class KeyIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.key;
+		}
+	}
+
+	static final class Item
+	{
+		String key; // intentionally mutable: the tests mutate it in place
+
+		Item(final String key)
+		{
+			this.key = key;
+		}
+
+		@Override
+		public boolean equals(final Object other)
+		{
+			return other instanceof Item && ((Item)other).key.equals(this.key);
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return this.key.hashCode();
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Item[" + this.key + "]";
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetIdenticalInstanceTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetIdenticalInstanceTest.java
@@ -78,7 +78,12 @@ public class SetIdenticalInstanceTest
 			() -> map.set(id, item)
 		);
 
-		// The message has to send the caller somewhere useful, since there is nothing set() can do.
+		// The message has to send the caller somewhere useful, since there is nothing set() can do -
+		// and "somewhere useful" is both remedies: reindex() for an entity already mutated, update /
+		// apply for doing it right in the first place. Naming only the latter would be a dead end,
+		// since it cannot repair an existing mutation either.
+		assertTrue(e.getMessage().contains("reindex"),
+			"the message must name reindex() as the repair for an already mutated entity, was: " + e.getMessage());
 		assertTrue(e.getMessage().contains("update"),
 			"the message must point at update(long, Consumer) / apply(long, Function), was: " + e.getMessage());
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetValueEqualInstanceTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetValueEqualInstanceTest.java
@@ -51,9 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  */
 public class SetValueEqualInstanceTest
 {
-	static final PayloadIndexer     PAYLOAD    = new PayloadIndexer();
-	static final KeyIndexer         KEY        = new KeyIndexer();
-	static final UniqueKeyIndexer   UNIQUE_KEY = new UniqueKeyIndexer();
+	static final PayloadIndexer   PAYLOAD    = new PayloadIndexer();
+	static final KeyIndexer       KEY        = new KeyIndexer();
+	static final UniqueKeyIndexer UNIQUE_KEY = new UniqueKeyIndexer();
 
 	/**
 	 * {@code set} with a value-equal but distinct instance must install it and re-index it.
@@ -61,13 +61,13 @@ public class SetValueEqualInstanceTest
 	@Test
 	void setValueEqualDistinctInstanceIsApplied()
 	{
-		final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+		final GigaMap<Rec> map = GigaMap.New(XHashing.hashEqualityValue());
 		map.index().bitmap().add(PAYLOAD);
 
-		final Record v1 = new Record("k", "A");
-		final long   id = map.add(v1);
+		final Rec  v1 = new Rec("k", "A");
+		final long id = map.add(v1);
 
-		final Record v2 = new Record("k", "B"); // equal per equals (key only), new payload
+		final Rec v2 = new Rec("k", "B"); // equal per equals (key only), new payload
 
 		assertSame(v1, map.set(id, v2), "the replaced entity is returned");
 
@@ -84,13 +84,13 @@ public class SetValueEqualInstanceTest
 	@Test
 	void replaceValueEqualDistinctInstanceIsApplied()
 	{
-		final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+		final GigaMap<Rec> map = GigaMap.New(XHashing.hashEqualityValue());
 		map.index().bitmap().add(PAYLOAD);
 
-		final Record v1 = new Record("k", "A");
-		final long   id = map.add(v1);
+		final Rec  v1 = new Rec("k", "A");
+		final long id = map.add(v1);
 
-		final Record v2 = new Record("k", "B");
+		final Rec v2 = new Rec("k", "B");
 
 		assertEquals(id, map.replace(v1, v2), "replace returns the id it wrote to");
 
@@ -109,17 +109,17 @@ public class SetValueEqualInstanceTest
 		final long id;
 
 		{
-			final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+			final GigaMap<Rec> map = GigaMap.New(XHashing.hashEqualityValue());
 			map.index().bitmap().add(PAYLOAD);
 
-			final Record v1 = new Record("k", "A");
+			final Rec v1 = new Rec("k", "A");
 			id = map.add(v1);
 
 			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
 			{
 				storage.storeRoot();
 
-				map.replace(v1, new Record("k", "B"));
+				map.replace(v1, new Rec("k", "B"));
 
 				map.store();
 			}
@@ -128,7 +128,7 @@ public class SetValueEqualInstanceTest
 		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
 		{
 			@SuppressWarnings("unchecked")
-			final GigaMap<Record> loaded = (GigaMap<Record>)storage.root();
+			final GigaMap<Rec> loaded = (GigaMap<Rec>)storage.root();
 
 			assertEquals("B", loaded.get(id).payload              , "the replacement must be persisted");
 			assertEquals(1L, loaded.query(PAYLOAD.is("B")).count(), "and the index must agree with it");
@@ -147,13 +147,13 @@ public class SetValueEqualInstanceTest
 		final long id;
 
 		{
-			final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+			final GigaMap<Rec> map = GigaMap.New(XHashing.hashEqualityValue());
 			map.index().bitmap().add(KEY); // indexes the equality field, not the payload
 
-			final Record v1 = new Record("k", "A");
+			final Rec v1 = new Rec("k", "A");
 			id = map.add(v1);
 
-			final Record v2 = new Record("k", "B");
+			final Rec v2 = new Rec("k", "B");
 
 			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
 			{
@@ -172,7 +172,7 @@ public class SetValueEqualInstanceTest
 		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
 		{
 			@SuppressWarnings("unchecked")
-			final GigaMap<Record> loaded = (GigaMap<Record>)storage.root();
+			final GigaMap<Rec> loaded = (GigaMap<Rec>)storage.root();
 
 			assertEquals("B", loaded.get(id).payload          , "the swap must be persisted");
 			assertEquals(1L, loaded.query(KEY.is("k")).count(), "and the index left intact");
@@ -191,14 +191,14 @@ public class SetValueEqualInstanceTest
 	@Test
 	void valueEqualReplacementDoesNotTripAUniqueConstraint()
 	{
-		final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+		final GigaMap<Rec> map = GigaMap.New(XHashing.hashEqualityValue());
 		map.index().bitmap().addUniqueConstraint(UNIQUE_KEY);
 
-		final Record v1 = new Record("k", "A");
-		final long   id = map.add(v1);
-		map.add(new Record("other", "A"));
+		final Rec  v1 = new Rec("k", "A");
+		final long id = map.add(v1);
+		map.add(new Rec("other", "A"));
 
-		final Record v2 = new Record("k", "B"); // same unique key - it IS the same record
+		final Rec v2 = new Rec("k", "B"); // same unique key - it IS the same record
 
 		assertDoesNotThrow(
 			() -> map.set(id, v2),
@@ -210,29 +210,29 @@ public class SetValueEqualInstanceTest
 		assertEquals(1L, map.query(UNIQUE_KEY.is("k")).count(), "and the unique key still resolves once");
 	}
 
-	static final class PayloadIndexer extends IndexerString.Abstract<Record>
+	static final class PayloadIndexer extends IndexerString.Abstract<Rec>
 	{
 		@Override
-		protected String getString(final Record entity)
+		protected String getString(final Rec entity)
 		{
 			return entity.payload;
 		}
 	}
 
-	static final class KeyIndexer extends IndexerString.Abstract<Record>
+	static final class KeyIndexer extends IndexerString.Abstract<Rec>
 	{
 		@Override
-		protected String getString(final Record entity)
+		protected String getString(final Rec entity)
 		{
 			return entity.key;
 		}
 	}
 
 	/** Binary, because only a binary index is suitable as a unique constraint. */
-	static final class UniqueKeyIndexer extends BinaryIndexerString.Abstract<Record>
+	static final class UniqueKeyIndexer extends BinaryIndexerString.Abstract<Rec>
 	{
 		@Override
-		protected String getString(final Record entity)
+		protected String getString(final Rec entity)
 		{
 			return entity.key;
 		}
@@ -241,12 +241,12 @@ public class SetValueEqualInstanceTest
 	/**
 	 * Equality is the business key alone; {@code payload} is the versioned part that a replacement changes.
 	 */
-	static final class Record
+	static final class Rec
 	{
 		final String key;
 		String       payload;
 
-		Record(final String key, final String payload)
+		Rec(final String key, final String payload)
 		{
 			this.key     = key;
 			this.payload = payload;
@@ -255,7 +255,7 @@ public class SetValueEqualInstanceTest
 		@Override
 		public boolean equals(final Object other)
 		{
-			return other instanceof Record && ((Record)other).key.equals(this.key);
+			return other instanceof Rec rec && rec.key.equals(this.key);
 		}
 
 		@Override
@@ -267,7 +267,7 @@ public class SetValueEqualInstanceTest
 		@Override
 		public String toString()
 		{
-			return "Record[" + this.key + "=" + this.payload + "]";
+			return "Rec[" + this.key + "=" + this.payload + "]";
 		}
 	}
 }

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetValueEqualInstanceTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/SetValueEqualInstanceTest.java
@@ -1,0 +1,273 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.serializer.hashing.XHashing;
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Regression test for internal issue #131, symptom B: on a map built with a value-equality equalator,
+ * {@code set} and {@code replace} silently discarded a replacement the equalator considered equal to the
+ * entity already stored - {@code replace} even returned a non-negative id that looked like success.
+ * <p>
+ * That hit the canonical "replace the record having this business key with a new version" idiom head on:
+ * the equalator says the two instances <em>are</em> the same record, which is precisely why the caller is
+ * replacing one with the other. {@code internalSet} read the same answer as "there is no change in the
+ * entity data" and skipped everything.
+ * <p>
+ * The equalator's job is to resolve an entity instance to <em>which id</em> is addressed; it never had any
+ * business deciding <em>whether</em> the write happens. The skip is now a reference-identity check, so a
+ * distinct instance is always applied - and the identical-instance case it still catches is rejected
+ * outright (see {@link SetIdenticalInstanceTest}).
+ * <p>
+ * The entity used here has {@code equals}/{@code hashCode} on a business key only, plus a mutable indexed
+ * field that is deliberately <em>not</em> part of equality - i.e. "the same record, a newer version".
+ *
+ * @see SetIdenticalInstanceTest the sibling symptom - {@code set(id, theInstanceAlreadyMappedThere)}
+ */
+public class SetValueEqualInstanceTest
+{
+	static final PayloadIndexer     PAYLOAD    = new PayloadIndexer();
+	static final KeyIndexer         KEY        = new KeyIndexer();
+	static final UniqueKeyIndexer   UNIQUE_KEY = new UniqueKeyIndexer();
+
+	/**
+	 * {@code set} with a value-equal but distinct instance must install it and re-index it.
+	 */
+	@Test
+	void setValueEqualDistinctInstanceIsApplied()
+	{
+		final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+		map.index().bitmap().add(PAYLOAD);
+
+		final Record v1 = new Record("k", "A");
+		final long   id = map.add(v1);
+
+		final Record v2 = new Record("k", "B"); // equal per equals (key only), new payload
+
+		assertSame(v1, map.set(id, v2), "the replaced entity is returned");
+
+		assertSame  (v2, map.get(id)                        , "the replacement must be installed");
+		assertEquals("B", map.get(id).payload               , "with its own payload");
+		assertEquals(1L, map.query(PAYLOAD.is("B")).count() , "and indexed under its new key");
+		assertEquals(0L, map.query(PAYLOAD.is("A")).count() , "the replaced key must be gone");
+		assertEquals(1L, map.size()                         , "a replacement is not an addition");
+	}
+
+	/**
+	 * The same through {@code replace}, which is where this bit hardest: it reported success.
+	 */
+	@Test
+	void replaceValueEqualDistinctInstanceIsApplied()
+	{
+		final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+		map.index().bitmap().add(PAYLOAD);
+
+		final Record v1 = new Record("k", "A");
+		final long   id = map.add(v1);
+
+		final Record v2 = new Record("k", "B");
+
+		assertEquals(id, map.replace(v1, v2), "replace returns the id it wrote to");
+
+		assertSame  (v2, map.get(id)                       , "and the returned id must not have been a lie");
+		assertEquals(1L, map.query(PAYLOAD.is("B")).count(), "the replacement is indexed");
+		assertEquals(0L, map.query(PAYLOAD.is("A")).count(), "the replaced key is gone");
+	}
+
+	/**
+	 * The data-loss cover. Pre-fix the reopened map showed the old payload: the replacement had never been
+	 * installed, so there was nothing for {@code store()} to persist.
+	 */
+	@Test
+	void valueEqualReplacementSurvivesARestart(@TempDir final Path dir)
+	{
+		final long id;
+
+		{
+			final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+			map.index().bitmap().add(PAYLOAD);
+
+			final Record v1 = new Record("k", "A");
+			id = map.add(v1);
+
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+			{
+				storage.storeRoot();
+
+				map.replace(v1, new Record("k", "B"));
+
+				map.store();
+			}
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Record> loaded = (GigaMap<Record>)storage.root();
+
+			assertEquals("B", loaded.get(id).payload              , "the replacement must be persisted");
+			assertEquals(1L, loaded.query(PAYLOAD.is("B")).count(), "and the index must agree with it");
+			assertEquals(0L, loaded.query(PAYLOAD.is("A")).count(), "under the new key only");
+		}
+	}
+
+	/**
+	 * With the index on the equality field itself, every derived key is unchanged, so the index machinery
+	 * legitimately does no work at all. The instance swap must not depend on that: it is the slot write and
+	 * the change marking that carry the new instance, not the index update.
+	 */
+	@Test
+	void valueEqualReplacementWithIdenticalKeysStillSwapsTheInstance(@TempDir final Path dir)
+	{
+		final long id;
+
+		{
+			final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+			map.index().bitmap().add(KEY); // indexes the equality field, not the payload
+
+			final Record v1 = new Record("k", "A");
+			id = map.add(v1);
+
+			final Record v2 = new Record("k", "B");
+
+			try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+			{
+				storage.storeRoot();
+
+				map.set(id, v2);
+
+				assertSame  (v2, map.get(id)                   , "the instance must be swapped anyway");
+				assertEquals(1L, map.query(KEY.is("k")).count(), "and stay indexed exactly once");
+				assertEquals(1L, map.size()                    , "and not be counted twice");
+
+				map.store();
+			}
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Record> loaded = (GigaMap<Record>)storage.root();
+
+			assertEquals("B", loaded.get(id).payload          , "the swap must be persisted");
+			assertEquals(1L, loaded.query(KEY.is("k")).count(), "and the index left intact");
+			assertEquals(1L, loaded.size()                    , "and the size left alone");
+		}
+	}
+
+	/**
+	 * The one place narrowing the skip could plausibly have regressed: a unique index on the equality field
+	 * now genuinely runs for a value-equal {@code set}, where it was previously skipped wholesale. The
+	 * entity must not be seen as its own duplicate.
+	 * <p>
+	 * A unique constraint needs a binary index, so this also covers the binary change handler - a different
+	 * {@code isEqual} implementation than the hashing one the other cases exercise.
+	 */
+	@Test
+	void valueEqualReplacementDoesNotTripAUniqueConstraint()
+	{
+		final GigaMap<Record> map = GigaMap.New(XHashing.hashEqualityValue());
+		map.index().bitmap().addUniqueConstraint(UNIQUE_KEY);
+
+		final Record v1 = new Record("k", "A");
+		final long   id = map.add(v1);
+		map.add(new Record("other", "A"));
+
+		final Record v2 = new Record("k", "B"); // same unique key - it IS the same record
+
+		assertDoesNotThrow(
+			() -> map.set(id, v2),
+			"replacing an entity with a new version of itself must not violate its own unique key"
+		);
+
+		assertSame  (v2, map.get(id)                          , "the replacement is installed");
+		assertEquals(2L, map.size()                           , "and the size is unchanged");
+		assertEquals(1L, map.query(UNIQUE_KEY.is("k")).count(), "and the unique key still resolves once");
+	}
+
+	static final class PayloadIndexer extends IndexerString.Abstract<Record>
+	{
+		@Override
+		protected String getString(final Record entity)
+		{
+			return entity.payload;
+		}
+	}
+
+	static final class KeyIndexer extends IndexerString.Abstract<Record>
+	{
+		@Override
+		protected String getString(final Record entity)
+		{
+			return entity.key;
+		}
+	}
+
+	/** Binary, because only a binary index is suitable as a unique constraint. */
+	static final class UniqueKeyIndexer extends BinaryIndexerString.Abstract<Record>
+	{
+		@Override
+		protected String getString(final Record entity)
+		{
+			return entity.key;
+		}
+	}
+
+	/**
+	 * Equality is the business key alone; {@code payload} is the versioned part that a replacement changes.
+	 */
+	static final class Record
+	{
+		final String key;
+		String       payload;
+
+		Record(final String key, final String payload)
+		{
+			this.key     = key;
+			this.payload = payload;
+		}
+
+		@Override
+		public boolean equals(final Object other)
+		{
+			return other instanceof Record && ((Record)other).key.equals(this.key);
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return this.key.hashCode();
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Record[" + this.key + "=" + this.payload + "]";
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`internalSet` gated its entire body behind an undocumented short-circuit:

```java
final E replacedEntity = this.get(entityId);

// only change state if there is an actual change in the entity data.
if(!this.equalator.equal(replacedEntity, entity))
{
    ... constraints, index update, slot write, markChanged ...
}
```

The equalator's job is to resolve an entity *instance* to its id - that is what `remove(E)`, `replace`, `apply(E, …)` and `update(E, …)` need it for. Asked instead whether a write is necessary, it gives the wrong answer twice.

**Under a value-equality equalator it discarded a genuinely different replacement.** `replace(current, replacement)` with a new version of the same record - equal by business key, different data - did nothing, and returned a non-negative id that looked like success:

```java
final GigaMap<Rec> map = GigaMap.New(XHashing.hashEqualityValue());
final long id = map.add(new Rec("a", "v1"));

final long r = map.replace(map.get(id), new Rec("a", "v2"));
// r == id                     <- looks like a successful replace
// map.get(id).data == "v1"    <- the replacement was silently discarded
```

Nothing was installed, so `store()` had nothing to persist and the new version was simply gone. The map already rejects `replace(x, x)` with an `IllegalArgumentException`, so silently dropping the equal-but-distinct case was clearly not the intent.

**With the default identity equalator the expression is literally `replacedEntity != entity`**, so that configuration behaved the same - but the one case it still caught, writing back the very instance the id already holds, was a complete silent no-op:

```java
a.key = "new";
map.set(id, a);   // javadoc: "updates the indices accordingly"
map.store();

// AFTER RESTART: entity.key=old  indexed(new)=0  indexed(old)=1
```

That is the ordinary "load it, mutate it, save it" idiom - and the class documentation and `reindex()`'s Javadoc both named `set` as a path that re-runs the indexers, so a user following the docs landed exactly here. It updated no index, marked nothing changed, and scheduled nothing for storing, so a restart reverted the mutation. `set()` returned normally throughout.

## Why `set` cannot be made to serve that idiom

Re-indexing a mutation needs the keys the entity had *before* it was mutated. Once it has been mutated in place those are gone: deriving from the instance yields the new keys, which de-indexes nothing and leaves the old key set. That is precisely why `update` / `apply` derive the previous keys up front and only then run the caller's logic.

Routing the case through that machinery would be worse than the status quo. Prev and new handlers would both derive from the mutated instance, so every `ChangeHandler.isEqual` compares equal and no index work happens at all - not even the `BitmapIndexStaleException` a hashing index throws on a stale de-index - while `retainMutatedEntity` *would* persist the entity. That trades today's self-consistent persisted state (old entity, old key) for a permanently divergent one (new entity, old key), undetectable without `reindex()`.

## The fix

The gate is gone in both directions. The identical-instance case becomes an early guard and the rest of the method becomes straight-line code:

```java
if(replacedEntity == entity)
{
    throw new IllegalArgumentException(
        "The passed entity is already the one mapped to id " + entityId + ". …"
        + " Use update(long, Consumer) or apply(long, Function) for in-place mutations"
        + " (they also schedule the entity for storing), or pass a different instance."
    );
}

this.constraints.check(entityId, replacedEntity, entity);
this.indices.internalUpdateIndices(entityId, replacedEntity, entity, this.constraints.custom());
if(replacedEntity == null) { this.baseSize++; }
… ensureLevel2 / ensureLevel1 / slot write / markChanged …
```

Rejecting is symmetric with the same-object rejection `replace()` has always had, and cheap to satisfy: the call could never do anything useful on **any** map configuration, indexed or not - a slot whose reference does not change gives the storer nothing to re-serialize either, which is what `retainMutatedEntity`'s own comment says.

**The guard sits in `internalSet`, not in `set()`, because `replace()` reaches it too.** On a value-equality map holding two equal instances `a` (id 5) and `b` (id 2), `replace(a, b)` passes the `current == replacement` check, then the lookup resolves to the *lowest* matching id - `b`'s own. Guarding `set()` alone would have left that silently doing nothing while returning a plausible id.

Nothing compensating was needed for the now-unconditional index update:

- A unique constraint compares **indexer-derived keys** (`BitmapIndex.equalKeys`, via the indexer's own hash equalator), not entities, and excludes the entity's own id through `ContainsOtherBreaker`. A value-equal `set` cannot trip it.
- The per-index equality skip in `BitmapIndices.internalUpdateIndices` already avoids pointless index work when the derived keys are unchanged - verified for `BitmapEntry`, `BinaryChangeHandler`, `NewKeyChangeChandler` and `ChangeHandler.Chain`.
- De-indexing stays correct because the previous handlers are derived from the **stored** instance, whose keys are the true current index keys.

## Behavior change

A previously silent no-op now throws. It can only surface problems, never corrupt: the throw precedes every state change. A caller doing `set(id, computeReplacement(id))` where the function sometimes returns the current instance, or a defensive `set(id, get(id))`, now needs an identity check or `update(id, e -> {})`. No existing test did either.

**This needs a migration note in the 5.0.0 release docs.** The changelog is maintained per release in this repo rather than per PR, so this PR does not touch it.

Two other new surfaces, both value-equality maps only and both intended: indexers and custom constraints now run for a value-equal `set` that previously exited early (small cost on a path that was silently wrong), and `BitmapIndexStaleException` from `set` after a class evolution now reaches those maps too - already documented, and non-destructive since the throw precedes the slot write.

## Documentation

`set()` and `replace()` now state that the entity must be a different instance, and that equalator equality does not suppress the write - the equalator selects *which* id is addressed, not *whether* a write happens. The class header, `reindex()`, `equalator()` (previously contentless) and `Builder.withValueEquality()` spell out the division of labour: `set` / `replace` install a **different** instance and re-index that; `update` / `apply` mutate the contained instance in place; `reindex()` repairs a mutation that already bypassed both. Same in the GigaMap CRUD and persistence pages.

`set` and `replace` stay in the "only these re-run the indexers" list - after this they do, correctly, for the instances they are meant to be handed.

## Tests

Both new files live in the gigamap module, which already has `storage-embedded` in test scope and existing two-session restart tests.

`SetIdenticalInstanceTest`:

- the rejection, with the map verifiably untouched
- the exact idiom from the report, including that `reindex()` repairs the staleness the direct mutation caused, and that the repair survives a restart
- `replace()` resolving to the replacement's own id on a value-equality map
- a map with no indices at all, so the contract cannot be made index-conditional
- **the guard for the `internal#130` fix (`6b7fb2fa`)**: restoring an entity into a slot `removeById` emptied is `set(id, theSameInstance)`, and must keep working. It can never hit the new check, because an empty slot holds `null` while the entity is non-null - this pins that reasoning.

`SetValueEqualInstanceTest`, on an entity whose `equals` is a business key with a mutable indexed field outside it:

- the discarded replacement through `set` and through `replace`
- its survival across a restart - the data-loss cover
- the case where the derived keys are identical, so the index legitimately does nothing and only the instance swap remains
- a unique constraint on the equality field, which the old skip had made vacuous

Nine of those ten fail on the unfixed code; the tenth is the `internal#130` guard, green on both sides.

Full `gigamap` suite 1151 tests, `gigamap/lucene` 74, `gigamap/jvector` 238, integration tests 1326 - all green, `SetAfterRemoveSizeTest` included. Javadoc builds clean under `-Xdoclint:all`.

## Not in this PR

`set(id, aDistinctInstanceThatWasAlreadyPersistedAndThenMutatedInPlace)` installs the reference but not the mutated content, because `internalSet` never calls `retainMutatedEntity`. Closing it would add a `WeakReference` per `set` accumulating until the next commit - a new cost on bulk-`set` workloads that deserves its own review and benchmark.

Separately: custom constraints run twice per successful `set` - once in `constraints.check`, once inside `BitmapIndices.internalUpdateIndices` with the same arguments. Pre-existing and unrelated.

Resolves `internal#131`.
