### PR TITLE
GigaMap: reindex() re-validates unique constraints instead of silently building a violating index

### DIFF
--- a/docs/modules/gigamap/pages/constraints.adoc
+++ b/docs/modules/gigamap/pages/constraints.adoc
@@ -27,6 +27,33 @@ GigaMap<Person> gigaMap = GigaMap.New();
 gigaMap.index().bitmap().addUniqueConstraint(PersonIndices.id);
 ----
 
+=== Validation Points
+
+A unique constraint is checked when it is registered (against the entities already in the map), on every write - and again by `reindex()`, which rebuilds the indices from the current entity state and therefore derives every key anew. A rebuild over data that violates the constraint - two or more entities sharing a key - is reported with a `UniqueConstraintViolationExceptionBitmap` naming the violated index and the first entity found under an already taken key.
+
+The report comes *after* the rebuild has completed: the indices are rebuilt and marked for storing either way, so they describe the entities as they actually are. That is also what the repair works on - re-distinguish the colliding keys via `update` / `apply`, then call `reindex()` again:
+
+[source, java]
+----
+try
+{
+    gigaMap.reindex();
+}
+catch(final UniqueConstraintViolationException e)
+{
+    // the completed rebuild answers for the actual entity state, so the collisions are queryable
+    final Person offender = (Person)e.getViolatingEntity();
+    for(final Person person : gigaMap.query(PersonIndices.id.is(offender.getId())).toList())
+    {
+        gigaMap.update(person, p -> p.setId(...)); // assign distinct values
+    }
+    gigaMap.reindex(); // passes now
+}
+gigaMap.store();
+----
+
+NOTE: Class evolution of an indexed *unique* field is the typical source of such data: renaming or retyping it across releases without a value-preserving refactoring mapping makes the legacy mapping default that field for *every* old entity, so they all reload carrying the same key. See xref:crud.adoc#_removing_and_updating_entities[CRUD - Removing and Updating Entities] for `reindex()` itself.
+
 === Combining With an Identity Index
 
 A unique constraint and an xref:indexing/bitmap/types.adoc#_identity_index[identity index] are independent concerns: the identity index defines how entities are looked up, the unique constraint enforces uniqueness at write time. Combine both to get an identifying field that is also guaranteed unique:

--- a/docs/modules/gigamap/pages/crud.adoc
+++ b/docs/modules/gigamap/pages/crud.adoc
@@ -87,6 +87,8 @@ gigaMap.update(person, p -> {
 
 The two are alternatives, not steps: an `update` after a direct modification does not undo it. `update` derives the previous keys from the entity it is handed, and those are already the new values by then, so the stale entries stay. Once a direct modification has happened, only `reindex()` repairs the indices — it rebuilds them from the current entity state rather than trying to reconstruct the previous keys. It rebuilds index structures only, so the modified entity still has to be stored explicitly.
 
+Because the rebuild derives every index key anew, it is also the point at which the registered unique constraints are validated again: a rebuild over data in which two entities share a key of a unique constraint reports that violation (after completing the rebuild) instead of building an index that maps one unique key to several entities. See xref:constraints.adoc#_validation_points[Constraints - Validation Points].
+
 Entities modified through `update` (or `apply`) are automatically persisted when calling `store()`. See xref:persistence.adoc[] for details.
 
 WARNING: Because `update` / `apply` mutate the entity in place, a constraint violation triggered by the new state cannot be rolled back. The GigaMap therefore **removes** the offending entity from the map and rethrows the `ConstraintViolationException`. The same applies to an exception thrown by the update logic itself, which leaves the entity partially mutated. See xref:constraints.adoc#_constraint_violations[Constraints — Constraint Violations] for the full rollback semantics across CRUD operations.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -928,6 +928,127 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			this.markStateChangeChildren();
 		}
 
+		/**
+		 * Rebuilds all bitmap indices from the current entity state and, unlike the generic
+		 * {@link IndexGroup.Internal#internalReindex(GigaMap) clear + re-add} default, re-validates the
+		 * registered unique constraints while doing so. A rebuild is the one path that derives every key
+		 * anew, so data whose keys collide - e.g. every entity of a class-evolved indexed field defaulting
+		 * to the same value - would otherwise silently yield an index in which one unique key maps to
+		 * several live entities, a state all write paths reject.
+		 * <p>
+		 * The rebuild is <b>completed</b> before a violation is reported: the resulting indices then
+		 * describe the entities as they actually are, which is what the documented repair - re-distinguish
+		 * the colliding keys via {@code update}/{@code apply}, then {@code reindex()} again - operates on.
+		 * Aborting mid-pass would leave the indices half-rebuilt, and aborting before the pass would keep
+		 * exactly the stale keys that made the rebuild necessary in the first place.
+		 */
+		@Override
+		public final void internalReindex(final GigaMap<E> parentMap)
+		{
+			this.internalRemoveAll();
+
+			if(this.uniqueConstraints == null)
+			{
+				// nothing to validate: plain rebuild, without paying for the per-entity containment checks.
+				parentMap.iterateIndexed(this::internalAdd);
+
+				return;
+			}
+
+			final UniquenessViolation<E> violation = new UniquenessViolation<>();
+			parentMap.iterateIndexed((final long entityId, final E entity) ->
+			{
+				this.collectUniquenessViolation(entityId, entity, violation);
+				this.internalAdd(entityId, entity);
+			});
+
+			if(violation.violatedIndex != null)
+			{
+				throw violation.toException();
+			}
+		}
+
+		/**
+		 * Checks the entity about to be re-indexed against the unique constraints and records a collision in
+		 * the given collector. Uses the same check-then-add order as
+		 * {@link #buildIndexDataAndValidateUniqueness(EqHashTable)}, which is correct during a rebuild
+		 * because the indices were just cleared: only entities re-added in the same pass can be found, so
+		 * every hit is a genuinely different entity (there is no own stale entry to exclude).
+		 * <p>
+		 * Only the first collision is reported, so once one has been found the remaining entities are
+		 * checked against that one index only - to report how many of them are affected - instead of
+		 * accumulating unrelated findings from the other constraints.
+		 *
+		 * @param entityId the entity's id
+		 * @param entity the entity about to be re-indexed
+		 * @param violation the collector of the violation to report after the rebuild
+		 */
+		private void collectUniquenessViolation(
+			final long                   entityId ,
+			final E                      entity   ,
+			final UniquenessViolation<E> violation
+		)
+		{
+			if(violation.violatedIndex != null)
+			{
+				if(violation.violatedIndex.internalContains(entity))
+				{
+					violation.duplicateCount++;
+				}
+
+				return;
+			}
+
+			for(final BitmapIndex.Internal<E, ?> index : this.uniqueConstraints)
+			{
+				if(index.internalContains(entity))
+				{
+					violation.violatedIndex   = index   ;
+					violation.entityId        = entityId;
+					violation.violatingEntity = entity  ;
+					violation.duplicateCount  = 1       ;
+
+					return;
+				}
+			}
+		}
+
+		/**
+		 * Mutable collector for the unique-constraint violation encountered during a rebuild. A rebuild
+		 * reports its violation only after it completed, and the per-entity check runs inside a lambda that
+		 * cannot assign to local variables, hence this holder instead of plain locals.
+		 *
+		 * @param <E> the entity type
+		 */
+		private static final class UniquenessViolation<E>
+		{
+			BitmapIndex.Internal<E, ?> violatedIndex   = null;
+			long                       entityId        = -1  ;
+			E                          violatingEntity = null;
+			long                       duplicateCount  = 0   ;
+
+			UniquenessViolation()
+			{
+				super();
+			}
+
+			UniqueConstraintViolationExceptionBitmap toException()
+			{
+				return new UniqueConstraintViolationExceptionBitmap(
+					this.entityId       ,
+					null                ,
+					this.violatingEntity,
+					this.violatedIndex  ,
+					"GigaMap.reindex() rebuilt the unique index \"" + this.violatedIndex.name()
+					+ "\" from the current entity state, which holds duplicate keys (entities re-indexed"
+					+ " under a key another entity already holds: " + this.duplicateCount
+					+ "; the first one is reported here). The rebuild was completed, so the indices now"
+					+ " describe the entities as they actually are: re-distinguish the colliding keys via"
+					+ " update()/apply(), then call reindex() again."
+				);
+			}
+		}
+
 		@Override
 		public <K> BitmapIndex<E, K> add(final Indexer<? super E, K> indexer)
 		{

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaIndices.java
@@ -314,15 +314,48 @@ public interface GigaIndices<E> extends GigaMap.Component<E>
 
 		void internalReindex()
 		{
-			// Rebuild every index group from the current entity state. Each group clears its data and
-			// re-indexes all entities of the parent map (see IndexGroup.Internal#internalReindex), so an
-			// index that drifted out of sync - e.g. because an indexed entity was mutated directly instead
-			// of via update()/apply() - is brought back in line.
-			for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+			/*
+			 * Rebuild every index group from the current entity state. Each group clears its data and
+			 * re-indexes all entities of the parent map (see IndexGroup.Internal#internalReindex), so an
+			 * index that drifted out of sync - e.g. because an indexed entity was mutated directly instead
+			 * of via update()/apply() - is brought back in line.
+			 *
+			 * Best-effort across the groups, mirroring #internalRemove: a group that reports a problem with
+			 * the rebuilt data (the bitmap group rejects data violating a unique constraint) must neither
+			 * keep the remaining groups from being rebuilt nor cost the already rebuilt ones their
+			 * state-change marks - unmarked, a subsequent store() would not persist the rebuild at all. The
+			 * first exception is rethrown at the end, subsequent failures are attached as suppressed ones.
+			 */
+			RuntimeException first = null;
+			try
 			{
-				indexGroup.internalReindex(this.parent);
+				for(final IndexGroup.Internal<E> indexGroup : this.indexGroups)
+				{
+					try
+					{
+						indexGroup.internalReindex(this.parent);
+					}
+					catch(final RuntimeException e)
+					{
+						if(first == null)
+						{
+							first = e;
+						}
+						else
+						{
+							first.addSuppressed(e);
+						}
+					}
+				}
 			}
-			this.markStateChangeChildren();
+			finally
+			{
+				this.markStateChangeChildren();
+			}
+			if(first != null)
+			{
+				throw first;
+			}
 		}
 
 		void internalUpdateIndices(

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/GigaMap.java
@@ -32,6 +32,7 @@ import org.eclipse.serializer.reference.Lazy;
 import org.eclipse.serializer.util.X;
 import org.eclipse.store.gigamap.exceptions.ConstraintViolationException;
 import org.eclipse.store.gigamap.exceptions.StaleIndexException;
+import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationException;
 import org.eclipse.store.gigamap.types.GigaQuery.ConditionBuilder;
 import org.eclipse.store.gigamap.types.IterationThreadProvider.IterationLogicProvider;
 
@@ -644,7 +645,20 @@ public interface GigaMap<E> extends XIterable<E>, Sized, Iterable<E>
 	 * indices stale in exactly the same way a direct mutation does: the loaded entities carry shifted/defaulted
 	 * values while the persisted index keeps the pre-evolution keys. This method is the recovery path for that
 	 * case too; call it (then {@link #store()}) before any query or update after such an evolution.
+	 * <p>
+	 * <b>Unique constraints:</b> deriving every key anew also means the current entity state is checked against
+	 * the registered unique constraints again, so a rebuild reports data that violates one instead of quietly
+	 * building an index in which one unique key maps to several live entities. Note that class evolution of an
+	 * <em>indexed unique</em> field is a prime source of such data: the legacy mapping defaults that field for
+	 * every old entity, so they all end up carrying the same key. The violation is reported <em>after</em> the
+	 * rebuild has completed - the indices are rebuilt and marked for storing either way, and therefore describe
+	 * the entities as they actually are. That is what the repair works on: re-distinguish the colliding keys
+	 * via {@link #update(long, Consumer) update} / {@link #apply(long, Function) apply}, then call this method
+	 * again.
 	 *
+	 * @throws UniqueConstraintViolationException if the rebuilt indices show two or more entities sharing a key
+	 *         of a unique constraint. The exception names the violated index and the first entity found under
+	 *         an already taken key; the rebuild itself is complete at that point.
 	 * @see #update(long, Consumer)
 	 * @see #apply(long, Function)
 	 */

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/IndexGroup.java
@@ -131,9 +131,15 @@ public interface IndexGroup<E> extends GigaMap.Component<E>
 		 * current state is correct.
 		 * <p>
 		 * The default implementation drops all data via {@link #internalRemoveAll()} and re-adds every
-		 * entity via {@link #internalAdd(long, Object)}, which is correct for in-memory groups (e.g. bitmap,
+		 * entity via {@link #internalAdd(long, Object)}, which is correct for in-memory groups (e.g.
 		 * vector). Groups with an external commit cost (e.g. Lucene) should override this to batch the
 		 * re-add and commit once.
+		 * <p>
+		 * The default performs <b>no</b> constraint validation: it is a plain re-add of data that is already
+		 * part of the map. A group that backs constraints must override this to re-validate them, because a
+		 * rebuild derives every key anew and the current entity state may well violate a constraint that
+		 * held when the entities were written (the bitmap group does so for its unique constraints, see
+		 * {@code BitmapIndices.Default#internalReindex(GigaMap)}).
 		 *
 		 * @param parentMap the map whose entities this group indexes
 		 */

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/UniqueConstraints.java
@@ -23,6 +23,10 @@ import java.util.function.Consumer;
  * Represents an interface for managing unique constraints on a category of elements.
  * Provides methods to add and access unique constraints utilizing indexing mechanisms.
  * It extends the functionality of GigaConstraints.Category with additional capabilities.
+ * <p>
+ * A registered constraint is validated when it is created (against the entities already present) and on
+ * every write, and again whenever {@link GigaMap#reindex()} rebuilds the indices from the current entity
+ * state - the one other occasion on which all keys are derived anew.
  *
  * @param <E> the type of elements for which the unique constraints are applied
  */

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap121Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap121Test.java
@@ -1,0 +1,279 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2025 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationExceptionBitmap;
+import org.eclipse.store.gigamap.types.BinaryIndexerInteger;
+import org.eclipse.store.gigamap.types.Condition;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression coverage for internal issue #121: {@code GigaMap.reindex()} used to rebuild a bitmap index
+ * that backs a unique constraint without re-validating uniqueness. Colliding data therefore yielded an
+ * index in which one unique key maps to several live entities - silently, and persistently across a
+ * restart, while every write path rejects exactly that state.
+ * <p>
+ * The realistic source of such data is class evolution of an indexed unique field: the legacy mapping
+ * defaults that field for every old entity, so they all reload carrying the same key. As in
+ * {@link GigaMap88Test}, the evolution is simulated by rewriting the persisted type dictionary - the
+ * indexed field is renamed to a dissimilar name AND retyped (same 4-byte layout), so on reload the legacy
+ * member is unmatched and the runtime field loads defaulted to 0.
+ * <p>
+ * These tests pin the fixed behavior: the violation is reported, the rebuild is nevertheless completed
+ * (so the indices describe the entities as they actually are, and are persisted), and the documented
+ * repair - re-distinguish the colliding keys, then {@code reindex()} again - reaches a clean state.
+ */
+public class GigaMap121Test
+{
+	/**
+	 * Session 1: store one {@code Rec} per given code under a unique constraint on {@code code}, then
+	 * simulate class evolution of that indexed field. Returns the entity ids, in the order of the codes.
+	 */
+	private static long[] seedAndEvolve(final Path storageDir, final int... codes) throws IOException
+	{
+		final long[]       ids = new long[codes.length];
+		final GigaMap<Rec> map = GigaMap.New();
+
+		// the unique constraint registers the backing bitmap index for the indexer as well
+		map.index().bitmap().addUniqueConstraint(new CodeIndexer());
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, storageDir))
+		{
+			for(int i = 0; i < codes.length; i++)
+			{
+				ids[i] = map.add(new Rec(codes[i]));
+			}
+			map.store();
+		}
+
+		// Simulate evolution: rewrite the indexed field's dictionary entry to a dissimilar name and a
+		// different (but same-width) type. The .ptd writes the field as "<type> <name>," (column padded,
+		// and only qualified with the declaring class when the simple name is ambiguous), so match it
+		// format-agnostically rather than assuming a fixed layout.
+		final Path   ptd     = storageDir.resolve("PersistenceTypeDictionary.ptd");
+		final String dict    = Files.readString(ptd, StandardCharsets.UTF_8);
+		final String evolved = dict.replaceAll("int(\\s+)((?:[\\w.$]+#)?)code(\\s*,)", "float$1$2qxz9$3");
+		assertTrue(!evolved.equals(dict), "sanity: the dictionary must contain the indexed field 'code'");
+		Files.writeString(ptd, evolved, StandardCharsets.UTF_8);
+
+		return ids;
+	}
+
+	@Test
+	@Timeout(120)
+	void reindexOverCollidingUniqueKeysReportsTheViolation(@TempDir final Path dir) throws IOException
+	{
+		final long[] ids = seedAndEvolve(dir, 5, 7);
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Rec> loaded = loadedMap(storage);
+
+			// sanity: the evolution simulation worked - both entities defaulted to the same key.
+			assertEquals(0, loaded.get(ids[0]).code, "sanity: field must have been defaulted by evolution");
+			assertEquals(0, loaded.get(ids[1]).code, "sanity: field must have been defaulted by evolution");
+
+			final UniqueConstraintViolationExceptionBitmap ex = assertThrows(
+				UniqueConstraintViolationExceptionBitmap.class,
+				loaded::reindex,
+				"reindex() must not silently build a unique index holding one key for two live entities"
+			);
+
+			assertEquals("code", ex.getViolatedIndex().name(), "the violated unique index must be named");
+			assertTrue(
+				ex.getEntityId() == ids[0] || ex.getEntityId() == ids[1],
+				"the exception must name one of the colliding entities; was id " + ex.getEntityId()
+			);
+			assertNotNull(ex.getViolatingEntity(), "the exception must carry the offending entity");
+			assertTrue(
+				ex.getMessage() != null && ex.getMessage().contains("reindex()"),
+				"the message must explain the reindex context; was: " + ex.getMessage()
+			);
+		}
+	}
+
+	/**
+	 * The violation is reported only after the rebuild has completed: the indices must describe the
+	 * entities as they actually are (which is what the repair operates on), and must be marked for
+	 * storing, so the throw does not cost the rebuild its persistence.
+	 */
+	@Test
+	@Timeout(120)
+	void reindexCompletesTheRebuildBeforeReporting(@TempDir final Path dir) throws IOException
+	{
+		final long[] ids = seedAndEvolve(dir, 5, 7);
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Rec> loaded = loadedMap(storage);
+
+			// precondition: the stale index still answers for the pre-evolution keys.
+			assertEquals(1, count(loaded, 5), "precondition: stale index answers for the old key 5");
+			assertEquals(1, count(loaded, 7), "precondition: stale index answers for the old key 7");
+
+			assertThrows(UniqueConstraintViolationExceptionBitmap.class, loaded::reindex);
+
+			assertEquals(2, loaded.size(), "no entity may be dropped by the reported rebuild");
+			assertNotNull(loaded.get(ids[0]));
+			assertNotNull(loaded.get(ids[1]));
+			assertEquals(0, count(loaded, 5), "after the rebuild: no stale key may remain");
+			assertEquals(0, count(loaded, 7), "after the rebuild: no stale key may remain");
+			assertEquals(2, count(loaded, 0), "after the rebuild: the index must match the actual entity state");
+
+			loaded.store();
+		}
+
+		// The completed rebuild was marked for storing despite the throw, so it survives the restart.
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Rec> loaded = loadedMap(storage);
+			assertEquals(2, loaded.size(), "both entities must survive the restart");
+			assertEquals(0, count(loaded, 5), "the rebuilt index must have been persisted");
+			assertEquals(2, count(loaded, 0), "the rebuilt index must have been persisted");
+		}
+	}
+
+	/**
+	 * The documented repair: re-distinguish the colliding keys via {@code apply()} over the reported
+	 * (duplicate-laden) unique index, then {@code reindex()} again. Neither step may delete a committed
+	 * entity - see internal issue #88 - and the result must be clean and restart-stable.
+	 */
+	@Test
+	@Timeout(120)
+	void repairAfterReportedViolationYieldsACleanIndex(@TempDir final Path dir) throws IOException
+	{
+		final long[] ids = seedAndEvolve(dir, 5, 7);
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Rec> loaded = loadedMap(storage);
+			assertThrows(UniqueConstraintViolationExceptionBitmap.class, loaded::reindex);
+
+			// re-distinguish the keys of the entities the rebuilt index reports under the colliding key
+			loaded.apply(ids[0], r ->
+			{
+				r.code = 5;
+				return null;
+			});
+			loaded.apply(ids[1], r ->
+			{
+				r.code = 7;
+				return null;
+			});
+			assertNotNull(loaded.get(ids[0]), "the repair must not delete a committed entity");
+			assertNotNull(loaded.get(ids[1]), "the repair must not delete a committed entity");
+
+			assertDoesNotThrow(loaded::reindex, "the rebuild over repaired data must pass");
+			assertEquals(1, count(loaded, 5));
+			assertEquals(1, count(loaded, 7));
+			assertEquals(0, count(loaded, 0), "no residue may remain under the collided key");
+
+			loaded.store();
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(dir))
+		{
+			final GigaMap<Rec> loaded = loadedMap(storage);
+			assertEquals(2, loaded.size(), "both entities must survive the restart");
+			assertEquals(5, loaded.get(ids[0]).code);
+			assertEquals(7, loaded.get(ids[1]).code);
+			assertEquals(1, count(loaded, 5), "the repaired index must have been persisted");
+			assertEquals(1, count(loaded, 7), "the repaired index must have been persisted");
+			assertEquals(0, count(loaded, 0), "the repaired index must have been persisted");
+		}
+	}
+
+	/**
+	 * The check must not be over-eager: an entity's own entry, re-added during the very same rebuild, is
+	 * not a duplicate of itself, so a rebuild over sound data must simply pass.
+	 */
+	@Test
+	@Timeout(120)
+	void reindexWithoutCollisionsStillSucceeds(@TempDir final Path dir)
+	{
+		final GigaMap<Rec> map = GigaMap.New();
+		map.index().bitmap().addUniqueConstraint(new CodeIndexer());
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, dir))
+		{
+			map.add(new Rec(5));
+			map.add(new Rec(7));
+			map.add(new Rec(9));
+
+			assertDoesNotThrow(map::reindex, "a rebuild over distinct unique keys must pass");
+			assertEquals(3, map.size());
+			assertEquals(1, count(map, 5));
+			assertEquals(1, count(map, 7));
+			assertEquals(1, count(map, 9));
+
+			map.store();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static GigaMap<Rec> loadedMap(final EmbeddedStorageManager storage)
+	{
+		return (GigaMap<Rec>)storage.root();
+	}
+
+	private static long count(final GigaMap<Rec> map, final int code)
+	{
+		final Condition<Rec> condition = new CodeIndexer().is(code);
+
+		return map.query(condition).count();
+	}
+
+	static final class Rec
+	{
+		int code;
+
+		Rec(final int code)
+		{
+			this.code = code;
+		}
+	}
+
+	/** Binary integer index - required to back a unique constraint. */
+	static final class CodeIndexer extends BinaryIndexerInteger.Abstract<Rec>
+	{
+		@Override
+		public String name()
+		{
+			return "code";
+		}
+
+		@Override
+		protected Integer getInteger(final Rec entity)
+		{
+			return entity.code;
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`reindex()` was the one path that derives every index key anew without checking the registered unique constraints. If two or more live entities carried the same key at reindex time, the rebuild returned normally and produced an index in which one unique key maps to several live entities - silently, and persistently across a restart, in contradiction to `add()` / `set()` / `update()` / `apply()`, which all reject exactly that state.

The realistic source of such data is class evolution of an indexed *unique* field: the legacy mapping defaults that field for every old entity, so they all reload carrying the same key - and `reindex()` is the documented recovery for a stale index after evolution, which then built the violating index instead of reporting the collision.

## Change

`BitmapIndices.Default` now overrides the generic clear + re-add rebuild and checks each entity against the unique constraints while re-adding, using the same check-then-add order as the validation that already runs when a unique constraint is added to a populated map. Maps without unique constraints take a plain fast path and pay nothing.

The violation is reported *after* the rebuild has completed, as a `UniqueConstraintViolationExceptionBitmap` naming the violated index, the first entity found under an already taken key, and how many entities were re-indexed under a key another entity already holds. Completing the rebuild keeps the post-report state consistent with the entities - which is what the documented repair operates on: re-distinguish the colliding keys via `update()` / `apply()`, then call `reindex()` again. Aborting mid-pass would leave the indices half-rebuilt; aborting before the pass would keep exactly the stale keys that made the rebuild necessary.

`GigaIndices.internalReindex` is now best-effort across the index groups, mirroring `internalRemove`: a bitmap group reporting a violation must neither keep the Lucene/vector groups from being rebuilt nor cost the already rebuilt groups their state-change marks, since unmarked index data would not be persisted by a subsequent `store()`.

Javadoc on `GigaMap#reindex()`, `IndexGroup.Internal#internalReindex` and `UniqueConstraints` documents the new validation point; the docs get a "Validation Points" section under Unique Constraints plus a pointer from the CRUD page.

## Behavior change

`reindex()` now throws where it previously returned normally, for data that already violates a unique constraint. That is the intended signal, and the repair cycle is documented in both the javadoc and `constraints.adoc`, but it is worth a release-note entry.

## Tests

New `GigaMap121Test` (reusing the type-dictionary rewrite of `GigaMap88Test` to simulate class evolution):

- the violation is reported, naming the index and one of the colliding entities
- the rebuild is completed before reporting: no entity dropped, stale keys gone, index matches the actual entity state, and the rebuild survives `store()` + restart despite the throw
- the documented repair - `apply()` to re-distinguish the keys, then `reindex()` again - reaches a clean, restart-stable state and deletes nothing (regression guard for internal#88 / #771)
- a rebuild over sound data under a unique constraint still passes (guards against an over-eager check)

Verified RED without the fix (3 of the 4 cases fail with "nothing was thrown"), green with it. Full gigamap suite 1196 tests green; gigamap-lucene 76 and gigamap-jvector 239 green (9 slow-tagged skipped by default).

Fixes internal#121
