### PR TITLE
GigaMap: entity ids are derived with long arithmetic, no longer wrapping at 2^31

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIterating.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/AbstractBitmapIterating.java
@@ -385,7 +385,8 @@ public abstract class AbstractBitmapIterating<E>
 	private void updateLevel3IterationState(final int level3Index)
 	{
 		this.currentLevel3Index = level3Index;
-		this.level2BaseId       = level3Index * BitmapLevel3.LEVEL_2_ID_COUNT;
+		// (long) cast mandatory: the int product overflows at level3 index 2^11, i.e. at entityId 2^31.
+		this.level2BaseId       = (long)level3Index * BitmapLevel3.LEVEL_2_ID_COUNT;
 		if(this.level2BaseId >= this.level2TrailingBaseId)
 		{
 			// when the trailing segment is reached, the level2 index bound is 1 beyond the upperId's level2 index.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -3067,7 +3067,18 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 					final GigaLevel2<E> level2 = level2Root.get();
 					try
 					{
-						this.iterate(level2, i<<level1p2Pow2, consumer);
+						/*
+						 * The (long) cast is mandatory, not cosmetic: entity ids range up to 2^50, so int
+						 * arithmetic is out of range twice over.
+						 * - Without it, i<<level1p2Pow2 overflows as soon as the level3 index reaches
+						 *   2^31 / 2^level1p2Pow2 (index 8192 with the default exponents), reporting
+						 *   negative ids from entity 2^31 on.
+						 * - Worse, level1Exp + level2Exp may legally reach 40 (each caps at 20, only their
+						 *   sum with level3Max is limited to 50), and an int shift uses only the low 5 bits
+						 *   of its distance (JLS 15.19). So i<<32 would evaluate to i<<0 == i, making high
+						 *   level3 segments report ids that collide with segment 0 instead of merely wrapping.
+						 */
+						this.iterate(level2, (long)i << level1p2Pow2, consumer);
 					}
 					catch(final ThrowBreak b)
 					{
@@ -3084,8 +3095,8 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 		}
 		
 		private void iterate(
-			final GigaLevel2<E>            level2   ,
-			final int                      baseIndex,
+			final GigaLevel2<E>            level2  ,
+			final long                     baseId  ,
 			final EntryConsumer<? super E> consumer
 		)
 		{
@@ -3099,13 +3110,14 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 					continue;
 				}
 				final GigaLevel1<E> level1 = level1Root.get();
-				this.iterate(level1.entities, baseIndex + (i << level1Pow2),  consumer);
+				// (long) cast mandatory: i<<level1Pow2 would overflow in int before the widening addition.
+				this.iterate(level1.entities, baseId + ((long)i << level1Pow2),  consumer);
 			}
 		}
-		
+
 		private void iterate(
-			final E[]                      level1   ,
-			final int                      baseIndex,
+			final E[]                      level1  ,
+			final long                     baseId  ,
 			final EntryConsumer<? super E> consumer
 		)
 		{
@@ -3116,7 +3128,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				{
 					continue;
 				}
-				consumer.accept(baseIndex + i, e);
+				consumer.accept(baseId + i, e);
 			}
 		}
 		

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ResultIdIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ResultIdIterator.java
@@ -336,7 +336,8 @@ public interface ResultIdIterator
 		private void updateLevel2IterationState(final int level3Index)
 		{
 			this.currentLevel3Index = level3Index;
-			this.level2BaseId       = level3Index * LEVEL_2_ID_COUNT;
+			// (long) cast mandatory: the int product overflows at level3 index 2^11, i.e. at entityId 2^31.
+			this.level2BaseId       = (long)level3Index * LEVEL_2_ID_COUNT;
 			this.level2IndexBound   = this.calculateIndexBoundLevel2();
 		}
 		
@@ -366,8 +367,9 @@ public interface ResultIdIterator
 		
 		private int calculateIndexBound(final long baseId, final int idCountPerSegment, final int totalSizeExp)
 		{
-			final int idRemainder = XTypes.to_int(this.highestUsedId - baseId);
-			
+			// long, not int: the remainder spans the whole id range, so it exceeds int for maps beyond 2^31.
+			final long idRemainder = this.highestUsedId - baseId;
+
 			/*
 			 * Nasty special case:
 			 * If the remainder is smaller than the id count per segment, the bound must be one more,
@@ -376,7 +378,8 @@ public interface ResultIdIterator
 			 */
 			return idRemainder >= idCountPerSegment
 				? idCountPerSegment >>> totalSizeExp
-				: (idRemainder >>> totalSizeExp) + 1
+				// safe narrowing: this branch has idRemainder < idCountPerSegment, which is an int.
+				: (int)(idRemainder >>> totalSizeExp) + 1
 			;
 		}
 		

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -202,12 +202,15 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 	/**
 	 * Calculates how many level1 segments are needed to cover the parent map's whole id range.
 	 * <p>
-	 * The count is kept as an {@code int} because it doubles as an index bound into the off-heap id
-	 * lists registry. That caps this iterator at a {@link GigaMap#highestUsedId()} of roughly 2^43,
-	 * which is well below the 2^50 a {@link GigaMap} may hold - but the registry needs eight bytes of
-	 * off-heap memory per segment, so the allocation becomes infeasible (16 GB) long before the type
-	 * does. The overflow is therefore rejected outright instead of silently allocating from a
-	 * negative length.
+	 * The count is kept as an {@code int} because it bounds this iterator's level1 segment indexing:
+	 * {@code ThreadLogic} walks that index as an {@code int}, and the count doubles as the end-of-data
+	 * sentinel in {@code hasMoreData()}. That caps the iterator at a {@link GigaMap#highestUsedId()} of
+	 * roughly 2^43, well below the 2^50 a {@link GigaMap} may hold.
+	 * <p>
+	 * Memory is not what binds here: the registry holds one slot per <i>registry</i> segment, not per
+	 * level1 segment (see {@code calculateIdListsRegistryLength()}), which is 256 MB at the cap. So the
+	 * limit is purely the index width, and exceeding it is rejected outright rather than silently
+	 * allocating from a negative length.
 	 *
 	 * @return the level1 segment count required for the parent map's id range, 0 for an empty map
 	 * @throws IllegalStateException if the required count exceeds {@link Integer#MAX_VALUE}
@@ -244,8 +247,8 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		{
 			throw new IllegalStateException(
 				"Highest used entityId " + highestUsedId + " requires " + segmentCount
-				+ " level1 segments and thus an id lists registry of " + segmentCount * Long.BYTES
-				+ " bytes, which exceeds the technical limit of this iterator."
+				+ " level1 segments, which exceeds this iterator's technical limit of "
+				+ Integer.MAX_VALUE + "."
 			);
 		}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -177,8 +177,9 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		 * An empty map has no registry segment, so there is nothing for a worker thread to fill in. It
 		 * must not be started either: a zero-slot registry is a zero-length allocation, whose address is
 		 * 0, and ThreadLogic would fail its bounds arithmetic on that (a not-positive address and a
-		 * registrySegmentCount - 1 of -1) - silently, on the worker thread. The reader is unaffected
-		 * because hasMoreData() is already false, so it never consults the registry at all.
+		 * registrySegmentCount - 1 of -1) - silently, on the worker thread. The reader is unaffected: its
+		 * registry scroll is bounded by registrySegmentCount, so with 0 the very first scroll falls
+		 * straight through to the end-of-data sentinel without ever resolving a registry slot.
 		 */
 		this.threads = this.registrySegmentCount == 0
 			? X.empty()
@@ -226,8 +227,10 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		final long highestUsedId = this.parent.highestUsedId();
 
 		/*
-		 * An empty map has no id at all, so there is nothing to partition and the count is 0, which
-		 * makes hasMoreData() false right away. The case needs handling before the formula because
+		 * An empty map has no id at all, so there is nothing to partition and the count is 0: the first
+		 * registry scroll then finds no segment to advance to and parks at the end-of-data sentinel, which
+		 * is what turns hasMoreData() false (it is still true right after construction, since
+		 * currentRegistryIndex starts at -1). The case needs handling before the formula because
 		 * highestUsedId is nextFreeId() - 1 and hence -1 here, whose unsigned shift is 2^52 - 1.
 		 */
 		if(highestUsedId < 0)

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/ThreadedIterator.java
@@ -19,6 +19,7 @@ import org.eclipse.serializer.collections.types.XGettingCollection;
 import org.eclipse.serializer.concurrency.XThreads;
 import org.eclipse.serializer.math.XMath;
 import org.eclipse.serializer.memory.XMemory;
+import org.eclipse.serializer.util.X;
 
 import java.lang.ref.Reference;
 import java.util.Iterator;
@@ -114,7 +115,13 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 
 	private long currentRegistrySegmentAddress;
 	private long currentValueGroupAddress;
-	private int  currentRegistryIndex;   // points to a level1segment (a valueGroupsSegment) in the result registry.
+	/*
+	 * Note on currentRegistryIndex: it points to a REGISTRY SEGMENT, not to a single level1 segment.
+	 * One registry slot covers REGISTRY_SEGMENT_SIZE (64) level1 segments - see the ThreadLogic loop,
+	 * which advances the level1 segment index by REGISTRY_SEGMENT_SIZE per registry slot, and
+	 * valueBaseId, which multiplies this index by REGISTRY_SEGMENT_ID_COUNT.
+	 */
+	private int  currentRegistryIndex;   // points to a registry segment (a valueGroupsSegment) in the result registry.
 	private int  currentRegistrySegmentIndex; // points to the value group in the current value groups segment.
 	private int  currentLevel1Index;      // points to a value in the current value group.
 	private int  currentBitPosition;     // the position (0 to 63) of the bit to be tested in the current bitmap value.
@@ -146,10 +153,11 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		 */
 		this.waitTimeNs = 1000;
 		
+		// registrySegmentCount before the allocation: it is the registry's slot count, hence its size.
 		this.level1SegmentCount   = this.calculateLevel1SegmentCount();
+		this.registrySegmentCount = this.calculateRegistrySegmentCount();
 		final long registryLength = this.calculateIdListsRegistryLength();
 		this.registryAddress      = allocateEmptyMemory(registryLength);
-		this.registrySegmentCount = this.calculateRegistrySegmentCount();
 
 		// Register Cleaner BEFORE threads start so a thread-startup failure still releases the registry.
 		this.cleanup = new Cleanup(this.registryAddress, this.registrySegmentCount);
@@ -163,8 +171,19 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 
 		this.isActive = true;
 
-		// create and start threads NOT before everything is setup, hence down here at the end.
-		this.threads = threadProvider.startIterationThreads(parent, threadCount, this);
+		/*
+		 * create and start threads NOT before everything is setup, hence down here at the end.
+		 *
+		 * An empty map has no registry segment, so there is nothing for a worker thread to fill in. It
+		 * must not be started either: a zero-slot registry is a zero-length allocation, whose address is
+		 * 0, and ThreadLogic would fail its bounds arithmetic on that (a not-positive address and a
+		 * registrySegmentCount - 1 of -1) - silently, on the worker thread. The reader is unaffected
+		 * because hasMoreData() is already false, so it never consults the registry at all.
+		 */
+		this.threads = this.registrySegmentCount == 0
+			? X.empty()
+			: threadProvider.startIterationThreads(parent, threadCount, this)
+		;
 	}
 	
 	
@@ -179,6 +198,19 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		return this.parent;
 	}
 	
+	/**
+	 * Calculates how many level1 segments are needed to cover the parent map's whole id range.
+	 * <p>
+	 * The count is kept as an {@code int} because it doubles as an index bound into the off-heap id
+	 * lists registry. That caps this iterator at a {@link GigaMap#highestUsedId()} of roughly 2^43,
+	 * which is well below the 2^50 a {@link GigaMap} may hold - but the registry needs eight bytes of
+	 * off-heap memory per segment, so the allocation becomes infeasible (16 GB) long before the type
+	 * does. The overflow is therefore rejected outright instead of silently allocating from a
+	 * negative length.
+	 *
+	 * @return the level1 segment count required for the parent map's id range, 0 for an empty map
+	 * @throws IllegalStateException if the required count exceeds {@link Integer#MAX_VALUE}
+	 */
 	private int calculateLevel1SegmentCount()
 	{
 		/*
@@ -191,13 +223,46 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		 * So the formula is:
 		 * (highestUsedId / level1IdCount) + 1.
 		 */
-		return (int)(this.parent.highestUsedId() >>> BitmapLevel3.LEVEL_1_TOTAL_SIZE_EXP) + 1;
+		final long highestUsedId = this.parent.highestUsedId();
+
+		/*
+		 * An empty map has no id at all, so there is nothing to partition and the count is 0, which
+		 * makes hasMoreData() false right away. The case needs handling before the formula because
+		 * highestUsedId is nextFreeId() - 1 and hence -1 here, whose unsigned shift is 2^52 - 1.
+		 */
+		if(highestUsedId < 0)
+		{
+			return 0;
+		}
+
+		final long segmentCount = (highestUsedId >>> BitmapLevel3.LEVEL_1_TOTAL_SIZE_EXP) + 1;
+
+		if(segmentCount > Integer.MAX_VALUE)
+		{
+			throw new IllegalStateException(
+				"Highest used entityId " + highestUsedId + " requires " + segmentCount
+				+ " level1 segments and thus an id lists registry of " + segmentCount * Long.BYTES
+				+ " bytes, which exceeds the technical limit of this iterator."
+			);
+		}
+
+		return (int)segmentCount;
 	}
 	
+	/**
+	 * The registry holds one pointer per <i>registry segment</i>, not one per level1 segment: a registry
+	 * segment covers {@value #REGISTRY_SEGMENT_SIZE} level1 segments, and their pointers live in that
+	 * segment's own memory block (see {@code ThreadLogic#process}). Sizing this by the level1 segment
+	 * count would over-allocate by that same factor, since every party that walks the registry - the
+	 * worker threads, {@code scrollToNextRegistrySegment} and {@code deallocateSegments} - bounds
+	 * itself by {@code registrySegmentCount}.
+	 *
+	 * @return the byte length of the id lists registry
+	 */
 	private long calculateIdListsRegistryLength()
 	{
-		// level1Segment count times long byte length to get the total byte length
-		return (long)this.level1SegmentCount * Long.BYTES;
+		// registrySegment count times long byte length to get the total byte length
+		return (long)this.registrySegmentCount * Long.BYTES;
 	}
 	
 	private int calculateRegistrySegmentCount()
@@ -249,6 +314,14 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		return this.valueBaseId + this.currentBitPosition++;
 	}
 	
+	/*
+	 * Deliberately compares a registry segment index against the level1 segment count. That is not the
+	 * index's own bound - the registry scroll is bounded by registrySegmentCount - but a pure
+	 * "is the exhaustion sentinel set?" test: scrollToNextRegistrySegment parks currentRegistryIndex at
+	 * exactly level1SegmentCount when it runs out, and since registrySegmentCount is
+	 * ceil(level1SegmentCount / REGISTRY_SEGMENT_SIZE), every index reachable during a live iteration
+	 * stays below that sentinel.
+	 */
 	private boolean hasMoreData()
 	{
 		return this.currentRegistryIndex < this.level1SegmentCount;
@@ -300,8 +373,9 @@ public final class ThreadedIterator implements ResultIdIterator, GigaMap.Reading
 		while(currentBitmapValue == 0L);
 		this.currentLevel1Index = currentLevel1Index;
 		this.currentBitmapValue = currentBitmapValue;
+		// (long) cast mandatory: the int product overflows at registry index 2^13, i.e. at entityId 2^31.
 		this.valueBaseId =
-			this.currentRegistryIndex * REGISTRY_SEGMENT_ID_COUNT
+			(long)this.currentRegistryIndex * REGISTRY_SEGMENT_ID_COUNT
 			+ this.currentRegistrySegmentIndex * LEVEL_1_ID_COUNT
 			+ this.currentLevel1Index * Long.SIZE
 		;

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/EntityIdAboveIntegerRangeTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/EntityIdAboveIntegerRangeTest.java
@@ -114,11 +114,15 @@ public class EntityIdAboveIntegerRangeTest
 	/**
 	 * {@code level1Exp + level2Exp == 32} makes the level3 shift distance reach the int width, where
 	 * masking turned {@code i<<32} into {@code i<<0 == i}. That is worse than an overflow: level3
-	 * segment 1 reported id 1, aliasing a perfectly valid id of segment 0. Both segments are populated
-	 * here so the aliasing is asserted against, not just the wrong magnitude.
+	 * segment 1 reported base id 1, which is a perfectly valid id belonging to segment 0.
+	 * <p>
+	 * So segment 0 is populated up to that very id here, which makes the defect an actual <i>collision</i>
+	 * rather than merely a wrong magnitude: two different entities reported the same id, and since every
+	 * consumer of {@code iterateIndexed} keys by it, the one that came first was silently dropped. Asserting
+	 * only the high entity's id would have missed that entirely.
 	 */
 	@Test
-	public void iterateIndexedReportsDistinctIdsWhenTheShiftDistanceReachesIntWidth()
+	public void iterateIndexedDoesNotAliasLowerIdsWhenTheShiftDistanceReachesIntWidth()
 	{
 		final GigaMap.Default<Item> map = mapStartingAt(14, 18, 8, 1L << 32);
 
@@ -126,15 +130,18 @@ public class EntityIdAboveIntegerRangeTest
 		final long highId = map.add(high);
 		assertEquals(1L << 32, highId, "the map hands out the seeded id");
 
-		// an entity in level3 segment 0, whose ids the aliasing collided with
-		final Item low = new Item("low");
-		assertNull(map.set(0L, low), "the slot in level3 segment 0 was still empty");
+		// entities in level3 segment 0, at exactly the ids the aliased base id collided with
+		final Item low0 = new Item("low0");
+		final Item low1 = new Item("low1");
+		assertNull(map.set(0L, low0), "the slot in level3 segment 0 was still empty");
+		assertNull(map.set(1L, low1), "the slot in level3 segment 0 was still empty");
 
 		final Map<Long, Item> iterated = iterateIndexed(map);
 
-		assertEquals(Set.of(0L, highId), iterated.keySet(),
-			"level3 segment 1 must report base id " + highId + ", not collide with segment 0");
-		assertSame(low , iterated.get(0L)    , "and each id must carry its own entity");
+		assertEquals(Set.of(0L, 1L, highId), iterated.keySet(),
+			"level3 segment 1 must report base id " + highId + ", not alias id 1 of segment 0");
+		assertSame(low0, iterated.get(0L)    , "and each id must carry its own entity");
+		assertSame(low1, iterated.get(1L)    , "id 1 must still carry the entity that actually lives there");
 		assertSame(high, iterated.get(highId), "and each id must carry its own entity");
 	}
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/EntityIdAboveIntegerRangeTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/EntityIdAboveIntegerRangeTest.java
@@ -1,0 +1,273 @@
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Entity ids beyond the int range have to keep working, over the whole documented capacity of 2^50
+ * (internal issue #133).
+ * <p>
+ * Several places derived an entity id from a segment index with {@code int} arithmetic and only widened
+ * to {@code long} on assignment or at the call - too late. All of them broke at the same boundary, id
+ * 2^31:
+ * <ul>
+ * <li>{@code GigaMap.Default#iterateIndexed} and its two private helpers reported wrapped, negative
+ * ids, corrupting everything built on them: {@code reindex()}, bitmap index registration back-fill,
+ * the Lucene back-fill (which persists the id) and the jvector graph rebuild. On top of the overflow,
+ * {@code level1Exp + level2Exp} may legally reach 40 while an {@code int} shift uses only the low 5
+ * bits of its distance (JLS 15.19), so {@code i<<32} evaluated to {@code i<<0 == i} and high level3
+ * segments reported ids <i>colliding</i> with those of segment 0.</li>
+ * <li>{@code AbstractBitmapIterating} and {@code ResultIdIterator} computed the level2 base id as
+ * {@code level3Index * LEVEL_2_ID_COUNT}, so every query silently returned nothing for entities above
+ * 2^31 - independently of {@code iterateIndexed}, and even for an index that was filled correctly by
+ * the ordinary add path.</li>
+ * </ul>
+ * Populating 2^31 entities is not feasible in a test, but the ids only have to be <i>sparse</i>, not
+ * numerous: this test lives in the {@code types} package so it can use the package-private
+ * {@code GigaMap.Default} constructor that seeds the id counter, and
+ * {@code GigaMap.Default#setupAddingState} then allocates just the one segment chain the seeded id
+ * points at. A map whose first entity sits at id 2^31 therefore costs a level3 array of a few thousand
+ * references plus one level2 and one level1 segment.
+ */
+public class EntityIdAboveIntegerRangeTest
+{
+	static class Item
+	{
+		final String name;
+
+		Item(final String name)
+		{
+			super();
+			this.name = name;
+		}
+	}
+
+	static class NameIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.name;
+		}
+	}
+
+	private static final NameIndexer NAME = new NameIndexer();
+
+	/** 2^31, the first id the former {@code int} arithmetic could not represent. */
+	private static final long FIRST_ID_ABOVE_INT_RANGE = 1L << 31;
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// the ids iterateIndexed reports //
+	///////////////////////////////////
+
+	/**
+	 * With the default dimensions {@code level1Exp + level2Exp == 18}, so id 2^31 is the base id of
+	 * level3 segment 8192 and {@code 8192<<18} used to be {@link Integer#MIN_VALUE}.
+	 */
+	@Test
+	public void iterateIndexedReportsIdsAboveIntegerRange()
+	{
+		final GigaMap.Default<Item> map = mapStartingAt(8, 10, 30, FIRST_ID_ABOVE_INT_RANGE);
+
+		final Item item0 = new Item("item0");
+		final Item item1 = new Item("item1");
+		final long id0   = map.add(item0);
+		final long id1   = map.add(item1);
+
+		assertEquals(FIRST_ID_ABOVE_INT_RANGE    , id0, "the map hands out the seeded id");
+		assertEquals(FIRST_ID_ABOVE_INT_RANGE + 1, id1, "and the one after it");
+
+		final Map<Long, Item> iterated = iterateIndexed(map);
+
+		assertEquals(Set.of(id0, id1), iterated.keySet(),
+			"the reported ids must be the ids the map handed out, not their int-wrapped counterparts "
+			+ (int)id0 + " and " + (int)id1);
+		assertSame(item0, iterated.get(id0), "and each id must carry its own entity");
+		assertSame(item1, iterated.get(id1), "and each id must carry its own entity");
+	}
+
+	/**
+	 * {@code level1Exp + level2Exp == 32} makes the level3 shift distance reach the int width, where
+	 * masking turned {@code i<<32} into {@code i<<0 == i}. That is worse than an overflow: level3
+	 * segment 1 reported id 1, aliasing a perfectly valid id of segment 0. Both segments are populated
+	 * here so the aliasing is asserted against, not just the wrong magnitude.
+	 */
+	@Test
+	public void iterateIndexedReportsDistinctIdsWhenTheShiftDistanceReachesIntWidth()
+	{
+		final GigaMap.Default<Item> map = mapStartingAt(14, 18, 8, 1L << 32);
+
+		final Item high   = new Item("high");
+		final long highId = map.add(high);
+		assertEquals(1L << 32, highId, "the map hands out the seeded id");
+
+		// an entity in level3 segment 0, whose ids the aliasing collided with
+		final Item low = new Item("low");
+		assertNull(map.set(0L, low), "the slot in level3 segment 0 was still empty");
+
+		final Map<Long, Item> iterated = iterateIndexed(map);
+
+		assertEquals(Set.of(0L, highId), iterated.keySet(),
+			"level3 segment 1 must report base id " + highId + ", not collide with segment 0");
+		assertSame(low , iterated.get(0L)    , "and each id must carry its own entity");
+		assertSame(high, iterated.get(highId), "and each id must carry its own entity");
+	}
+
+	/**
+	 * The level2 helper has the same defect on its own: with {@code level1Exp == 20} the level2 index
+	 * 2048 makes {@code 2048<<20} overflow while the level3 index is still 0, so the level3 shift is
+	 * not involved at all here.
+	 */
+	@Test
+	public void iterateIndexedReportsIdsAboveIntegerRangeWithinALevel3Segment()
+	{
+		final GigaMap.Default<Item> map = mapStartingAt(20, 12, 8, 2048L << 20);
+
+		final Item item = new Item("item");
+		final long id   = map.add(item);
+
+		assertEquals(FIRST_ID_ABOVE_INT_RANGE, id, "the map hands out the seeded id");
+
+		final Map<Long, Item> iterated = iterateIndexed(map);
+
+		assertEquals(Set.of(id), iterated.keySet(),
+			"the level2 index shift must not wrap the id to " + (int)id);
+		assertSame(item, iterated.get(id), "and the id must carry its entity");
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// the ids queries iterate over //
+	/////////////////////////////////
+
+	/**
+	 * The index is registered before anything is added, so it is filled purely by the ordinary add
+	 * path and {@code iterateIndexed} is not involved at all. This isolates the query-side base id
+	 * computation, which used to drop every hit above 2^31.
+	 */
+	@Test
+	public void queryFindsEntitiesAboveIntegerRange()
+	{
+		final GigaMap.Default<Item> map = mapStartingAt(8, 10, 30, FIRST_ID_ABOVE_INT_RANGE);
+		map.index().bitmap().add(NAME);
+
+		final Item item0 = new Item("item0");
+		final Item item1 = new Item("item1");
+		final long id0   = map.add(item0);
+		final long id1   = map.add(item1);
+
+		assertEquals(1L, map.query(NAME, "item0").count(), "the entity must be findable");
+		assertEquals(Set.of(id0), queryIds(map, "item0"), "at the id the map handed out");
+		assertEquals(List.of(item0), map.query(NAME, "item0").toList(), "and it must be the entity itself");
+		assertEquals(Set.of(id1), queryIds(map, "item1"), "and each entity keeps its own id");
+	}
+
+	/**
+	 * Registering an index on a populated map back-fills it through {@code iterateIndexed}
+	 * ({@code BitmapIndices#internalAddBitmapIndex}), so a wrong id made the index corrupt from birth.
+	 */
+	@Test
+	public void bitmapIndexBackfillAboveIntegerRangeKeepsTheEntityQueryable()
+	{
+		final GigaMap.Default<Item> map = mapStartingAt(8, 10, 30, FIRST_ID_ABOVE_INT_RANGE);
+		final Item item = new Item("item0");
+		final long id   = map.add(item);
+
+		map.index().bitmap().add(NAME);
+
+		assertEquals(1L, map.query(NAME, "item0").count(), "the back-filled entity must be findable");
+		assertEquals(Set.of(id), queryIds(map, "item0"), "and at the id the map handed out");
+		assertEquals(List.of(item), map.query(NAME, "item0").toList(), "and it must be the entity itself");
+	}
+
+	/**
+	 * {@code reindex()} drops and rebuilds every index group from {@code iterateIndexed}
+	 * ({@code IndexGroup.Internal#internalReindex}), so a wrong id turned the recovery tool into the
+	 * thing that breaks the index.
+	 */
+	@Test
+	public void reindexAboveIntegerRangeRealignsTheIndex()
+	{
+		final GigaMap.Default<Item> map = mapStartingAt(8, 10, 30, FIRST_ID_ABOVE_INT_RANGE);
+		map.index().bitmap().add(NAME);
+		final Item item = new Item("item0");
+		final long id   = map.add(item);
+
+		map.reindex();
+
+		assertEquals(1L, map.query(NAME, "item0").count(), "reindex must not lose the entity");
+		assertEquals(Set.of(id), queryIds(map, "item0"), "and must keep it at its own id");
+		assertEquals(List.of(item), map.query(NAME, "item0").toList(), "and it must be the entity itself");
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// helpers //
+	////////////
+
+	/**
+	 * Creates a map whose id counter starts at the given id, so that the first added entity lands in
+	 * the segment chain that id points at without any of the ids below it being populated.
+	 */
+	private static GigaMap.Default<Item> mapStartingAt(
+		final int  lowLevelLengthExponent        ,
+		final int  midLevelLengthExponent        ,
+		final int  highLevelMaximumLengthExponent,
+		final long startId
+	)
+	{
+		return new GigaMap.Default<>(
+			new GigaMap.DefaultEqualator<>(),
+			lowLevelLengthExponent,
+			midLevelLengthExponent,
+			0,
+			highLevelMaximumLengthExponent,
+			0,
+			startId
+		);
+	}
+
+	private static Map<Long, Item> iterateIndexed(final GigaMap<Item> map)
+	{
+		final Map<Long, Item> collected = new LinkedHashMap<>();
+		map.iterateIndexed((id, entity) -> collected.put(id, entity));
+
+		return collected;
+	}
+
+	private static Set<Long> queryIds(final GigaMap<Item> map, final String name)
+	{
+		final Set<Long> ids = new LinkedHashSet<>();
+		map.query(NAME, name).iterateIndexed((id, entity) -> ids.add(id));
+
+		return ids;
+	}
+
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorSegmentCountTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/types/ThreadedIteratorSegmentCountTest.java
@@ -1,0 +1,221 @@
+package org.eclipse.store.gigamap.types;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code ThreadedIterator#calculateLevel1SegmentCount} derives its off-heap registry size from
+ * {@link GigaMap#highestUsedId()}, which has two edge cases that its former {@code int} narrowing
+ * papered over (internal issue #133).
+ * <p>
+ * An empty map reports {@code highestUsedId() == -1} ({@code nextFreeId() - 1}), and
+ * {@code -1L >>> 12} is {@code 2^52 - 1}. The old {@code (int)} cast truncated that to {@code -1} and
+ * {@code +1} landed on exactly 0, which is the value the iterator needs to report "no data" - so the
+ * empty case worked purely by accident of the overflow. It now has an explicit branch, and this test
+ * pins it, because the whole gigamap suite has no other coverage for a threaded query on an empty map.
+ * <p>
+ * The other edge is the opposite end: the registry index is an {@code int}, so a
+ * {@code highestUsedId} beyond roughly 2^43 cannot be represented. It is rejected explicitly instead
+ * of allocating from a negative count.
+ * <p>
+ * {@code IterationThreadProvider.Pooling} with a fixed thread count is what forces
+ * {@code GigaMap.Default#createIterator} onto the {@link ThreadedIterator} path.
+ */
+public class ThreadedIteratorSegmentCountTest
+{
+	static class Item
+	{
+		final String name;
+
+		Item(final String name)
+		{
+			super();
+			this.name = name;
+		}
+	}
+
+	static class NameIndexer extends IndexerString.Abstract<Item>
+	{
+		@Override
+		protected String getString(final Item entity)
+		{
+			return entity.name;
+		}
+	}
+
+	private static final String SEARCHED_KEY = "item3";
+
+	/** Grace period for a worker thread to reach its uncaught exception handler, if it has one to reach. */
+	private static final long WORKER_SETTLE_MS = 200;
+
+	@Test
+	public void threadedIterationOverAnEmptyMapYieldsNothing()
+	{
+		final GigaMap<Item>   map  = GigaMap.New();
+		final NameIndexer     name = new NameIndexer();
+		map.index().bitmap().add(name);
+
+		assertEquals(-1L, map.highestUsedId(), "an empty map reports nextFreeId() - 1");
+		assertEquals(0, countThreaded(map, name, "anything"), "and a threaded query over it finds nothing");
+	}
+
+	/**
+	 * The empty map allocates no registry, and a zero-length allocation has the address 0, on which
+	 * {@code ThreadLogic}'s bounds arithmetic fails. The failure was invisible: it happened on a worker
+	 * thread, and the reader never consults the registry in that case, so the iteration still produced
+	 * the correct (empty) result. Hence this case asserts against the worker threads rather than the
+	 * result - no iteration may leave a worker dead behind, whether there is data or not.
+	 */
+	@Test
+	public void threadedIterationLeavesNoWorkerThreadFailing() throws InterruptedException
+	{
+		final Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+		final Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
+		Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> failures.add(throwable));
+		try
+		{
+			for(final int entityCount : new int[]{0, 1, 1000})
+			{
+				final GigaMap<Item> map  = GigaMap.New();
+				final NameIndexer   name = new NameIndexer();
+				map.index().bitmap().add(name);
+				for(int i = 0; i < entityCount; i++)
+				{
+					map.add(new Item("item" + i % 10));
+				}
+
+				countThreaded(map, name, SEARCHED_KEY);
+
+				// the worker threads run concurrently with the reader, so give a failing one time to die
+				Thread.sleep(WORKER_SETTLE_MS);
+				assertTrue(failures.isEmpty(),
+					"a threaded query over " + entityCount + " entities must not fail a worker thread, got "
+					+ failures);
+			}
+		}
+		finally
+		{
+			Thread.setDefaultUncaughtExceptionHandler(previous);
+		}
+	}
+
+	/**
+	 * The counterpart, so the empty-map branch cannot be satisfied by a count that is always 0.
+	 */
+	@Test
+	public void threadedIterationOverAPopulatedMapYieldsTheMatches()
+	{
+		final GigaMap<Item>   map  = GigaMap.New();
+		final NameIndexer     name = new NameIndexer();
+		map.index().bitmap().add(name);
+		for(int i = 0; i < 1000; i++)
+		{
+			map.add(new Item("item" + i % 10));
+		}
+
+		assertEquals(100, countThreaded(map, name, "item3"), "every match must be iterated");
+		assertEquals(0  , countThreaded(map, name, "nope") , "and a miss must yield nothing");
+	}
+
+	/**
+	 * The registry is allocated with one slot per registry segment, each covering
+	 * {@code REGISTRY_SEGMENT_SIZE} level1 segments. It used to be sized by the level1 segment count
+	 * instead, i.e. up to 64 times too large. Under-allocating it would be far worse than the waste it
+	 * replaced - the worker threads and the registry scroll would run off the end of the block - so this
+	 * case deliberately spans more than one registry segment and checks that every match still arrives.
+	 */
+	@Test
+	public void threadedIterationAcrossMultipleRegistrySegmentsYieldsEveryMatch()
+	{
+		final long idsPerRegistrySegment =
+			(long)ThreadedIterator.REGISTRY_SEGMENT_SIZE * BitmapLevel3.LEVEL_1_ID_COUNT;
+
+		final GigaMap<Item> map  = GigaMap.New();
+		final NameIndexer   name = new NameIndexer();
+		map.index().bitmap().add(name);
+
+		final int entityCount = (int)idsPerRegistrySegment + 40_000;
+		int       expected    = 0;
+		for(int i = 0; i < entityCount; i++)
+		{
+			final String key = "item" + i % 10;
+			map.add(new Item(key));
+			if(SEARCHED_KEY.equals(key))
+			{
+				expected++;
+			}
+		}
+
+		assertTrue(map.highestUsedId() > idsPerRegistrySegment,
+			"the map must span more than one registry segment for this case to mean anything");
+		assertEquals(expected, countThreaded(map, name, SEARCHED_KEY),
+			"every match across all registry segments must be iterated");
+	}
+
+	/**
+	 * The upper edge. The registry index is an {@code int}, so beyond roughly 2^43 ids the count is not
+	 * representable - and the registry it sizes would need 16 GB of off-heap memory, so the limit is a
+	 * reporting problem, not one worth widening the type for.
+	 * <p>
+	 * Reachable cheaply because the seeded id counter can start at 2^43 while exponents 20/20 keep that
+	 * id at level3 index 8, so the whole map costs about 26 MB.
+	 */
+	@Test
+	public void threadedIterationBeyondTheRepresentableSegmentCountIsRejected()
+	{
+		final GigaMap.Default<Item> map = new GigaMap.Default<>(
+			new GigaMap.DefaultEqualator<>(), 20, 20, 0, 8, 0, 1L << 43
+		);
+		final NameIndexer name = new NameIndexer();
+		map.index().bitmap().add(name);
+		map.add(new Item("item0"));
+
+		assertEquals(1L << 43, map.highestUsedId(), "the map hands out the seeded id");
+
+		final IllegalStateException e = assertThrows(IllegalStateException.class,
+			() -> countThreaded(map, name, "item0"),
+			"a segment count beyond int must be reported, not silently truncated");
+		assertTrue(e.getMessage().contains("8796093022208"),
+			"the message must name the offending highestUsedId, was: " + e.getMessage());
+	}
+
+	private static int countThreaded(final GigaMap<Item> map, final NameIndexer name, final String key)
+	{
+		final IterationThreadProvider provider = IterationThreadProvider.Pooling(
+			4, ThreadCountProvider.Fixed(2)
+		);
+
+		int count = 0;
+		try(final GigaIterator<Item> iterator = map.query(provider).and(name.is(key)).iterator())
+		{
+			while(iterator.hasNext())
+			{
+				iterator.next();
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+}


### PR DESCRIPTION
Fixes internal#133.

Several places derived an entity id from a segment index with `int` arithmetic and widened to `long` only on assignment or at the call, although a `GigaMap` may hold up to 2^50 entities. All of them broke at the same boundary, entity id 2^31.

## The defects

**`GigaMap.Default#iterateIndexed` and its two private `iterate` helpers** reported wrapped, negative ids, corrupting every consumer of the id: `reindex()`, bitmap index registration back-fill, the Lucene back-fill (which persists the id into `ENTITY_ID_FIELD`) and the jvector graph rebuild.

Beyond the plain overflow there is a second, worse mode that the issue did not mention: `level1Exp + level2Exp` may legally reach 40 (each caps at 20, and `validateSegmentSizeDistribution` only limits their sum with `level3Max` to 50), while an `int` shift uses only the low 5 bits of its distance (JLS 15.19). So with e.g. `GigaMap.New(eq, 14, 18, 8)`, `i<<32` evaluates to `i<<0 == i` and level3 segment 1 reports base id 1 - **colliding** with a valid id of segment 0 rather than merely wrapping.

**`AbstractBitmapIterating` and `ResultIdIterator`** computed the level2 base id as `level3Index * LEVEL_2_ID_COUNT`, so **every query silently returned nothing for entities above 2^31** - independently of `iterateIndexed`, and even for an index the ordinary `add()` path had filled correctly. This surfaced because the impact tests still failed after `iterateIndexed` was fixed. `ResultIdIterator#calculateIndexBound` additionally narrowed the id-range remainder through `XTypes.to_int`, which throws for maps beyond 2^31; the remainder is now kept as a `long` and narrowed only in the branch where it is provably below one segment's id count.

**`ThreadedIterator`** had the same defect in its `valueBaseId` computation. Its `calculateLevel1SegmentCount` also narrowed the segment count, which stays an `int` because it doubles as an index bound into the off-heap id lists registry: that caps the iterator at roughly 2^43 ids, so a count beyond that is now rejected with an explicit message instead of allocating from a negative length. The empty map needs its own branch there, because `highestUsedId` is `nextFreeId() - 1` and hence `-1`, whose unsigned shift is 2^52 - 1 - the former `int` truncation happened to land on exactly the 0 the iterator needs to report "no data", so that case worked purely by accident of the overflow.

## Adjacent findings in `ThreadedIterator`

Two comments were corrected while reading it. `currentRegistryIndex` points to a **registry segment** covering `REGISTRY_SEGMENT_SIZE` level1 segments, not to a single level1 segment as its comment claimed - which is what makes the `REGISTRY_SEGMENT_ID_COUNT` multiplier in `valueBaseId` correct. And `hasMoreData` compares that index against `level1SegmentCount` rather than `registrySegmentCount`, which is not the index's bound but an "is the exhaustion sentinel set?" test; it is correct, and now says so.

That same confusion had sized the registry itself: `calculateIdListsRegistryLength` allocated one slot per level1 segment, while the worker threads, `scrollToNextRegistrySegment` and `deallocateSegments` all bound themselves by `registrySegmentCount`, so up to 63 of every 64 slots were never touched (74 slots allocated for 2 used, at 300k entities). The registry is now sized by `registrySegmentCount`, which required computing that count before the allocation. The length is 0 for an empty map exactly as before, since `ceil(n/64)` is 0 only for `n == 0`.

That zero-slot registry is a zero-length allocation, and `XMemory.allocateCleared(0)` yields the address 0, on which `ThreadLogic`'s bounds arithmetic fails - a not-positive start address, and a `registrySegmentCount - 1` of `-1`. So every worker thread of a query over an empty map died with a `NumberRangeException`. It was invisible: the failures happened on the worker threads, while the reader never resolves a registry slot in that case - its scroll is bounded by `registrySegmentCount`, so at 0 it falls straight through to the end-of-data sentinel - and the query still produced the correct empty result. No worker threads are started when there is no registry segment to process.

Note that the `int` cap on the level1 segment count is an index-width limit, not a memory one: since the registry holds one slot per registry segment, it is 256 MB at the cap rather than the 16 GB an earlier revision of this branch claimed.

## Audited and left alone

`toLevel1Index` / `toLevel2Index` (masked), `toLevel3Index` (bounded by the `maximumEntityId` guard), `GigaMap.Itr` and `GigaQuery#iterateIndexed` (already `long` - which is why no existing test caught any of this), `viewEntities`, `size()`, `highestUsedId()`, and the Lucene and jvector back-fills themselves, which only relayed a corrupt input.

## Tests

Populating 2^31 entities is not feasible, but the ids only have to be *sparse*, not numerous. Both new test classes live in the `types` package so they can use the package-private `GigaMap.Default` constructor that seeds the id counter; `setupAddingState` then allocates just the one segment chain the seeded id points at, so a map whose first entity sits at 2^31 costs a few hundred KB. The same seam makes the 2^43 rejection reachable for about 26 MB, using exponents 20/20 to keep the seeded id at level3 index 8.

- `EntityIdAboveIntegerRangeTest` (6) - the ids `iterateIndexed` reports at 2^31, at a level3 shift distance of 32 (including the collision), and within a level3 segment; then the query, back-fill and `reindex()` paths.
- `ThreadedIteratorSegmentCountTest` (5) - the empty and 2^43 segment-count edges, iteration spanning more than one registry segment (under-allocating the registry would be worse than the waste it replaced), and worker thread health. The last one asserts against a default uncaught exception handler rather than against the iteration result, since a dead worker does not change the result.

Every case was verified to fail against the unfixed code with the specific wrong value - `[-2147483648, -2147483647]` for the reported ids, `count: 0` for the query, and the two dead workers for the empty map. The shift-masking case populates ids 0 and 1 in level3 segment 0, so the masked base id 1 is a genuine collision: three entities collapse into the two reported ids `[0, 1]`, and the entity that actually lives at id 1 is silently dropped. An earlier revision of this branch populated only id 0, which demonstrated a wrong magnitude but not the aliasing, and would have passed a fix that merely got the number right.

Full runs: gigamap 1179, lucene 74, jvector 238 (plus 121 with `-Pslow-tests`), no failures. `javadoc:javadoc` is clean.
