### PR TITLE
update jetty version to 9.4.58.v20250814

### DIFF
--- a/storage/rest/service-sparkjava/pom.xml
+++ b/storage/rest/service-sparkjava/pom.xml
@@ -21,7 +21,7 @@
 	
 	<properties>
 		<sparkjava.version>2.9.3</sparkjava.version>
-		<jetty.version>9.4.57.v20241219</jetty.version>
+		<jetty.version>9.4.58.v20250814</jetty.version>
 		<gson.version>2.8.9</gson.version>
 	</properties>
 


### PR DESCRIPTION
This pull request updates the Jetty server dependency version in the `storage/rest/service-sparkjava/pom.xml` file to ensure the project uses the latest available bug fixes and security patches.

- Dependency update:
  * Upgraded the Jetty server version from `9.4.57.v20241219` to `9.4.58.v20250814` in the Maven project properties.