### PR TITLE
GigaMap: Condition.and/or no longer modify the receiver chain

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Condition.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/Condition.java
@@ -51,6 +51,10 @@ public interface Condition<E> extends Predicate<E>
 	
 	/**
 	 * Links the current condition with another condition using the specified linker.
+	 * <p>
+	 * Linking never modifies this condition: the result is always a newly created condition instance.
+	 * A condition instance is therefore safe to cache, share and reuse as the base of arbitrarily many
+	 * derived conditions.
 	 *
 	 * @param condition the condition to be linked with the current condition
 	 * @param linker the linker function that defines how the conditions are linked
@@ -66,14 +70,18 @@ public interface Condition<E> extends Predicate<E>
 	
 	/**
 	 * Combines the current condition with another condition using a logical AND operation.
+	 * <p>
+	 * This condition is left unchanged, see {@link #linkCondition(Condition, Linker)}.
 	 *
 	 * @param condition the condition to be combined with the current condition
 	 * @return a new condition that represents the logical AND of the current condition and the specified condition
 	 */
 	public Condition<E> and(Condition<E> condition);
-	
+
 	/**
 	 * Combines the current condition with another condition using a logical OR operation.
+	 * <p>
+	 * This condition is left unchanged, see {@link #linkCondition(Condition, Linker)}.
 	 *
 	 * @param condition the condition to be combined with the current condition
 	 * @return a new condition that represents the logical OR of the current condition and the specified condition
@@ -308,17 +316,18 @@ public interface Condition<E> extends Predicate<E>
 			final Linker linker
 		)
 		{
-			// Prevent self-reference which would cause infinite recursion during evaluation.
-			if(condition == this)
-			{
-				return linker.linkCondition(condition, this);
-			}
-
 			// AND condition can just be added to this chainAnd's conditions (flattening).
 			if(linker == CREATOR_AND)
 			{
-				this.conditions.add(condition);
-				return this;
+				/* But it is added to a COPY of them: this instance must not be modified, since the
+				 * application may hold and reuse it as the base of other conditions. Copying also makes
+				 * a reference cycle (and thus infinite recursion during evaluation) impossible, as the
+				 * linked condition can never contain the instance returned here.
+				 */
+				final BulkList<Condition<E>> linkedConditions = BulkList.New(this.conditions);
+				linkedConditions.add(condition);
+
+				return new And<>(linkedConditions);
 			}
 
 			// otherwise (i.e., OR), the last condition is bound with priority to the new condition
@@ -359,7 +368,12 @@ public interface Condition<E> extends Predicate<E>
 			this.conditions.add(leftCondition);
 			this.conditions.add(rightCondition);
 		}
-		
+
+		protected Or(final BulkList<Condition<E>> conditions)
+		{
+			super(conditions);
+		}
+
 		@Override
 		public Condition<E> complete()
 		{
@@ -396,23 +410,25 @@ public interface Condition<E> extends Predicate<E>
 			final Linker linker
 		)
 		{
-			// Prevent self-reference which would cause infinite recursion during evaluation.
-			if(condition == this)
-			{
-				return linker.linkCondition(condition, this);
-			}
+			/* Both linking cases are applied to a COPY of this chainOr's conditions: this instance must not
+			 * be modified, since the application may hold and reuse it as the base of other conditions.
+			 * Copying also makes a reference cycle (and thus infinite recursion during evaluation)
+			 * impossible, as the linked condition can never contain the instance returned here.
+			 */
+			final BulkList<Condition<E>> linkedConditions = BulkList.New(this.conditions);
 
 			if(linker == CREATOR_OR)
 			{
 				// OR condition can just be added to this chainOr's conditions (flattening).
-				this.conditions.add(condition);
-				return this;
+				linkedConditions.add(condition);
+			}
+			else
+			{
+				// otherwise (i.e. AND), the last condition is bound with priority to the new condition
+				linkedConditions.setLast(linker.linkCondition(condition, linkedConditions.last()));
 			}
 
-			// otherwise (i.e. AND), the last condition is bound with priority to the new condition
-			final Condition<E> linkingCondition = linker.linkCondition(condition, this.conditions.last());
-			this.conditions.setLast(linkingCondition);
-			return this;
+			return new Or<>(linkedConditions);
 		}
 		
 		@Override

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ConditionAndOrWhiteBoxTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ConditionAndOrWhiteBoxTest.java
@@ -1,0 +1,214 @@
+package org.eclipse.store.gigamap.indexer.edge;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+
+import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/**
+ * Tests for the linking behavior of {@link Condition#and(Condition)} / {@link Condition#or(Condition)}
+ * on an existing {@code And}/{@code Or} chain.
+ * <p>
+ * Root cause of both defects covered here: {@code And/Or.linkCondition} added the incoming condition to
+ * <strong>this</strong> chain's condition list and returned the receiver.
+ * <ul>
+ * <li>A base condition that the application holds and reuses therefore accumulated every term ever
+ * chained onto it, so subsequent queries built from that base silently returned wrong results - while
+ * the javadoc promises "a new condition".</li>
+ * <li>Mutating the receiver also allowed a reference cycle to form: chaining the receiver onto a
+ * condition that already contained it ({@code c1.and(c1.or(x))}) made evaluation recurse infinitely.
+ * The {@code condition == this} guard only covered the direct case.</li>
+ * </ul>
+ * Fix: linking copies the chain's condition list, so the receiver is never modified and the returned
+ * instance can never be contained in itself.
+ */
+public class ConditionAndOrWhiteBoxTest
+{
+	static final class Rec
+	{
+		final String f1;
+		final String f2;
+		final String f3;
+
+		Rec(final String f1, final String f2, final String f3)
+		{
+			this.f1 = f1;
+			this.f2 = f2;
+			this.f3 = f3;
+		}
+	}
+
+	static final class F1Idx extends IndexerString.Abstract<Rec>
+	{
+		@Override
+		protected String getString(final Rec entity)
+		{
+			return entity.f1;
+		}
+	}
+
+	static final class F2Idx extends IndexerString.Abstract<Rec>
+	{
+		@Override
+		protected String getString(final Rec entity)
+		{
+			return entity.f2;
+		}
+	}
+
+	static final class F3Idx extends IndexerString.Abstract<Rec>
+	{
+		@Override
+		protected String getString(final Rec entity)
+		{
+			return entity.f3;
+		}
+	}
+
+	private final F1Idx f1 = new F1Idx();
+	private final F2Idx f2 = new F2Idx();
+	private final F3Idx f3 = new F3Idx();
+
+	/**
+	 * 24 entities: all 8 combinations of the three binary-valued indexed fields, 3 entities each.
+	 */
+	private GigaMap<Rec> newMap()
+	{
+		final GigaMap<Rec> map = GigaMap.New();
+		map.index().bitmap().addAll(this.f1, this.f2, this.f3);
+
+		for(int i = 0; i < 3; i++)
+		{
+			for(final String a : new String[]{"a0", "a1"})
+			{
+				for(final String b : new String[]{"b0", "b1"})
+				{
+					for(final String c : new String[]{"c0", "c1"})
+					{
+						map.add(new Rec(a, b, c));
+					}
+				}
+			}
+		}
+
+		return map;
+	}
+
+	@Test
+	@Timeout(60)
+	void reusedBaseConditionMustNotBeMutatedByDerivedQueries()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		final Condition<Rec> base = this.f1.is("a0").and(this.f2.is("b0"));
+
+		assertEquals(6, map.query(base).count(), "base condition (f1 AND f2)");
+
+		final Condition<Rec> derived = base.and(this.f3.is("c0"));
+		assertEquals(3, map.query(derived).count(), "derived condition (f1 AND f2 AND f3)");
+
+		assertEquals(
+			6,
+			map.query(base).count(),
+			"deriving a query from a base condition must not modify the base"
+		);
+		assertNotSame(base, derived, "and() must return a new condition, not the receiver");
+	}
+
+	@Test
+	@Timeout(60)
+	void reusedBaseOrConditionMustNotBeMutatedByDerivedQueries()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		final Condition<Rec> base = this.f1.is("a0").or(this.f2.is("b0"));
+
+		assertEquals(18, map.query(base).count(), "base condition (f1 OR f2)");
+
+		// fluent AND on an OR chain binds to the chain's last clause: f1 OR (f2 AND f3)
+		final Condition<Rec> derived = base.and(this.f3.is("c0"));
+		assertEquals(15, map.query(derived).count(), "derived condition (f1 OR (f2 AND f3))");
+
+		assertEquals(
+			18,
+			map.query(base).count(),
+			"deriving a query from a base condition must not modify the base"
+		);
+		assertNotSame(base, derived, "and() must return a new condition, not the receiver");
+	}
+
+	@Test
+	@Timeout(60)
+	void indirectSelfReferenceMustNotBlowTheStack()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		final Condition<Rec> c1  = this.f1.is("a0").and(this.f2.is("b0"));
+		final Condition<Rec> cOr = c1.or(this.f3.is("c0"));
+
+		// (f1 AND f2) AND ((f1 AND f2) OR f3) == f1 AND f2
+		assertEquals(6, map.query(c1.and(cOr)).count(), "condition containing the receiver");
+	}
+
+	@Test
+	@Timeout(60)
+	void directSelfReferenceIsIdempotent()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		final Condition<Rec> c1 = this.f1.is("a0").and(this.f2.is("b0"));
+
+		assertEquals(6, map.query(c1.and(c1)).count(), "c AND c == c");
+	}
+
+	/**
+	 * Guard rail for the documented fluent precedence semantics, which the copy-on-link fix must not change.
+	 */
+	@Test
+	@Timeout(60)
+	void fluentAndOnQueryBindsToTheLastOrClause()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		// f1 OR (f2 AND f3), since AND binds stronger than OR
+		assertEquals(
+			15,
+			map.query(this.f1.is("a0")).or(this.f2.is("b0")).and(this.f3.is("c0")).count()
+		);
+	}
+
+	/**
+	 * Guard rail for the documented fluent precedence semantics, which the copy-on-link fix must not change.
+	 */
+	@Test
+	@Timeout(60)
+	void completedOrChainIsAndedAsAWhole()
+	{
+		final GigaMap<Rec> map = this.newMap();
+
+		// (f1 OR f2) AND f3, since query(...) completes the OR chain into a term
+		assertEquals(
+			9,
+			map.query(this.f1.is("a0").or(this.f2.is("b0"))).and(this.f3.is("c0")).count()
+		);
+	}
+}


### PR DESCRIPTION
## Problem

`Condition.And#linkCondition` / `Condition.Or#linkCondition` added the incoming condition to **this** chain's condition list and returned the receiver. Two defects follow from that single root cause:

**Aliasing (silently wrong results).** A base condition that the application holds and reuses accumulated every term ever chained onto it:

```java
final Condition<Rec> base = f1.is("a0").and(f2.is("b0"));

map.query(base).count();                     // 6  - correct
map.query(base.and(f3.is("c0"))).count();    // 3  - correct
map.query(base).count();                     // 3  - WRONG: base permanently carries f3 now
```

No exception, no warning, and it contradicts the javadoc, which promises "a new condition". The realistic trigger is a cached base condition (`static final Condition<X> ACTIVE_ITEMS = ...`) reused by two call sites.

**Indirect cycle (internal#127, crash).** Mutating the receiver also allowed a reference cycle to form. Chaining the receiver onto a condition that already contained it made evaluation recurse infinitely:

```java
final Condition<Rec> c1  = f1.is("a0").and(f2.is("b0"));
final Condition<Rec> cOr = c1.or(f3.is("c0"));   // holds c1

map.query(c1.and(cOr)).count();                  // StackOverflowError
```

The `condition == this` guard from #450 caught only the direct case.

## Change

Linking copies the chain's condition list instead of modifying it, so the receiver is never touched and the returned instance can never contain itself. Composition can only build a directed acyclic graph out of already existing conditions, which closes the indirect-cycle crash structurally rather than by another guard, so both `condition == this` guards are gone.

`Or` gains the `BulkList` constructor that `And` already had.

The fluent precedence semantics are deliberately unchanged, both in the "replace the last clause" rule of `Or` and in the `Term` ("parenthesis") mechanism, so this is not a repeat of #653:

- `query(C1).or(C2).and(C3)` stays `C1 OR (C2 AND C3)`
- `query(C1.or(C2)).and(C3)` stays `(C1 OR C2) AND C3`

Both are covered by guard-rail tests. The `.complete()` wrapping added to the range factories in #655 also stays as it is: it encodes precedence, not aliasing.

## Behavior change

Callers that discarded the result of `and()`/`or()` and then queried the receiver no longer see the discarded term, e.g.:

```java
base.and(f3.is("c0"));      // result discarded
map.query(base).count();    // no longer narrowed by f3
```

That is the intended reversal (the old behavior is the bug), but it is observable and probably worth a release note. Note this applies to `Condition` only: the `GigaQuery` fluent API keeps returning `this`, and internal code such as `GigaMap.Default#lookupEntityIdPeeking` relies on that.

## Tests

New `ConditionAndOrWhiteBoxTest` covers the reused `And` base, the reused `Or` base, the indirect cycle, direct self-reference, and the two precedence guard rails. The aliasing and cycle tests fail on `main`.

Verified green: `gigamap` module suite (1150 tests), `lucene` (74) and `jvector` (121, `-Pslow-tests`), plus `QueryVariableTests` (the internal#11 regression shape).
