### PR TITLE
GigaMap: index registration and redefinition build the index before registering it

### DIFF
--- a/docs/modules/gigamap/pages/indexing/bitmap/defining.adoc
+++ b/docs/modules/gigamap/pages/indexing/bitmap/defining.adoc
@@ -183,6 +183,21 @@ GigaMap<Person> gigaMap = GigaMap.<Person>Builder()
     .build();
 ----
 
+=== Registering on a Populated Map
+
+Indices can also be registered later, on a GigaMap that already holds entities. `add`, `addAll` and `ensure` then back-fill the new index from those entities, so it answers queries about them as well.
+
+The back-fill is the only step that runs your indexer over existing data, and it is therefore the only one that can fail — typically an indexer that cannot handle a value the previous logic never read. Registration is all-or-nothing: the index is built completely before it becomes part of the map, so a throwing indexer registers nothing, leaves the existing indices untouched, and persists nothing on the next `store()`. `addAll` extends that across the whole batch: either every index of the call is registered, or none is. After fixing the indexer, simply repeat the call.
+
+To change the logic of an index that is already registered, use `update(Indexer)` rather than `removeIndex` followed by `add`:
+
+[source, java]
+----
+gigaMap.index().bitmap().update(PersonIndices.email); // same name, new logic
+----
+
+`update` rebuilds and validates the replacement before dropping the existing index, so a failure leaves the old index in place, and it carries unique-constraint and identity-index membership over to the rebuilt index. Removing and re-adding does neither: the re-added index is a plain index that accepts duplicates.
+
 == With Annotations
 
 Alternatively, indices can be defined by annotating the relevant fields of the entity.

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -1169,14 +1169,7 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		 */
 		private void validateIndexToRegister(final BitmapIndex.Internal<E, ?> index)
 		{
-			if(index.parent() != this)
-			{
-				throw new BitmapIndicesException(
-					"Inconsistent parent reference for index " + BitmapIndex.class.getSimpleName()
-					+ " \"" + index.name() + "\".",
-					this
-				);
-			}
+			this.validateIndexParent(index);
 
 			final String indexName = index.name();
 			if(indexName == null)
@@ -1187,6 +1180,26 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			{
 				throw new BitmapIndicesException(
 					BitmapIndex.class.getSimpleName() + " already registered for name \"" + indexName + "\".",
+					this
+				);
+			}
+		}
+
+		/**
+		 * Validates that a freshly created index belongs to this group. Separate from
+		 * {@link #validateIndexToRegister(BitmapIndex.Internal)} because a redefinition needs exactly this
+		 * check and not the name check: the name it will be registered under is still occupied by the index
+		 * it replaces.
+		 *
+		 * @param index the freshly created index
+		 */
+		private void validateIndexParent(final BitmapIndex.Internal<E, ?> index)
+		{
+			if(index.parent() != this)
+			{
+				throw new BitmapIndicesException(
+					"Inconsistent parent reference for index " + BitmapIndex.class.getSimpleName()
+					+ " \"" + index.name() + "\".",
 					this
 				);
 			}
@@ -1372,10 +1385,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
 				try
 				{
-					// The replacement must carry the very name that selected the index being replaced:
-					// #createFor may be overridden to name the index differently, which would either
-					// register the rebuilt index under a foreign name or fail below - after the old index
-					// has already been dropped. Checked here, while nothing has been changed yet.
+					// Everything #internalAddBitmapIndex could reject, checked while nothing has been changed
+					// yet - the registration below runs after the old index has been dropped, so it must not
+					// be able to fail. The name check is the update-specific half: the replacement must carry
+					// the very name that selected the index being replaced, whereas #createFor may be
+					// overridden to name the index it creates differently.
+					this.validateIndexParent(index);
 					if(!name.equals(index.name()))
 					{
 						throw new BitmapIndicesException(

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -1997,17 +1997,21 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 
 			// Building unique indices, their data and data-related validation.
+			// Every created index is collected separately from the by-name table: one that fails validation
+			// is not in that table (a suitability failure never reaches it, a name collision is what the
+			// insert rejected), and the cleanup below must not depend on which of the two it landed in.
 			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
+			final BulkList<BitmapIndex.Internal<E, ?>>            created = BulkList.New();
 			try
 			{
-				this.buildUniqueIndices(indexers, indices);
+				this.buildUniqueIndices(indexers, indices, created);
 				// names the indexers did not reveal, checked before anything is built or registered
 				this.validateIndicesToRegister(indices.values());
 				this.buildIndexDataAndValidateUniqueness(indices);
 			}
 			catch(final Throwable t)
 			{
-				releaseAbandonedIndexData(indices.values(), t);
+				releaseAbandonedIndexData(created, t);
 
 				throw t;
 			}
@@ -2060,14 +2064,21 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			return existing != null && this.uniqueConstraints != null && this.uniqueConstraints.contains(existing);
 		}
 
+		/**
+		 * @param indices receives the created indices by name, for the subsequent build and registration
+		 * @param created receives every created index, including one this method then rejects, so that the
+		 *        caller can discard all of them regardless of where the failure happened
+		 */
 		private void buildUniqueIndices(
 			final XGettingCollection<? extends Indexer<? super E, ?>> indexers,
-			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices
+			final EqHashTable<String, BitmapIndex.Internal<E, ?>>     indices ,
+			final BulkList<BitmapIndex.Internal<E, ?>>                created
 		)
 		{
 			for(final Indexer<? super E, ?> indexer : indexers)
 			{
 				final BitmapIndex.Internal<E, ?> index = indexer.createFor(this);
+				created.add(index);
 				if(!index.isSuitableAsUniqueConstraint())
 				{
 					throw new BitmapIndicesException(

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -2130,6 +2130,13 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		 */
 		private void buildIndexData(final XGettingCollection<? extends BitmapIndex.Internal<E, ?>> indices)
 		{
+			if(indices.isEmpty())
+			{
+				// nothing to fill: skip the pass over the entities, which would otherwise materialize every
+				// lazily loaded segment to hand each one to no index at all.
+				return;
+			}
+
 			this.parent.iterateIndexed((final long entityId, final E entity) ->
 			{
 				for(final BitmapIndex.Internal<E, ?> index : indices)
@@ -2143,6 +2150,12 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices
 		)
 		{
+			if(indices.isEmpty())
+			{
+				// see #buildIndexData(XGettingCollection)
+				return;
+			}
+
 			this.parent.iterateIndexed((final long entityId, final E entity) ->
 			{
 				for(final BitmapIndex.Internal<E, ?> index : indices.values())

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -1122,9 +1122,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		 * Registers a single index without checking mutability. Callers must have passed
 		 * {@link #ensureMutable(String)} and must still hold the parent-map monitor.
 		 * <p>
-		 * The index is back-filled while it is still standalone and only registered once its data is
-		 * complete, so an {@link Indexer} throwing for one of the already-present entities leaves this
-		 * group untouched instead of a partially filled index registered
+		 * Registration is always the last step: where a back-fill happens at all ({@code initialize == true}),
+		 * it runs while the index is still standalone, so an {@link Indexer} throwing for one of the
+		 * already-present entities leaves this group untouched instead of a partially filled index registered
 		 * (see {@link #buildIndexData(BitmapIndex.Internal)}).
 		 *
 		 * @param initialize whether to back-fill the new index from the already-present entities

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -1135,14 +1135,84 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			this.validateIndexToAdd(indexer);
 
 			final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
-			if(initialize)
+			try
 			{
-				this.buildIndexData(index);
+				// before anything is built, so that registration below cannot fail
+				this.validateIndexToRegister(index);
+				if(initialize)
+				{
+					this.buildIndexData(index);
+				}
+				this.internalAddBitmapIndex(index);
 			}
-			this.internalAddBitmapIndex(index);
+			catch(final Throwable t)
+			{
+				releaseAbandonedIndexData(index, t);
+
+				throw t;
+			}
 			this.rebuildCache();
 
 			return index;
+		}
+
+		/**
+		 * Validates an index that was just created and is about to be filled and registered.
+		 * <p>
+		 * {@link #validateIndexToAdd(Indexer)} only saw the <i>indexer's</i> name, but
+		 * {@link Indexer#createFor(BitmapIndices)} may be overridden to name the index it creates
+		 * differently. Checking here - while nothing has been built, dropped or registered yet - is what lets
+		 * {@link #internalAddBitmapIndex(BitmapIndex.Internal)} be a step that cannot fail, which in turn is
+		 * what makes a batch registration all-or-nothing and a redefinition atomic.
+		 *
+		 * @param index the freshly created, not yet registered index
+		 */
+		private void validateIndexToRegister(final BitmapIndex.Internal<E, ?> index)
+		{
+			if(index.parent() != this)
+			{
+				throw new BitmapIndicesException(
+					"Inconsistent parent reference for index " + BitmapIndex.class.getSimpleName()
+					+ " \"" + index.name() + "\".",
+					this
+				);
+			}
+
+			final String indexName = index.name();
+			if(indexName == null)
+			{
+				throw new IllegalArgumentException("Index name may not be null.");
+			}
+			if(this.bitmapIndices.get(indexName) != null)
+			{
+				throw new BitmapIndicesException(
+					BitmapIndex.class.getSimpleName() + " already registered for name \"" + indexName + "\".",
+					this
+				);
+			}
+		}
+
+		/**
+		 * Validates a batch of freshly created indices, additionally rejecting a name collision <i>within</i>
+		 * the batch - which the indexer-level validation cannot see either, for the reason given in
+		 * {@link #validateIndexToRegister(BitmapIndex.Internal)}.
+		 *
+		 * @param indices the freshly created, not yet registered indices
+		 */
+		private void validateIndicesToRegister(final XGettingCollection<? extends BitmapIndex.Internal<E, ?>> indices)
+		{
+			final EqHashTable<String, BitmapIndex.Internal<E, ?>> byName = EqHashTable.New();
+			for(final BitmapIndex.Internal<E, ?> index : indices)
+			{
+				this.validateIndexToRegister(index);
+				if(!byName.add(index.name(), index))
+				{
+					throw new BitmapIndicesException(
+						"Conflicted index name: \"" + index.name() + "\".",
+						this
+					);
+				}
+			}
 		}
 
 		/**
@@ -1300,25 +1370,47 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				// the existing index untouched (atomic failure). The new index is standalone (not yet
 				// registered) for the whole build.
 				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
-				if(wasUnique)
+				try
 				{
-					if(!index.isSuitableAsUniqueConstraint())
+					// The replacement must carry the very name that selected the index being replaced:
+					// #createFor may be overridden to name the index differently, which would either
+					// register the rebuilt index under a foreign name or fail below - after the old index
+					// has already been dropped. Checked here, while nothing has been changed yet.
+					if(!name.equals(index.name()))
 					{
 						throw new BitmapIndicesException(
-							"Index not suited as a unique constraint: \"" + index.name() + "\" class " + index.getClass(),
+							"Indexer \"" + name + "\" created an index named \"" + index.name()
+							+ "\"; a redefinition must keep the name that selects the index to replace.",
 							this
 						);
 					}
-					final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
-					indices.add(index.name(), index);
-					this.buildIndexDataAndValidateUniqueness(indices);
+					if(wasUnique)
+					{
+						if(!index.isSuitableAsUniqueConstraint())
+						{
+							throw new BitmapIndicesException(
+								"Index not suited as a unique constraint: \"" + index.name() + "\" class " + index.getClass(),
+								this
+							);
+						}
+						final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
+						indices.add(index.name(), index);
+						this.buildIndexDataAndValidateUniqueness(indices);
+					}
+					else
+					{
+						this.buildIndexData(index);
+					}
 				}
-				else
+				catch(final Throwable t)
 				{
-					this.buildIndexData(index);
+					releaseAbandonedIndexData(index, t);
+
+					throw t;
 				}
 
-				// commit: drop the old index (logic + data), then register the rebuilt index.
+				// commit: nothing below can fail. Drop the old index (logic + data), then register the
+				// rebuilt one - its name is the one just freed, so registration cannot be rejected.
 				// identity removal is allowed here and restored below; skip the intermediate cache
 				// rebuild since update() rebuilds the cache once at the end.
 				this.internalRemoveIndex(name, true, false);
@@ -1387,13 +1479,25 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				// Deliberately a plain list, not a table keyed by name: the validation above de-duplicates
 				// the indexers' names, but #createFor may be overridden to name the index differently, and
 				// a keyed collection would silently drop such a collision - both from the batch and from
-				// the release below. A name that is nonetheless taken is rejected when it is registered.
+				// the release below.
 				final BulkList<BitmapIndex.Internal<E, ?>> indices = BulkList.New(requested.intSize());
-				for(final Indexer<? super E, ?> indexer : requested)
+				try
 				{
-					indices.add(indexer.createFor(this));
+					for(final Indexer<? super E, ?> indexer : requested)
+					{
+						indices.add(indexer.createFor(this));
+					}
+					// Names the indexers did not reveal are checked before anything is built, so that the
+					// registration loop below cannot fail with part of the batch already registered.
+					this.validateIndicesToRegister(indices);
+					this.buildIndexData(indices);
 				}
-				this.buildIndexData(indices);
+				catch(final Throwable t)
+				{
+					releaseAbandonedIndexData(indices, t);
+
+					throw t;
+				}
 
 				for(final BitmapIndex.Internal<E, ?> index : indices)
 				{
@@ -1686,29 +1790,23 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		
 		/**
 		 * Registers an index whose data is already complete. Deliberately performs no back-fill: filling
-		 * happens beforehand, while the index is still standalone (see {@link #buildIndexData(BitmapIndex.Internal)}),
-		 * so that registration is the last step of every add/update path and runs no user code that could
-		 * fail with the index already in the registry.
+		 * happens beforehand, while the index is still standalone (see {@link #buildIndexData(BitmapIndex.Internal)}).
+		 * <p>
+		 * This step must not fail - callers register a batch index by index, and a redefinition registers the
+		 * replacement after having dropped the original - so everything that could reject the index is checked
+		 * by {@link #validateIndexToRegister(BitmapIndex.Internal)} before anything is built or dropped. The
+		 * guard below therefore only asserts that invariant rather than enforcing it; a caller reaching it has
+		 * skipped the validation.
 		 */
 		private void internalAddBitmapIndex(final BitmapIndex.Internal<E, ?> index)
 		{
-			// just to be safe and the performance cost is irrelevant for a structural element.
-			// Checked before registering, so a foreign index is not left behind in the registry.
-			if(index.parent() != this)
+			// #add does not overwrite, so a taken name would otherwise leave the caller believing an index it
+			// never registered is in place.
+			if(index.parent() != this || !this.bitmapIndices.add(index.name(), index))
 			{
 				throw new BitmapIndicesException(
-					"Inconsistent parent reference for index " + BitmapIndex.class.getSimpleName() + " \"" + index.name() + "\".",
-					this
-				);
-			}
-
-			// Rejected rather than silently ignored: #add does not overwrite, so a taken name would leave
-			// the caller believing an index it never registered is in place. The public entry points
-			// validate the name up front; this catches a name that only #createFor produced.
-			if(!this.bitmapIndices.add(index.name(), index))
-			{
-				throw new BitmapIndicesException(
-					BitmapIndex.class.getSimpleName() + " already registered for name \"" + index.name() + "\".",
+					"Index " + BitmapIndex.class.getSimpleName() + " \"" + index.name()
+					+ "\" cannot be registered: inconsistent parent reference, or the name is already taken.",
 					this
 				);
 			}
@@ -1885,8 +1983,19 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 
 			// Building unique indices, their data and data-related validation.
 			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
-			this.buildUniqueIndices(indexers, indices);
-			this.buildIndexDataAndValidateUniqueness(indices);
+			try
+			{
+				this.buildUniqueIndices(indexers, indices);
+				// names the indexers did not reveal, checked before anything is built or registered
+				this.validateIndicesToRegister(indices.values());
+				this.buildIndexDataAndValidateUniqueness(indices);
+			}
+			catch(final Throwable t)
+			{
+				releaseAbandonedIndexData(indices.values(), t);
+
+				throw t;
+			}
 
 			// When everything is guaranteed to be valid and consistent, the indices - whose data is complete
 			// by now - are actually registered.
@@ -1970,23 +2079,17 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		 * the already-present entities would otherwise leave a partially filled index registered - silently
 		 * answering queries with a torso of the data, and persisted by the next {@code store()}.
 		 * <p>
-		 * On failure the abandoned index' off-heap memory is released, because an index that never gets
-		 * registered is never reached by {@link #internalRemoveIndex(String, boolean, boolean)}'s release.
+		 * Releasing the off-heap memory of an index abandoned because this failed is the caller's job: the
+		 * caller owns the index for its whole standalone life - creation, validation, filling, registration -
+		 * and a failure anywhere in that span must discard it (see {@link #releaseAbandonedIndexData}). An
+		 * index that never gets registered is never reached by
+		 * {@link #internalRemoveIndex(String, boolean, boolean)}'s release.
 		 *
 		 * @param index the standalone index to fill
 		 */
 		private void buildIndexData(final BitmapIndex.Internal<E, ?> index)
 		{
-			try
-			{
-				this.parent.iterateIndexed(index::internalAdd);
-			}
-			catch(final Throwable t)
-			{
-				releaseAbandonedIndexData(index, t);
-
-				throw t;
-			}
+			this.parent.iterateIndexed(index::internalAdd);
 		}
 
 		/**
@@ -2001,48 +2104,30 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		 */
 		private void buildIndexData(final XGettingCollection<? extends BitmapIndex.Internal<E, ?>> indices)
 		{
-			try
+			this.parent.iterateIndexed((final long entityId, final E entity) ->
 			{
-				this.parent.iterateIndexed((final long entityId, final E entity) ->
+				for(final BitmapIndex.Internal<E, ?> index : indices)
 				{
-					for(final BitmapIndex.Internal<E, ?> index : indices)
-					{
-						index.internalAdd(entityId, entity);
-					}
-				});
-			}
-			catch(final Throwable t)
-			{
-				releaseAbandonedIndexData(indices, t);
-
-				throw t;
-			}
+					index.internalAdd(entityId, entity);
+				}
+			});
 		}
 
 		private void buildIndexDataAndValidateUniqueness(
 			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices
 		)
 		{
-			try
+			this.parent.iterateIndexed((final long entityId, final E entity) ->
 			{
-				this.parent.iterateIndexed((final long entityId, final E entity) ->
+				for(final BitmapIndex.Internal<E, ?> index : indices.values())
 				{
-					for(final BitmapIndex.Internal<E, ?> index : indices.values())
+					if(index.internalContains(entity))
 					{
-						if(index.internalContains(entity))
-						{
-							throw new UniqueConstraintViolationExceptionBitmap(entityId, null, entity, index);
-						}
-						index.internalAdd(entityId, entity);
+						throw new UniqueConstraintViolationExceptionBitmap(entityId, null, entity, index);
 					}
-				});
-			}
-			catch(final Throwable t)
-			{
-				releaseAbandonedIndexData(indices.values(), t);
-
-				throw t;
-			}
+					index.internalAdd(entityId, entity);
+				}
+			});
 		}
 
 		private static void releaseAbandonedIndexData(

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -1384,16 +1384,18 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				// Build every index' data while they are all still standalone, so that an indexer throwing
 				// for one of the already-present entities registers none of the batch instead of leaving it
 				// half applied - with the throwing index registered and partially filled at that.
-				// The names are already de-duplicated by the validation above.
-				final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
+				// Deliberately a plain list, not a table keyed by name: the validation above de-duplicates
+				// the indexers' names, but #createFor may be overridden to name the index differently, and
+				// a keyed collection would silently drop such a collision - both from the batch and from
+				// the release below. A name that is nonetheless taken is rejected when it is registered.
+				final BulkList<BitmapIndex.Internal<E, ?>> indices = BulkList.New(requested.intSize());
 				for(final Indexer<? super E, ?> indexer : requested)
 				{
-					final BitmapIndex.Internal<E, ?> index = indexer.createFor(this);
-					indices.add(index.name(), index);
+					indices.add(indexer.createFor(this));
 				}
 				this.buildIndexData(indices);
 
-				for(final BitmapIndex.Internal<E, ?> index : indices.values())
+				for(final BitmapIndex.Internal<E, ?> index : indices)
 				{
 					this.internalAddBitmapIndex(index);
 				}
@@ -1700,7 +1702,16 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				);
 			}
 
-			this.bitmapIndices.add(index.name(), index);
+			// Rejected rather than silently ignored: #add does not overwrite, so a taken name would leave
+			// the caller believing an index it never registered is in place. The public entry points
+			// validate the name up front; this catches a name that only #createFor produced.
+			if(!this.bitmapIndices.add(index.name(), index))
+			{
+				throw new BitmapIndicesException(
+					BitmapIndex.class.getSimpleName() + " already registered for name \"" + index.name() + "\".",
+					this
+				);
+			}
 
 			this.markStateChangeInstance();
 			this.parent.internalReportIndexGroupStateChange(this);
@@ -1986,15 +1997,15 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		 * For the failure contract see {@link #buildIndexData(BitmapIndex.Internal)}: none of the indices is
 		 * registered yet, so a throwing indexer leaves the group untouched - the batch is all-or-nothing.
 		 *
-		 * @param indices the standalone indices to fill, keyed by their name
+		 * @param indices the standalone indices to fill
 		 */
-		private void buildIndexData(final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices)
+		private void buildIndexData(final XGettingCollection<? extends BitmapIndex.Internal<E, ?>> indices)
 		{
 			try
 			{
 				this.parent.iterateIndexed((final long entityId, final E entity) ->
 				{
-					for(final BitmapIndex.Internal<E, ?> index : indices.values())
+					for(final BitmapIndex.Internal<E, ?> index : indices)
 					{
 						index.internalAdd(entityId, entity);
 					}
@@ -2028,18 +2039,18 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 			catch(final Throwable t)
 			{
-				releaseAbandonedIndexData(indices, t);
+				releaseAbandonedIndexData(indices.values(), t);
 
 				throw t;
 			}
 		}
 
 		private static void releaseAbandonedIndexData(
-			final EqHashTable<String, ? extends BitmapIndex.Internal<?, ?>> indices,
-			final Throwable                                                 cause
+			final XGettingCollection<? extends BitmapIndex.Internal<?, ?>> indices,
+			final Throwable                                               cause
 		)
 		{
-			for(final BitmapIndex.Internal<?, ?> index : indices.values())
+			for(final BitmapIndex.Internal<?, ?> index : indices)
 			{
 				releaseAbandonedIndexData(index, cause);
 			}

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -63,8 +63,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * <b>Behavior on failure:</b> the index is built completely before it is registered, so if
 	 * {@code indexer} throws for one of the already-present entities, nothing is registered and this group
 	 * is left exactly as it was: no index is queryable under the given name, no sibling index is affected,
-	 * and nothing of the attempt is persisted by a subsequent {@code store()}. The exception is rethrown
-	 * unchanged; the name stays free, so the call can simply be repeated with corrected logic.
+	 * and nothing of the attempt is persisted by a subsequent {@code store()}. The indexer's exception is
+	 * the one propagated - should discarding the half-built index fail in turn, that secondary failure is
+	 * attached to it as a suppressed exception. The name stays free, so the call can simply be repeated
+	 * with corrected logic.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the indexing logic
@@ -91,8 +93,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * indexer that <i>would</i> match already-present entities leaves the index inconsistent and
 	 * produces wrong query results. When in doubt, use {@link #add(Indexer)}.
 	 * <p>
-	 * Since no back-fill runs, {@code indexer} is not invoked at all here and the failure mode
-	 * {@link #add(Indexer)} documents cannot occur: registration is the only operation performed.
+	 * Since no back-fill runs, {@link Indexer#index(Object)} is never called for an already-present entity,
+	 * so the failure mode {@link #add(Indexer)} documents - a partially built index - cannot occur here.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the indexing logic

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapIndices.java
@@ -56,6 +56,15 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * but it can bite when {@link Indexer#name() name()} is overridden manually or
 	 * when anonymous {@link Indexer} instances produce colliding default names; give
 	 * each indexer an explicit, unique name in those cases.
+	 * <p>
+	 * On a parent {@link GigaMap} that already contains entities, the new index is back-filled from them,
+	 * so that it answers queries about the entities added before it as well.
+	 * <p>
+	 * <b>Behavior on failure:</b> the index is built completely before it is registered, so if
+	 * {@code indexer} throws for one of the already-present entities, nothing is registered and this group
+	 * is left exactly as it was: no index is queryable under the given name, no sibling index is affected,
+	 * and nothing of the attempt is persisted by a subsequent {@code store()}. The exception is rethrown
+	 * unchanged; the name stays free, so the call can simply be repeated with corrected logic.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the indexing logic
@@ -81,6 +90,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * yet (e.g. a per-value index created the first time that value appears). Using this for an
 	 * indexer that <i>would</i> match already-present entities leaves the index inconsistent and
 	 * produces wrong query results. When in doubt, use {@link #add(Indexer)}.
+	 * <p>
+	 * Since no back-fill runs, {@code indexer} is not invoked at all here and the failure mode
+	 * {@link #add(Indexer)} documents cannot occur: registration is the only operation performed.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the indexing logic
@@ -113,6 +125,16 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * The passed iterable is traversed exactly once, so a single-use iterable (e.g. stream-backed) is fine.
 	 * Passing no indexer at all is a no-op. Two indexers with the same {@link Indexer#name() name} within the
 	 * same call are rejected, just like an indexer whose name is already registered.
+	 * <p>
+	 * The back-fill over the already-present entities is a single pass for the whole batch, so every entity -
+	 * and, with lazily loaded segments, every segment - is visited once rather than once per indexer. The
+	 * indices are independent of each other, so the only difference to filling them one after another is the
+	 * order in which the indexers see the entities.
+	 * <p>
+	 * <b>Behavior on failure:</b> all-or-nothing across the batch. Every index is built completely before any
+	 * of them is registered, so an indexer throwing for one of the already-present entities registers
+	 * <b>no</b> index of the batch - not even those whose own logic never threw - and leaves this group
+	 * exactly as it was. For the per-index details see {@link #add(Indexer)}.
 	 *
 	 * @param indexers the new indexing logic
 	 * @return this
@@ -123,9 +145,14 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * Removes the index registered under the given name.
 	 * <p>
 	 * The index and its data are dropped from this group. If the index is also registered as a
-	 * unique constraint, that constraint is lifted as well. The orphaned index data is reclaimed
-	 * by the storage's garbage collection on the next housekeeping cycle after the surrounding
-	 * {@link GigaMap} is stored - it is not freed synchronously.
+	 * unique constraint, that constraint is lifted as well. The index' off-heap memory is freed
+	 * synchronously; the orphaned data <i>on disk</i> is reclaimed by the storage's garbage collection
+	 * on the next housekeeping cycle after the surrounding {@link GigaMap} is stored.
+	 * <p>
+	 * Registering an index under the same name again via {@link #add(Indexer)} or {@link #ensure(Indexer)}
+	 * does <b>not</b> restore the lifted unique constraint, nor identity-index membership: the re-added
+	 * index is a plain index that accepts duplicates. To change the logic of an index while preserving both
+	 * memberships, use {@link #update(Indexer)} instead of removing and re-adding it.
 	 * <p>
 	 * Removing an index that is currently registered as an
 	 * {@link #identityIndices() identity index} is rejected with a {@link RuntimeException},
@@ -165,6 +192,17 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * {@link org.eclipse.store.gigamap.exceptions.UniqueConstraintViolationException} if the current
 	 * data is no longer unique); if it was an identity index, the identity set is re-pointed to the
 	 * rebuilt index.
+	 * <p>
+	 * <b>Behavior on failure:</b> atomic, for a unique constraint and a plain index alike. The replacement
+	 * index is built from all current entities - and, for a unique constraint, validated - <b>before</b> the
+	 * existing index is dropped, so a uniqueness violation or an {@code indexer} throwing for one of the
+	 * entities leaves the existing index registered, fully populated and still enforcing its unique and
+	 * identity membership. Nothing of the attempt is persisted by a subsequent {@code store()}, and the call
+	 * can simply be repeated with corrected logic.
+	 * <p>
+	 * The price of that atomicity is that the old and the new data of this one index are held simultaneously
+	 * for the duration of the rebuild, which roughly doubles that index' peak footprint - noticeable for a
+	 * high-cardinality index over a large map.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the new indexing logic, whose name selects the index to replace
@@ -183,6 +221,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 	 * <b>unchanged</b> and the passed {@code indexer}'s logic is ignored. {@code ensure} therefore
 	 * never modifies an existing index. To change the logic of an already-registered index, use
 	 * {@link #update(Indexer)}.
+	 * <p>
+	 * When it does create an index, it does so exactly like {@link #add(Indexer)}, including that method's
+	 * back-fill and its behavior on failure.
 	 *
 	 * @param <K> the key type
 	 * @param indexer the indexing logic
@@ -1078,6 +1119,11 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 		/**
 		 * Registers a single index without checking mutability. Callers must have passed
 		 * {@link #ensureMutable(String)} and must still hold the parent-map monitor.
+		 * <p>
+		 * The index is back-filled while it is still standalone and only registered once its data is
+		 * complete, so an {@link Indexer} throwing for one of the already-present entities leaves this
+		 * group untouched instead of a partially filled index registered
+		 * (see {@link #buildIndexData(BitmapIndex.Internal)}).
 		 *
 		 * @param initialize whether to back-fill the new index from the already-present entities
 		 *        (see {@link #addWithoutInitialization(Indexer)})
@@ -1087,7 +1133,11 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			this.validateIndexToAdd(indexer);
 
 			final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
-			this.internalAddBitmapIndex(index, initialize);
+			if(initialize)
+			{
+				this.buildIndexData(index);
+			}
+			this.internalAddBitmapIndex(index);
 			this.rebuildCache();
 
 			return index;
@@ -1243,6 +1293,10 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				final boolean wasUnique   = this.isUniqueConstraint(existing);
 				final boolean wasIdentity = this.isIdentityIndex(existing);
 
+				// Build the new index' data against all existing entities BEFORE dropping the old one, so
+				// that a failure under the new logic - a uniqueness violation or a throwing indexer - leaves
+				// the existing index untouched (atomic failure). The new index is standalone (not yet
+				// registered) for the whole build.
 				final BitmapIndex.Internal<E, K> index = indexer.createFor(this);
 				if(wasUnique)
 				{
@@ -1253,12 +1307,13 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 							this
 						);
 					}
-					// Build and validate the new index' data against all existing entities BEFORE dropping
-					// the old one, so that a uniqueness violation under the new logic leaves the existing
-					// index untouched (atomic failure). The new index is standalone (not yet registered).
 					final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
 					indices.add(index.name(), index);
 					this.buildIndexDataAndValidateUniqueness(indices);
+				}
+				else
+				{
+					this.buildIndexData(index);
 				}
 
 				// commit: drop the old index (logic + data), then register the rebuilt index.
@@ -1269,7 +1324,6 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				{
 					this.internalAddUniqueConstraint(index);
 				}
-				// registers the index and back-fills it from all existing entities (idempotent for the unique branch).
 				this.internalAddBitmapIndex(index);
 
 				if(wasIdentity)
@@ -1325,9 +1379,20 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 					}
 				}
 
+				// Build every index' data while they are all still standalone, so that an indexer throwing
+				// for one of the already-present entities registers none of the batch instead of leaving it
+				// half applied - with the throwing index registered and partially filled at that.
+				// The names are already de-duplicated by the validation above.
+				final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices = EqHashTable.New();
 				for(final Indexer<? super E, ?> indexer : requested)
 				{
 					final BitmapIndex.Internal<E, ?> index = indexer.createFor(this);
+					indices.add(index.name(), index);
+				}
+				this.buildIndexData(indices);
+
+				for(final BitmapIndex.Internal<E, ?> index : indices.values())
+				{
 					this.internalAddBitmapIndex(index);
 				}
 				this.rebuildCache();
@@ -1615,16 +1680,16 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			return this;
 		}
 		
+		/**
+		 * Registers an index whose data is already complete. Deliberately performs no back-fill: filling
+		 * happens beforehand, while the index is still standalone (see {@link #buildIndexData(BitmapIndex.Internal)}),
+		 * so that registration is the last step of every add/update path and runs no user code that could
+		 * fail with the index already in the registry.
+		 */
 		private void internalAddBitmapIndex(final BitmapIndex.Internal<E, ?> index)
 		{
-			this.internalAddBitmapIndex(index, true);
-		}
-
-		private void internalAddBitmapIndex(final BitmapIndex.Internal<E, ?> index, final boolean initialize)
-		{
-			this.bitmapIndices.add(index.name(), index);
-
 			// just to be safe and the performance cost is irrelevant for a structural element.
+			// Checked before registering, so a foreign index is not left behind in the registry.
 			if(index.parent() != this)
 			{
 				throw new BitmapIndicesException(
@@ -1633,14 +1698,9 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 				);
 			}
 
-			this.markStateChangeInstance();
+			this.bitmapIndices.add(index.name(), index);
 
-			// initialize==false: caller guarantees no existing entity would be indexed, so the
-			// back-fill over the already-present entities is skipped (see addWithoutInitialization).
-			if(initialize)
-			{
-				this.parent.iterateIndexed(index::internalAdd);
-			}
+			this.markStateChangeInstance();
 			this.parent.internalReportIndexGroupStateChange(this);
 		}
 		
@@ -1815,7 +1875,8 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			this.buildUniqueIndices(indexers, indices);
 			this.buildIndexDataAndValidateUniqueness(indices);
 
-			// When everything is guaranteed to be valid and consistent, the indices are actually added.
+			// When everything is guaranteed to be valid and consistent, the indices - whose data is complete
+			// by now - are actually registered.
 			for(final BitmapIndex.Internal<E, ?> index : indices.values())
 			{
 				this.internalAddUniqueConstraint(index);
@@ -1887,21 +1948,117 @@ Iterable<KeyValue<String, ? extends BitmapIndex<E, ?>>>
 			}
 		}
 		
+		/**
+		 * Back-fills a standalone - created, but not yet registered - index from the entities the parent map
+		 * already holds.
+		 * <p>
+		 * Must run <b>before</b> {@link #internalAddBitmapIndex(BitmapIndex.Internal)}: the back-fill is the
+		 * only step that runs user code ({@link Indexer#index(Object)}), so an indexer throwing for one of
+		 * the already-present entities would otherwise leave a partially filled index registered - silently
+		 * answering queries with a torso of the data, and persisted by the next {@code store()}.
+		 * <p>
+		 * On failure the abandoned index' off-heap memory is released, because an index that never gets
+		 * registered is never reached by {@link #internalRemoveIndex(String, boolean, boolean)}'s release.
+		 *
+		 * @param index the standalone index to fill
+		 */
+		private void buildIndexData(final BitmapIndex.Internal<E, ?> index)
+		{
+			try
+			{
+				this.parent.iterateIndexed(index::internalAdd);
+			}
+			catch(final Throwable t)
+			{
+				releaseAbandonedIndexData(index, t);
+
+				throw t;
+			}
+		}
+
+		/**
+		 * Back-fills several standalone indices in a single pass over the entities, which materializes every
+		 * lazily loaded segment once instead of once per index. The indices are independent, so the per-entity
+		 * order is the only difference to filling them one after another.
+		 * <p>
+		 * For the failure contract see {@link #buildIndexData(BitmapIndex.Internal)}: none of the indices is
+		 * registered yet, so a throwing indexer leaves the group untouched - the batch is all-or-nothing.
+		 *
+		 * @param indices the standalone indices to fill, keyed by their name
+		 */
+		private void buildIndexData(final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices)
+		{
+			try
+			{
+				this.parent.iterateIndexed((final long entityId, final E entity) ->
+				{
+					for(final BitmapIndex.Internal<E, ?> index : indices.values())
+					{
+						index.internalAdd(entityId, entity);
+					}
+				});
+			}
+			catch(final Throwable t)
+			{
+				releaseAbandonedIndexData(indices, t);
+
+				throw t;
+			}
+		}
+
 		private void buildIndexDataAndValidateUniqueness(
 			final EqHashTable<String, BitmapIndex.Internal<E, ?>> indices
 		)
 		{
-			this.parent.iterateIndexed((final long entityId, final E entity) ->
+			try
 			{
-				for(final BitmapIndex.Internal<E, ?> index : indices.values())
+				this.parent.iterateIndexed((final long entityId, final E entity) ->
 				{
-					if(index.internalContains(entity))
+					for(final BitmapIndex.Internal<E, ?> index : indices.values())
 					{
-						throw new UniqueConstraintViolationExceptionBitmap(entityId, null, entity, index);
+						if(index.internalContains(entity))
+						{
+							throw new UniqueConstraintViolationExceptionBitmap(entityId, null, entity, index);
+						}
+						index.internalAdd(entityId, entity);
 					}
-					index.internalAdd(entityId, entity);
-				}
-			});
+				});
+			}
+			catch(final Throwable t)
+			{
+				releaseAbandonedIndexData(indices, t);
+
+				throw t;
+			}
+		}
+
+		private static void releaseAbandonedIndexData(
+			final EqHashTable<String, ? extends BitmapIndex.Internal<?, ?>> indices,
+			final Throwable                                                 cause
+		)
+		{
+			for(final BitmapIndex.Internal<?, ?> index : indices.values())
+			{
+				releaseAbandonedIndexData(index, cause);
+			}
+		}
+
+		/**
+		 * Releases the off-heap memory of an index that is being abandoned because building its data failed,
+		 * mirroring the eager release a dropped index gets (see {@link #internalRemoveIndex(String, boolean, boolean)}).
+		 * A failure of the release itself is attached to the original cause rather than replacing it: what
+		 * made the build fail is what the caller has to act on.
+		 */
+		private static void releaseAbandonedIndexData(final BitmapIndex.Internal<?, ?> index, final Throwable cause)
+		{
+			try
+			{
+				index.internalReleaseOffHeap();
+			}
+			catch(final Throwable t)
+			{
+				cause.addSuppressed(t);
+			}
 		}
 		
 		@Override

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap140Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap140Test.java
@@ -1,0 +1,357 @@
+package org.eclipse.store.gigamap.issues;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Path;
+
+import org.eclipse.store.gigamap.types.BinaryIndexerString;
+import org.eclipse.store.gigamap.types.BitmapIndices;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerString;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression coverage for internal issue #140: the back-fill that populates a bitmap index from the
+ * entities a {@link GigaMap} already holds used to run <i>after</i> the index was registered. An
+ * {@link org.eclipse.store.gigamap.types.Indexer} throwing for one entity therefore left a partially
+ * filled index as part of the map's state - silently answering queries with a torso of the data, and
+ * persisted by the next {@code store()}. For a non-unique
+ * {@link BitmapIndices#update(org.eclipse.store.gigamap.types.Indexer)} it was worse still: the old index
+ * had already been dropped, so the map lost the working index and gained a broken one.
+ * <p>
+ * The unique branch of {@code update} was the one path that already built its replacement standalone
+ * before dropping the existing index ("atomic failure"). These tests pin the fixed behavior: every
+ * registering path builds the index completely before registering it, so a failure leaves the group
+ * exactly as it was, and {@code addAll} is all-or-nothing across its batch.
+ */
+public class GigaMap140Test
+{
+	static class Rec
+	{
+		String key;
+
+		Rec()
+		{
+			// required for deserialization
+			super();
+		}
+
+		Rec(final String key)
+		{
+			super();
+			this.key = key;
+		}
+	}
+
+	/** The established logic: index the key as it is. */
+	static final class KeyIndexer extends IndexerString.Abstract<Rec>
+	{
+		@Override
+		public String name()
+		{
+			return "key";
+		}
+
+		@Override
+		protected String getString(final Rec entity)
+		{
+			return entity.key;
+		}
+	}
+
+	/** Binary variant of {@link KeyIndexer}, suitable as a unique constraint. */
+	static final class BinaryKeyIndexer extends BinaryIndexerString.Abstract<Rec>
+	{
+		@Override
+		public String name()
+		{
+			return "binkey";
+		}
+
+		@Override
+		protected String getString(final Rec entity)
+		{
+			return entity.key;
+		}
+	}
+
+	/**
+	 * New logic under a configurable name: upper-cases the key, but throws for one designated entity -
+	 * the realistic case of an indexer that cannot handle a value the previous logic never read.
+	 */
+	static final class PoisonedIndexer extends IndexerString.Abstract<Rec>
+	{
+		final String name  ;
+		final String poison;
+
+		PoisonedIndexer(final String name, final String poison)
+		{
+			super();
+			this.name   = name  ;
+			this.poison = poison;
+		}
+
+		@Override
+		public String name()
+		{
+			return this.name;
+		}
+
+		@Override
+		protected String getString(final Rec entity)
+		{
+			if(entity.key.equals(this.poison))
+			{
+				throw new IllegalStateException("indexer failure on " + entity.key);
+			}
+
+			return entity.key.toUpperCase();
+		}
+	}
+
+	/** Binary counterpart of {@link PoisonedIndexer}, so the unique branch can be driven the same way. */
+	static final class PoisonedBinaryIndexer extends BinaryIndexerString.Abstract<Rec>
+	{
+		final String poison;
+
+		PoisonedBinaryIndexer(final String poison)
+		{
+			super();
+			this.poison = poison;
+		}
+
+		@Override
+		public String name()
+		{
+			return "binkey";
+		}
+
+		@Override
+		protected String getString(final Rec entity)
+		{
+			if(entity.key.equals(this.poison))
+			{
+				throw new IllegalStateException("indexer failure on " + entity.key);
+			}
+
+			return entity.key.toUpperCase();
+		}
+	}
+
+	private static GigaMap<Rec> populatedMap(final KeyIndexer keyIndexer)
+	{
+		final GigaMap<Rec> map = GigaMap.New();
+		map.index().bitmap().add(keyIndexer);
+		map.add(new Rec("a"));
+		map.add(new Rec("b"));
+		map.add(new Rec("c"));
+
+		return map;
+	}
+
+	@Test
+	@Timeout(120)
+	void update_nonUniqueIndexerThrowsDuringRebuild_keepsOldIndex()
+	{
+		final KeyIndexer   keyIndexer = new KeyIndexer();
+		final GigaMap<Rec> map        = populatedMap(keyIndexer);
+
+		assertThrows(
+			IllegalStateException.class,
+			() -> map.index().bitmap().update(new PoisonedIndexer("key", "c")),
+			"the failing back-fill must surface"
+		);
+
+		// the old index is still the registered one: all three entities are findable under their
+		// original keys, and none of the partially derived new keys resolves.
+		assertEquals(1, map.query(keyIndexer.is("a")).count(), "old index dropped");
+		assertEquals(1, map.query(keyIndexer.is("b")).count(), "old index dropped");
+		assertEquals(1, map.query(keyIndexer.is("c")).count(), "old index dropped");
+		assertEquals(0, map.query(keyIndexer.is("A")).count(), "partial new index registered");
+		assertEquals(0, map.query(keyIndexer.is("B")).count(), "partial new index registered");
+	}
+
+	@Test
+	@Timeout(120)
+	void update_uniqueIndexerThrowsDuringRebuild_keepsOldIndexAndConstraint()
+	{
+		final GigaMap<Rec>      map        = GigaMap.New();
+		final BitmapIndices<Rec> indices   = map.index().bitmap();
+		final BinaryKeyIndexer  keyIndexer = new BinaryKeyIndexer();
+		indices.addUniqueConstraint(keyIndexer);
+		map.add(new Rec("a"));
+		map.add(new Rec("b"));
+		map.add(new Rec("c"));
+
+		assertThrows(
+			IllegalStateException.class,
+			() -> indices.update(new PoisonedBinaryIndexer("c")),
+			"the failing back-fill must surface"
+		);
+
+		assertEquals(1, map.query(keyIndexer.is("a")).count(), "old index dropped");
+		assertEquals(0, map.query(keyIndexer.is("A")).count(), "partial new index registered");
+		assertEquals(1, indices.uniqueConstraints().size(), "unique membership lost");
+		assertThrows(RuntimeException.class, () -> map.add(new Rec("a")), "constraint no longer enforced");
+	}
+
+	@Test
+	@Timeout(120)
+	void add_indexerThrowsDuringBackfill_registersNothing()
+	{
+		final KeyIndexer   keyIndexer = new KeyIndexer();
+		final GigaMap<Rec> map        = populatedMap(keyIndexer);
+
+		final PoisonedIndexer poisoned = new PoisonedIndexer("key2", "c");
+		assertThrows(
+			IllegalStateException.class,
+			() -> map.index().bitmap().add(poisoned),
+			"the failing back-fill must surface"
+		);
+
+		assertNull(map.index().bitmap().get("key2"), "partial index left registered");
+		// no torso answers queries: the name is not resolvable at all
+		assertThrows(
+			IllegalArgumentException.class,
+			() -> map.query(poisoned.is("A")).count(),
+			"partial index answers queries"
+		);
+
+		// the healthy sibling is untouched, and the map is still fully usable: an ordinary update must
+		// reach every registered index (a stale index cache would silently skip one).
+		assertEquals(1, map.query(keyIndexer.is("a")).count());
+		final Rec first = map.query(keyIndexer.is("a")).findFirst().get();
+		map.update(first, rec -> rec.key = "z");
+		assertEquals(0, map.query(keyIndexer.is("a")).count(), "update did not reach the index");
+		assertEquals(1, map.query(keyIndexer.is("z")).count(), "update did not reach the index");
+	}
+
+	@Test
+	@Timeout(120)
+	void addAll_indexerThrowsMidBatch_registersNoIndexOfTheBatch()
+	{
+		final KeyIndexer   keyIndexer = new KeyIndexer();
+		final GigaMap<Rec> map        = populatedMap(keyIndexer);
+
+		assertThrows(
+			IllegalStateException.class,
+			() -> map.index().bitmap().addAll(
+				new PoisonedIndexer("healthy", "no-such-key"),
+				new PoisonedIndexer("poisoned", "c")
+			),
+			"the failing back-fill must surface"
+		);
+
+		assertNull(map.index().bitmap().get("healthy") , "batch applied in part");
+		assertNull(map.index().bitmap().get("poisoned"), "partial index left registered");
+	}
+
+	@Test
+	@Timeout(120)
+	void retryWithFixedIndexerSucceedsAfterFailedRegistration()
+	{
+		final KeyIndexer   keyIndexer = new KeyIndexer();
+		final GigaMap<Rec> map        = populatedMap(keyIndexer);
+
+		assertThrows(
+			IllegalStateException.class,
+			() -> map.index().bitmap().add(new PoisonedIndexer("key2", "c"))
+		);
+
+		// the name stayed free and the corrected indexer back-fills all three entities.
+		final PoisonedIndexer fixed = new PoisonedIndexer("key2", "no-such-key");
+		map.index().bitmap().add(fixed);
+		assertNotNull(map.index().bitmap().get("key2"));
+		assertEquals(1, map.query(fixed.is("A")).count());
+		assertEquals(1, map.query(fixed.is("B")).count());
+		assertEquals(1, map.query(fixed.is("C")).count());
+
+		// the same for a failed update, which must leave the name occupied by the old index
+		assertThrows(
+			IllegalStateException.class,
+			() -> map.index().bitmap().update(new PoisonedIndexer("key", "c"))
+		);
+		map.index().bitmap().update(new PoisonedIndexer("key", "no-such-key"));
+		assertEquals(1, map.query(keyIndexer.is("A")).count(), "corrected update did not rebuild");
+		assertEquals(0, map.query(keyIndexer.is("a")).count(), "corrected update did not rebuild");
+	}
+
+	@Test
+	@Timeout(120)
+	void failedRegistrationIsNotPersisted(@TempDir final Path storageDir)
+	{
+		final KeyIndexer keyIndexer = new KeyIndexer();
+
+		final GigaMap<Rec> map = populatedMap(keyIndexer);
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(map, storageDir))
+		{
+			map.store();
+
+			assertThrows(
+				IllegalStateException.class,
+				() -> map.index().bitmap().add(new PoisonedIndexer("key2", "c"))
+			);
+
+			// an ordinary successful mutation marks the parent flags through the normal path, so a
+			// half-registered index would be reached by this store() and become durable.
+			map.add(new Rec("d"));
+			map.store();
+		}
+
+		try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDir))
+		{
+			@SuppressWarnings("unchecked")
+			final GigaMap<Rec> loaded = (GigaMap<Rec>)storage.root();
+
+			assertNull(loaded.index().bitmap().get("key2"), "failed registration was persisted");
+			assertEquals(4, loaded.size());
+			assertEquals(1, loaded.query(keyIndexer.is("a")).count(), "surviving index incomplete");
+			assertEquals(1, loaded.query(keyIndexer.is("d")).count(), "surviving index incomplete");
+		}
+	}
+
+	/**
+	 * Pinned, not fixed: {@code removeIndex} + {@code add} is not a redefinition. It drops the unique
+	 * constraint along with the index, and re-adding under the same name does not restore it -
+	 * {@link BitmapIndices#update(org.eclipse.store.gigamap.types.Indexer)} is the supported way, and
+	 * {@code removeIndex}'s javadoc says so.
+	 */
+	@Test
+	@Timeout(120)
+	void manualRedefineDropsUniqueConstraintPinned()
+	{
+		final GigaMap<Rec>       map     = GigaMap.New();
+		final BitmapIndices<Rec> indices = map.index().bitmap();
+		indices.addUniqueConstraint(new BinaryKeyIndexer());
+		map.add(new Rec("a"));
+		assertThrows(RuntimeException.class, () -> map.add(new Rec("a")), "constraint not active");
+
+		indices.removeIndex("binkey");
+		indices.add(new BinaryKeyIndexer());
+
+		map.add(new Rec("a")); // accepted: the constraint membership is gone
+		assertEquals(2, map.query(new BinaryKeyIndexer().is("a")).count());
+		assertNull(indices.uniqueConstraints(), "the registry is emptied to null, not to an empty enum");
+	}
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap140Test.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/issues/GigaMap140Test.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 
@@ -352,6 +353,9 @@ public class GigaMap140Test
 
 		map.add(new Rec("a")); // accepted: the constraint membership is gone
 		assertEquals(2, map.query(new BinaryKeyIndexer().is("a")).count());
-		assertNull(indices.uniqueConstraints(), "the registry is emptied to null, not to an empty enum");
+		assertTrue(
+			indices.uniqueConstraints() == null || indices.uniqueConstraints().isEmpty(),
+			"the constraint is still registered"
+		);
 	}
 }


### PR DESCRIPTION
Back-filling a bitmap index from the entities a `GigaMap` already holds ran *after* the index had been put into the registry. The back-fill is the only step of a registration that runs user code, so an `Indexer` throwing for one entity - the realistic case of logic that cannot handle a value the previous logic never read - left a partially filled index as part of the map's state: it answered queries with a torso of the data, and the next `store()` made that durable. For a non-unique `update(Indexer)` it was worse, because the old index had already been dropped by then: the map lost a working index and gained a broken one. `reindex()`, the instinctive repair, re-runs the same throwing indexer and fails again.

| Entry point | Order before | State after the indexer threw |
|---|---|---|
| `update(Indexer)`, unique constraint | build standalone, validate, drop old, register | unchanged - already atomic |
| `update(Indexer)`, non-unique | drop old, register, fill | old index gone, partial new index registered |
| `add` / `ensure` on a populated map | register, fill | partial index registered |
| `addAll` on a populated map | per indexer: register, fill | batch half applied |

## What changed

The unique branch of `update(Indexer)` was the one path that already got this right, and its comment says so ("atomic failure"). Every registering path now uses that same shape: the index is created, back-filled while it is still absent from the registry, and only then registered. Filling a standalone index marks nothing for persistence - propagation to the group happens exclusively in `internalAddBitmapIndex` / `internalRemoveIndex` - so a failed attempt leaves no trace for a subsequent `store()` to pick up.

Three things follow from that:

- **`internalAddBitmapIndex` lost its `initialize` flag.** With the fill moved out, every caller passed `false`. Registration is now a single-responsibility step that runs no user code at all, so there is no longer a code path that fills an index already in the registry. This also removes the redundant second full back-fill the unique branch paid, and with it the reliance on `internalAdd` being idempotent. The parent-reference sanity check moved ahead of the registry insert, which previously left a foreign index behind when it fired.
- **`addAll` is all-or-nothing across its batch**, and builds it in a single pass over the entities instead of one pass per indexer - relevant under lazy loading, where each segment is now materialized once. The indices are independent, so the only observable difference is the order in which the indexers see the entities.
- **An abandoned index releases its off-heap memory**, mirroring what a dropped index gets in `internalRemoveIndex`; it is never registered, so nothing else would ever reach it. A failure of the release itself is attached to the original cause as a suppressed exception rather than replacing it. This also closes the same leak in the pre-existing unique path.

## Documentation

`add`, `addAll`, `update` and `ensure` gain the **Behavior on failure** section the mutating `GigaMap` methods already carry. `update`'s includes the note that it holds the old and the new data of that index simultaneously and therefore roughly doubles its peak footprint - the inherent price of the atomicity, since `internalRemoveIndex` frees the old data eagerly and a dropped index cannot be restored.

`removeIndex` now states that re-adding under the same name restores neither unique-constraint nor identity membership - `update(Indexer)` is for that - and its claim that the index data "is not freed synchronously" is corrected: the off-heap memory is, the on-disk data is what waits for housekeeping.

The bitmap "Defining Indices" page gains a *Registering on a Populated Map* section covering the back-fill, the all-or-nothing failure behavior, and `update` versus remove-and-re-add.

## Tests

`GigaMap140Test` (7 tests). Against the unfixed source, 5 are RED: the non-unique `update` losing the old index, `add` leaving a partial index registered, `addAll` applying in part, the name staying occupied after a failed `add`, and the failed registration surviving a store/restart. The other two are pins that are green either way - the unique branch was already atomic, and `removeIndex` + `add` dropping unique membership is pinned as accepted behavior, now stated in the javadoc.

Full suites green: gigamap 1203, lucene 76, jvector.

## Not in this change

The vector and Lucene index families still have the original register-then-fill order. Their back-fills own external resources - the jvector HNSW graph, the Lucene `IndexWriter` - so the standalone pre-build does not transfer unchanged and needs its own design. Filed as internal#143.
