### PR TITLE
GigaMap: an index failure during apply()/update() no longer deletes the committed entity

### DIFF
--- a/docs/modules/gigamap/pages/constraints.adoc
+++ b/docs/modules/gigamap/pages/constraints.adoc
@@ -207,3 +207,5 @@ What happens to the map on violation depends on the operation:
 |`update` / `apply`
 |The offending entity is **removed** from the map. The provided logic mutates the entity in place, so a constraint failure cannot be rolled back to the previous state — the only consistent option is to drop the entry. The removed entity and its id are carried by the `ConstraintViolationException` (`violatingEntity`, `entityId`), so the caller can recover or re-add it after fixing the violation.
 |===
+
+NOTE: Only a *constraint* violation removes the entity — a constraint is what decides whether an entity may exist at all. A failure of an *index* does not: if an indexer throws for the new value, or an index implementation rejects it (e.g. a Lucene term over its length limit, an embedding of the wrong dimension, or a stale index), the entity is kept and the exception is rethrown. The indices may then be out of sync with the retained entity; rebuild them with `reindex()`. A custom constraint that signals a violation by throwing something other than a `ConstraintViolationException` is treated like an index failure, i.e. non-destructively.

--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -89,7 +89,9 @@ The two are alternatives, not steps: an `update` after a direct modification doe
 
 Entities modified through `update` (or `apply`) are automatically persisted when calling `store()`. See xref:persistence.adoc[] for details.
 
-WARNING: Because `update` / `apply` mutate the entity in place, a constraint violation triggered by the new state cannot be rolled back. The GigaMap therefore **removes** the offending entity from the map and rethrows the `ConstraintViolationException`. See xref:constraints.adoc#_constraint_violations[Constraints — Constraint Violations] for the full rollback semantics across CRUD operations.
+WARNING: Because `update` / `apply` mutate the entity in place, a constraint violation triggered by the new state cannot be rolled back. The GigaMap therefore **removes** the offending entity from the map and rethrows the `ConstraintViolationException`. The same applies to an exception thrown by the update logic itself, which leaves the entity partially mutated. See xref:constraints.adoc#_constraint_violations[Constraints — Constraint Violations] for the full rollback semantics across CRUD operations.
+
+NOTE: A failure of an *index* is not destructive: if an indexer throws for the new value, or an index implementation rejects it (e.g. a Lucene term over its length limit, an embedding of the wrong dimension, or a stale index), the entity's own data is still the value the logic produced, so `update` / `apply` keep the entity and only rethrow the exception. The indices may then be out of sync with it — repair them with `reindex()`.
 
 === Updating by Entity Id
 

--- a/docs/modules/gigamap/pages/persistence.adoc
+++ b/docs/modules/gigamap/pages/persistence.adoc
@@ -109,7 +109,7 @@ This matters when an *indexed* field's class layout evolves between releases. {p
 Evolving an *indexed* field without a value-preserving refactoring mapping leaves the indices stale — with the same consequences as a direct (untracked) mutation:
 
 * Queries return pre-evolution results: `is(oldValue)` still matches, `is(actualValue)` returns nothing. Only `reindex()` restores correct query results.
-* A subsequent `update` / `apply` / `set` that writes the entity's true value may fail with a `StaleIndexException`. The committed entity is **not** deleted by this: a stale index never causes a phantom unique-constraint violation against the entity's own entry, and a stale-index failure retains the entity rather than removing it. You still need to `reindex()` to make the index consistent again.
+* A subsequent `update` / `apply` / `set` that writes the entity's true value may fail with a `StaleIndexException`. The committed entity is **not** deleted by this: a stale index never causes a phantom unique-constraint violation against the entity's own entry, and — like any other index failure — a stale-index failure retains the entity rather than removing it. You still need to `reindex()` to make the index consistent again.
 
 After evolving an indexed field, rebuild every index from the current entity state with `reindex()` **before** running any query or update, then `store()`:
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -668,6 +668,15 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		private transient boolean[]                    cachedIsUniqueIndex     ;
 		private transient ChangeHandler[]              cachedPrevChangeHandlers;
 		private transient ChangeHandler[]              cachedNewChangeHandlers ;
+
+		/**
+		 * Whether the current update already moved entries from the prepared previous state to the new
+		 * state. Only relevant between {@link #internalPrepareIndicesUpdate(Object)} and
+		 * {@link #internalFinishIndicesUpdate()}: once set, the prepared previous state no longer
+		 * describes what is in the indices, so {@link #internalRemovePreparedState(long)} must not use
+		 * it any more.
+		 */
+		private transient boolean                      cachedStateChangeApplied;
 		
 		
 		///////////////////////////////////////////////////////////////////////////
@@ -713,6 +722,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				this.cachedPrevChangeHandlers[i] = null;
 				this.cachedNewChangeHandlers[i]  = null;
 			}
+			this.cachedStateChangeApplied = false;
 		}
 		
 		@SuppressWarnings("unchecked")
@@ -1244,6 +1254,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				return;
 			}
 
+			this.cachedStateChangeApplied = false;
+
 			// Derive state handlers for the state of the replaced entity.
 			this.createChangeHandlers(this.cachedPrevChangeHandlers, replacedEntity);
 		}
@@ -1261,14 +1273,40 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		}
 		
 		@Override
-		public final void internalUpdateIndices(
-			final long                         entityId         ,
-			final E                            replacedEntity   ,
-			final E                            entity           ,
-			final CustomConstraints<? super E> customConstraints
-		)
+		public final void internalRemovePreparedState(final long entityId)
 		{
-			this.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints, false);
+			if(this.bitmapIndices.isEmpty())
+			{
+				// no-op
+				return;
+			}
+
+			if(this.cachedStateChangeApplied)
+			{
+				/*
+				 * The entries were already moved to the entity's new state, which the removal re-derives
+				 * from that same state and can therefore locate itself. The prepared previous state no
+				 * longer describes anything that is in the indices.
+				 */
+				return;
+			}
+
+			/*
+			 * The cached prev handlers de-index the entity's previous state without re-running any user
+			 * code, which is exactly what a removal that re-derives the keys from the entity's mutated
+			 * state cannot do.
+			 */
+			try
+			{
+				for(final ChangeHandler cachedPrevChangeHandler : this.cachedPrevChangeHandlers)
+				{
+					cachedPrevChangeHandler.removeFromIndex(entityId);
+				}
+			}
+			finally
+			{
+				this.markStateChangeChildren();
+			}
 		}
 
 		@Override
@@ -1276,8 +1314,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			final long                         entityId         ,
 			final E                            replacedEntity   ,
 			final E                            entity           ,
-			final CustomConstraints<? super E> customConstraints,
-			final boolean                      removeOnFailure
+			final CustomConstraints<? super E> customConstraints
 		)
 		{
 			if(this.bitmapIndices.isEmpty())
@@ -1290,64 +1327,36 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			 * Phase 1: derive the new change handlers and run all checks. This is where all user code
 			 * (indexers, key equality, constraints) runs; no index state has been mutated, yet, since
 			 * handler derivation defers entry creation to changeInIndex (see NewKeyChangeChandler).
+			 * A throw here therefore needs no cleanup in this group: whether the entity's previous state
+			 * must be de-indexed depends on whether the calling context keeps or removes the entity,
+			 * which only that context can decide (see IndexGroup.Internal#internalRemovePreparedState).
 			 */
-			try
+			// Derive state handlers for the new, potentially changed state
+			this.createChangeHandlers(this.cachedNewChangeHandlers, entity);
+
+			if(customConstraints != null)
 			{
-				// Derive state handlers for the new, potentially changed state
-				this.createChangeHandlers(this.cachedNewChangeHandlers, entity);
-
-				if(customConstraints != null)
-				{
-					customConstraints.check(entityId, replacedEntity, entity);
-				}
-
-				// Evaluate changes for each index
-				for(int i = 0; i < this.cachedPrevChangeHandlers.length; i++)
-				{
-					if(this.cachedPrevChangeHandlers[i].isEqual(this.cachedNewChangeHandlers[i]))
-					{
-						// Mark index position to be irrelevant (unchanged)
-						this.cachedNewChangeHandlers[i] = null;
-						continue;
-					}
-					if(this.cachedIsUniqueIndex[i])
-					{
-						// A key held only by the entity being updated (e.g. its own stale entry after a
-						// class evolution) is not a duplicate; only a different entity is a violation.
-						if(this.cachedIndices[i].internalContains(entity, entityId))
-						{
-							throw new UniqueConstraintViolationExceptionBitmap(entityId, replacedEntity, entity, this.cachedIndices[i]);
-						}
-					}
-				}
+				customConstraints.check(entityId, replacedEntity, entity);
 			}
-			catch(final RuntimeException e)
+
+			// Evaluate changes for each index
+			for(int i = 0; i < this.cachedPrevChangeHandlers.length; i++)
 			{
-				if(removeOnFailure)
+				if(this.cachedPrevChangeHandlers[i].isEqual(this.cachedNewChangeHandlers[i]))
 				{
-					/*
-					 * The calling context removes the in-place mutated entity from the map on failure,
-					 * so this entity's previous state must be de-indexed as well. The cached prev
-					 * handlers accomplish that without re-running any user code.
-					 */
-					try
+					// Mark index position to be irrelevant (unchanged)
+					this.cachedNewChangeHandlers[i] = null;
+					continue;
+				}
+				if(this.cachedIsUniqueIndex[i])
+				{
+					// A key held only by the entity being updated (e.g. its own stale entry after a
+					// class evolution) is not a duplicate; only a different entity is a violation.
+					if(this.cachedIndices[i].internalContains(entity, entityId))
 					{
-						for(final ChangeHandler cachedPrevChangeHandler : this.cachedPrevChangeHandlers)
-						{
-							cachedPrevChangeHandler.removeFromIndex(entityId);
-						}
-					}
-					catch(final RuntimeException suppressed)
-					{
-						e.addSuppressed(suppressed);
-					}
-					finally
-					{
-						this.markStateChangeChildren();
+						throw new UniqueConstraintViolationExceptionBitmap(entityId, replacedEntity, entity, this.cachedIndices[i]);
 					}
 				}
-				// without removeOnFailure nothing was mutated, so no state change marking, either.
-				throw e;
 			}
 
 			// Phase 2: update indices for all actual changes. Runs no more user code apart from key hashing.
@@ -1360,6 +1369,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					{
 						continue;
 					}
+					// from here on the prepared previous state no longer describes the indices' content.
+					this.cachedStateChangeApplied = true;
 					this.cachedNewChangeHandlers[i].changeInIndex(entityId, this.cachedPrevChangeHandlers[i]);
 				}
 			}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -670,8 +670,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		private transient ChangeHandler[]              cachedNewChangeHandlers ;
 
 		/**
-		 * Whether the current update already moved entries from the prepared previous state to the new
-		 * state. Only relevant between {@link #internalPrepareIndicesUpdate(Object)} and
+		 * Whether the current update already moved at least one entry from the prepared previous state
+		 * to the new state. Only relevant between {@link #internalPrepareIndicesUpdate(Object)} and
 		 * {@link #internalFinishIndicesUpdate()}: once set, the prepared previous state no longer
 		 * describes what is in the indices, so {@link #internalRemovePreparedState(long)} must not use
 		 * it any more.
@@ -1369,9 +1369,15 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					{
 						continue;
 					}
-					// from here on the prepared previous state no longer describes the indices' content.
-					this.cachedStateChangeApplied = true;
 					this.cachedNewChangeHandlers[i].changeInIndex(entityId, this.cachedPrevChangeHandlers[i]);
+
+					/*
+					 * Set only after a change went through: changeInIndex de-indexes the previous key
+					 * first, so a throw from the very first one (notably the stale-index path) leaves
+					 * this group's entries untouched - and the prepared previous state then still
+					 * describes them exactly, which is what makes the cleanup valid.
+					 */
+					this.cachedStateChangeApplied = true;
 				}
 			}
 			finally

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -20,7 +20,6 @@ import org.eclipse.serializer.persistence.types.Storer;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.function.Function;
 
 import static org.eclipse.serializer.util.X.notNull;
 
@@ -341,11 +340,11 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 					try
 					{
 						/*
-						 * removeOnFailure == false: the calling context (set/replace) keeps the replaced
-						 * entity in place when the update fails, so the previous index entries must
-						 * remain untouched.
+						 * The calling context (set/replace) keeps the replaced entity in place when the
+						 * update fails, so the previous index entries must remain untouched: no
+						 * internalRemovePreparedState here.
 						 */
-						indexGroup.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints, false);
+						indexGroup.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints);
 					}
 					finally
 					{
@@ -399,72 +398,127 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 		}
 
 		/**
-		 * Second phase of an in-place entity update: executes the mutating logic and updates all
-		 * index groups from the entity's resulting state. Must be preceded by a successful
+		 * Second phase of an in-place entity update: updates all index groups from the entity's state
+		 * as the update logic left it. Must be preceded by a successful
 		 * {@link #internalPrepareUpdate(Object)}.
+		 * <p>
+		 * If a group fails, the calling context decides whether the entity survives. It removes the
+		 * entity only if the exception rejects the entity itself instead of just the derived index (see
+		 * {@link GigaMap.Default#isEntityRejected(Throwable)}); that removal re-derives the keys from
+		 * the entity's mutated state, so the groups that did not get to update - the failing one and
+		 * all after it - de-index the entity's previous state here. The groups before the failing one
+		 * already carry the new state, which the removal locates by itself.
 		 */
-		<R> R internalApplyUpdate(
+		void internalApplyUpdate(
 			final long                         entityId         ,
 			final E                            entity           ,
-			final Function<? super E, R>       logic            ,
 			final CustomConstraints<? super E> customConstraints
 		)
 		{
+			int updated = 0;
 			try
 			{
-				R result;
 				try
 				{
-					result = logic.apply(entity);
+					for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+					{
+						indexGroup.internalUpdateIndices(entityId, entity, entity, customConstraints);
+						updated++;
+					}
 				}
 				catch(final RuntimeException e)
 				{
-					/*
-					 * The logic threw: the entity's state is unreliable and the calling context will
-					 * remove the entity. The indices are still updated from the entity's current state
-					 * so that the subsequent removal, which re-derives the keys from that same state,
-					 * can locate all entries. This runs best-effort per group so every group gets its
-					 * chance to align; a group whose own update fails de-indexes its previous entries
-					 * via the prepared change handlers instead (removeOnFailure) and the failure is
-					 * attached as a suppressed exception. Custom constraints are not checked; the
-					 * entity is doomed either way.
-					 */
-					for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+					if(GigaMap.Default.isEntityRejected(e))
 					{
-						try
-						{
-							indexGroup.internalUpdateIndices(entityId, entity, entity, null, true);
-						}
-						catch(final RuntimeException suppressed)
-						{
-							e.addSuppressed(suppressed);
-						}
+						this.internalRemovePreparedState(entityId, updated, e);
 					}
+					this.internalFinishUpdate(e);
 					throw e;
 				}
 
-				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
-				{
-					/*
-					 * removeOnFailure == true: the calling context removes the in-place mutated entity
-					 * from the map when the update fails, so on failure a group must de-index the
-					 * entity's previous state via its prepared change handlers.
-					 */
-					indexGroup.internalUpdateIndices(entityId, entity, entity, customConstraints, true);
-				}
-
 				this.internalFinishUpdate(null);
-
-				return result;
-			}
-			catch(final RuntimeException e)
-			{
-				this.internalFinishUpdate(e);
-				throw e;
 			}
 			finally
 			{
 				this.markStateChangeChildren();
+			}
+		}
+
+		/**
+		 * Aligns the indices with an entity whose update logic threw: that entity's state is unreliable
+		 * and the calling context removes it, so the indices are updated from the entity's current
+		 * state to let the subsequent removal, which re-derives the keys from that same state, locate
+		 * all entries.
+		 * <p>
+		 * This runs best-effort per group so every group gets its chance to align; a group whose own
+		 * update fails de-indexes its previous entries via the prepared state instead and the failure
+		 * is attached to the logic's exception as a suppressed exception. Custom constraints are not
+		 * checked, the entity is doomed either way.
+		 */
+		void internalApplyLogicFailure(
+			final long             entityId    ,
+			final E                entity      ,
+			final RuntimeException logicFailure
+		)
+		{
+			try
+			{
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					try
+					{
+						indexGroup.internalUpdateIndices(entityId, entity, entity, null);
+					}
+					catch(final RuntimeException suppressed)
+					{
+						logicFailure.addSuppressed(suppressed);
+						try
+						{
+							indexGroup.internalRemovePreparedState(entityId);
+						}
+						catch(final RuntimeException alsoSuppressed)
+						{
+							logicFailure.addSuppressed(alsoSuppressed);
+						}
+					}
+				}
+				this.internalFinishUpdate(logicFailure);
+			}
+			finally
+			{
+				this.markStateChangeChildren();
+			}
+		}
+
+		/**
+		 * De-indexes the entity's previous state in all index groups from the given position on,
+		 * attaching failures to the given exception as suppressed exceptions.
+		 *
+		 * @param entityId the entity's id
+		 * @param skipCount the number of leading index groups that already carry the entity's new state
+		 * @param failure the exception that caused the cleanup
+		 */
+		private void internalRemovePreparedState(
+			final long             entityId ,
+			final int              skipCount,
+			final RuntimeException failure
+		)
+		{
+			int i = 0;
+			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			{
+				if(i++ < skipCount)
+				{
+					continue;
+				}
+				try
+				{
+					indexGroup.internalRemovePreparedState(entityId);
+				}
+				catch(final RuntimeException suppressed)
+				{
+					failure.addSuppressed(suppressed);
+				}
 			}
 		}
 

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -2412,8 +2412,9 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				/*
 				 * The logic mutated the entity in place and a state change done by custom logic cannot be
 				 * rolled back, so the entity's state is unreliable: there is no other choice but to remove
-				 * it from the map and report it, along with its entityId, to the calling context in the
-				 * exception.
+				 * it from the map. The logic's own exception is rethrown unchanged - unlike a constraint
+				 * violation it carries no entity/entityId, so the caller only learns which entity was
+				 * dropped from the arguments it passed in.
 				 */
 				this.indices.internalApplyLogicFailure(entityId, current, e);
 				this.removeAfterFailedApply(entityId, e);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -431,12 +431,11 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * non-destructive semantics are required - passing a corrected, separate instance, since those methods
 	 * reject the instance the map already holds.
 	 * <p>
-	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
-	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
-	 * may have (partially) mutated the entity: the entity is removed from the map and the original
-	 * exception is rethrown, with cleanup failures attached as suppressed exceptions. Only exceptions
-	 * thrown while the entity's <em>pre-update</em> state is being indexed (i.e. before {@code logic}
-	 * runs) abort cleanly and leave the map and the entity unchanged.
+	 * <b>Behavior on other exceptions:</b> the destructive-removal contract also applies to a
+	 * {@link RuntimeException} thrown by {@code logic} itself, which leaves the entity partially mutated
+	 * and thus unreliable: the entity is removed from the map and the original exception is rethrown,
+	 * with cleanup failures attached as suppressed exceptions. It does <em>not</em> apply to a failure of
+	 * an <em>index</em> - see the corresponding section of {@link #apply(Object, Function)}.
 	 *
 	 * @param current the entity to be updated
 	 * @param logic the update logic to be executed
@@ -477,8 +476,8 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * {@link ConstraintViolationException ConstraintViolationException} is thrown <em>and the entity is
 	 * removed from this GigaMap</em>, because the in-place mutation cannot be rolled back. The same
 	 * destructive-removal contract applies to any other {@link RuntimeException} thrown by {@code logic}
-	 * or by an {@link Indexer} once {@code logic} may have mutated the entity; exceptions thrown while
-	 * the <em>pre-update</em> state is being indexed abort cleanly and leave the map unchanged.
+	 * itself, but <em>not</em> to a failure of an index - see the corresponding section of
+	 * {@link #apply(long, Function)}.
 	 *
 	 * @param entityId the id of the entity to be updated
 	 * @param logic the update logic to be executed
@@ -529,20 +528,23 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * non-destructive semantics are required - passing a corrected, separate instance, since those methods
 	 * reject the instance the map already holds.
 	 * <p>
-	 * A <em>stale index</em> (persisted index keys no longer matching the entities, e.g. after a direct
-	 * mutation of an indexed field or entity class evolution) is treated as a special case so it can
-	 * <em>never</em> destroy a committed entity: a write of the entity's true value is not mistaken for a
-	 * duplicate merely because of the entity's own stale entry (a unique violation requires a
-	 * <em>different</em> entity), and if a stale index cannot be updated in place, this method retains the
-	 * entity and throws a {@link org.eclipse.store.gigamap.exceptions.StaleIndexException} instead of
-	 * removing it. Rebuild the indices with {@link #reindex()} to restore correct query results.
+	 * <b>Behavior on an index failure (non-destructive):</b> if updating a derived <em>index</em> fails,
+	 * the entity is <em>kept</em> and the original exception is rethrown. The entity's own data is the
+	 * value {@code logic} produced; only the index could not represent it - be it an {@link Indexer} that
+	 * threw for the new value, an index implementation that rejected it (e.g. a Lucene term over its
+	 * length limit or an embedding of the wrong dimension), or a <em>stale index</em> whose persisted keys
+	 * no longer match the keys re-derived from the (e.g. class-evolved) entities, which is reported as a
+	 * {@link StaleIndexException}. A stale index also never makes a write of the entity's true value be
+	 * mistaken for a duplicate: a unique violation requires a <em>different</em> entity. The indices may be
+	 * left out of sync with the retained entity in all these cases; rebuild them with {@link #reindex()}
+	 * to restore correct query results.
 	 * <p>
-	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
-	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
-	 * may have (partially) mutated the entity: the entity is removed from the map and the original
-	 * exception is rethrown, with cleanup failures attached as suppressed exceptions. Only exceptions
-	 * thrown while the entity's <em>pre-application</em> state is being indexed (i.e. before {@code logic}
-	 * runs) abort cleanly and leave the map and the entity unchanged.
+	 * <b>Behavior on other exceptions:</b> the destructive-removal contract also applies to any other
+	 * {@link RuntimeException} thrown by {@code logic} itself, which leaves the entity partially mutated
+	 * and thus unreliable: the entity is removed from the map and the original exception is rethrown, with
+	 * cleanup failures attached as suppressed exceptions. Exceptions thrown while the entity's
+	 * <em>pre-application</em> state is being indexed (i.e. before {@code logic} runs) abort cleanly and
+	 * leave the map and the entity unchanged.
 	 *
 	 * @param current the entity to be updated
 	 * @param logic the logic to be executed
@@ -580,20 +582,23 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * non-destructive semantics are required - passing a corrected, separate instance, since {@code set}
 	 * rejects the instance the map already holds.
 	 * <p>
-	 * A <em>stale index</em> (persisted index keys no longer matching the entities, e.g. after a direct
-	 * mutation of an indexed field or entity class evolution) is treated as a special case so it can
-	 * <em>never</em> destroy a committed entity: a write of the entity's true value is not mistaken for a
-	 * duplicate merely because of the entity's own stale entry (a unique violation requires a
-	 * <em>different</em> entity), and if a stale index cannot be updated in place, this method retains the
-	 * entity and throws a {@link org.eclipse.store.gigamap.exceptions.StaleIndexException} instead of
-	 * removing it. Rebuild the indices with {@link #reindex()} to restore correct query results.
+	 * <b>Behavior on an index failure (non-destructive):</b> if updating a derived <em>index</em> fails,
+	 * the entity is <em>kept</em> and the original exception is rethrown. The entity's own data is the
+	 * value {@code logic} produced; only the index could not represent it - be it an {@link Indexer} that
+	 * threw for the new value, an index implementation that rejected it (e.g. a Lucene term over its
+	 * length limit or an embedding of the wrong dimension), or a <em>stale index</em> whose persisted keys
+	 * no longer match the keys re-derived from the (e.g. class-evolved) entities, which is reported as a
+	 * {@link StaleIndexException}. A stale index also never makes a write of the entity's true value be
+	 * mistaken for a duplicate: a unique violation requires a <em>different</em> entity. The indices may be
+	 * left out of sync with the retained entity in all these cases; rebuild them with {@link #reindex()}
+	 * to restore correct query results.
 	 * <p>
-	 * <b>Behavior on other exceptions:</b> the same destructive-removal contract applies to any other
-	 * {@link RuntimeException} thrown by {@code logic} itself or by an {@link Indexer} once {@code logic}
-	 * may have (partially) mutated the entity: the entity is removed from the map and the original
-	 * exception is rethrown, with cleanup failures attached as suppressed exceptions. Only exceptions
-	 * thrown while the entity's <em>pre-application</em> state is being indexed (i.e. before {@code logic}
-	 * runs) abort cleanly and leave the map and the entity unchanged.
+	 * <b>Behavior on other exceptions:</b> the destructive-removal contract also applies to any other
+	 * {@link RuntimeException} thrown by {@code logic} itself, which leaves the entity partially mutated
+	 * and thus unreliable: the entity is removed from the map and the original exception is rethrown, with
+	 * cleanup failures attached as suppressed exceptions. Exceptions thrown while the entity's
+	 * <em>pre-application</em> state is being indexed (i.e. before {@code logic} runs) abort cleanly and
+	 * leave the map and the entity unchanged.
 	 *
 	 * @param entityId the id of the entity the logic is applied to
 	 * @param logic the logic to be executed
@@ -2397,72 +2402,112 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 			 */
 			this.indices.internalPrepareUpdate(current);
 
+			final R result;
 			try
 			{
-				final R result = this.indices.internalApplyUpdate(entityId, current, logic, this.constraints.custom());
-
-				this.retainMutatedEntity(entityId, current);
-
-				return result;
+				result = logic.apply(current);
 			}
 			catch(final RuntimeException e)
 			{
-				this.ensureClearedAddingState();
-
 				/*
-				 * A stale index is a special case: the failure means the persisted index keys no longer
-				 * match the keys re-derived from the (e.g. class-evolved) entities, NOT that the entity's
-				 * data is bad. Removing the entity here would be a real data loss for a still-valid,
-				 * committed entity - and the removal itself, re-deriving the same stale keys, cannot even
-				 * de-index it correctly. So the committed entity is retained and the exception is rethrown,
-				 * directing the caller to rebuild the indices via reindex(). See StaleIndexException.
+				 * The logic mutated the entity in place and a state change done by custom logic cannot be
+				 * rolled back, so the entity's state is unreliable: there is no other choice but to remove
+				 * it from the map and report it, along with its entityId, to the calling context in the
+				 * exception.
 				 */
-				if(isStaleIndexFailure(e))
+				this.indices.internalApplyLogicFailure(entityId, current, e);
+				this.removeAfterFailedApply(entityId, e);
+				throw e;
+			}
+
+			try
+			{
+				this.indices.internalApplyUpdate(entityId, current, this.constraints.custom());
+			}
+			catch(final RuntimeException e)
+			{
+				/*
+				 * Only the entity itself being rejected justifies destroying it: a constraint decides
+				 * whether an entity may exist at all, so its violation is answered with the documented
+				 * removal. A failure of a derived index is not: the entity's own data is the value the
+				 * logic produced, only the index could not represent it - be it an indexer that threw for
+				 * the new value, an index implementation that rejected it (e.g. a Lucene term over its
+				 * length limit), or an index that is stale because its persisted keys no longer match the
+				 * keys re-derived from the (e.g. class-evolved) entities. Removing the entity in those
+				 * cases would be a real data loss for a still-valid, committed entity - and a removal
+				 * re-deriving the same failing keys could not even de-index it correctly. So the committed
+				 * entity is retained and the exception is rethrown, directing the caller to rebuild the
+				 * indices via reindex(). See StaleIndexException.
+				 */
+				if(isEntityRejected(e))
 				{
-					/*
-					 * The update logic already mutated the entity in place and we keep it. Give it the SAME
-					 * persistence bookkeeping as a successful mutation - pin the segment and track it for
-					 * re-storing - so a later reindex() + store() persists both the rebuilt index and the
-					 * mutated entity. Skipping this would let store() persist the rebuilt index while
-					 * silently skipping the (same-identity) entity, reintroducing entity/index divergence
-					 * after a restart.
-					 */
-					this.retainMutatedEntity(entityId, current);
+					this.removeAfterFailedApply(entityId, e);
 					throw e;
 				}
 
+				this.ensureClearedAddingState();
+
 				/*
-				 * Since a state change done by a custom logic cannot be rolled back, there is no other choice
-				 * but to remove the entity from the map and report the entity and entityId to the calling
-				 * context in the exception. This applies not only to constraint violations but to any
-				 * exception thrown by the update logic or an indexer once the logic may have run: in all
-				 * those cases the entity's state is unreliable. The removal completes best-effort;
-				 * cleanup failures are attached as suppressed exceptions.
+				 * The update logic already mutated the entity in place and we keep it. Give it the SAME
+				 * persistence bookkeeping as a successful mutation - pin the segment and track it for
+				 * re-storing - so a later reindex() + store() persists both the rebuilt index and the
+				 * mutated entity. Skipping this would let store() persist the rebuilt index while silently
+				 * skipping the (same-identity) entity, reintroducing entity/index divergence after a
+				 * restart.
 				 */
-				try
-				{
-					this.internalRemove(entityId);
-				}
-				catch(final RuntimeException suppressed)
-				{
-					e.addSuppressed(suppressed);
-				}
+				this.retainMutatedEntity(entityId, current);
 				throw e;
+			}
+
+			this.retainMutatedEntity(entityId, current);
+
+			return result;
+		}
+
+		/**
+		 * Removes an entity whose in-place update failed in a way that makes the entity itself invalid.
+		 * The removal completes best-effort; cleanup failures are attached to the causing exception as
+		 * suppressed exceptions.
+		 */
+		private void removeAfterFailedApply(final long entityId, final RuntimeException failure)
+		{
+			this.ensureClearedAddingState();
+
+			try
+			{
+				this.internalRemove(entityId);
+			}
+			catch(final RuntimeException suppressed)
+			{
+				failure.addSuppressed(suppressed);
 			}
 		}
 
 		/**
 		 * Detects whether the given throwable, or anything reachable through its cause and suppressed
-		 * throwables (recursively), is a {@link StaleIndexException} - i.e. signals that an index is out of
-		 * date rather than that the entity's data is bad. Used to keep {@link #internalApply} from
-		 * destroying a still-valid, committed entity when only the index is stale.
+		 * throwables (recursively), is a {@link ConstraintViolationException} - i.e. signals that the
+		 * entity itself was rejected rather than that only a derived index failed. This is what decides
+		 * whether a failed in-place update destroys the committed entity (see {@link #internalApply}):
+		 * a constraint decides whether an entity may exist at all, an index does not.
+		 * <p>
+		 * A constraint that does not comply with the {@link CustomConstraint} API and throws some other
+		 * exception type instead is treated like an index failure, i.e. non-destructively.
+		 */
+		static boolean isEntityRejected(final Throwable t)
+		{
+			return containsThrowable(t, ConstraintViolationException.class);
+		}
+
+		/**
+		 * Detects whether the given throwable, or anything reachable through its cause and suppressed
+		 * throwables (recursively), is an instance of the given type.
 		 * <p>
 		 * The JDK offers no ready-made utility for this ({@link Throwable} exposes only
 		 * {@link Throwable#getCause()} and {@link Throwable#getSuppressed()}), so the full graph is walked
 		 * here. An identity-based visited set guards against cyclic cause/suppressed graphs, mirroring how
 		 * {@link Throwable#printStackTrace()} avoids infinite loops internally.
 		 */
-		private static boolean isStaleIndexFailure(final Throwable t)
+		private static boolean containsThrowable(final Throwable t, final Class<?> type)
 		{
 			if(t == null)
 			{
@@ -2480,7 +2525,7 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 				{
 					continue;
 				}
-				if(current instanceof StaleIndexException)
+				if(type.isInstance(current))
 				{
 					return true;
 				}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
@@ -69,34 +69,22 @@ public interface IndexGroup<E> extends GigaMap.Component<E>
 		public void internalUpdateIndices(long entityId, E replacedEntity, E entity, CustomConstraints<? super E> customConstraints);
 
 		/**
-		 * Variant of {@link #internalUpdateIndices(long, Object, Object, CustomConstraints)} that
-		 * additionally states how a failure is to be handled.
+		 * De-indexes the entity's previous state, i.e. the state prepared via
+		 * {@link #internalPrepareIndicesUpdate(Object)}, without running any user code again.
 		 * <p>
-		 * With {@code removeOnFailure == true} the calling context signals that the entity was mutated
-		 * in place and will be removed from the map if the update fails, so on a failure this group
-		 * should de-index the entity's previous state (using the state prepared via
-		 * {@link #internalPrepareIndicesUpdate(Object)}) before propagating the exception. With
-		 * {@code false} the calling context guarantees that the entity's previous state stays in place
-		 * on failure, so the group must leave its previous entries untouched.
+		 * The calling context uses this after a failed in-place update whose entity it removes from the
+		 * map: the removal re-derives the keys from the entity's mutated state and can therefore not
+		 * locate the entries of the entity's previous state. Only the prepared state can, which is why
+		 * this must be called before {@link #internalFinishIndicesUpdate()} releases it.
 		 * <p>
-		 * The default implementation ignores the flag and delegates to the 4-arg variant, which is
-		 * correct for groups without such cleanup capability.
+		 * The default implementation does nothing, which is correct for groups that de-index by entity
+		 * id instead of by re-derived keys and hence have no such leftovers.
 		 *
 		 * @param entityId the entity's id
-		 * @param replacedEntity old entity
-		 * @param entity new entity from which the key will be extracted
-		 * @param customConstraints the custom constraints to check, may be {@code null}
-		 * @param removeOnFailure whether a failed update is followed by the entity's removal
 		 */
-		public default void internalUpdateIndices(
-			final long                         entityId         ,
-			final E                            replacedEntity   ,
-			final E                            entity           ,
-			final CustomConstraints<? super E> customConstraints,
-			final boolean                      removeOnFailure
-		)
+		public default void internalRemovePreparedState(final long entityId)
 		{
-			this.internalUpdateIndices(entityId, replacedEntity, entity, customConstraints);
+			// no-op by default: groups that de-index by entity id have no state-derived leftovers.
 		}
 
 		public void internalFinishIndicesUpdate();

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
@@ -65,6 +65,7 @@ public interface IndexGroup<E> extends GigaMap.Component<E>
 		 * @param entityId the entity's id
 		 * @param replacedEntity old entity
 		 * @param entity new entity from which the key will be extracted
+		 * @param customConstraints the custom constraints to check, may be {@code null} to check none
 		 */
 		public void internalUpdateIndices(long entityId, E replacedEntity, E entity, CustomConstraints<? super E> customConstraints);
 

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ApplyIndexerFailureRetentionTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ApplyIndexerFailureRetentionTest.java
@@ -1,0 +1,153 @@
+package org.eclipse.store.gigamap.indexer.edge;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression coverage for internal issue #119: {@code apply()}/{@code update()} used to DELETE a
+ * committed entity whenever an indexer threw while indexing the new value. The entity's own data is
+ * the value the update logic produced and is perfectly valid; only the derived index rejected it, yet
+ * the destructive exception fallback removed the committed entity and the next {@code store()}
+ * persisted that loss.
+ * <p>
+ * The trigger is mundane and index-family independent - any value an indexer cannot encode: an
+ * unexpected format in a custom indexer's key extraction, a computed key that overflows, a Lucene term
+ * over the 32766-byte limit, an embedding of the wrong dimension. A stock {@link IndexerString} whose
+ * key extraction throws is enough to reproduce it, which is what this test uses.
+ * <p>
+ * {@code set(id, entity)} never shared that behavior - it updates the indices BEFORE overwriting the
+ * storage slot, so an indexer throw leaves the entity in its prior committed state. The two mutation
+ * APIs therefore used to disagree on the exact same failing input; the parity is asserted here.
+ */
+public class ApplyIndexerFailureRetentionTest
+{
+	static class Doc
+	{
+		String key;
+
+		Doc(final String key)
+		{
+			this.key = key;
+		}
+	}
+
+	/** Stock bitmap indexer whose key extraction throws for the poison value. */
+	static final class KeyIndexer extends IndexerString.Abstract<Doc>
+	{
+		static final String POISON = "POISON";
+
+		@Override
+		public String name()
+		{
+			return "key";
+		}
+
+		@Override
+		protected String getString(final Doc entity)
+		{
+			if(POISON.equals(entity.key))
+			{
+				throw new IllegalStateException("indexer cannot derive a key for this value");
+			}
+			return entity.key;
+		}
+	}
+
+	private static GigaMap<Doc> newIndexedMap()
+	{
+		final GigaMap<Doc> map = GigaMap.New();
+		map.index().bitmap().add(new KeyIndexer());
+		return map;
+	}
+
+	@Test
+	@Timeout(60)
+	void updateWhoseIndexerThrowsRetainsTheCommittedEntity()
+	{
+		final GigaMap<Doc> map = newIndexedMap();
+
+		final Doc  doc = new Doc("valid");
+		final long id  = map.add(doc);
+		assertEquals(1, map.size());
+
+		assertThrows(IllegalStateException.class, () -> map.update(id, e -> e.key = KeyIndexer.POISON));
+
+		// a committed entity must not be destroyed because an indexer rejected the NEW value
+		assertSame(doc, map.get(id), "the committed entity must survive an indexer failure");
+		assertEquals(1, map.size());
+		assertEquals(KeyIndexer.POISON, doc.key, "the in-place mutation is kept");
+	}
+
+	@Test
+	@Timeout(60)
+	void setWithTheSameFailingInputBehavesLikeUpdate()
+	{
+		final GigaMap<Doc> map = newIndexedMap();
+
+		final Doc  doc = new Doc("valid");
+		final long id  = map.add(doc);
+
+		// set() fails before the slot is overwritten, so the prior committed value stays in place
+		assertThrows(IllegalStateException.class, () -> map.set(id, new Doc(KeyIndexer.POISON)));
+
+		assertSame(doc, map.get(id), "set() must not delete the entity on an indexer failure");
+		assertEquals(1, map.size());
+		assertEquals("valid", doc.key, "set() failure must leave the prior committed value intact");
+	}
+
+	@Test
+	@Timeout(60)
+	void retainedEntityAndItsMutationSurviveStoreAndRestart(@TempDir final Path dir)
+	{
+		final long id;
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(newIndexedMap(), dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Doc> map = (GigaMap<Doc>)storage.root();
+
+			id = map.add(new Doc("valid"));
+			map.store(); // the entity is now committed and durable
+
+			assertThrows(IllegalStateException.class, () -> map.update(id, e -> e.key = KeyIndexer.POISON));
+
+			map.store(); // persist whatever state apply() left behind
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(GigaMap.<Doc>New(), dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Doc> map = (GigaMap<Doc>)storage.root();
+
+			final Doc reloaded = map.get(id);
+			assertNotNull(reloaded, "the committed entity must survive the restart");
+			assertEquals(1, map.size());
+			assertEquals(KeyIndexer.POISON, reloaded.key, "the retained mutation must be persisted, too");
+		}
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ThrowingIndexerConsistencyTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/indexer/edge/ThrowingIndexerConsistencyTest.java
@@ -45,10 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li>{@code removeById}/{@code remove} always complete the removal, cleaning the remaining
  *       indices best-effort and rethrowing afterwards.</li>
  *   <li>{@code set}/{@code replace} leave the map observably unchanged.</li>
- *   <li>{@code update}/{@code apply} abort cleanly while the pre-mutation state is being indexed
- *       and extend the documented destructive-removal contract (previously limited to
- *       {@link ConstraintViolationException}) to all exceptions once the logic may have mutated
- *       the entity.</li>
+ *   <li>{@code update}/{@code apply} abort cleanly while the pre-mutation state is being indexed,
+ *       apply the documented destructive-removal contract to a {@link ConstraintViolationException}
+ *       and to exceptions thrown by the update logic itself, and keep the entity when only a derived
+ *       index failed.</li>
  * </ul>
  */
 public class ThrowingIndexerConsistencyTest
@@ -485,27 +485,38 @@ public class ThrowingIndexerConsistencyTest
 	}
 
 	@Test
-	void apply_indexerThrowsOnMutatedValue_entityRemovedWithSuppressedCleanupFailure()
+	void apply_indexerThrowsOnMutatedValue_entityRetainedAndIndexRepairableByReindex()
 	{
 		final GigaMap<Item> map = GigaMap.New();
 		map.index().bitmap().add(NAME);
 		map.index().bitmap().add(POISON);
 
-		final long id = map.add(new Item("a", "c1"));
+		final Item item = new Item("a", "c1");
+		final long id   = map.add(item);
 
 		final IndexerBoomException thrown = assertThrows(IndexerBoomException.class, () ->
-			map.apply(id, item ->
+			map.apply(id, e ->
 			{
-				item.name = "poison";
+				e.name = "poison";
 				return null;
 			})
 		);
 
-		// destructive removal, original exception raw, cleanup failure attached
-		assertNull(map.get(id));
-		assertEquals(0, map.size());
+		/*
+		 * Only the derived index rejected the new value, the entity's own data is fine: the committed
+		 * entity must survive. The original exception is rethrown raw, nothing was removed and hence
+		 * no cleanup could fail.
+		 */
+		assertSame(item, map.get(id));
+		assertEquals(1, map.size());
+		assertEquals("poison", item.name, "the in-place mutation is kept");
+		assertEquals(0, thrown.getSuppressed().length);
+
+		// the indices are left stale, which reindex() is the documented repair for
+		assertTrue(map.index().bitmap().removeIndex(POISON), "drop the index that cannot handle the value");
+		map.reindex();
 		assertEquals(0, map.query(NAME.is("a")).count());
-		assertTrue(thrown.getSuppressed().length > 0);
+		assertEquals(1, map.query(NAME.is("poison")).count());
 	}
 
 	// ---------------------------------------------------------------

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexUpdateRetentionTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexUpdateRetentionTest.java
@@ -1,0 +1,90 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The vector projection of internal issue #119: {@code update()} of a committed entity whose new
+ * embedding the index rejects - a mundane mistake such as an embedding produced by a differently-sized
+ * model - used to trigger GigaMap's destructive {@code apply()} fallback and delete the committed
+ * entity. The entity's own data is valid; only the derived index could not represent it, so the
+ * exception must escape while the entity stays.
+ * <p>
+ * Together with the bitmap and Lucene cases this confirms the rule is index-family independent.
+ */
+class VectorIndexUpdateRetentionTest
+{
+    static final int DIM = 3;
+
+    static final class Doc
+    {
+        float[] embedding; // mutable so update(id, logic) can change it in place
+
+        Doc(final float[] embedding)
+        {
+            this.embedding = embedding;
+        }
+    }
+
+    static final class EmbeddingVectorizer extends Vectorizer<Doc>
+    {
+        @Override
+        public float[] vectorize(final Doc entity)
+        {
+            return entity.embedding;
+        }
+
+        @Override
+        public boolean isEmbedded()
+        {
+            return true;
+        }
+    }
+
+    private static VectorIndexConfiguration config()
+    {
+        return VectorIndexConfiguration.builder()
+            .dimension(DIM)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .build();
+    }
+
+    @Test
+    @Timeout(60)
+    void updateToWrongDimensionRetainsTheCommittedEntity()
+    {
+        final GigaMap<Doc>       map     = GigaMap.New();
+        final VectorIndices<Doc> indices = map.index().register(VectorIndices.Category());
+        indices.add("embeddings", config(), new EmbeddingVectorizer());
+
+        final Doc  doc = new Doc(new float[]{1.0f, 0.0f, 0.0f});
+        final long id  = map.add(doc);
+        assertEquals(1, map.size());
+
+        final float[] wrongDimension = new float[]{0.0f, 0.0f, 0.0f, 0.0f};
+        assertThrows(RuntimeException.class, () -> map.update(id, e -> e.embedding = wrongDimension));
+
+        assertSame(doc, map.get(id), "the committed entity must survive the index's rejection");
+        assertEquals(1, map.size());
+        assertSame(wrongDimension, doc.embedding, "the in-place mutation is kept");
+    }
+}

--- a/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneImmenseTermRetentionTest.java
+++ b/gigamap/lucene/src/test/java/org/eclipse/store/gigamap/lucene/LuceneImmenseTermRetentionTest.java
@@ -1,0 +1,127 @@
+package org.eclipse.store.gigamap.lucene;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap Lucene
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.apache.lucene.document.Document;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The Lucene projection of internal issue #119: {@code update()} of a committed entity whose new value
+ * produces a document Lucene rejects - the mundane case being a single term longer than Lucene's hard
+ * 32766-byte limit ("Document contains at least one immense term") - used to trigger GigaMap's
+ * destructive {@code apply()} fallback, which removed the committed entity, and the next
+ * {@code store()} persisted that loss.
+ * <p>
+ * The entity's own data is perfectly valid; only the derived index rejected a document. The exception
+ * must escape, the deletion must not - deleting the entity would destroy committed data over an
+ * index-layer input limit the user has never heard of.
+ */
+public class LuceneImmenseTermRetentionTest
+{
+	/** Longer than Lucene's 32766-byte term limit. */
+	private static final String IMMENSE = "x".repeat(40_000);
+
+	public static class Article
+	{
+		String title;
+
+		Article(final String title)
+		{
+			this.title = title;
+		}
+	}
+
+	static class ArticlePopulator extends DocumentPopulator<Article>
+	{
+		@Override
+		public void populate(final Document document, final Article entity)
+		{
+			// untokenized field: the whole title is one term, so a long title is an "immense term"
+			document.add(createStringField("exact", entity.title));
+		}
+	}
+
+	private static GigaMap<Article> newIndexedMap()
+	{
+		final GigaMap<Article> map = GigaMap.New();
+		map.index().register(LuceneIndex.Category(LuceneContext.New(
+			DirectoryCreator.ByteBuffers(),
+			new ArticlePopulator()
+		)));
+		return map;
+	}
+
+	@Test
+	@Timeout(60)
+	void updateWithOverlongValueRetainsTheCommittedEntity()
+	{
+		final GigaMap<Article> map = newIndexedMap();
+
+		final Article article = new Article("ok");
+		final long    id      = map.add(article);
+		assertEquals(1, map.size());
+
+		// control: ADDING an entity with the immense value fails loudly, nothing is lost
+		assertThrows(RuntimeException.class, () -> map.add(new Article(IMMENSE)));
+		assertEquals(1, map.size(), "control: a failed add must not affect existing data");
+
+		// the k.o. path: updating the EXISTING committed entity to the immense value
+		assertThrows(RuntimeException.class, () -> map.update(id, a -> a.title = IMMENSE));
+
+		assertSame(article, map.get(id), "the committed entity must survive the index's rejection");
+		assertEquals(1, map.size());
+		assertEquals(IMMENSE, article.title, "the in-place mutation is kept");
+	}
+
+	@Test
+	@Timeout(60)
+	void retainedEntitySurvivesStoreAndRestart(@TempDir final Path dir)
+	{
+		final long id;
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(newIndexedMap(), dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Article> map = (GigaMap<Article>)storage.root();
+
+			id = map.add(new Article("ok"));
+			map.store(); // the entity is now committed and durable
+
+			assertThrows(RuntimeException.class, () -> map.update(id, a -> a.title = IMMENSE));
+
+			map.store(); // persist whatever state apply() left behind
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(GigaMap.<Article>New(), dir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Article> map = (GigaMap<Article>)storage.root();
+
+			assertNotNull(map.get(id), "the committed entity must survive store() and restart");
+			assertEquals(1, map.size());
+		}
+	}
+}


### PR DESCRIPTION
`apply()` / `update()` removed a committed entity whenever anything in the index-update phase threw - for any index family, not just Lucene. The entity's own data is the value the update logic produced and is perfectly valid; only the derived index rejected it, yet the destructive exception fallback removed the entity and the next `store()` persisted the loss (verified durable across a restart). The trigger is mundane: an indexer that throws for the new value, a Lucene term over the 32766-byte limit, an embedding of the wrong dimension. `set()` / `replace()` never shared this, because they update the indices *before* overwriting the storage slot, so the two mutation APIs disagreed on the exact same failing input.

## The rule

Removal is now bound to the *entity* being doomed rather than to "something threw":

| failure source | entity | why |
| --- | --- | --- |
| the update `logic` threw | **removed** | the in-place mutation cannot be rolled back, so the state is unreliable |
| a constraint rejected the new state (`ConstraintViolationException`, incl. `UniqueConstraintViolationException`) | **removed** | a constraint decides whether an entity may exist at all - documented `apply()` behavior |
| anything else while updating a derived index (an `Indexer`, a Lucene/vector index group, a stale index) | **retained**, original exception rethrown | the entity is valid, only the index could not represent it |

A retained entity gets the same persistence bookkeeping as a successful mutation (`retainMutatedEntity`), so a later `reindex()` + `store()` persists both the entity and the rebuilt index. The indices may be left out of sync with it; `reindex()` is the documented repair. This subsumes the `StaleIndexException` exemption from #771 under one rule instead of keeping it as a special case.

## How the source is determined

`GigaIndices.internalApplyUpdate` ran the user `logic` and the index update behind one `catch(RuntimeException)`, so its caller could not tell them apart. The `logic.apply` call moved up into `GigaMap.internalApply`, which now has one `try` per source, and the index phase is classified by exception type via `isEntityRejected` - the former `isStaleIndexFailure` throwable-graph walk, generalized into `containsThrowable(Throwable, Class<?>)`. The original exception is always rethrown unchanged, never wrapped.

A custom constraint that does not comply with the `CustomConstraint` API and throws some other exception type is treated like an index failure, i.e. non-destructively. That is the safe direction and is documented on `isEntityRejected` and in `constraints.adoc`.

## SPI change

`removeOnFailure` on `IndexGroup.Internal#internalUpdateIndices` had the group guess what the caller would do on failure, which is no longer decidable before the exception exists. It is replaced by `internalRemovePreparedState(long)`: a no-op by default, because Lucene and vector groups de-index by entity id and have no state-derived leftovers, and implemented by `BitmapIndices` via its cached prev change handlers. `GigaIndices` calls it once it knows the entity is doomed - now for the failing group *and every group after it*, closing a pre-existing leftover leak: the groups before it already carry the new keys, which the removal locates by itself, while the later ones would otherwise keep their previous entries. With a single bitmap group per map that extension is currently defensive rather than observable. A `cachedStateChangeApplied` flag keeps the cleanup from touching entries a group already moved.

## Tests

New regression coverage for all three index families, each verified **red before the fix**:

- `ApplyIndexerFailureRetentionTest` (gigamap) - a stock `IndexerString` whose key extraction throws; covers `update()` retention, the `set()`-vs-`update()` parity, and a `store()` + restart durability case
- `LuceneImmenseTermRetentionTest` (lucene) - immense term on `update()`, with the control `add()` still failing loudly, plus store + restart
- `VectorIndexUpdateRetentionTest` (jvector) - wrong-dimension embedding on `update()`

`ThrowingIndexerConsistencyTest`'s destructive apply-on-indexer-throw case is inverted to the retention contract and extended with the `reindex()` repair. `GigaMap88Test`, `ApplyByIdTest`, `MultiValueConstraintRollbackTest`, `UniqueConstraintsTest` and `CustomConstraintsTest` cover the surviving destructive paths and stay green.

Full suites green: gigamap (1189), lucene, jvector (incl. `-Pslow-tests`), codegen-test. Javadoc builds clean.

Docs updated: the four `update` / `apply` javadoc blocks, `crud.adoc`, `constraints.adoc`, `persistence.adoc`.
