### PR TITLE
heap eviction must not delete from the backing store; removeAll() purges evicted entries

### DIFF
--- a/cache/cache/src/main/java/org/eclipse/store/cache/types/Cache.java
+++ b/cache/cache/src/main/java/org/eclipse/store/cache/types/Cache.java
@@ -1753,11 +1753,55 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 				final HashSet<K> keys = new HashSet<>();
 				this.cacheTable.keys().forEach(key -> keys.add(this.objectConverter.externalize(key)));
 
+				final boolean       writeThrough  = this.cacheWriter != null && this.configuration.isWriteThrough();
+				// heap-evicted durable mapping -> old value (null = not loaded or unavailable)
+				final HashMap<K, V> ghostMappings = new HashMap<>();
+
+				/*
+				 * A CacheStore's table holds exactly this cache's durable mappings, including
+				 * entries evicted from the heap. Those are still mappings of this cache
+				 * (iteration and read-through expose them), so removeAll() must delete them
+				 * as well. For any other CacheWriter the cache knows no mappings beyond the
+				 * heap ones and must not enumerate the external resource.
+				 */
+				if(writeThrough && this.cacheWriter instanceof CacheStore)
+				{
+					@SuppressWarnings("unchecked")
+					final CacheStore<K, V> cacheStore = (CacheStore<K, V>)this.cacheWriter;
+					cacheStore.keys().forEachRemaining(key ->
+					{
+						if(!keys.contains(key))
+						{
+							ghostMappings.put(key, null);
+						}
+					});
+
+					/*
+					 * Old values are needed only for REMOVED events and must be read before the
+					 * delete. Loaded in one bulk call, and only when a removed-listener is
+					 * actually registered (any listener registration would make the dispatcher
+					 * non-null, e.g. the eviction manager's created-listener).
+					 */
+					if(!ghostMappings.isEmpty() && this.hasCacheEntryRemovedListener())
+					{
+						try
+						{
+							ghostMappings.putAll(cacheStore.loadAll(ghostMappings.keySet()));
+						}
+						catch(final Exception e)
+						{
+							// a failed old-value read must not veto the purge;
+							// the affected REMOVED events are skipped instead
+						}
+					}
+				}
+
 				final Set<K> keysToDelete;
 
-				if(this.cacheWriter != null && this.configuration.isWriteThrough())
+				if(writeThrough)
 				{
 					keysToDelete = new HashSet<>(keys);
+					keysToDelete.addAll(ghostMappings.keySet());
 
 					if(keysToDelete.size() > 0)
 					{
@@ -1809,6 +1853,26 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 							}
 							removed++;
 						}
+					}
+				}
+
+				// heap-evicted durable mappings that the writer successfully deleted
+				for(final K ghostKey : ghostMappings.keySet())
+				{
+					if(!keysToDelete.contains(ghostKey))
+					{
+						if(eventDispatcher != null)
+						{
+							final V oldValue = ghostMappings.get(ghostKey);
+							if(oldValue != null)
+							{
+								eventDispatcher.addEvent(
+									CacheEntryRemovedListener.class,
+									new CacheEvent<>(this, EventType.REMOVED, ghostKey, oldValue, oldValue)
+								);
+							}
+						}
+						removed++;
 					}
 				}
 			}
@@ -2509,6 +2573,13 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 					throw new CacheWriterException(e);
 				}
 			}
+		}
+
+		private boolean hasCacheEntryRemovedListener()
+		{
+			return this.listenerRegistrations.containsSearched(
+				registration -> registration.getCacheEntryListener() instanceof CacheEntryRemovedListener
+			);
 		}
 
 		private void closeIfCloseable(final Object obj)

--- a/cache/cache/src/main/java/org/eclipse/store/cache/types/Cache.java
+++ b/cache/cache/src/main/java/org/eclipse/store/cache/types/Cache.java
@@ -2356,7 +2356,11 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 					final K evictedKey   = this.objectConverter.externalize(entryToEvict.key());
 					final V evictedValue = this.objectConverter.externalize(entryToEvict.value().value());
 
-					this.deleteCacheEntry(evictedKey);
+					/*
+					 * Eviction only frees heap space; it must not write through to the CacheWriter.
+					 * JSR-107 treats eviction, like expiry, as a cache-internal removal: the entry
+					 * stays in the external resource and is reloaded via read-through on demand.
+					 */
 
 					if(eventDispatcher != null)
 					{

--- a/integration-tests/src/test/java/test/eclipse/store/cache/CacheEvictionDeletesFromStorageReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/cache/CacheEvictionDeletesFromStorageReproTest.java
@@ -1,0 +1,95 @@
+package test.eclipse.store.cache;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.file.Path;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+
+import org.eclipse.serializer.reference.LazyReferenceManager;
+import org.eclipse.store.cache.types.CacheConfiguration;
+import org.eclipse.store.cache.types.EvictionManager;
+import org.eclipse.store.cache.types.EvictionPolicy;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression test for internal issue #96: a storage-backed JCache configured with a size-based
+ * eviction policy must not delete entries from the backing {@code EmbeddedStorage} on mere
+ * heap eviction.
+ * <p>
+ * Eviction only frees heap space. Per the JSR-107 contract, eviction — like expiry — is a
+ * cache-internal removal and must not invoke {@code CacheWriter.delete}; only application-driven
+ * {@code remove}/{@code removeAll} operations do. An evicted entry therefore stays durable in the
+ * backing store and is reloaded via read-through on the next {@code get()}.
+ */
+public class CacheEvictionDeletesFromStorageReproTest
+{
+    private static final long MAX_CACHE_SIZE = 3;
+
+    @Test
+    @Timeout(60)
+    void sizeBasedEvictionMustNotDeleteFromBackingStorage(@TempDir final Path tempdir)
+    {
+        final EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempdir);
+
+        final CachingProvider provider     = Caching.getCachingProvider();
+        final CacheManager    cacheManager = provider.getCacheManager();
+
+        final CacheConfiguration<Integer, String> configuration = CacheConfiguration
+            .Builder(Integer.class, String.class, "evictCache", storageManager)
+            // bounded heap working set + full durable backing store — the headline use case
+            .evictionManagerFactory(() ->
+                EvictionManager.OnEntryCreation(EvictionPolicy.LeastRecentlyUsed(MAX_CACHE_SIZE)))
+            .build();
+
+        final Cache<Integer, String> cache = cacheManager.createCache("evictCache", configuration);
+        try
+        {
+            // Put more than the cap; key 0 becomes the least-recently-used and is evicted from heap.
+            for(int i = 0; i <= (int)MAX_CACHE_SIZE; i++)
+            {
+                cache.put(i, "value-" + i);
+                // touch the survivors so key 0 is the definite LRU victim
+                for(int j = 1; j <= i; j++)
+                {
+                    cache.get(j);
+                }
+            }
+
+            // Key 0 was only EVICTED FROM HEAP. It must remain durable and reload via read-through.
+            final String reloaded = cache.get(0);
+            assertNotNull(reloaded,
+                "heap-evicted entry was deleted from backing storage (size-based eviction called "
+                + "CacheWriter.delete) — durable value lost");
+            assertEquals("value-0", reloaded, "the durable value must be intact after heap eviction");
+        }
+        finally
+        {
+            cacheManager.close();
+            storageManager.shutdown();
+            LazyReferenceManager.get().stop();
+        }
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/cache/CacheEvictionDeletesFromStorageReproTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/cache/CacheEvictionDeletesFromStorageReproTest.java
@@ -15,9 +15,12 @@ package test.eclipse.store.cache;
  */
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -35,18 +38,19 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Regression test for internal issue #96: a storage-backed JCache configured with a size-based
- * eviction policy must not delete entries from the backing {@code EmbeddedStorage} on mere
- * heap eviction.
+ * Regression test for internal issue #96: a storage-backed JCache with a size-based eviction
+ * policy must not delete entries from the backing {@code EmbeddedStorage} on mere heap eviction.
  * <p>
- * Eviction only frees heap space. Per the JSR-107 contract, eviction — like expiry — is a
+ * Eviction only frees heap space. Per the JSR-107 contract, eviction - like expiry - is a
  * cache-internal removal and must not invoke {@code CacheWriter.delete}; only application-driven
- * {@code remove}/{@code removeAll} operations do. An evicted entry therefore stays durable in the
- * backing store and is reloaded via read-through on the next {@code get()}.
+ * remove operations do. An evicted entry therefore stays durable in the backing store and is
+ * reloaded via read-through on the next {@code get()}. Application {@code remove()}, in
+ * contrast, must still delete the entry from the backing store.
  */
 public class CacheEvictionDeletesFromStorageReproTest
 {
-    private static final long MAX_CACHE_SIZE = 3;
+    private static final int MAX_CACHE_SIZE = 3;
+    private static final int ENTRY_COUNT    = MAX_CACHE_SIZE + 1;
 
     @Test
     @Timeout(60)
@@ -58,37 +62,55 @@ public class CacheEvictionDeletesFromStorageReproTest
         final CacheManager    cacheManager = provider.getCacheManager();
 
         final CacheConfiguration<Integer, String> configuration = CacheConfiguration
-            .Builder(Integer.class, String.class, "evictCache", storageManager)
-            // bounded heap working set + full durable backing store — the headline use case
+            .Builder(Integer.class, String.class, "internal96EvictCache", storageManager)
+            // bounded heap working set + full durable backing store
             .evictionManagerFactory(() ->
                 EvictionManager.OnEntryCreation(EvictionPolicy.LeastRecentlyUsed(MAX_CACHE_SIZE)))
             .build();
 
-        final Cache<Integer, String> cache = cacheManager.createCache("evictCache", configuration);
+        final Cache<Integer, String> cache =
+            cacheManager.createCache("internal96EvictCache", configuration);
         try
         {
-            // Put more than the cap; key 0 becomes the least-recently-used and is evicted from heap.
-            for(int i = 0; i <= (int)MAX_CACHE_SIZE; i++)
+            // Put more entries than the cap so the eviction policy must evict from the heap.
+            for(int i = 0; i < ENTRY_COUNT; i++)
             {
                 cache.put(i, "value-" + i);
-                // touch the survivors so key 0 is the definite LRU victim
-                for(int j = 1; j <= i; j++)
-                {
-                    cache.get(j);
-                }
             }
 
-            // Key 0 was only EVICTED FROM HEAP. It must remain durable and reload via read-through.
-            final String reloaded = cache.get(0);
-            assertNotNull(reloaded,
-                "heap-evicted entry was deleted from backing storage (size-based eviction called "
-                + "CacheWriter.delete) — durable value lost");
-            assertEquals("value-0", reloaded, "the durable value must be intact after heap eviction");
+            // Determine the actual heap contents. Per JSR-107, containsKey never calls the
+            // CacheLoader, so it probes the heap table only: keys missing here were evicted.
+            // (The cache iterator is no probe - for storage-backed caches it walks the store.)
+            final Set<Integer> heapKeys = new HashSet<>();
+            for(int i = 0; i < ENTRY_COUNT; i++)
+            {
+                if(cache.containsKey(i))
+                {
+                    heapKeys.add(i);
+                }
+            }
+            assertFalse(heapKeys.size() >= ENTRY_COUNT,
+                "test setup: no entry was evicted, the eviction path was not exercised");
+
+            // Every entry must still be retrievable: heap survivors directly, evicted entries
+            // durably from the backing store via read-through. On the bug, eviction called
+            // CacheWriter.delete and the evicted entries' get() returns null - durable value lost.
+            for(int i = 0; i < ENTRY_COUNT; i++)
+            {
+                assertEquals("value-" + i, cache.get(i),
+                    heapKeys.contains(i)
+                        ? "heap-resident entry lost"
+                        : "heap-evicted entry was deleted from the backing storage");
+            }
+
+            // Inverse contract: an application-driven remove must still delete durably.
+            cache.remove(0);
+            assertNull(cache.get(0), "remove() must delete the entry from the backing store");
         }
         finally
         {
             cacheManager.close();
-            storageManager.shutdown();
+            storageManager.close();
             LazyReferenceManager.get().stop();
         }
     }

--- a/integration-tests/src/test/java/test/eclipse/store/cache/CacheRemoveAllDurableEntriesTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/cache/CacheRemoveAllDurableEntriesTest.java
@@ -72,7 +72,7 @@ public class CacheRemoveAllDurableEntriesTest
             createStorageBackedLruCache(cacheManager, storageManager, "removeAllCache");
         try
         {
-            final Set<Integer> heapKeys = putUntilEvicted(cache);
+            putUntilEvicted(cache);
 
             // Registered after the puts, so it observes only the removeAll() events.
             final Map<Integer, String> removedEvents = new HashMap<>();

--- a/integration-tests/src/test/java/test/eclipse/store/cache/CacheRemoveAllDurableEntriesTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/cache/CacheRemoveAllDurableEntriesTest.java
@@ -1,0 +1,263 @@
+package test.eclipse.store.cache;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.event.CacheEntryRemovedListener;
+import javax.cache.integration.CacheWriter;
+import javax.cache.spi.CachingProvider;
+
+import org.eclipse.serializer.reference.LazyReferenceManager;
+import org.eclipse.store.cache.types.CacheConfiguration;
+import org.eclipse.store.cache.types.EvictionManager;
+import org.eclipse.store.cache.types.EvictionPolicy;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * removeAll() must remove ALL mappings of the cache, including entries that were evicted
+ * from the heap but remain durable in a backing CacheStore. Per JSR-107, for every mapping
+ * that exists, removeAll() calls the registered CacheEntryRemovedListeners and, for a
+ * write-through cache, the CacheWriter. The purge must not depend on whether a
+ * removed-listener is registered (old values are loaded only for listeners).
+ * <p>
+ * For a generic (non-CacheStore) CacheWriter the external resource is not owned by the
+ * cache: removeAll() must pass only the mappings the cache holds, never enumerate the
+ * external resource.
+ */
+public class CacheRemoveAllDurableEntriesTest
+{
+    private static final long MAX_CACHE_SIZE = 3;
+    private static final int  ENTRY_COUNT    = (int)MAX_CACHE_SIZE + 1;
+
+    @Test
+    @Timeout(60)
+    void removeAllDeletesEvictedEntriesDurably(@TempDir final Path tempdir)
+    {
+        EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempdir);
+
+        final CachingProvider provider     = Caching.getCachingProvider();
+        CacheManager          cacheManager = provider.getCacheManager();
+
+        Cache<Integer, String> cache =
+            createStorageBackedLruCache(cacheManager, storageManager, "removeAllCache");
+        try
+        {
+            final Set<Integer> heapKeys = putUntilEvicted(cache);
+
+            // Registered after the puts, so it observes only the removeAll() events.
+            final Map<Integer, String> removedEvents = new HashMap<>();
+            final CacheEntryRemovedListener<Integer, String> listener = events ->
+                events.forEach(event -> removedEvents.put(event.getKey(), event.getOldValue()));
+            cache.registerCacheEntryListener(new MutableCacheEntryListenerConfiguration<>(
+                () -> listener,
+                null,
+                true, // old value required
+                true  // synchronous
+            ));
+
+            cache.removeAll();
+
+            // Every mapping - heap-resident and heap-evicted alike - must be gone...
+            for(int i = 0; i < ENTRY_COUNT; i++)
+            {
+                assertNull(cache.get(i), "entry survived removeAll() and resurrected via read-through");
+            }
+            // ...and every mapping must have produced a REMOVED event with its old value.
+            assertEquals(ENTRY_COUNT, removedEvents.size(),
+                "removeAll() must raise a REMOVED event for every mapping, including heap-evicted ones");
+            for(int i = 0; i < ENTRY_COUNT; i++)
+            {
+                assertEquals("value-" + i, removedEvents.get(i),
+                    "REMOVED event must carry the old value");
+            }
+
+            // Restart and re-read: the purge must hold against the storage on disk,
+            // not merely against in-heap state.
+            cacheManager.close();
+            storageManager.close();
+
+            storageManager = EmbeddedStorage.start(tempdir);
+            cacheManager   = provider.getCacheManager();
+            final CacheConfiguration<Integer, String> restartedConfiguration = CacheConfiguration
+                .Builder(Integer.class, String.class, "removeAllCache", storageManager)
+                .build();
+            cache = cacheManager.createCache("removeAllCache", restartedConfiguration);
+
+            for(int i = 0; i < ENTRY_COUNT; i++)
+            {
+                assertNull(cache.get(i), "entry survived removeAll() durably across a storage restart");
+            }
+        }
+        finally
+        {
+            cacheManager.close();
+            storageManager.close();
+            LazyReferenceManager.get().stop();
+        }
+    }
+
+    @Test
+    @Timeout(60)
+    void removeAllPurgesEvictedEntriesWithoutRemovedListener(@TempDir final Path tempdir)
+    {
+        final EmbeddedStorageManager storageManager = EmbeddedStorage.start(tempdir);
+
+        final CachingProvider provider     = Caching.getCachingProvider();
+        final CacheManager    cacheManager = provider.getCacheManager();
+
+        final Cache<Integer, String> cache =
+            createStorageBackedLruCache(cacheManager, storageManager, "noListenerCache");
+        try
+        {
+            putUntilEvicted(cache);
+
+            // No CacheEntryRemovedListener is registered: the purge must not depend on
+            // the old-value loading that only removed-listeners require.
+            cache.removeAll();
+
+            for(int i = 0; i < ENTRY_COUNT; i++)
+            {
+                assertNull(cache.get(i), "entry survived removeAll() without a removed-listener");
+            }
+        }
+        finally
+        {
+            cacheManager.close();
+            storageManager.close();
+            LazyReferenceManager.get().stop();
+        }
+    }
+
+    @Test
+    @Timeout(60)
+    void removeAllWithGenericWriterPassesHeapKeysOnly()
+    {
+        final Set<Integer> deletedKeys = new HashSet<>();
+        final CacheWriter<Integer, String> recordingWriter = new CacheWriter<>()
+        {
+            @Override
+            public void write(final Cache.Entry<? extends Integer, ? extends String> entry)
+            {
+                // external resource not relevant for this test
+            }
+
+            @Override
+            public void writeAll(final Collection<Cache.Entry<? extends Integer, ? extends String>> entries)
+            {
+                // external resource not relevant for this test
+            }
+
+            @Override
+            public void delete(final Object key)
+            {
+                deletedKeys.add((Integer)key);
+            }
+
+            @Override
+            public void deleteAll(final Collection<?> keys)
+            {
+                keys.forEach(key -> deletedKeys.add((Integer)key));
+                keys.clear(); // all deletes succeeded
+            }
+        };
+
+        final CachingProvider provider     = Caching.getCachingProvider();
+        final CacheManager    cacheManager = provider.getCacheManager();
+
+        final CacheConfiguration<Integer, String> configuration = CacheConfiguration
+            .Builder(Integer.class, String.class)
+            .cacheWriterFactory(() -> recordingWriter)
+            .writeThrough()
+            .evictionManagerFactory(() ->
+                EvictionManager.OnEntryCreation(EvictionPolicy.LeastRecentlyUsed(MAX_CACHE_SIZE)))
+            .build();
+
+        final Cache<Integer, String> cache =
+            cacheManager.createCache("genericWriterCache", configuration);
+        try
+        {
+            final Set<Integer> heapKeys = putUntilEvicted(cache);
+
+            deletedKeys.clear(); // ignore anything recorded before removeAll()
+            cache.removeAll();
+
+            // The external resource is not owned by the cache: only the cache's own
+            // (heap) mappings may be passed to the writer, nothing may be enumerated.
+            assertEquals(heapKeys, deletedKeys,
+                "removeAll() with a generic CacheWriter must delete exactly the heap mappings");
+        }
+        finally
+        {
+            cacheManager.close();
+        }
+    }
+
+    private static Cache<Integer, String> createStorageBackedLruCache(
+        final CacheManager           cacheManager  ,
+        final EmbeddedStorageManager storageManager,
+        final String                 cacheName
+    )
+    {
+        final CacheConfiguration<Integer, String> configuration = CacheConfiguration
+            .Builder(Integer.class, String.class, cacheName, storageManager)
+            .evictionManagerFactory(() ->
+                EvictionManager.OnEntryCreation(EvictionPolicy.LeastRecentlyUsed(MAX_CACHE_SIZE)))
+            .build();
+        return cacheManager.createCache(cacheName, configuration);
+    }
+
+    /**
+     * Puts more entries than the eviction cap and returns the keys still heap-resident.
+     * containsKey never calls the loader (JSR-107), so it probes the heap only: keys
+     * missing from the result were evicted. Fails if no eviction occurred, so no test
+     * can pass without exercising the eviction path.
+     */
+    private static Set<Integer> putUntilEvicted(final Cache<Integer, String> cache)
+    {
+        for(int i = 0; i < ENTRY_COUNT; i++)
+        {
+            cache.put(i, "value-" + i);
+        }
+        final Set<Integer> heapKeys = new HashSet<>();
+        for(int i = 0; i < ENTRY_COUNT; i++)
+        {
+            if(cache.containsKey(i))
+            {
+                heapKeys.add(i);
+            }
+        }
+        assertFalse(heapKeys.size() >= ENTRY_COUNT,
+            "test setup: no entry was evicted, the eviction path was not exercised");
+        return heapKeys;
+    }
+}


### PR DESCRIPTION
A storage-backed cache with a size-based eviction policy (LRU etc.) deleted
every evicted entry from the backing EmbeddedStorage: eviction routed through
CacheWriter.delete, which removed the entry from the persistent table. A later
get() of the evicted key read through to an empty store and returned null -
silent, permanent loss of data the application never removed.

Two changes:

1. Eviction only frees heap space. Evicted entries stay durable in the
   backing store and reload transparently via read-through - heap as working
   set, store as full data set. This matches the JSR-107 CacheWriter contract,
   which treats eviction (like expiry) as a cache-internal removal that must
   not invoke the writer.

2. removeAll() now purges those heap-evicted durable entries as well. Its key
   collection was heap-only, so entries evicted at that moment survived the
   purge and resurrected via read-through. When the writer is the cache-owned
   CacheStore, its keys are unioned in; evicted entries raise REMOVED events
   (old values fetched in one bulk load, only when a removed-listener is
   registered; a failed read skips events, never the purge) and count as
   removals. Generic CacheWriters are untouched - an external resource the
   cache does not own is never enumerated.

Application-driven per-key removal is unchanged.

New regression tests: CacheEvictionDeletesFromStorageReproTest (evicted
entries survive in the store and reload; remove() still deletes durably) and
CacheRemoveAllDurableEntriesTest (durable purge incl. storage restart, with
and without listeners; generic-writer scoping).