### PR TITLE
update jackson-databind version to 2.22.2

### DIFF
--- a/examples/gigamap/pom.xml
+++ b/examples/gigamap/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/storage/rest/service-javalin/pom.xml
+++ b/storage/rest/service-javalin/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This pull request updates the `jackson-databind` dependency to a newer patch version in two separate Maven project files. This change ensures that both modules use the latest bug fixes and security updates provided by the Jackson library.

Dependency updates:

* Updated the `jackson-databind` version from `2.22.0` to `2.22.2` in `examples/gigamap/pom.xml` to address potential bug fixes and security improvements.
* Updated the `jackson-databind` version from `2.22.0` to `2.22.2` in `storage/rest/service-javalin/pom.xml` for consistency and improved security.