### PR TITLE
GigaMap/jvector: deferred builder ops no longer double-add an ordinal after a persist

### DIFF
--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -103,11 +103,26 @@ interface DiskIndexManager extends Closeable
     public OnDiskGraphIndex getDiskIndex();
 
     /**
-     * Attempts to load the index from disk.
+     * Attempts to load the index from disk, validating the {@code .meta} witnesses against the
+     * current live store state. This is the load-time self-heal check: a graph the store has
+     * advanced past is rejected so it gets rebuilt from the source vectors.
      *
      * @return true if successfully loaded, false otherwise
      */
     public boolean tryLoad();
+
+    /**
+     * Attempts to load the index from disk, validating the {@code .meta} witnesses against
+     * {@code expected} instead of the live store state.
+     * <p>
+     * Used to reload an index this process has just written, where the graph on disk is known to
+     * correspond to {@code expected} and the live store may legitimately have advanced past it in
+     * the meantime. Comparing against the live state there would reject a perfectly usable file.
+     *
+     * @param expected the witnesses the {@code .meta} is required to carry
+     * @return true if successfully loaded, false otherwise
+     */
+    public boolean tryLoad(MetaState expected);
 
     /**
      * Writes the in-memory index to disk.
@@ -255,6 +270,16 @@ interface DiskIndexManager extends Closeable
         @Override
         public boolean tryLoad()
         {
+            return this.tryLoad(new MetaState(
+                this.provider.getExpectedVectorCount(),
+                this.provider.getHighestEntityId()    ,
+                this.provider.getStructuralModCount()
+            ));
+        }
+
+        @Override
+        public boolean tryLoad(final MetaState expected)
+        {
             if(this.indexDirectory == null)
             {
                 return false;
@@ -272,7 +297,7 @@ interface DiskIndexManager extends Closeable
             try
             {
                 // Verify metadata matches current configuration
-                if(!this.verifyMetadata(metaPath))
+                if(!this.verifyMetadata(metaPath, expected))
                 {
                     LOG.info("Disk index metadata mismatch for '{}', will rebuild", this.name);
                     return false;
@@ -297,9 +322,10 @@ interface DiskIndexManager extends Closeable
         }
 
         /**
-         * Verifies that the metadata file matches the current configuration.
+         * Verifies that the metadata file matches the current configuration and the expected
+         * witness values.
          */
-        private boolean verifyMetadata(final Path metaPath) throws IOException
+        private boolean verifyMetadata(final Path metaPath, final MetaState expected) throws IOException
         {
             try(final DataInputStream dis = new DataInputStream(new FileInputStream(metaPath.toFile())))
             {
@@ -318,29 +344,26 @@ interface DiskIndexManager extends Closeable
                 }
 
                 final long vectorCount = dis.readLong();
-                final long expectedCount = this.provider.getExpectedVectorCount();
-                if(vectorCount != expectedCount)
+                if(vectorCount != expected.expectedVectorCount)
                 {
-                    LOG.debug("Vector count mismatch: expected {}, got {}", expectedCount, vectorCount);
+                    LOG.debug("Vector count mismatch: expected {}, got {}", expected.expectedVectorCount, vectorCount);
                     return false;
                 }
 
                 final long highestEntityId = dis.readLong();
-                final long expectedHighestEntityId = this.provider.getHighestEntityId();
-                if(highestEntityId != expectedHighestEntityId)
+                if(highestEntityId != expected.highestEntityId)
                 {
-                    LOG.debug("Highest entity id mismatch: expected {}, got {}", expectedHighestEntityId, highestEntityId);
+                    LOG.debug("Highest entity id mismatch: expected {}, got {}", expected.highestEntityId, highestEntityId);
                     return false;
                 }
 
                 final long structuralModCount = dis.readLong();
-                final long expectedStructuralModCount = this.provider.getStructuralModCount();
-                if(structuralModCount != expectedStructuralModCount)
+                if(structuralModCount != expected.structuralModCount)
                 {
                     // The store advanced past the on-disk graph since it was written (e.g. a
                     // vec↔null transition committed via storeRoot() but not yet persistToDisk()).
                     // Reject the disk graph so it is rebuilt from the current source vectors.
-                    LOG.debug("Structural mod count mismatch: expected {}, got {}", expectedStructuralModCount, structuralModCount);
+                    LOG.debug("Structural mod count mismatch: expected {}, got {}", expected.structuralModCount, structuralModCount);
                     return false;
                 }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -3336,6 +3336,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 currentIndex.getDeletedNodes().clear(ordinal);
                 return;
             }
+            // containsNode only inspects layer 0, so "absent" can still mean "present in an upper
+            // layer" after an earlier interleaved add/remove. Purge all layers before adding, or the
+            // add throws the very IllegalStateException this change is about.
+            currentIndex.removeNode(ordinal);
             currentBuilder.addGraphNode(ordinal, vf);
         }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -772,9 +772,16 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         long structuralModCount;
 
         // HNSW graph components (transient - rebuilt on load)
-        private transient VectorTypeSupport vectorTypeSupport;
-        private transient GraphIndexBuilder builder          ;
-        private transient OnHeapGraphIndex  index            ;
+        // Volatile: the pair is swapped wholesale by exitIncrementalMode / reenterIncrementalMode /
+        // initializeInMemoryBuilder under builderLock.writeLock(), but read by sync-mode mutations and
+        // by drainDeferredBuilderOps, neither of which holds that lock. Without volatile a reader can
+        // observe a torn pair (stale index, fresh builder), which is how a guard evaluated on `index`
+        // ended up authorizing a mutation on a different `builder` (internal #142). Code that mutates
+        // the graph must additionally read `builder` ONCE into a local and derive the graph from it
+        // (see internalReplaceGraphNode) so guard and mutation cannot target different objects.
+        private transient VectorTypeSupport          vectorTypeSupport;
+        private transient volatile GraphIndexBuilder builder          ;
+        private transient volatile OnHeapGraphIndex  index            ;
 
         // Managers (transient - recreated on load)
         private transient DiskIndexManager      diskManager          ;
@@ -844,6 +851,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         // a mutation into the exact window where a deferred builder op is drained after the swap.
         // Null (and a no-op) in production. See VectorIndex(persist-window deletion) regression test.
         transient volatile Runnable persistPhase2TestHook;
+
+        // Test-only seam: run on entry to drainDeferredBuilderOps, BEFORE the parentMap monitor is
+        // acquired. Lets a test collide two drains deterministically (persist thread vs application
+        // thread) to assert that the drain is serialized. Null (and a no-op) in production.
+        // See VectorIndexPersistWindowConcurrencyTest.
+        transient volatile Runnable drainEntryTestHook;
 
 
         ///////////////////////////////////////////////////////////////////////////
@@ -1571,9 +1584,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     this.drainDeferredBuilderOps();
                 }
 
-                // Add to HNSW graph using entity ID as ordinal
+                // Add to HNSW graph using entity ID as ordinal. Idempotent: a deferred op may be
+                // drained into a builder that already carries the ordinal (internal #142).
                 final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
-                this.executeOrDeferBuilderOp(() -> this.builder.addGraphNode(ordinal, vf));
+                this.executeOrDeferBuilderOp(() -> this.internalAddGraphNodeIdempotent(ordinal, vf));
 
                 // Mark dirty for background managers
                 this.markDirtyForBackgroundManagers(1);
@@ -1605,7 +1619,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             // Update the computed-mode vector store to reflect the new (possibly absent) vector.
             // Keyed by source entity id (not positionally), so the four vec/null transitions map
             // cleanly onto add / replace / remove.
-            boolean changed = false;
+            boolean changed         = false;
+            boolean vectorUnchanged = false;
             if(!embedded)
             {
                 // Resolve the store-internal id by source entity id via the fast index, then
@@ -1625,9 +1640,24 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 }
                 else if(storeId != null)
                 {
-                    // vec→vec (store-internal id unchanged)
-                    this.vectorStore.set(storeId, new VectorEntry(entityId, vector));
-                    changed = true;
+                    // vec→vec (store-internal id unchanged). An update whose vector did not actually
+                    // change is a no-op for this index: unlike the embedded case there is no live
+                    // re-scoring from the entity, the stored vector IS the indexed value. Detect it
+                    // with one lazy store read and skip the store write, the graph repair
+                    // (markNodeDeleted + removeDeletedNodes + addGraphNode, two ForkJoinPool round
+                    // trips per level) and all the change bookkeeping. Callers that touch unrelated
+                    // entity fields (an adjacency list, say) would otherwise pay full graph repair
+                    // per update (internal #142), which is also what floods the deferred op queue.
+                    final VectorEntry existing = this.vectorStore.get(storeId);
+                    if(existing != null && Arrays.equals(existing.vector, vector))
+                    {
+                        vectorUnchanged = true;
+                    }
+                    else
+                    {
+                        this.vectorStore.set(storeId, new VectorEntry(entityId, vector));
+                        changed = true;
+                    }
                 }
                 else
                 {
@@ -1700,8 +1730,14 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // monitor we hold for embedded vectorizers.
                     // Route through internalMarkOrdinalDeleted so a deferral drained after a persist
                     // builder swap still records the deletion (via diskDeletedOrdinals) instead of
-                    // no-op'ing against the new empty builder.
-                    if(inGraph)
+                    // no-op'ing against the new empty builder. The pre-deferral inGraph check is no
+                    // longer sufficient on its own: in incremental mode a disk-only node is not in
+                    // the in-memory graph, so gating on it alone would queue nothing and the eager
+                    // diskDeletedOrdinals entry made above is wiped by the persist's mode swap,
+                    // leaving the stale disk node visible to search (internal #142). contentChanged
+                    // covers that case; inGraph is kept as well so a transition this method cannot
+                    // classify (a null replacedEntity) still clears the node it can see.
+                    if(contentChanged || inGraph)
                     {
                         this.executeOrDeferBuilderOp(() -> this.internalMarkOrdinalDeleted(ordinal));
                         changed = true;
@@ -1715,13 +1751,17 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // a marked-deleted node. A prior vec→null in this same session (without an
                     // intervening optimize) leaves the node present-but-deleted, which is a third
                     // case the plain !inGraph guard would silently mis-handle.
+                    //
+                    // The classification below only selects WHICH op to enqueue; each op re-derives
+                    // the graph state itself when it runs, because a deferred op can be drained into
+                    // a builder that was swapped in the meantime (internal #142).
                     if(!inGraph)
                     {
                         // null→vec: the node was never added (or a prior optimize physically removed
                         // it) — add it now. addGraphNode alone is monitor-safe (no removeDeletedNodes),
                         // the same call internalAdd makes.
                         final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
-                        this.executeOrDeferBuilderOp(() -> this.builder.addGraphNode(ordinal, vf));
+                        this.executeOrDeferBuilderOp(() -> this.internalReaddGraphNode(ordinal, vf));
                     }
                     else if(this.index.getDeletedNodes().get(ordinal))
                     {
@@ -1733,7 +1773,8 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                         // from the entity via EntityBackedVectorValues — identical to the vec→vec
                         // "leave as-is" contract below; the next optimize/persist rebuilds connections.
                         // Without this, the entity would stay excluded from liveNodes() forever.
-                        this.executeOrDeferBuilderOp(() -> this.index.getDeletedNodes().clear(ordinal));
+                        final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
+                        this.executeOrDeferBuilderOp(() -> this.internalResurrectGraphNode(ordinal, vf));
                     }
                     // else vec→vec: leave the graph as-is — removeDeletedNodes() uses a ForkJoinPool
                     // whose workers call parentMap.get(), deadlocking with the GigaMap monitor we
@@ -1742,20 +1783,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // rebuilds the graph connections.
                     changed = true;
                 }
-                else
+                else if(!vectorUnchanged)
                 {
-                    // Computed, non-null (vec→vec or null→vec): vectors are stored separately, so
-                    // removeDeletedNodes() won't call parentMap.get(). Safe to inline.
+                    // Computed, non-null and actually different (vec→vec' or null→vec): vectors are
+                    // stored separately, so removeDeletedNodes() won't call parentMap.get().
+                    // Safe to inline.
                     final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
-                    this.executeOrDeferBuilderOp(() ->
-                    {
-                        if(this.index != null && this.index.containsNode(ordinal))
-                        {
-                            this.builder.markNodeDeleted(ordinal);
-                            this.builder.removeDeletedNodes();
-                        }
-                        this.builder.addGraphNode(ordinal, vf);
-                    });
+                    this.executeOrDeferBuilderOp(() -> this.internalReplaceGraphNode(ordinal, vf));
                     changed = true;
                 }
 
@@ -1888,7 +1922,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 }
                 final int ordinal = toOrdinal(entry.sourceEntityId);
                 final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(entry.vector);
-                this.builder.addGraphNode(ordinal, vf);
+                this.internalAddGraphNodeIdempotent(ordinal, vf);
             });
         }
 
@@ -1940,10 +1974,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 // via diskDeletedOrdinals and won't be in the builder. Route through
                 // internalMarkOrdinalDeleted so a deferral drained after a persist builder swap
                 // still records the deletion instead of no-op'ing against the new empty builder.
-                if(this.index != null && this.index.containsNode(ordinal))
-                {
-                    this.executeOrDeferBuilderOp(() -> this.internalMarkOrdinalDeleted(ordinal));
-                }
+                // Enqueued unconditionally: the helper checks the builder itself when it runs, and
+                // gating here on the CURRENT builder would queue nothing for a disk-only node, whose
+                // eager diskDeletedOrdinals entry above is then wiped by a concurrent persist's mode
+                // swap, resurrecting the removed entity in search (internal #142).
+                this.executeOrDeferBuilderOp(() -> this.internalMarkOrdinalDeleted(ordinal));
 
                 // Mark dirty for background managers
                 this.markDirtyForBackgroundManagers(1);
@@ -1978,6 +2013,13 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
 
                 // Shutdown background task manager (discard pending ops — they're stale)
                 this.shutdownBackgroundTaskManager(false, false, false);
+
+                // Same for deferred sync-mode ops: the graph they describe is about to be destroyed,
+                // so replaying them into the fresh builder would resurrect removed entities.
+                if(this.deferredBuilderOps != null)
+                {
+                    this.deferredBuilderOps.clear();
+                }
 
                 this.closeInternalResources();
 
@@ -2461,10 +2503,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             finally
             {
                 this.cleanupInProgress = false;
-            }
 
-            // Apply any deferred sync-mode mutations now that cleanup is done.
-            this.drainDeferredBuilderOps();
+                // Apply any deferred sync-mode mutations now that cleanup is done. Inside the finally
+                // so no exit path can strand the queue; builderLock is already released above.
+                this.drainDeferredBuilderOps();
+            }
 
             this.markStateChangeChildren();
         }
@@ -2616,7 +2659,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     capturedDiskMgr.writeIndex(capturedIndex, capturedRavv, capturedPqMgr, capturedMeta);
 
                     // After writing, re-enter incremental mode for fast subsequent operation
-                    this.reenterIncrementalMode();
+                    this.reenterIncrementalMode(capturedMeta);
                 }
                 catch(final IOException ioe)
                 {
@@ -2630,10 +2673,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
             finally
             {
                 this.cleanupInProgress = false;
-            }
 
-            // Apply any deferred sync-mode mutations now that cleanup + persistence is done.
-            this.drainDeferredBuilderOps();
+                // Apply any deferred sync-mode mutations now that cleanup + persistence is done.
+                // Inside the finally so the early returns above (incremental-clean, shutdown skip,
+                // no builder) cannot strand the queue; builderLock is already released above.
+                this.drainDeferredBuilderOps();
+            }
         }
 
         /**
@@ -2707,8 +2752,21 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          * Re-enters incremental mode after a disk write: reloads the disk index,
          * resets the in-memory builder to empty, and sets incremental state.
          * Must be called under builderLock.writeLock().
+         * <p>
+         * The reload is validated against {@code writtenMeta} - the witnesses that were just stamped
+         * into the {@code .meta} - and NOT against the live store state. Persist Phase 2 runs with the
+         * parentMap monitor released, so under sustained writes the live counters always advance past
+         * the written graph and a live comparison would reject the file we just produced ourselves,
+         * dropping the index into full in-memory mode for the rest of the session (internal #142).
+         * Those newer mutations are not lost: they are exactly the ops sitting in
+         * {@code deferredBuilderOps}, which the drain then applies on top of the reloaded graph -
+         * which is what incremental mode is for. Crash-restart safety is unaffected: the store
+         * counter now legitimately exceeds the {@code .meta} counter, so a restart before the next
+         * persist still rejects the disk graph and rebuilds from the store.
+         *
+         * @param writtenMeta the witnesses stamped into the {@code .meta} by the preceding write
          */
-        private void reenterIncrementalMode()
+        private void reenterIncrementalMode(final DiskIndexManager.MetaState writtenMeta)
         {
             // Close existing disk manager if present
             if(this.diskManager != null)
@@ -2727,7 +2785,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 this.configuration.parallelOnDiskWrite()
             );
 
-            if(this.diskManager.tryLoad())
+            if(this.diskManager.tryLoad(writtenMeta))
             {
                 if(this.pqManager != null)
                 {
@@ -3158,14 +3216,132 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          */
         private void internalMarkOrdinalDeleted(final int ordinal)
         {
+            this.recordDiskOrdinalSuperseded(ordinal);
+            final GraphIndexBuilder currentBuilder = this.builder;
+            if(currentBuilder != null && graphOf(currentBuilder).containsNode(ordinal))
+            {
+                currentBuilder.markNodeDeleted(ordinal);
+            }
+        }
+
+        /**
+         * Records that the disk-resident version of an ordinal is no longer authoritative, so
+         * {@link #createDiskAcceptBits()} excludes it from disk search.
+         * <p>
+         * Must be called by every op that removes or re-adds an ordinal in the in-memory builder while
+         * incremental mode is active, and it must be called when the op RUNS, not when it is created:
+         * a persist allocates a fresh, empty {@link #diskDeletedOrdinals} in
+         * {@code reenterIncrementalMode}, so an entry made before deferral is gone by the time the op
+         * is drained, and the stale disk node would keep answering searches next to the fresh
+         * in-memory one (internal #142).
+         * <p>
+         * Not called for a plain add: a newly allocated entity id was never written to disk, so
+         * recording it would only enlarge the {@code boolean[maxOrdinal+1]} mask that
+         * {@code createDiskAcceptBits()} rebuilds on every search.
+         */
+        private void recordDiskOrdinalSuperseded(final int ordinal)
+        {
             if(this.incrementalMode && this.diskDeletedOrdinals != null)
             {
                 this.diskDeletedOrdinals.add(ordinal);
             }
-            if(this.index != null && this.index.containsNode(ordinal))
+        }
+
+        /**
+         * Replaces a graph node with a new vector, re-deriving every premise from CURRENT state at
+         * execution time. Used by the computed (non-embedded) update path, whose deferred op may be
+         * drained against a builder that was swapped since the op was created.
+         * <p>
+         * The removal half must never be skipped while the add half runs unconditionally: jvector's
+         * {@code OnHeapGraphIndex.addNode} is a non-atomic loop over layers {@code 0..level} that
+         * throws {@code IllegalStateException: Node N already exists} on the first layer already
+         * holding the ordinal, and {@code containsNode} only inspects layer 0. So the final
+         * {@code removeNode} is not redundant with {@code removeDeletedNodes}: it purges the ordinal
+         * from ALL layers and thereby also repairs a node left in an upper layer only by an earlier
+         * interleaved add/remove (internal #142).
+         * <p>
+         * Only safe for the computed vectorizer: {@code removeDeletedNodes()} scores through a
+         * ForkJoinPool, whose workers read the separate vector store rather than the parent GigaMap,
+         * so it cannot deadlock against the GigaMap monitor the drain holds.
+         */
+        private void internalReplaceGraphNode(final int ordinal, final VectorFloat<?> vf)
+        {
+            this.recordDiskOrdinalSuperseded(ordinal);
+            final GraphIndexBuilder currentBuilder = this.builder;
+            if(currentBuilder == null)
             {
-                this.builder.markNodeDeleted(ordinal);
+                return;
             }
+            final OnHeapGraphIndex currentIndex = graphOf(currentBuilder);
+            if(currentIndex.containsNode(ordinal))
+            {
+                // Repairs the neighbor lists that referenced the node before dropping it.
+                currentBuilder.markNodeDeleted(ordinal);
+                currentBuilder.removeDeletedNodes();
+            }
+            currentIndex.removeNode(ordinal);
+            currentBuilder.addGraphNode(ordinal, vf);
+        }
+
+        /**
+         * Adds a graph node, tolerating an ordinal that is already present. Monitor-safe: it never
+         * calls {@code removeDeletedNodes()}, whose ForkJoinPool workers resolve vectors through the
+         * parent GigaMap for an embedded vectorizer and would deadlock against the monitor the caller
+         * holds. The re-added node loses its neighbor links, which the next optimize/persist rebuilds
+         * - the same contract the embedded vec-vec path documents.
+         * <p>
+         * Re-deriving presence here rather than at deferral time is what makes the op idempotent
+         * against whatever builder it is eventually drained into (internal #142).
+         */
+        private void internalAddGraphNodeIdempotent(final int ordinal, final VectorFloat<?> vf)
+        {
+            final GraphIndexBuilder currentBuilder = this.builder;
+            if(currentBuilder == null)
+            {
+                return;
+            }
+            graphOf(currentBuilder).removeNode(ordinal);
+            currentBuilder.addGraphNode(ordinal, vf);
+        }
+
+        /**
+         * {@link #internalAddGraphNodeIdempotent} for an ordinal that may already have a version on
+         * disk, i.e. the embedded {@code null→vec} update path. Masks the disk-resident node first so
+         * search does not answer from both copies.
+         */
+        private void internalReaddGraphNode(final int ordinal, final VectorFloat<?> vf)
+        {
+            this.recordDiskOrdinalSuperseded(ordinal);
+            this.internalAddGraphNodeIdempotent(ordinal, vf);
+        }
+
+        /**
+         * Re-adds or resurrects an embedded-mode node, deciding from CURRENT state at execution time.
+         * A node marked deleted only carries a bit (it stays in every layer), so clearing that bit is
+         * enough and keeps the op monitor-safe; a node that is gone entirely - e.g. because the
+         * builder was swapped between deferral and drain - must be added instead, otherwise the
+         * entity silently disappears from the graph.
+         */
+        private void internalResurrectGraphNode(final int ordinal, final VectorFloat<?> vf)
+        {
+            this.recordDiskOrdinalSuperseded(ordinal);
+            final GraphIndexBuilder currentBuilder = this.builder;
+            if(currentBuilder == null)
+            {
+                return;
+            }
+            final OnHeapGraphIndex currentIndex = graphOf(currentBuilder);
+            if(currentIndex.containsNode(ordinal))
+            {
+                currentIndex.getDeletedNodes().clear(ordinal);
+                return;
+            }
+            currentBuilder.addGraphNode(ordinal, vf);
+        }
+
+        private static OnHeapGraphIndex graphOf(final GraphIndexBuilder builder)
+        {
+            return (OnHeapGraphIndex)builder.getGraph();
         }
 
         /**
@@ -3188,13 +3364,47 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
         /**
          * Drains and executes all deferred builder operations.
          * Called after cleanup completes (cleanupInProgress is already false).
+         * <p>
+         * Runs under {@code synchronized(parentMap())} because that monitor is the only lock the
+         * sync-mode mutation paths hold: without it the persist/optimize threads drain the queue
+         * bare (they release builderLock before draining) and race the application thread, which
+         * drains and executes the very same kind of op inline. Two such threads both seeing
+         * {@code containsNode(ordinal) == false} both call {@code addGraphNode} and one dies with
+         * {@code IllegalStateException: Node N already exists}, aborting the drain and killing the
+         * persist cycle for good (internal #142). The monitor is the outermost lock here - the
+         * persist/optimize drains hold nothing at this point - so it introduces no lock inversion.
+         * <p>
+         * INVARIANT: a deferred op must never enter a ForkJoinPool whose workers need this monitor.
+         * {@code addGraphNode} never does; {@code removeDeletedNodes()} does, and is therefore
+         * reachable only from the computed path, which scores through the separate vector store.
+         * <p>
+         * A failing op is logged and skipped rather than allowed to abort the drain: the op is
+         * already polled and lost either way, but stranding the rest of the queue would leave the
+         * index unable to ever persist again.
          */
         private void drainDeferredBuilderOps()
         {
-            Runnable op;
-            while((op = this.deferredBuilderOps.poll()) != null)
+            final Runnable entryHook = this.drainEntryTestHook;
+            if(entryHook != null)
             {
-                op.run();
+                entryHook.run();
+            }
+
+            synchronized(this.parentMap())
+            {
+                Runnable op;
+                while((op = this.deferredBuilderOps.poll()) != null)
+                {
+                    try
+                    {
+                        op.run();
+                    }
+                    catch(final RuntimeException e)
+                    {
+                        LOG.error("Deferred builder operation failed for index '{}', skipping it: {}",
+                            this.name, e.getMessage(), e);
+                    }
+                }
             }
         }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -1720,7 +1720,12 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     this.drainDeferredBuilderOps();
                 }
 
-                final boolean inGraph = this.index != null && this.index.containsNode(ordinal);
+                // Classify against ONE builder read, derived graph included: two separate reads of
+                // the volatile fields can straddle a persist's builder swap and answer from
+                // different graphs.
+                final GraphIndexBuilder currentBuilder = this.builder;
+                final OnHeapGraphIndex  currentGraph   = currentBuilder == null ? null : graphOf(currentBuilder);
+                final boolean           inGraph        = currentGraph != null && currentGraph.containsNode(ordinal);
 
                 if(vector == null)
                 {
@@ -1763,7 +1768,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                         final VectorFloat<?> vf = this.vectorTypeSupport.createFloatVector(vector);
                         this.executeOrDeferBuilderOp(() -> this.internalReaddGraphNode(ordinal, vf));
                     }
-                    else if(this.index.getDeletedNodes().get(ordinal))
+                    else if(currentGraph.getDeletedNodes().get(ordinal))
                     {
                         // vec→null→vec on the SAME entity: the node is still present but marked
                         // deleted. Resurrect it by clearing the deleted bit — monitor-safe (no

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConcurrentStressTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConcurrentStressTest.java
@@ -1223,9 +1223,12 @@ class VectorIndexConcurrentStressTest
                 running.set(false);
             }
 
-            assertTrue(done.await(60, TimeUnit.SECONDS), "writer threads should finish");
-            executor.shutdown();
-            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+            // Shut down before asserting: a writer stuck here must not leak its pool threads into
+            // the rest of the suite just because this assertion throws first.
+            final boolean writersFinished = done.await(60, TimeUnit.SECONDS);
+            executor.shutdownNow();
+            assertTrue(writersFinished, "writer threads should finish");
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS), "executor should terminate");
 
             if(!errors.isEmpty())
             {

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConcurrentStressTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConcurrentStressTest.java
@@ -15,6 +15,7 @@ package org.eclipse.store.gigamap.jvector;
  */
 
 import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.ScoredSearchResult;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -1118,6 +1119,137 @@ class VectorIndexConcurrentStressTest
                 randomVector(new Random(999), dimension), 5
             );
             assertNotNull(finalResult);
+        }
+    }
+
+
+    // ==================== Persist vs. Sustained Writes Regression ====================
+
+    /**
+     * Regression test for internal #142: a repeated persist racing a sustained write stream.
+     * <p>
+     * This is the shape the reported failure had - a bulk load updating the same few vector-carrying
+     * entities over and over while background persistence ticks. Each persist defers the in-flight
+     * builder ops and then drains them, and the drain used to run without any lock, so it raced the
+     * application thread's own drain and died with
+     * {@code IllegalStateException: Node N already exists}. Once that happened the op was lost, the
+     * drain aborted mid-queue and every later persistence tick failed the same way.
+     * <p>
+     * The writers concentrate on a handful of ordinals on purpose: consecutive queue entries for the
+     * same ordinal are what make two concurrent drains collide on it.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void testPersistDuringSustainedWrites(@TempDir final Path tempDir) throws Exception
+    {
+        final int  dimension     = 64;
+        final int  seedCount     = 40;
+        final int  hotOrdinals   = 5;
+        final int  persistRounds = 12;
+        final int  writerThreads = 3;
+        final Path indexDir      = tempDir.resolve("persist_vs_writes");
+
+        final GigaMap<Document> gigaMap = GigaMap.New();
+        final VectorIndices<Document> vectorIndices = gigaMap.index().register(VectorIndices.Category());
+
+        final VectorIndexConfiguration config = VectorIndexConfiguration.builder()
+            .dimension(dimension)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .maxDegree(16)
+            .beamWidth(100)
+            .onDisk(true)
+            .indexDirectory(indexDir)
+            .build();
+
+        try(final VectorIndex<Document> index = vectorIndices.add(
+            "embeddings", config, new ComputedDocumentVectorizer()
+        ))
+        {
+            final Random seedRandom = new Random(42);
+            for(int i = 0; i < seedCount; i++)
+            {
+                gigaMap.add(new Document("seed_" + i, randomVector(seedRandom, dimension)));
+            }
+            index.persistToDisk(); // enter incremental on-disk mode
+
+            final AtomicBoolean    running = new AtomicBoolean(true);
+            final List<Throwable>  errors  = java.util.Collections.synchronizedList(new ArrayList<>());
+            final CountDownLatch   done    = new CountDownLatch(writerThreads);
+            final ExecutorService  executor = Executors.newFixedThreadPool(writerThreads);
+
+            for(int t = 0; t < writerThreads; t++)
+            {
+                final int threadId = t;
+                executor.submit(() ->
+                {
+                    try
+                    {
+                        final Random random = new Random(3000 + threadId);
+                        while(running.get())
+                        {
+                            final long targetId = random.nextInt(hotOrdinals);
+                            synchronized(gigaMap)
+                            {
+                                gigaMap.set(targetId, new Document(
+                                    "hot_" + targetId, randomVector(random, dimension)
+                                ));
+                            }
+                        }
+                    }
+                    catch(final Throwable e)
+                    {
+                        errors.add(e);
+                    }
+                    finally
+                    {
+                        done.countDown();
+                    }
+                });
+            }
+
+            try
+            {
+                for(int round = 0; round < persistRounds; round++)
+                {
+                    index.persistToDisk();
+                }
+            }
+            catch(final Throwable e)
+            {
+                errors.add(e);
+            }
+            finally
+            {
+                running.set(false);
+            }
+
+            assertTrue(done.await(60, TimeUnit.SECONDS), "writer threads should finish");
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+
+            if(!errors.isEmpty())
+            {
+                final StringBuilder sb = new StringBuilder("Persist vs. sustained writes failed");
+                sb.append("\n").append(errors.size()).append(" error(s):");
+                for(final Throwable err : errors)
+                {
+                    sb.append("\n  - ").append(err.getClass().getSimpleName())
+                        .append(": ").append(err.getMessage());
+                }
+                fail(sb.toString());
+            }
+
+            // The index must still answer, and every seed entity must still be reachable exactly once.
+            index.optimize();
+            final VectorSearchResult<Document> result = index.search(
+                randomVector(new Random(999), dimension), 10
+            );
+            assertNotNull(result);
+            assertEquals(
+                result.stream().map(ScoredSearchResult.Entry::entityId).distinct().count(),
+                result.size(),
+                "no entity may be indexed twice"
+            );
         }
     }
 }

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConcurrentStressTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexConcurrentStressTest.java
@@ -1246,8 +1246,8 @@ class VectorIndexConcurrentStressTest
             );
             assertNotNull(result);
             assertEquals(
+                (long)result.size(),
                 result.stream().map(ScoredSearchResult.Entry::entityId).distinct().count(),
-                result.size(),
                 "no entity may be indexed twice"
             );
         }

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexPersistWindowConcurrencyTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexPersistWindowConcurrencyTest.java
@@ -1,0 +1,439 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the persist window: the stretch of {@code doPersistToDisk} Phase 2 during
+ * which the parentMap monitor is released, sync-mode mutations defer their builder ops, and the
+ * in-memory builder is swapped underneath them (internal #142).
+ * <p>
+ * Covered here:
+ * <ul>
+ *   <li>a drain on the persist thread racing a drain on an application thread must not double-add
+ *       an ordinal ({@code IllegalStateException: Node N already exists}), which used to abort the
+ *       drain, lose the op and kill the persist cycle for the rest of the session;</li>
+ *   <li>a persist that races ongoing writes must still re-enter incremental mode instead of falling
+ *       back to full in-memory mode, since the fallback is what put a swapped builder underneath the
+ *       deferred ops in the first place;</li>
+ *   <li>an update whose computed vector did not change must not perform any graph work.</li>
+ * </ul>
+ */
+@Tag("slow")
+class VectorIndexPersistWindowConcurrencyTest
+{
+    static final int DIM             = 64;
+    static final int ENTITY_COUNT    = 60;
+    static final int HOT_ORDINALS    = 4;
+    static final int OPS_PER_ORDINAL = 12;
+    static final int WRITER_BURSTS   = 2;
+    static final int PERSIST_ROUNDS  = 6;
+
+    record Doc(String content, float[] embedding) {}
+
+    /** Computed (non-embedded) vectorizer: the branch the reported stack trace came from. */
+    static class ComputedDocVectorizer extends Vectorizer<Doc>
+    {
+        @Override
+        public float[] vectorize(final Doc entity)
+        {
+            return entity.embedding();
+        }
+    }
+
+    /**
+     * Deterministic pseudo-random unit vector. Two calls with the same seed produce equal but not
+     * identical arrays, so an equality-based fast path is actually exercised.
+     */
+    static float[] vec(final int seed)
+    {
+        // Scramble the seed: java.util.Random's first outputs for nearby seeds are strongly
+        // correlated, which would make "nearest neighbor" assertions depend on luck.
+        final Random random = new Random(seed * 6364136223846793005L + 1442695040888963407L);
+        final float[] vector = new float[DIM];
+        float norm = 0;
+        for(int i = 0; i < DIM; i++)
+        {
+            vector[i] = random.nextFloat() * 2 - 1;
+            norm += vector[i] * vector[i];
+        }
+        norm = (float)Math.sqrt(norm);
+        for(int i = 0; i < DIM; i++)
+        {
+            vector[i] /= norm;
+        }
+        return vector;
+    }
+
+    private static VectorIndexConfiguration diskConfig(final Path indexDirectory)
+    {
+        return VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDirectory)
+            .build();
+    }
+
+    /**
+     * Reads a private field of {@link VectorIndex.Default}. The state under test (incremental mode,
+     * the deferred op queue) is deliberately internal; asserting on it is what makes these tests
+     * fail for the right reason instead of only observing degraded-but-still-correct search.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> T internalState(final VectorIndex<?> index, final String fieldName)
+    {
+        try
+        {
+            final Field field = VectorIndex.Default.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T)field.get(index);
+        }
+        catch(final ReflectiveOperationException e)
+        {
+            throw new AssertionError("cannot read VectorIndex.Default." + fieldName, e);
+        }
+    }
+
+    private static boolean isIncrementalMode(final VectorIndex<?> index)
+    {
+        return internalState(index, "incrementalMode");
+    }
+
+    private static int deferredOpCount(final VectorIndex<?> index)
+    {
+        final Queue<Runnable> queue = internalState(index, "deferredBuilderOps");
+        return queue == null ? 0 : queue.size();
+    }
+
+    /**
+     * Meeting point for the two drains. Timeouts are benign: they only mean the other side did not
+     * reach its drain this round, so the round simply does not collide.
+     *
+     * @return {@code true} if both sides met
+     */
+    private static boolean rendezvous(final CyclicBarrier barrier)
+    {
+        try
+        {
+            barrier.await(2, TimeUnit.SECONDS);
+            return true;
+        }
+        catch(final TimeoutException e)
+        {
+            barrier.reset();
+        }
+        catch(final BrokenBarrierException e)
+        {
+            // the other side timed out and reset the barrier; nothing left to synchronize on
+        }
+        catch(final InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+        }
+        return false;
+    }
+
+
+    // ==================== 1. Concurrent drain must not double-add ====================
+
+    /**
+     * {@code drainDeferredBuilderOps} used to run without any lock: the persist thread drains after
+     * releasing {@code builderLock}, while an application thread drains the same queue holding only
+     * the GigaMap monitor. Two ops for the same ordinal then both observed
+     * {@code containsNode(ordinal) == false} and both called {@code addGraphNode}, so one died with
+     * {@code IllegalStateException: Node N already exists} - aborting the drain (losing the polled
+     * op) and failing every subsequent persistence tick.
+     * <p>
+     * {@code persistPhase2TestHook} queues several ops per hot ordinal inside the persist window and
+     * releases a competing writer; {@code drainEntryTestHook} then parks both threads immediately in
+     * front of the drain so they enter it together.
+     */
+    @Test
+    @Timeout(value = 180, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("unchecked")
+    void concurrentDrainDuringPersistDoesNotDoubleAdd(@TempDir final Path indexDir)
+        throws InterruptedException
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        try(final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+            .add("embeddings", diskConfig(indexDir), new ComputedDocVectorizer()))
+        {
+            final long[] ids = new long[ENTITY_COUNT];
+            for(int i = 0; i < ENTITY_COUNT; i++)
+            {
+                ids[i] = map.add(new Doc("d" + i, vec(i)));
+            }
+            index.persistToDisk(); // enter incremental on-disk mode
+
+            final VectorIndex.Default<Doc> def = (VectorIndex.Default<Doc>)index;
+            final AtomicReference<Throwable> writerFailure = new AtomicReference<>();
+            final AtomicBoolean              writerActive  = new AtomicBoolean();
+            final CyclicBarrier              drainBarrier  = new CyclicBarrier(2);
+            final AtomicBoolean              collided      = new AtomicBoolean();
+
+            // Both the persist thread and the competing writer park here right before draining.
+            def.drainEntryTestHook = () ->
+            {
+                if(rendezvous(drainBarrier))
+                {
+                    collided.set(true);
+                }
+            };
+
+            try
+            {
+                for(int round = 0; round < PERSIST_ROUNDS; round++)
+                {
+                    final int roundIndex = round;
+                    final AtomicReference<Thread> writer = new AtomicReference<>();
+
+                    // Dirty the index, otherwise the persist is skipped as incremental-clean and
+                    // never reaches Phase 2.
+                    map.set(ids[ENTITY_COUNT - 1], new Doc("last", vec(700_000 + roundIndex)));
+
+                    def.persistPhase2TestHook = () ->
+                    {
+                        def.persistPhase2TestHook = null;
+
+                        // Queue a RUN of deferred ops per hot ordinal. Consecutive queue entries for
+                        // the same ordinal are what makes two concurrent drains collide on it, which
+                        // is the shape a bulk load produces (every edge insert re-updates both
+                        // endpoint nodes).
+                        for(int i = 0; i < HOT_ORDINALS; i++)
+                        {
+                            for(int pass = 0; pass < OPS_PER_ORDINAL; pass++)
+                            {
+                                map.set(ids[i], new Doc("d" + i, vec(1_000 + roundIndex * 1_000 + pass * 100 + i)));
+                            }
+                        }
+
+                        writerActive.set(true);
+                        collided.set(false);
+                        final Thread writerThread = new Thread(() ->
+                        {
+                            try
+                            {
+                                // A bounded burst of real updates on the same hot ordinals, so both
+                                // drains find clustered work for the same nodes.
+                                for(int pass = 0; pass < WRITER_BURSTS && writerActive.get(); pass++)
+                                {
+                                    for(int i = 0; i < HOT_ORDINALS; i++)
+                                    {
+                                        for(int repeat = 0; repeat < OPS_PER_ORDINAL; repeat++)
+                                        {
+                                            map.set(ids[i], new Doc("d" + i,
+                                                vec(500_000 + pass * 1_000 + repeat * 100 + i)));
+                                        }
+                                    }
+                                }
+
+                                // Then wait for the drain window with updates that re-set an
+                                // unchanged vector: those still run the drain (and so meet the
+                                // barrier) but queue no further graph work, keeping the queue - and
+                                // the test runtime - bounded.
+                                final float[] parked = vec(600_000);
+                                while(writerActive.get() && !collided.get())
+                                {
+                                    map.set(ids[HOT_ORDINALS], new Doc("parked", parked));
+                                    Thread.sleep(1);
+                                }
+                            }
+                            catch(final InterruptedException e)
+                            {
+                                Thread.currentThread().interrupt();
+                            }
+                            catch(final Throwable t)
+                            {
+                                writerFailure.compareAndSet(null, t);
+                            }
+                        }, "vector-index-competing-writer");
+                        writerThread.setDaemon(true);
+                        writerThread.start();
+                        writer.set(writerThread);
+                    };
+
+                    index.persistToDisk();
+
+                    writerActive.set(false);
+                    final Thread writerThread = writer.get();
+                    if(writerThread != null)
+                    {
+                        writerThread.join(TimeUnit.SECONDS.toMillis(30));
+                    }
+
+                    assertNull(writerFailure.get(),
+                        "a concurrent writer must not observe a builder-op failure in round " + roundIndex);
+                    assertTrue(collided.get(),
+                        "the writer must actually have met the persist thread at the drain in round " + roundIndex);
+                }
+            }
+            finally
+            {
+                writerActive.set(false);
+                def.drainEntryTestHook   = null;
+                def.persistPhase2TestHook = null;
+            }
+
+            // The queue must be fully applied, not stranded by an aborted drain.
+            assertEquals(0, deferredOpCount(index), "deferred builder ops must be fully drained");
+
+            // Normalize to a known state and verify the graph still holds every entity exactly once.
+            for(int i = 0; i < ENTITY_COUNT; i++)
+            {
+                map.set(ids[i], new Doc("d" + i, vec(9_000 + i)));
+            }
+            index.optimize();
+
+            final Set<Long> found = new HashSet<>();
+            for(int i = 0; i < ENTITY_COUNT; i++)
+            {
+                final long hit = index.search(vec(9_000 + i), 1).stream()
+                    .findFirst()
+                    .orElseThrow()
+                    .entityId();
+                assertEquals(ids[i], hit, "entity " + i + " must still be its own nearest neighbor");
+                assertTrue(found.add(hit), "entity " + i + " must not be indexed twice");
+            }
+        }
+    }
+
+
+    // ==================== 2. A persist racing writes must re-enter incremental mode ====================
+
+    /**
+     * {@code reenterIncrementalMode} reloads the file it has just written. It used to validate that
+     * file against the LIVE store witnesses, but persist Phase 2 runs with the parentMap monitor
+     * released, so any mutation landing in that window advances the live counters past the written
+     * graph and the freshly written, perfectly usable file was rejected: "Disk index metadata
+     * mismatch ... will rebuild" followed by "staying in full in-memory mode". That mode flip - a
+     * builder swap between deferral and drain - is the precondition for the double-add crash.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("unchecked")
+    void persistRacingAWriteStaysInIncrementalMode(@TempDir final Path indexDir)
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        try(final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+            .add("embeddings", diskConfig(indexDir), new ComputedDocVectorizer()))
+        {
+            final long[]    ids      = new long[10];
+            final float[][] expected = new float[ids.length][];
+            for(int i = 0; i < ids.length; i++)
+            {
+                expected[i] = vec(i);
+                ids[i]      = map.add(new Doc("d" + i, expected[i]));
+            }
+
+            index.persistToDisk();
+            assertTrue(isIncrementalMode(index), "the first persist must enter incremental mode");
+
+            // Dirty the index, otherwise the next persist is skipped as incremental-clean.
+            expected[1] = vec(101);
+            map.set(ids[1], new Doc("d1", expected[1]));
+
+            final VectorIndex.Default<Doc> def = (VectorIndex.Default<Doc>)index;
+            def.persistPhase2TestHook = () ->
+            {
+                def.persistPhase2TestHook = null;
+                // Advances structuralModCount after the .meta witnesses were captured in Phase 1.
+                expected[0] = vec(777);
+                map.set(ids[0], new Doc("d0", expected[0]));
+            };
+
+            index.persistToDisk();
+
+            assertTrue(isIncrementalMode(index),
+                "a persist racing a write must reload its own output instead of dropping to full in-memory mode");
+            assertEquals(0, deferredOpCount(index), "deferred builder ops must be fully drained");
+
+            // The Phase 2 mutation itself must have survived the re-entry, and so must everything else.
+            assertEquals(ids[0], index.search(expected[0], 1).stream().findFirst().orElseThrow().entityId(),
+                "the mutation that landed in the persist window must be searchable");
+            for(int i = 1; i < ids.length; i++)
+            {
+                assertEquals(ids[i], index.search(expected[i], 1).stream().findFirst().orElseThrow().entityId(),
+                    "entity " + i + " must survive the persist");
+            }
+        }
+    }
+
+
+    // ==================== 3. Unchanged computed vector must be a no-op ====================
+
+    /**
+     * In computed mode the stored vector IS the indexed value, so an update that leaves it untouched
+     * has nothing to do. Without the equality check every {@code update()} paid
+     * {@code markNodeDeleted + removeDeletedNodes + addGraphNode} - two ForkJoinPool round trips per
+     * level - which is what flooded the deferred op queue during a bulk load (internal #142).
+     * {@code structuralModCount} is the observable witness: it is bumped by exactly the
+     * {@code markContentChanged()} that the fast path must skip.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("unchecked")
+    void updateWithUnchangedComputedVectorDoesNoGraphWork(@TempDir final Path indexDir)
+    {
+        final GigaMap<Doc> map = GigaMap.New();
+        try(final VectorIndex<Doc> index = map.index().register(VectorIndices.Category())
+            .add("embeddings", diskConfig(indexDir), new ComputedDocVectorizer()))
+        {
+            final long a = map.add(new Doc("a", vec(0)));
+            final long b = map.add(new Doc("b", vec(1)));
+
+            final VectorIndex.Default<Doc> def = (VectorIndex.Default<Doc>)index;
+            final long modCountAfterAdds = def.structuralModCount;
+
+            // Same vector content (a fresh array), unrelated field changed.
+            map.set(a, new Doc("a-renamed", vec(0)));
+            assertEquals(modCountAfterAdds, def.structuralModCount,
+                "an update that does not change the vector must not count as a structural change");
+            assertEquals(a, index.search(vec(0), 1).stream().findFirst().orElseThrow().entityId(),
+                "the entity must stay searchable by its unchanged vector");
+
+            // A real vector change must still be recorded and applied.
+            map.set(a, new Doc("a-renamed", vec(2)));
+            assertTrue(def.structuralModCount > modCountAfterAdds,
+                "an update that changes the vector must count as a structural change");
+            assertEquals(a, index.search(vec(2), 1).stream().findFirst().orElseThrow().entityId(),
+                "the entity must be searchable by its new vector");
+            assertEquals(b, index.search(vec(1), 1).stream().findFirst().orElseThrow().entityId(),
+                "the untouched entity must be unaffected");
+        }
+    }
+}

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexPersistWindowConcurrencyTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexPersistWindowConcurrencyTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -294,6 +295,10 @@ class VectorIndexPersistWindowConcurrencyTest
                     if(writerThread != null)
                     {
                         writerThread.join(TimeUnit.SECONDS.toMillis(30));
+                        // A writer that outlives its round would keep mutating into the next one and
+                        // make every later assertion depend on timing, so fail here instead.
+                        assertFalse(writerThread.isAlive(),
+                            "the competing writer must terminate before round " + roundIndex + " ends");
                     }
 
                     assertNull(writerFailure.get(),

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexPersistWindowConcurrencyTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexPersistWindowConcurrencyTest.java
@@ -142,8 +142,11 @@ class VectorIndexPersistWindowConcurrencyTest
     }
 
     /**
-     * Meeting point for the two drains. Timeouts are benign: they only mean the other side did not
-     * reach its drain this round, so the round simply does not collide.
+     * Meeting point for the two drains.
+     * <p>
+     * A timeout means the other side never reached its drain, so that round collided with nothing
+     * and proves nothing. It is reported rather than swallowed - the caller asserts on the returned
+     * flag - and the barrier is reset so the next round can still use it.
      *
      * @return {@code true} if both sides met
      */


### PR DESCRIPTION
## Problem

A persist that ran while the map was still being written could kill background persistence for the rest of the session:

```
java.lang.IllegalStateException: Node 234 already exists
    at io.github.jbellis.jvector.graph.ConcurrentNeighborMap.addNode(ConcurrentNeighborMap.java:129)
    at io.github.jbellis.jvector.graph.GraphIndexBuilder.addGraphNode(GraphIndexBuilder.java:612)
    at org.eclipse.store.gigamap.jvector.VectorIndex$Default.lambda$internalUpdate$12(VectorIndex.java:1757)
    at org.eclipse.store.gigamap.jvector.VectorIndex$Default.drainDeferredBuilderOps(VectorIndex.java:3197)
    at org.eclipse.store.gigamap.jvector.VectorIndex$Default.doPersistToDisk(VectorIndex.java:2636)
```

The op that threw was already polled off the queue, the drain aborted mid-queue, and every later persistence tick failed the same way. The index kept serving from memory but never persisted again until restart.

## Root cause

`drainDeferredBuilderOps` held no lock at all. The persist and optimize threads drain after releasing `builderLock`, while an application thread drains - and executes the same kind of op inline via `executeOrDeferBuilderOp` - holding only the GigaMap monitor. Under a bulk load the queue holds many ops for the same ordinal, so two of them both observed `containsNode(ordinal) == false` and both called `addGraphNode`.

Checked against the jvector 4.0.0-rc.8 sources: `OnHeapGraphIndex.containsNode` inspects layer 0 only, and `addNode` is a non-atomic loop over layers `0..level` with no rollback. So besides the plain check-then-act race, an interleaved add/remove can leave a node in an upper layer only, where the guard cannot see it but the add still collides.

## Changes

**The drain is serialized** under `synchronized(parentMap())` - the only lock the sync-mode mutation paths hold, and the outermost lock at that point (the persist/optimize drains hold nothing), so no inversion is introduced. `builder` and `index` become volatile, and every graph-mutating op reads the builder once into a local and derives the graph from it, so a guard can no longer authorize a mutation against a different builder.

**The deferred ops are idempotent and self-deriving.** `internalReplaceGraphNode`, `internalAddGraphNodeIdempotent`, `internalReaddGraphNode` and `internalResurrectGraphNode` all re-check the current builder when they run, instead of relying on state captured at deferral time. The replace path purges the ordinal from all layers before re-adding, which also repairs a layer-skewed node left by an earlier interleaved add/remove.

**The queue is never stranded.** A failing op is logged and skipped rather than aborting the drain, the drain moved into the `finally` of `doPersistToDisk`/`doOptimize` so no early return can leave ops behind, and `internalRemoveAll` clears it.

**Two related holes in the same family are closed.** Deletions (`internalRemove`, and `internalUpdate` on vec to null) now enqueue unconditionally, because gating on the current in-memory graph queued nothing for a disk-only node whose eager `diskDeletedOrdinals` entry a concurrent persist then wiped. And every op that removes or re-adds an ordinal records into `diskDeletedOrdinals` when it runs, since `reenterIncrementalMode` allocates a fresh set and an entry made before deferral is gone by drain time.

**`reenterIncrementalMode` no longer validates the file it just wrote against live store state** (observation 1 in the issue). Phase 2 runs with the parentMap monitor released, so under sustained writes the live witnesses always advance past the written graph and the freshly written index was rejected - "Disk index metadata mismatch, will rebuild" followed by "staying in full in-memory mode". That mode flip is the builder swap that put a stale premise underneath the deferred ops in the first place. `DiskIndexManager` gains `tryLoad(MetaState)`, and re-entry compares the `.meta` against the witnesses captured in Phase 1. The load-time self-heal path is untouched, and crash-restart safety is unchanged: the store counter legitimately exceeds the `.meta` counter afterwards, so a restart before the next persist still rebuilds from the store.

**The computed update path gets the unchanged-vector fast path the embedded path already had** (observation 2). Every `update()` used to pay `markNodeDeleted + removeDeletedNodes + addGraphNode` - two ForkJoinPool round trips per level - even when the vector was identical. That is what floods the deferred queue during a bulk load in the first place; the reporter measured ~40-46ms per edge insert in pure vector-graph repair for vectors that never changed.

## Tests

New `VectorIndexPersistWindowConcurrencyTest`, plus `testPersistDuringSustainedWrites` in `VectorIndexConcurrentStressTest`. A `drainEntryTestHook` seam (alongside the existing `persistPhase2TestHook`) lets a test park the persist thread and a competing writer in front of the drain so they enter it together.

Each test was verified to fail without its fix:

| Test | Without the fix |
| --- | --- |
| `concurrentDrainDuringPersistDoesNotDoubleAdd` | `IllegalStateException: Node 0 already exists` in round 0, on all 3 reruns |
| `persistRacingAWriteStaysInIncrementalMode` | drops to full in-memory mode |
| `updateWithUnchangedComputedVectorDoesNoGraphWork` | `structuralModCount` bumped by a no-op update |

`mvn -pl gigamap,gigamap/jvector -am test -Pslow-tests` is green: 39 gigamap + 125 jvector tests.
