### PR TITLE
GigaMap: a query registered as its own sub-query no longer recurses infinitely

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaQuery.java
@@ -446,6 +446,10 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 	/**
 	 * Combines the current query with the given {@link GigaMap.SubQuery} using a logical AND operator.
 	 * The sub-query contributes an {@link EntityIdMatcher} that further restricts the matching entity ids.
+	 * <p>
+	 * Passing this query itself is a no-op, since a query AND itself is the query. Registering sub-queries
+	 * in a way that forms a cycle (e.g. {@code q1.and(q2); q2.and(q1);}) is invalid and is rejected when the
+	 * query is executed.
 	 *
 	 * @param subQuery the sub-query to combine with the current query
 	 * @return the current {@link GigaQuery} instance with the added sub-query
@@ -775,10 +779,13 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 		private final IterationThreadProvider threadProvider;
 
 		private BulkList<GigaMap.SubQuery> subQueries;
-		
+
 		private Condition<E> condition;
 		private long         idStart  ;
 		private long         idBound  ;
+
+		// guards against sub-query cycles, see #buildEntityIdMatcher
+		private boolean isBuildingEntityIdMatcher;
 		
 		
 		
@@ -813,6 +820,14 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 		@Override
 		public GigaQuery<E> and(final GigaMap.SubQuery subQuery)
 		{
+			/* Registering this query as its own sub-query would recurse infinitely while resolving the
+			 * matchers. It is also pointless: a query AND itself is the query, so it is simply skipped.
+			 */
+			if(subQuery == this)
+			{
+				return this;
+			}
+
 			if(this.subQueries == null)
 			{
 				this.subQueries = BulkList.New();
@@ -894,22 +909,41 @@ public interface GigaQuery<E> extends XIterable<E>, Iterable<E>, GigaMap.Compone
 				return EntityIdMatcher.NoOp();
 			}
 
-			final int size = this.subQueries.intSize();
-			if(size == 1)
+			/* A sub-query may be a query itself, so resolving the matchers recurses into other queries.
+			 * Re-entering this query while it is still resolving means the sub-queries form a cycle
+			 * (e.g. q1.and(q2); q2.and(q1);), which must be reported instead of overflowing the stack.
+			 */
+			if(this.isBuildingEntityIdMatcher)
 			{
-				// Single sub-query — no Multiple wrapper needed.
-				return this.subQueries.first().provideEntityIdMatcher();
+				throw new IllegalStateException(
+					"Cyclic sub-query registration: this query is (indirectly) registered as its own sub-query."
+				);
 			}
 
-			final EntityIdMatcher[] idMatchers = new EntityIdMatcher[size];
-
-			int i = 0;
-			for(final GigaMap.SubQuery q : this.subQueries)
+			this.isBuildingEntityIdMatcher = true;
+			try
 			{
-				idMatchers[i++] = q.provideEntityIdMatcher();
-			}
+				final int size = this.subQueries.intSize();
+				if(size == 1)
+				{
+					// Single sub-query — no Multiple wrapper needed.
+					return this.subQueries.first().provideEntityIdMatcher();
+				}
 
-			return new EntityIdMatcher.Multiple(idMatchers);
+				final EntityIdMatcher[] idMatchers = new EntityIdMatcher[size];
+
+				int i = 0;
+				for(final GigaMap.SubQuery q : this.subQueries)
+				{
+					idMatchers[i++] = q.provideEntityIdMatcher();
+				}
+
+				return new EntityIdMatcher.Multiple(idMatchers);
+			}
+			finally
+			{
+				this.isBuildingEntityIdMatcher = false;
+			}
 		}
 
 		public GigaIterator<E> iterator(final EntityResolver<E> resolver)

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/SubQuerySelfReferenceTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/SubQuerySelfReferenceTest.java
@@ -1,0 +1,112 @@
+package org.eclipse.store.gigamap.indexer.edge;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.GigaQuery;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for cyclic sub-query registration via {@link GigaQuery#and(GigaMap.SubQuery)}.
+ * <p>
+ * Root cause: {@code GigaQuery} implements {@code GigaMap.SubQuery} itself, and
+ * {@code and(GigaMap.SubQuery)} registered the passed sub-query without any identity check. A query
+ * registered as its own sub-query therefore made {@code buildEntityIdMatcher} re-enter
+ * {@code provideEntityIdMatcher()} on the very same query, recursing until the stack was exhausted -
+ * before a single entity was tested.
+ * <p>
+ * Fix: registering the query itself is skipped (a query AND itself is the query), and an indirect
+ * cycle is reported while resolving the matchers instead of overflowing the stack.
+ */
+public class SubQuerySelfReferenceTest
+{
+	static final class Rec
+	{
+		final String cat;
+
+		Rec(final String cat)
+		{
+			this.cat = cat;
+		}
+	}
+
+	static final class CatIdx extends IndexerString.Abstract<Rec>
+	{
+		@Override
+		protected String getString(final Rec entity)
+		{
+			return entity.cat;
+		}
+	}
+
+	private final CatIdx cat = new CatIdx();
+
+	private GigaMap<Rec> newMap()
+	{
+		final GigaMap<Rec> map = GigaMap.New();
+		map.index().bitmap().add(this.cat);
+		map.add(new Rec("a"));
+		map.add(new Rec("b"));
+		map.add(new Rec("a"));
+
+		return map;
+	}
+
+	@Test
+	@Timeout(60)
+	void selfSubQueryIsIdempotent()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		final long plain = map.query(this.cat.is("a")).count();
+		assertEquals(2, plain);
+
+		final GigaQuery<Rec> query = map.query(this.cat.is("a"));
+		assertEquals(plain, query.and(query).count(), "q AND q == q");
+	}
+
+	@Test
+	@Timeout(60)
+	void indirectSubQueryCycleIsReported()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		final GigaQuery<Rec> q1 = map.query(this.cat.is("a"));
+		final GigaQuery<Rec> q2 = map.query(this.cat.is("b"));
+
+		q1.and(q2);
+		q2.and(q1);
+
+		assertThrows(IllegalStateException.class, q1::count, "cyclic sub-query registration");
+	}
+
+	@Test
+	@Timeout(60)
+	void acyclicSubQueryStillRestrictsTheResult()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		final GigaQuery<Rec> subQuery = map.query(this.cat.is("b"));
+
+		assertEquals(0, map.query(this.cat.is("a")).and(subQuery).count(), "cat=a AND cat=b");
+		assertEquals(2, map.query(this.cat.is("a")).and(map.query(this.cat.is("a"))).count(), "cat=a AND cat=a");
+	}
+}


### PR DESCRIPTION
## Problem

`GigaQuery` implements `GigaMap.SubQuery` itself, and `GigaQuery.Default#and(GigaMap.SubQuery)` registered the passed sub-query without any identity check. `q.and(q)` therefore type-checked and stored the query inside itself, and `buildEntityIdMatcher` re-entered `provideEntityIdMatcher()` on the very same query, so the next terminal operation (`count()`, iteration, ...) died with a `StackOverflowError` before a single entity was tested. The same held for an indirect cycle (`q1.and(q2); q2.and(q1)`).

The self-reference fix from #450 added the `condition == this` guard at the `Condition` level; the `SubQuery` path was never guarded, even though the reproducer was literally the `query(...).and(same)` shape.

## Change

- `and(GigaMap.SubQuery)` skips the registration when the passed sub-query is this query, since a query AND itself is the query.
- `buildEntityIdMatcher()` detects re-entry into a query that is still resolving its matchers and throws an `IllegalStateException`, so an indirect cycle is reported instead of exhausting the stack.
- Javadoc on `GigaQuery#and(SubQuery)` documents both.

## Tests

New `SubQuerySelfReferenceTest` covers the direct case (`q.and(q)` is idempotent), the indirect cycle (reported, not a crash) and the unaffected acyclic sub-query composition. All three fail on `main` (two `StackOverflowError`s).

Verified green: `gigamap` module suite (1150 tests), plus `SubQueryCompositionTest`, `MixedIndexCompositeConditionTest`, `QueryInQueryTest` and `QueryVariableTests` (the internal#11 regression shape).
