### PR TITLE
update spring boot version

### DIFF
--- a/examples/spring-boot3-advanced/pom.xml
+++ b/examples/spring-boot3-advanced/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.5.13</spring.boot.version>
+        <spring.boot.version>3.5.16</spring.boot.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/spring-boot3-simple/pom.xml
+++ b/examples/spring-boot3-simple/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.5.13</spring.boot.version>
+        <spring.boot.version>3.5.16</spring.boot.version>
     </properties>
 
 

--- a/integrations/spring-boot3-console/pom.xml
+++ b/integrations/spring-boot3-console/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.5.14</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.16</org.springframework.boot.version>
     </properties>
 
     <dependencies>

--- a/integrations/spring-boot3/pom.xml
+++ b/integrations/spring-boot3/pom.xml
@@ -16,7 +16,7 @@
     <url>https://projects.eclipse.org/projects/technology.store</url>
 
     <properties>
-        <org.springframework.boot.version>3.5.14</org.springframework.boot.version>
+        <org.springframework.boot.version>3.5.16</org.springframework.boot.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request updates the Spring Boot dependencies to the latest patch version across multiple Maven project files. The goal is to ensure all Spring Boot integrations and examples are using version 3.5.16 for improved stability and security.

Dependency version updates:

* Updated the `spring.boot.version` property from 3.5.13 to 3.5.16 in `examples/spring-boot3-advanced/pom.xml` and `examples/spring-boot3-simple/pom.xml` [[1]](diffhunk://#diff-3d878e0c0b66f01e7bdea2254ba1440c7b658e35a8d8ad4141e0d1165899f983L20-R20) [[2]](diffhunk://#diff-804ca3fe8bab5d865dba840ea1ea85d471729c6838b8e6de0daa171d2a127b7cL19-R19)
* Updated the `org.springframework.boot.version` property from 3.5.14 to 3.5.16 in `integrations/spring-boot3/pom.xml` and `integrations/spring-boot3-console/pom.xml` [[1]](diffhunk://#diff-8f4b084553286c4f43a0b984055b14d03d602925fd2497cd0e52c2d8289424ecL19-R19) [[2]](diffhunk://#diff-edb745cc289cf9d279366e508f6468114761d00e2e79f7ec98ef6d977ef109cfL19-R19)