### PR TITLE
Update Vaadin version to 24.10.7

### DIFF
--- a/storage/rest/client-app-standalone-assembly/pom.xml
+++ b/storage/rest/client-app-standalone-assembly/pom.xml
@@ -19,7 +19,7 @@
 	<url>https://projects.eclipse.org/projects/technology.store</url>
 
 	<properties>
-		<vaadin.version>24.8.10</vaadin.version>
+		<vaadin.version>24.10.7</vaadin.version>
 		<spring.boot.version>3.5.6</spring.boot.version>
 	</properties>
 

--- a/storage/rest/client-app/pom.xml
+++ b/storage/rest/client-app/pom.xml
@@ -20,7 +20,7 @@
 	<url>https://projects.eclipse.org/projects/technology.store</url>
 
 	<properties>
-		<vaadin.version>24.8.17</vaadin.version>
+		<vaadin.version>24.10.7</vaadin.version>
 		<spring.boot.version>3.5.6</spring.boot.version>
 	</properties>
 


### PR DESCRIPTION
This pull request updates the Vaadin framework version used in both the `client-app` and `client-app-standalone-assembly` modules to ensure consistency and take advantage of the latest features and fixes.

**Dependency Updates:**

* Updated the `vaadin.version` property from `24.8.10` to `24.10.7` in `storage/rest/client-app-standalone-assembly/pom.xml`
* Updated the `vaadin.version` property from `24.8.17` to `24.10.7` in `storage/rest/client-app/pom.xml`