### PR TITLE
GigaMap: numeric binary indexers reject null keys with a designed exception instead of a raw NPE

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIndexBinary.java
@@ -289,9 +289,8 @@ public abstract class AbstractBitmapIndexBinary<E, I> extends BitmapIndex.Abstra
 	
 	protected long indexBinary(final I entity)
 	{
-		final long keys = this.indexer.indexBinary(entity);
-		BinaryIndexer.Static.validate(keys, this.indexer);
-		return keys;
+		// note: null keys are rejected by the indexer itself, since a long can never be null once it got here.
+		return this.indexer.indexBinary(entity);
 	}
 	
 	@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexer.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexer.java
@@ -26,7 +26,9 @@ import java.util.function.Predicate;
  * <p>
  * Current limitation are:
  * <ul>
- * <li>null is not allowed</li>
+ * <li>null is not allowed: a binary index encodes the key directly into a single {@code long} bit pattern, which
+ * leaves no collision-free encoding for null. Null keys are rejected with an {@link IllegalArgumentException},
+ * both when extracted from an entity and when passed to a condition.</li>
  * <li>only <code>equality/is</code> conditions are supported</li>
  * </ul>
  *
@@ -79,9 +81,9 @@ public interface BinaryIndexer<E> extends Indexer<E, Long>
 	 * the key extracted by this index is equal to the specified key.
 	 *
 	 * @param <S> the type of entity this condition applies to, extending the base entity type
-	 * @param key the key to compare for equality, not negative
+	 * @param key the key to compare for equality, must not be null
 	 * @return a new condition representing the equality check for the given key
-	 * @throws IllegalArgumentException if the key is negative
+	 * @throws IllegalArgumentException if the key is {@code null}
 	 */
 	@Override
 	public default <S extends E> Condition<S> is(final Long key)
@@ -91,6 +93,14 @@ public interface BinaryIndexer<E> extends Indexer<E, Long>
 		return Indexer.super.is(key);
 	}
 	
+	/**
+	 * Creates a condition that checks if the key extracted by this index is contained within the specified keys.
+	 *
+	 * @param <S> the type of entity this condition applies to, extending the base entity type
+	 * @param keys the keys to compare to, none of which may be null
+	 * @return a new condition representing the containment check for the provided keys
+	 * @throws IllegalArgumentException if any of the keys is {@code null}
+	 */
 	@Override
 	public default <S extends E> Condition<S> in(final Long... keys)
 	{
@@ -133,11 +143,27 @@ public interface BinaryIndexer<E> extends Indexer<E, Long>
 	
 	public static class Static
 	{
-		static void validate(final Long key, final BinaryIndexer<?> indexer)
+		/**
+		 * Rejects a null key with a descriptive {@link IllegalArgumentException}.
+		 * <p>
+		 * The parameter is {@link Number} rather than {@link Long} so that the numeric indexers can validate their
+		 * own key type before the unboxing in their {@code toLong} conversion turns a null key into a raw
+		 * {@link NullPointerException}.
+		 *
+		 * @param key the key to validate
+		 * @param indexer the indexer the key belongs to, used to name the index in the exception message
+		 * @throws IllegalArgumentException if the key is {@code null}
+		 */
+		static void validate(final Number key, final BinaryIndexer<?> indexer)
 		{
 			if(key == null)
 			{
-				throw new IllegalArgumentException("Null keys are not allowed in index " + indexer.name());
+				throw new IllegalArgumentException(
+					"Null keys are not allowed in index " + indexer.name()
+					+ ": a binary index encodes the key directly into a single long bit pattern, which leaves no"
+					+ " collision-free encoding for null. Use the hashing IndexerNumber variant"
+					+ " (e.g. IndexerLong) to index a nullable numeric field."
+				);
 			}
 		}
 		
@@ -197,7 +223,11 @@ public interface BinaryIndexer<E> extends Indexer<E, Long>
 		@Override
 		public long indexBinary(final E entity)
 		{
-			return this.subject.index(entity);
+			// must be validated before the unboxing below, which would turn a null key into a raw NullPointerException.
+			final Long key = this.subject.index(entity);
+			Static.validate(key, this);
+			
+			return key;
 		}
 		
 	}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerByte.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerByte.java
@@ -18,6 +18,10 @@ package org.eclipse.store.gigamap.types;
  * An interface that extends {@link BinaryIndexerNumber} specifically for using {@link Byte} as the key type.
  * It provides indexing capabilities, optimized for binary operations and high-cardinality indices,
  * while working with entities of type {@code E}.
+ * <p>
+ * <b>Restriction:</b> {@code null} is not supported as an index key and is rejected with an
+ * {@link IllegalArgumentException}. See {@link BinaryIndexerNumber} for the details and use
+ * {@link IndexerByte} to index a nullable {@link Byte} field.
  *
  * @param <E> the type of entities being indexed
  */

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerDouble.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerDouble.java
@@ -18,6 +18,10 @@ package org.eclipse.store.gigamap.types;
  * An interface that extends {@link BinaryIndexerNumber} specifically for using {@link Double} as the key type.
  * It provides indexing capabilities, optimized for binary operations and high-cardinality indices,
  * while working with entities of type {@code E}.
+ * <p>
+ * <b>Restriction:</b> {@code null} is not supported as an index key and is rejected with an
+ * {@link IllegalArgumentException}. See {@link BinaryIndexerNumber} for the details and use
+ * {@link IndexerDouble} to index a nullable {@link Double} field.
  *
  * @param <E> the type of entities being indexed
  */

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerFloat.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerFloat.java
@@ -18,6 +18,10 @@ package org.eclipse.store.gigamap.types;
  * An interface that extends {@link BinaryIndexerNumber} specifically for using {@link Float} as the key type.
  * It provides indexing capabilities, optimized for binary operations and high-cardinality indices,
  * while working with entities of type {@code E}.
+ * <p>
+ * <b>Restriction:</b> {@code null} is not supported as an index key and is rejected with an
+ * {@link IllegalArgumentException}. See {@link BinaryIndexerNumber} for the details and use
+ * {@link IndexerFloat} to index a nullable {@link Float} field.
  *
  * @param <E> the type of entities being indexed
  */

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerInteger.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerInteger.java
@@ -18,6 +18,10 @@ package org.eclipse.store.gigamap.types;
  * An interface that extends {@link BinaryIndexerNumber} specifically for using {@link Integer} as the key type.
  * It provides indexing capabilities, optimized for binary operations and high-cardinality indices,
  * while working with entities of type {@code E}.
+ * <p>
+ * <b>Restriction:</b> {@code null} is not supported as an index key and is rejected with an
+ * {@link IllegalArgumentException}. See {@link BinaryIndexerNumber} for the details and use
+ * {@link IndexerInteger} to index a nullable {@link Integer} field.
  *
  * @param <E> the type of entities being indexed
  */

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerLong.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerLong.java
@@ -22,6 +22,11 @@ package org.eclipse.store.gigamap.types;
  * <b>Restriction:</b> {@code Long.MAX_VALUE} is not supported as an index key and will throw an
  * {@link IllegalArgumentException}. It is reserved internally as a sentinel for zero in the binary
  * bitmap index. All other long values, including zero and negative values, are fully supported.
+ * <p>
+ * <b>Restriction:</b> {@code null} is not supported as an index key either and is likewise rejected with an
+ * {@link IllegalArgumentException}. Because the zero sentinel already consumes the only bit pattern this
+ * indexer could have spared, no collision-free null sentinel is left. See {@link BinaryIndexerNumber} for the
+ * details and use {@link IndexerLong} to index a nullable {@link Long} field.
  *
  * @param <E> the type of entities being indexed
  */

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerNumber.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerNumber.java
@@ -18,6 +18,16 @@ package org.eclipse.store.gigamap.types;
 /**
  * An interface providing indexing capabilities for entities using numerical keys.
  * This interface extends {@link BinaryIndexer} which is optimized for high-cardinality indices.
+ * <p>
+ * <b>Restriction:</b> {@code null} is not supported as an index key and is rejected with an
+ * {@link IllegalArgumentException} - both when extracted from an entity during indexing and when passed to
+ * {@code is}, {@code not}, {@code in}, {@code notIn}, {@code isNull} or {@code notNull}. A binary index encodes
+ * the key directly into a single {@code long} bit pattern whose every bit position is an index entry, so unlike
+ * the composite binary indexers ({@link BinaryIndexerString}, {@link BinaryIndexerUUID}) it has no spare slot for
+ * a null sentinel, and unlike the sub-64-bit numeric types {@link BinaryIndexerLong} has no unused bit pattern
+ * left either. To index a nullable numeric field, use the hashing {@link IndexerNumber} variants
+ * (for example {@link IndexerLong}), which support {@code isNull()}/{@code notNull()} and keep {@code 0}
+ * distinct from {@code null}.
  *
  * @param <E> the type of entities being indexed
  * @param <K> the numerical type of the key, which must extend {@link Number}
@@ -29,8 +39,9 @@ public interface BinaryIndexerNumber<E, K extends Number> extends BinaryIndexer<
 	 * the key extracted by this index is equal to the specified key.
 	 *
 	 * @param <S> the type of entity this condition applies to, extending the base entity type
-	 * @param key the key to compare for equality
+	 * @param key the key to compare for equality, must not be null
 	 * @return a new condition representing the equality check for the given key
+	 * @throws IllegalArgumentException if the key is {@code null}
 	 */
 	public <S extends E> Condition<S> is(K key);
 	
@@ -39,8 +50,9 @@ public interface BinaryIndexerNumber<E, K extends Number> extends BinaryIndexer<
 	 * the key extracted by this index is not equal to the specified key.
 	 *
 	 * @param <S> the type of entity this condition applies to, extending the base entity type
-	 * @param key the key to compare for inequality
+	 * @param key the key to compare for inequality, must not be null
 	 * @return a new condition representing the inequality check for the given key
+	 * @throws IllegalArgumentException if the key is {@code null}
 	 */
 	public <S extends E> Condition<S> not(K key);
 	
@@ -49,8 +61,9 @@ public interface BinaryIndexerNumber<E, K extends Number> extends BinaryIndexer<
 	 * within the specified keys.
 	 *
 	 * @param <S> the type of entity this condition applies to, extending the base entity type
-	 * @param keys the array of keys to compare to
+	 * @param keys the array of keys to compare to, none of which may be null
 	 * @return a new condition representing the containment check for the provided keys
+	 * @throws IllegalArgumentException if any of the keys is {@code null}
 	 */
 	@SuppressWarnings("unchecked")
 	public <S extends E> Condition<S> in(K... keys);
@@ -60,8 +73,9 @@ public interface BinaryIndexerNumber<E, K extends Number> extends BinaryIndexer<
 	 * within the specified keys.
 	 *
 	 * @param <S> the type of entity this condition applies to, extending the base entity type
-	 * @param keys the array of keys to compare to
+	 * @param keys the array of keys to compare to, none of which may be null
 	 * @return a new condition representing the negated containment check for the provided keys
+	 * @throws IllegalArgumentException if any of the keys is {@code null}
 	 */
 	@SuppressWarnings("unchecked")
 	public <S extends E> Condition<S> notIn(final K... keys);
@@ -84,12 +98,18 @@ public interface BinaryIndexerNumber<E, K extends Number> extends BinaryIndexer<
 		@Override
 		public long indexBinary(final E entity)
 		{
-			return this.toLong(this.getNumber(entity));
+			// must be validated before #toLong, whose unboxing would turn a null key into a raw NullPointerException.
+			final K number = this.getNumber(entity);
+			BinaryIndexer.Static.validate(number, this);
+			
+			return this.toLong(number);
 		}
 		
 		@Override
 		public <S extends E> Condition<S> is(final K key)
 		{
+			BinaryIndexer.Static.validate(key, this);
+			
 			return super.is(this.toLong(key));
 		}
 		
@@ -106,6 +126,7 @@ public interface BinaryIndexerNumber<E, K extends Number> extends BinaryIndexer<
 			final Long[] longKeys = new Long[keys.length];
 			for(int i = 0; i < keys.length; i++)
 			{
+				BinaryIndexer.Static.validate(keys[i], this);
 				longKeys[i] = this.toLong(keys[i]);
 			}
 			return super.in(longKeys);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerShort.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryIndexerShort.java
@@ -18,6 +18,10 @@ package org.eclipse.store.gigamap.types;
  * An interface that extends {@link BinaryIndexerNumber} specifically for using {@link Short} as the key type.
  * It provides indexing capabilities, optimized for binary operations and high-cardinality indices,
  * while working with entities of type {@code E}.
+ * <p>
+ * <b>Restriction:</b> {@code null} is not supported as an index key and is rejected with an
+ * {@link IllegalArgumentException}. See {@link BinaryIndexerNumber} for the details and use
+ * {@link IndexerShort} to index a nullable {@link Short} field.
  *
  * @param <E> the type of entities being indexed
  */

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerNumberNullKeyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/binary/BinaryIndexerNumberNullKeyTest.java
@@ -1,0 +1,288 @@
+package org.eclipse.store.gigamap.indexer.binary;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexer;
+import org.eclipse.store.gigamap.types.BinaryIndexerByte;
+import org.eclipse.store.gigamap.types.BinaryIndexerDouble;
+import org.eclipse.store.gigamap.types.BinaryIndexerFloat;
+import org.eclipse.store.gigamap.types.BinaryIndexerInteger;
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.BinaryIndexerNumber;
+import org.eclipse.store.gigamap.types.BinaryIndexerShort;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.Indexer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The numeric binary indexers encode their key directly into a single long bit pattern, and every one of them
+ * unboxes that key in its {@code toLong} conversion. A null key therefore used to escape as a raw
+ * {@link NullPointerException} - from {@code map.add(...)} for all six types, and additionally from
+ * {@code isNull()}/{@code notNull()} for {@link BinaryIndexerLong}, whose {@code is(Long)} override shadows the
+ * validating {@code BinaryIndexer.is(Long)} default that the other five already went through.
+ * <p>
+ * Null cannot be supported here: unlike the composite binary indexers ({@code BinaryIndexerString},
+ * {@code BinaryIndexerUUID}) the single-long family has no spare slot for a null sentinel, and
+ * {@link BinaryIndexerLong} has already sacrificed its only spare bit pattern ({@code Long.MAX_VALUE}) to the zero
+ * sentinel. So null is rejected - but with the same designed, descriptive {@link IllegalArgumentException} that
+ * already guards {@code Long.MAX_VALUE}, on every entry point, for every numeric type.
+ */
+public class BinaryIndexerNumberNullKeyTest
+{
+	/**
+	 * A single entity type for all six indexers: each indexer casts the value to its own key type, and each test
+	 * builds a map carrying only its own index, so only matching values are ever put in.
+	 */
+	record Box(String name, Number value) {}
+
+	static final BinaryIndexerLong<Box> LONG_INDEX = new BinaryIndexerLong.Abstract<>()
+	{
+		@Override
+		protected Long getLong(final Box entity)
+		{
+			return (Long)entity.value();
+		}
+	};
+
+	static final BinaryIndexerInteger<Box> INTEGER_INDEX = new BinaryIndexerInteger.Abstract<>()
+	{
+		@Override
+		protected Integer getInteger(final Box entity)
+		{
+			return (Integer)entity.value();
+		}
+	};
+
+	static final BinaryIndexerShort<Box> SHORT_INDEX = new BinaryIndexerShort.Abstract<>()
+	{
+		@Override
+		protected Short getShort(final Box entity)
+		{
+			return (Short)entity.value();
+		}
+	};
+
+	static final BinaryIndexerByte<Box> BYTE_INDEX = new BinaryIndexerByte.Abstract<>()
+	{
+		@Override
+		protected Byte getByte(final Box entity)
+		{
+			return (Byte)entity.value();
+		}
+	};
+
+	static final BinaryIndexerFloat<Box> FLOAT_INDEX = new BinaryIndexerFloat.Abstract<>()
+	{
+		@Override
+		protected Float getFloat(final Box entity)
+		{
+			return (Float)entity.value();
+		}
+	};
+
+	static final BinaryIndexerDouble<Box> DOUBLE_INDEX = new BinaryIndexerDouble.Abstract<>()
+	{
+		@Override
+		protected Double getDouble(final Box entity)
+		{
+			return (Double)entity.value();
+		}
+	};
+
+	/** A plain {@link Indexer} yielding a {@link Long} key, to be wrapped by {@link BinaryIndexer#Wrap(Indexer)}. */
+	static final Indexer<Box, Long> WRAPPED_SUBJECT = new Indexer.Abstract<Box, Long>()
+	{
+		@Override
+		public Long index(final Box entity)
+		{
+			return (Long)entity.value();
+		}
+
+		@Override
+		public Class<Long> keyType()
+		{
+			return Long.class;
+		}
+	};
+
+	private static GigaMap<Box> newMap(final Indexer<? super Box, ?> index)
+	{
+		return GigaMap.<Box>Builder()
+			.withBitmapIndex(index)
+			.build();
+	}
+
+	/**
+	 * A null key extracted from an entity must be rejected with a descriptive
+	 * {@link IllegalArgumentException} instead of a raw {@link NullPointerException}, and the rejected add must
+	 * roll back cleanly, leaving the map empty and fully usable.
+	 */
+	private static <K extends Number> void assertNullKeyRejectedOnAdd(
+		final BinaryIndexerNumber<Box, K> indexer  ,
+		final K                           sampleKey
+	)
+	{
+		final GigaMap<Box> map = newMap(indexer);
+
+		final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+			() -> map.add(new Box("nullKey", null)),
+			() -> indexer.name() + " must reject a null key on add instead of throwing a raw NullPointerException");
+		assertTrue(e.getMessage().contains(indexer.name()),
+			"the exception message must name the index: " + e.getMessage());
+
+		assertEquals(0, map.size(), "a rejected add must not leave the entity in the map");
+
+		map.add(new Box("valid", sampleKey));
+		assertEquals(1, map.query(indexer.is(sampleKey)).count(),
+			"the map must stay usable after a rejected add");
+	}
+
+	/**
+	 * Every condition factory taking a key must reject null before the {@code toLong} conversion unboxes it,
+	 * including the inherited {@code isNull()}/{@code notNull()} that route through {@code is(null)}.
+	 */
+	private static <K extends Number> void assertNullKeyRejectedOnQuery(
+		final BinaryIndexerNumber<Box, K> indexer  ,
+		final K                           sampleKey
+	)
+	{
+		// a K-typed local rather than a cast literal: it keeps the calls unambiguous against the inherited
+		// is(Long) / is(Predicate) overloads without an unchecked cast to the type variable.
+		final K nullKey = null;
+
+		assertThrows(IllegalArgumentException.class,
+			() -> indexer.is(nullKey),
+			() -> indexer.name() + ": is(null) must be rejected");
+		assertThrows(IllegalArgumentException.class,
+			() -> indexer.not(nullKey),
+			() -> indexer.name() + ": not(null) must be rejected");
+		assertThrows(IllegalArgumentException.class,
+			() -> indexer.in(sampleKey, nullKey),
+			() -> indexer.name() + ": in(...) must reject a null element");
+		assertThrows(IllegalArgumentException.class,
+			() -> indexer.notIn(sampleKey, nullKey),
+			() -> indexer.name() + ": notIn(...) must reject a null element");
+		assertThrows(IllegalArgumentException.class,
+			() -> indexer.isNull(),
+			() -> indexer.name() + ": isNull() must be rejected, since null cannot be indexed at all");
+		assertThrows(IllegalArgumentException.class,
+			() -> indexer.notNull(),
+			() -> indexer.name() + ": notNull() must be rejected, since null cannot be indexed at all");
+	}
+
+	@Test
+	void longNullKeyRejected()
+	{
+		assertNullKeyRejectedOnAdd(LONG_INDEX, 42L);
+		assertNullKeyRejectedOnQuery(LONG_INDEX, 42L);
+	}
+
+	@Test
+	void integerNullKeyRejected()
+	{
+		assertNullKeyRejectedOnAdd(INTEGER_INDEX, 42);
+		assertNullKeyRejectedOnQuery(INTEGER_INDEX, 42);
+	}
+
+	@Test
+	void shortNullKeyRejected()
+	{
+		assertNullKeyRejectedOnAdd(SHORT_INDEX, (short)42);
+		assertNullKeyRejectedOnQuery(SHORT_INDEX, (short)42);
+	}
+
+	@Test
+	void byteNullKeyRejected()
+	{
+		assertNullKeyRejectedOnAdd(BYTE_INDEX, (byte)42);
+		assertNullKeyRejectedOnQuery(BYTE_INDEX, (byte)42);
+	}
+
+	@Test
+	void floatNullKeyRejected()
+	{
+		assertNullKeyRejectedOnAdd(FLOAT_INDEX, 42.0f);
+		assertNullKeyRejectedOnQuery(FLOAT_INDEX, 42.0f);
+	}
+
+	@Test
+	void doubleNullKeyRejected()
+	{
+		assertNullKeyRejectedOnAdd(DOUBLE_INDEX, 42.0d);
+		assertNullKeyRejectedOnQuery(DOUBLE_INDEX, 42.0d);
+	}
+
+	@Test
+	void singleNullElementInVarargsRejected()
+	{
+		// in((Long)null) passes an array holding one null, as opposed to a null array; the cast is only needed
+		// to disambiguate the varargs call and is spelled out here where the key type is concrete.
+		assertThrows(IllegalArgumentException.class,
+			() -> LONG_INDEX.in((Long)null),
+			"in(...) must reject a lone null element");
+		assertThrows(IllegalArgumentException.class,
+			() -> LONG_INDEX.notIn((Long)null),
+			"notIn(...) must reject a lone null element");
+	}
+
+	@Test
+	void wrappedIndexerRejectsNullKeyOnAdd()
+	{
+		// BinaryIndexer.Wrap unboxes the wrapped indexer's Long key, so it had the same raw-NPE defect.
+		final BinaryIndexer<Box> wrapped = BinaryIndexer.Wrap(WRAPPED_SUBJECT);
+		final GigaMap<Box>       map     = newMap(wrapped);
+
+		assertThrows(IllegalArgumentException.class,
+			() -> map.add(new Box("nullKey", null)),
+			"a wrapped indexer yielding a null key must be rejected instead of throwing a raw NullPointerException");
+
+		assertEquals(0, map.size(), "a rejected add must not leave the entity in the map");
+
+		map.add(new Box("valid", 42L));
+		assertEquals(1, map.query(wrapped.is(42L)).count(), "the map must stay usable after a rejected add");
+	}
+
+	@Test
+	void reservedZeroSentinelStillRejected()
+	{
+		// Regression guard: the pre-existing Long.MAX_VALUE restriction must survive the null validation.
+		final GigaMap<Box> map = newMap(LONG_INDEX);
+
+		assertThrows(IllegalArgumentException.class,
+			() -> map.add(new Box("sentinel", Long.MAX_VALUE)),
+			"Long.MAX_VALUE must still be rejected on add");
+		assertThrows(IllegalArgumentException.class,
+			() -> LONG_INDEX.is(Long.MAX_VALUE),
+			"Long.MAX_VALUE must still be rejected on query");
+	}
+
+	@Test
+	void nonNullKeysStillWork()
+	{
+		final GigaMap<Box> map = newMap(LONG_INDEX);
+		map.add(new Box("zero", 0L));
+		map.add(new Box("negative", -1L));
+		map.add(new Box("positive", 42L));
+
+		assertEquals(3, map.size(), "all non-null keys must be indexable");
+		assertEquals(1, map.query(LONG_INDEX.is(0L)).count(), "zero must remain queryable via its sentinel");
+		assertEquals(1, map.query(LONG_INDEX.is(-1L)).count(), "negative keys must remain queryable");
+		assertEquals(1, map.query(LONG_INDEX.is(42L)).count(), "positive keys must remain queryable");
+	}
+}


### PR DESCRIPTION
## Problem

`BinaryIndexerLong/Integer/Short/Byte/Float/Double` all unbox the index key in their `toLong` conversion, so a `null` key escaped as a raw `NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because "number" is null
    at BinaryIndexerLong$Abstract.toLong(BinaryIndexerLong.java:82)
    at BinaryIndexerNumber$Abstract.indexBinary(BinaryIndexerNumber.java:87)
    at GigaMap$Default.add(GigaMap.java:2353)
```

An entity with a nullable numeric field therefore could not be added at all. The failure hit `map.add(...)` for all six types, and additionally `isNull()`/`notNull()` for `BinaryIndexerLong`, whose `is(Long)` override shadows the *validating* `BinaryIndexer.is(Long)` default that the other five already went through. `BinaryIndexer.Wrapper#indexBinary` had the same defect whenever the wrapped `Indexer<E, Long>` returned `null`.

The map itself was never corrupted - the rollback is clean and subsequent adds work - so this is an API/usability defect, not a data-integrity one. What was wrong was the *shape* of the failure: `toLong` rejects `Long.MAX_VALUE` with a designed, descriptive `IllegalArgumentException` one line below the NPE site, so invalid keys were considered and null was simply missed.

## Why rejection rather than null support

Null cannot be encoded in this family. A scalar binary index packs the key into a single `long` whose every bit position is an index entry, so unlike the composite binary indexers (`BinaryIndexerString`, `BinaryIndexerUUID`, which have a spare slot for `BinaryCompositeIndexer.NULL()`) there is nowhere to put a sentinel - and `BinaryIndexerLong` has already sacrificed its only spare bit pattern (`Long.MAX_VALUE`) to the zero sentinel. Supporting null only in the five types that do have spare encoding space would make `isNull()` semantics differ per type inside one family.

This is also the family's documented contract already: `BinaryIndexer`'s javadoc lists *"null is not allowed"* as a current limitation, and `BinaryIndexer.Static.validate` has always thrown a descriptive `IllegalArgumentException` for it. The numeric subclasses simply bypassed both by unboxing first.

## Change

- `BinaryIndexerNumber.Abstract` validates in `indexBinary`, `is` and `in` before any `toLong` call. `not`, `notIn`, `isNull` and `notNull` route through those, so all six types now fail identically and descriptively.
- `BinaryIndexer.Static.validate` takes a `Number` so the numeric key types can reuse it, and its message now names the hashing `IndexerNumber` variants as the alternative for nullable numeric fields.
- `BinaryIndexer.Wrapper#indexBinary` validates before unboxing.
- The `validate` call in `AbstractBitmapIndexBinary#indexBinary` was dead - it was handed a primitive `long` that autoboxes to a never-null `Long` - and is removed in favour of the real guards in the indexers.
- The restriction is documented on `BinaryIndexerNumber` and cross-referenced from all six concrete indexers, pointing at the hashing `IndexerLong`/`IndexerInteger`/... as the workaround. Also corrects `BinaryIndexer.is(Long)`'s stale *"not negative"* / *"if the key is negative"* javadoc, which never matched the actual check.

Behaviour for every valid key is unchanged, including the zero sentinels and the pre-existing `Long.MAX_VALUE` rejection. The composite `BinaryIndexerString`/`BinaryIndexerUUID` null support is deliberately untouched.

## Verification

- New `BinaryIndexerNumberNullKeyTest` (10 tests) covers, per numeric type: the add path (descriptive `IllegalArgumentException`, message names the index, clean rollback to `size() == 0`, map usable afterwards), the query path (`is`/`not`/`in`/`notIn` with a null element), and `isNull()`/`notNull()`. Plus `BinaryIndexer.Wrap` with a null-yielding subject, and regression guards for the `Long.MAX_VALUE` rejection and for non-null keys including zero and negatives.
- Confirmed RED on the pre-fix sources: 8 of the 10 fail, every one of them with a raw `NullPointerException`. The 2 that pass either way are the regression guards.
- Full `gigamap` module suite green: 1178 tests, 0 failures, 1 skipped - including `CompositeIndexerNullConditionTest` (sibling null support intact) and `BitmapIndexKeyEntityPairsTest`.
- `javadoc:javadoc` clean with `failOnWarnings=true`; all gigamap submodules, `integration-tests` and the gigamap examples compile.
