### PR TITLE
GigaMap: turn internalAddAll(long, E[]) into a default method across the index fan-out

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractCompositeBitmapIndex.java
@@ -207,19 +207,6 @@ implements BitmapIndex.TopLevel<E, KS>
 	}
 	
 	@Override
-	public final void internalAddAll(final long firstEntityId, final E[] entities)
-	{
-		try
-		{
-			super.internalAddAll(firstEntityId, entities);
-		}
-		finally
-		{
-			this.clearCarrier();
-		}
-	}
-	
-	@Override
 	protected final void removeEntry(final BitmapEntry<E, E, KS> entry)
 	{
 		// not used in this implementation since the actual removing is done in a sub index

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndex.java
@@ -22,6 +22,7 @@ import org.eclipse.serializer.persistence.types.Unpersistable;
 import org.eclipse.serializer.typing.KeyValue;
 import org.eclipse.serializer.util.X;
 
+import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.function.ObjLongConsumer;
 import java.util.function.Predicate;
@@ -207,8 +208,11 @@ public interface BitmapIndex<E, K> extends IndexIdentifier<E, K>, GigaIndex<E>
 		public void internalAdd(long entityId, E entity);
 		
 		public void internalAddAll(long firstEntityId, Iterable<? extends E> entities);
-		
-		public void internalAddAll(long firstEntityId, E[] entities);
+
+		public default void internalAddAll(final long firstEntityId, final E[] entities)
+		{
+			this.internalAddAll(firstEntityId, Arrays.asList(entities));
+		}
 		
 		public void internalRemove(long entityId, E entity);
 		
@@ -400,17 +404,7 @@ public interface BitmapIndex<E, K> extends IndexIdentifier<E, K>, GigaIndex<E>
 			}
 			this.markStateChangeChildren();
 		}
-		
-		public void internalAddAll(final long firstEntityId, final I[] entities)
-		{
-			long currentEntityId = firstEntityId;
-			for(final I entity : entities)
-			{
-				this.internalAddToEntry(currentEntityId++, entity);
-			}
-			this.markStateChangeChildren();
-		}
-		
+
 		protected abstract void internalAddToEntry(long entityId, I indexable);
 		
 		public BitmapEntry<E, I, K> internalEnsureEntry(final I indexable)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -867,22 +867,6 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		}
 
 		@Override
-		public final void internalAddAll(final long firstEntityId, final E[] entities)
-		{
-			try
-			{
-				for(final BitmapIndex.Internal<E, ?> index : this.bitmapIndices.values())
-				{
-					index.internalAddAll(firstEntityId, entities);
-				}
-			}
-			finally
-			{
-				this.markStateChangeChildren();
-			}
-		}
-
-		@Override
 		public final void internalRemove(final long entityId, final E entity)
 		{
 			/*

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -264,21 +264,6 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 			}
 		}
 
-		protected final void internalAddAll(final long firstEntityId, final E[] entities)
-		{
-			try
-			{
-				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
-				{
-					indexGroup.internalAddAll(firstEntityId, entities);
-				}
-			}
-			finally
-			{
-				this.markStateChangeChildren();
-			}
-		}
-
 		protected final void internalRemove(final long entityId, final E entity)
 		{
 			/*

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
@@ -9,11 +9,12 @@ package org.eclipse.store.gigamap.types;
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  * #L%
  */
 
+import java.util.Arrays;
 
 /**
  * General typing interface for specialized index category types.
@@ -47,11 +48,14 @@ public interface IndexGroup<E> extends GigaMap.Component<E>
 		
 		/**
 		 * Adds entities starting with a certain id to this index.
-		 * 
+		 *
 		 * @param firstEntityId the first id which will be incremented for remaining entities
 		 * @param entities the entities to add
 		 */
-		public void internalAddAll(long firstEntityId, E[] entities);
+		public default void internalAddAll(final long firstEntityId, final E[] entities)
+		{
+			this.internalAddAll(firstEntityId, Arrays.asList(entities));
+		}
 		
 		public void internalPrepareIndicesUpdate(E replacedEntity);
 		

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/SingleBitmapIndex.java
@@ -196,28 +196,7 @@ implements BitmapIndex.TopLevel<E, Boolean>, ChangeHandler
 		}
 		this.markStateChangeChildren();
 	}
-	
-	@Override
-	public final void internalAddAll(final long firstEntityId, final E[] entities)
-	{
-		final BitmapEntry<E, E, Boolean>  entry   = this.entry;
-		final Indexer<? super E, Boolean> indexer = this.indexer;
-		
-		long currentEntityId = firstEntityId - 1;
-		for(final E entity : entities)
-		{
-			// entityId must be incremented in any case to ensure consistency to the parent map.
-			++currentEntityId;
-			final Boolean key = indexer.index(entity);
-			if(key == null || !key)
-			{
-				continue;
-			}
-			entry.add(currentEntityId);
-		}
-		this.markStateChangeChildren();
-	}
-	
+
 	@Override
 	public final void internalRemove(final long entityId, final E entity)
 	{

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -706,7 +706,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
         public void internalAddAll(long firstEntityId, Iterable<? extends E> entities);
 
-        public void internalAddAll(long firstEntityId, E[] entities);
+        public default void internalAddAll(final long firstEntityId, final E[] entities)
+        {
+            this.internalAddAll(firstEntityId, Arrays.asList(entities));
+        }
 
         public void internalUpdate(long entityId, E replacedEntity, E entity);
 
@@ -1575,12 +1578,6 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 // Mark dirty for background managers
                 this.markDirtyForBackgroundManagers(1);
             }
-        }
-
-        @Override
-        public void internalAddAll(final long firstEntityId, final E[] entities)
-        {
-            this.internalAddAll(firstEntityId, Arrays.asList(entities));
         }
 
         @Override

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndices.java
@@ -242,16 +242,6 @@ Iterable<KeyValue<String, ? extends VectorIndex<E>>>
         }
 
         @Override
-        public final void internalAddAll(final long firstEntityId, final E[] entities)
-        {
-            for(final VectorIndex.Internal<E> index : this.vectorIndices.values())
-            {
-                index.internalAddAll(firstEntityId, entities);
-            }
-            this.markStateChangeChildren();
-        }
-
-        @Override
         public void internalPrepareIndicesUpdate(final E replacedEntity)
         {
             // Vector indices don't need preparation for updates

--- a/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
+++ b/gigamap/lucene/src/main/java/org/eclipse/store/gigamap/lucene/LuceneIndex.java
@@ -411,12 +411,6 @@ public interface LuceneIndex<E> extends IndexGroup<E>, Closeable
 		}
 		
 		@Override
-		public void internalAddAll(final long firstEntityId, final E[] entities)
-		{
-			this.internalAddAll(firstEntityId, Arrays.asList(entities));
-		}
-		
-		@Override
 		public void internalRemove(final long entityId, final E entity)
 		{
 			try


### PR DESCRIPTION
## Summary
- The `internalAddAll(long, E[])` overload had no live caller anywhere in the fan-out: `GigaMap#addAll(E...)` wraps its input into a `ConstList` and only ever uses the `Iterable` overload, so every per-family array-loop implementation was dead, duplicated logic.
- `IndexGroup.Internal`, `BitmapIndex.Internal` and `VectorIndex.Internal` now declare the array overload as a `default` method delegating to the `Iterable` variant via `Arrays.asList`, and the per-family implementations (`BitmapIndex.Abstract`, `BitmapIndices.Default`, `SingleBitmapIndex`, `AbstractCompositeBitmapIndex`, `LuceneIndex.Default`, `VectorIndices.Default`) are removed.
- Stays source-compatible for external implementors of these public `Internal` interfaces, while removing the duplicated loops that were the actual maintenance risk.
- Cleanup only, no functional change. Fixes internal#134.

## Test plan
- [x] `mvn compile` / `test-compile` for gigamap, lucene, jvector modules
- [x] `mvn test` for gigamap, lucene, jvector modules (all green)