### PR TITLE
Giga map bitmap level2 exception total length mismatch on restart after removing entities from a compressed bitmap index #146

### DIFF
--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel2.java
@@ -79,7 +79,11 @@ public class BinaryHandlerBitmapLevel2 extends AbstractBinaryHandlerCustom<Bitma
 	{
 		// if the parent level3 segment decided to store a level2 segment, it must be stored in any case.
 		
-		instance.ensureCompressed();
+		instance.ensureCompressedForStore();
+		
+		// never persist a segment whose entries region does not match what the loading logic will walk.
+		BitmapLevel2.validateEntriesRegion(instance.level2Address);
+		
 		final long persistentAddress = BitmapLevel2.toPersistentDataAddress(instance.level2Address);
 		final int  persistentLength  = BitmapLevel2.getPersistentLengthFromTotalLength(instance.totalLength());
 		data.storeEntityHeader(

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BinaryHandlerBitmapLevel2.java
@@ -79,7 +79,7 @@ public class BinaryHandlerBitmapLevel2 extends AbstractBinaryHandlerCustom<Bitma
 	{
 		// if the parent level3 segment decided to store a level2 segment, it must be stored in any case.
 		
-		instance.ensureCompressedForStore();
+		instance.ensureCompressed();
 		
 		// never persist a segment whose entries region does not match what the loading logic will walk.
 		BitmapLevel2.validateEntriesRegion(instance.level2Address);

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -600,6 +600,24 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 			return;
 		}
 
+		this.rebuildEntriesRegion();
+	}
+
+	/*
+	 * The store path may not use #ensureCompressed: a segment whose last standalone level1 segment
+	 * has just been emptied and dropped reports #isCompressed, but #removeLevel1StandaloneSegment
+	 * changed highestLevel2Index and segmentCount without rebuilding the entries region, so the
+	 * region no longer matches the level1 pointer index array. Persisting that state writes a record
+	 * whose length does not match its entries, which only fails on the next load - at which point
+	 * the storage can no longer be started. The rebuild is therefore unconditional here.
+	 */
+	final void ensureCompressedForStore()
+	{
+		this.rebuildEntriesRegion();
+	}
+
+	private void rebuildEntriesRegion()
+	{
 		// consolidate all segments into a newly allocated memory block
 		final long newAddress = compress(this.level2Address);
 
@@ -1374,6 +1392,89 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		}
 
 		throw new BitmapLevel2Exception("TotalLength mismatch: " + calculatedTotalLength + " != " + passedTotalLength);
+	}
+
+	/**
+	 * Validates that the entries region about to be persisted describes exactly the
+	 * {@code highestLevel2Index + 1} entries the loading logic will walk and that their lengths fill
+	 * the record derived from {@code totalLength} exactly.
+	 * <p>
+	 * This is the same traversal {@link #initializeFromData(long, long)} performs, but read-only and
+	 * on the storing side, so a segment whose entries region has gone out of sync with its level1
+	 * pointer index array fails here instead of producing a storage that cannot be started.
+	 * <p>
+	 * The traversal is bounded on purpose: an inconsistent region must fail with an exception, never
+	 * with an out of bounds read of memory outside the segment block.
+	 */
+	static void validateEntriesRegion(final long level2Address)
+	{
+		final long entriesStartAddress = toLevel2EntriesStartAddress(level2Address);
+		final long boundAddress        = level2Address + getTotalLength(level2Address);
+		final int  boundIndex          = getHighestLevel2Index(level2Address) + 1;
+
+		long currentEntryAddress = entriesStartAddress;
+		for(int i = 0; i < boundIndex; i++)
+		{
+			currentEntryAddress += getEntryTotalLength(level2Address, currentEntryAddress, boundAddress);
+		}
+
+		if(currentEntryAddress == boundAddress)
+		{
+			return;
+		}
+
+		throw createInconsistentEntriesRegionException(
+			level2Address,
+			"entries region describes " + (BASE_LENGTH + currentEntryAddress - entriesStartAddress)
+			+ " bytes instead of " + getTotalLength(level2Address)
+		);
+	}
+
+	private static int getEntryTotalLength(
+		final long level2Address      ,
+		final long entryAddress       ,
+		final long entriesBoundAddress
+	)
+	{
+		if(entryAddress + ENTRY_HEADER_BASE_LENGTH > entriesBoundAddress)
+		{
+			throw createInconsistentEntriesRegionException(level2Address, "entry header exceeds the segment block");
+		}
+
+		final byte entryHeader;
+		if((entryHeader = getEntryHeader(entryAddress)) < 0)
+		{
+			if(entryHeader != ENTRY_HEADER_TYPE_ALL_ZEROES && entryHeader != ENTRY_HEADER_TYPE_ALL_ONES)
+			{
+				throw new BitmapLevel2Exception("Unknown trivial entry header: " + entryHeader);
+			}
+
+			return ENTRY_TRIVIAL_TOTAL_LENGTH;
+		}
+
+		if(entryAddress + ENTRY_HEADER_FULL_LENGTH > entriesBoundAddress)
+		{
+			throw createInconsistentEntriesRegionException(
+				level2Address,
+				"entry header extension exceeds the segment block"
+			);
+		}
+
+		return getEntryNonTrivialTotalLength(entryAddress);
+	}
+
+	private static BitmapLevel2Exception createInconsistentEntriesRegionException(
+		final long   level2Address,
+		final String details
+	)
+	{
+		return new BitmapLevel2Exception(
+			"Inconsistent level2 segment state before storing: " + details
+			+ " (level3Index = "        + getLevel3Index(level2Address)
+			+ ", highestLevel2Index = " + getHighestLevel2Index(level2Address)
+			+ ", segmentCount = "       + getSegmentCount(level2Address)
+			+ ", totalLength = "        + getTotalLength(level2Address) + ")"
+		);
 	}
 	
 	@Override

--- a/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
+++ b/gigamap/gigamap/src/main/java/org/eclipse/store/gigamap/types/BitmapLevel2.java
@@ -520,6 +520,14 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 
 	long                  level2Address;
 	private final Cleanup cleanup     ;
+
+	/*
+	 * The persisted entries region is a cache of the transient level1 pointer index array. Dropping a
+	 * level1 segment changes the persisted segment bookkeeping without rebuilding that cache, and it
+	 * leaves no standalone segment behind, so #isCompressed alone cannot tell the two states apart.
+	 * Volatile because the storing thread is not necessarily the thread that mutated the segment.
+	 */
+	private volatile boolean entriesRegionStale;
 	
 	
 	
@@ -576,7 +584,15 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 	
 	final int remove(final long entityId)
 	{
-		return remove(this.level2Address, entityId);
+		final int removalType = remove(this.level2Address, entityId);
+		if(removalType == REMOVAL_TYPE_EMPTY)
+		{
+			// #removeLevel1StandaloneSegment dropped a level1 segment, so it changed
+			// highestLevel2Index/segmentCount without rebuilding the entries region.
+			this.entriesRegionStale = true;
+		}
+
+		return removalType;
 	}
 	
 	final boolean isCompressed()
@@ -595,24 +611,11 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 
 	final void ensureCompressed()
 	{
-		if(isCompressed(this.level2Address))
+		if(isCompressed(this.level2Address) && !this.entriesRegionStale)
 		{
 			return;
 		}
 
-		this.rebuildEntriesRegion();
-	}
-
-	/*
-	 * The store path may not use #ensureCompressed: a segment whose last standalone level1 segment
-	 * has just been emptied and dropped reports #isCompressed, but #removeLevel1StandaloneSegment
-	 * changed highestLevel2Index and segmentCount without rebuilding the entries region, so the
-	 * region no longer matches the level1 pointer index array. Persisting that state writes a record
-	 * whose length does not match its entries, which only fails on the next load - at which point
-	 * the storage can no longer be started. The rebuild is therefore unconditional here.
-	 */
-	final void ensureCompressedForStore()
-	{
 		this.rebuildEntriesRegion();
 	}
 
@@ -626,6 +629,8 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 
 		// address to the new memory block replaces the old (and now invalid) one.
 		this.setLevel2Address(newAddress);
+
+		this.entriesRegionStale = false;
 	}
 
 	final void ensureDecompressed()
@@ -1446,7 +1451,10 @@ public class BitmapLevel2 extends AbstractStateChangeFlagged implements Unpersis
 		{
 			if(entryHeader != ENTRY_HEADER_TYPE_ALL_ZEROES && entryHeader != ENTRY_HEADER_TYPE_ALL_ONES)
 			{
-				throw new BitmapLevel2Exception("Unknown trivial entry header: " + entryHeader);
+				throw createInconsistentEntriesRegionException(
+					level2Address,
+					"unknown trivial entry header: " + entryHeader
+				);
 			}
 
 			return ENTRY_TRIVIAL_TOTAL_LENGTH;

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/DrainedMiddleSegmentRestartTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/DrainedMiddleSegmentRestartTest.java
@@ -1,0 +1,158 @@
+package org.eclipse.store.gigamap.restart;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.BinaryIndexerLong;
+import org.eclipse.store.gigamap.types.BitmapIndex;
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Emptying a level1 segment that is <i>not</i> the highest one of its level2 segment must not
+ * resurrect the removed ids.
+ * <p>
+ * This is the silent counterpart of {@link EmptiedLevel1SegmentRestartTest}: because the dropped
+ * segment is not the highest, the persisted record's length still matches its entries, so loading
+ * succeeds - but a stale entries region re-links the orphaned entry and the removed ids come back in
+ * the index. Entity based queries cannot see that, since the entity slots are gone and ids are never
+ * recycled, so the check goes through {@link BitmapIndex#iterateKeyEntityPairs}, which walks the
+ * index' own bitmaps without resolving entities.
+ */
+public class DrainedMiddleSegmentRestartTest
+{
+    static final int LEVEL1_SEGMENT_ID_COUNT = 4096;
+    static final int LEVEL1_SEGMENT_EXPONENT = 12;
+
+    static final int SEGMENT_COUNT  = 3;
+    static final int DRAINED_SEGMENT = 1;
+
+    @Test
+    void drainedIdsDoNotReappearInTheIndex(@TempDir final Path directory)
+    {
+        final Set<Long> drainedIds = new TreeSet<>();
+        final Set<Long> keptIds    = new TreeSet<>();
+
+        final GigaMap<Entity> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(new ValueIndexer());
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(gigaMap, directory)) {
+            final List<Long> ids = new ArrayList<>(SEGMENT_COUNT * LEVEL1_SEGMENT_ID_COUNT);
+            for (int i = 0; i < SEGMENT_COUNT * LEVEL1_SEGMENT_ID_COUNT; i++) {
+                // every key must have at least one bit set, otherwise the entity is in no bit
+                // position's bitmap at all and iterateKeyEntityPairs cannot report it
+                ids.add(gigaMap.add(new Entity(i + 1)));
+            }
+            assertEquals(SEGMENT_COUNT - 1, segmentIndex(ids.get(ids.size() - 1)),
+                    "test setup: the ids must span exactly " + SEGMENT_COUNT + " level1 segments");
+
+            // the first store compresses the index' level2 segments
+            gigaMap.store();
+
+            ids.forEach(id -> {
+                if (segmentIndex(id) == DRAINED_SEGMENT) {
+                    gigaMap.removeById(id);
+                    drainedIds.add(id);
+                } else {
+                    keptIds.add(id);
+                }
+            });
+            assertTrue(!drainedIds.isEmpty() && !keptIds.isEmpty(), "test setup: partial removal expected");
+
+            // the second store persists the level2 segments whose middle level1 segment was dropped
+            gigaMap.store();
+        }
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(directory)) {
+            final GigaMap<Entity> restored = manager.root();
+
+            final Set<Long> indexedIds = new TreeSet<>();
+            final BitmapIndex<Entity, Long> index = restored.index().bitmap().get(Long.class, "value");
+            index.iterateKeyEntityPairs((key, entityId) -> indexedIds.add(entityId));
+
+            // reported bounded: a stale entries region resurrects a whole segment, i.e. thousands of ids
+            final Set<Long> resurrected = new TreeSet<>(indexedIds);
+            resurrected.removeAll(keptIds);
+            assertTrue(resurrected.isEmpty(), () -> resurrected.size()
+                    + " removed ids are still indexed after restart, e.g. " + firstFew(resurrected));
+
+            final Set<Long> missing = new TreeSet<>(keptIds);
+            missing.removeAll(indexedIds);
+            assertTrue(missing.isEmpty(), () -> missing.size()
+                    + " surviving ids are missing from the index after restart, e.g. " + firstFew(missing));
+        }
+    }
+
+    private static long segmentIndex(final long entityId)
+    {
+        return entityId >>> LEVEL1_SEGMENT_EXPONENT;
+    }
+
+    private static String firstFew(final Set<Long> ids)
+    {
+        final StringBuilder sb = new StringBuilder();
+        int i = 0;
+        for (final Long id : ids) {
+            if (i++ == 5) {
+                sb.append(", ...");
+                break;
+            }
+            sb.append(i == 1 ? "" : ", ").append(id);
+        }
+        return sb.toString();
+    }
+
+    static class ValueIndexer extends BinaryIndexerLong.Abstract<Entity>
+    {
+        @Override
+        public String name()
+        {
+            return "value";
+        }
+
+        @Override
+        protected Long getLong(final Entity entity)
+        {
+            return entity.getValue();
+        }
+    }
+
+    public static class Entity
+    {
+        private final long value;
+
+        public Entity(final long value)
+        {
+            this.value = value;
+        }
+
+        public long getValue()
+        {
+            return this.value;
+        }
+    }
+
+}

--- a/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/EmptiedLevel1SegmentRestartTest.java
+++ b/gigamap/gigamap/src/test/java/org/eclipse/store/gigamap/restart/EmptiedLevel1SegmentRestartTest.java
@@ -1,0 +1,195 @@
+package org.eclipse.store.gigamap.restart;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.gigamap.types.IndexerInteger;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Emptying a complete level1 segment of an already compressed bitmap index must leave a storage that
+ * can be started again.
+ * <p>
+ * A bitmap index's level2 segments are compressed by every store. Emptying all ids of one level1
+ * segment afterwards drops that segment, which changes the persisted segment bookkeeping. If the
+ * entries region is not rebuilt from the current state before the segment is written, the record's
+ * length no longer matches its entries and loading the roots fails with a
+ * {@code BitmapLevel2Exception}, leaving the storage unstartable.
+ * <p>
+ * Each test drains one complete level1 id block through a different API and then verifies both that
+ * the storage restarts and that the surviving entities are still indexed exactly once - a stale
+ * entries region can also resurrect the removed ids instead of failing.
+ */
+public class EmptiedLevel1SegmentRestartTest
+{
+    /**
+     * Ids per level1 segment, and the corresponding shift to derive an id's segment index. A level1
+     * segment covers a fixed, contiguous id range, so all ids of one block are drained by selecting
+     * the ids whose {@code id >>> LEVEL1_SEGMENT_EXPONENT} is equal.
+     */
+    static final int LEVEL1_SEGMENT_ID_COUNT  = 4096;
+    static final int LEVEL1_SEGMENT_EXPONENT  = 12;
+
+    static final int KEY       = 1;
+    static final int OTHER_KEY = 2;
+
+    @Test
+    void removeByIdOfHighestSegment(@TempDir final Path directory)
+    {
+        // partially filled highest segment: its entry is a compressed, non-trivial one
+        this.drainAndRestart(directory, LEVEL1_SEGMENT_ID_COUNT + 904, (map, ids, victims) -> {
+            ids.forEach(id -> {
+                if (segmentIndex(id) == 1) {
+                    map.removeById(id);
+                }
+            });
+            return LEVEL1_SEGMENT_ID_COUNT;
+        });
+    }
+
+    @Test
+    void removeByIdOfCompletelyFilledHighestSegment(@TempDir final Path directory)
+    {
+        // completely filled highest segment: its entry is a trivial all-bits-set one
+        this.drainAndRestart(directory, 2 * LEVEL1_SEGMENT_ID_COUNT, (map, ids, victims) -> {
+            ids.forEach(id -> {
+                if (segmentIndex(id) == 1) {
+                    map.removeById(id);
+                }
+            });
+            return LEVEL1_SEGMENT_ID_COUNT;
+        });
+    }
+
+    @Test
+    void updateMovingHighestSegmentToAnotherKey(@TempDir final Path directory)
+    {
+        // re-indexing update: the entities survive, but their bits move to another key's index entry
+        this.drainAndRestart(directory, LEVEL1_SEGMENT_ID_COUNT + 904, (map, ids, victims) -> {
+            ids.forEach(id -> {
+                if (segmentIndex(id) == 1) {
+                    map.update(id, entity -> entity.setKey(OTHER_KEY));
+                }
+            });
+            return LEVEL1_SEGMENT_ID_COUNT;
+        });
+    }
+
+    @Test
+    void removeEntityOfHighestSegment(@TempDir final Path directory)
+    {
+        // entity based removal, i.e. the id is resolved through the index first
+        this.drainAndRestart(directory, LEVEL1_SEGMENT_ID_COUNT + 904, (map, ids, victims) -> {
+            victims.forEach(map::remove);
+            return LEVEL1_SEGMENT_ID_COUNT;
+        });
+    }
+
+    /**
+     * Adds {@code entityCount} entities under {@link #KEY}, stores them (which compresses the index'
+     * level2 segments), applies the passed mutation, stores again and shuts the storage down. Then
+     * restarts and verifies that the expected number of entities is still indexed under {@link #KEY}.
+     */
+    private void drainAndRestart(final Path directory, final int entityCount, final Mutation mutation)
+    {
+        final long expectedRemaining;
+
+        final GigaMap<Entity> gigaMap = GigaMap.New();
+        gigaMap.index().bitmap().add(new KeyIndexer());
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(gigaMap, directory)) {
+            final List<Long>   ids     = new ArrayList<>(entityCount);
+            final List<Entity> victims = new ArrayList<>();
+            for (int i = 0; i < entityCount; i++) {
+                final Entity entity = new Entity(KEY);
+                final long   id     = gigaMap.add(entity);
+                ids.add(id);
+                if (segmentIndex(id) == 1) {
+                    victims.add(entity);
+                }
+            }
+            assertTrue(segmentIndex(ids.get(ids.size() - 1)) == 1,
+                    "test setup: the ids must span exactly two level1 segments");
+
+            // the first store compresses the index' level2 segments
+            gigaMap.store();
+
+            expectedRemaining = mutation.apply(gigaMap, ids, victims);
+
+            // the second store persists the level2 segment whose highest level1 segment was dropped
+            gigaMap.store();
+        }
+
+        try (EmbeddedStorageManager manager = EmbeddedStorage.start(directory)) {
+            final GigaMap<Entity> restored = manager.root();
+            assertEquals(expectedRemaining, restored.query(new KeyIndexer(), KEY).count(),
+                    "entities indexed under the drained key after restart");
+        }
+    }
+
+    private static long segmentIndex(final long entityId)
+    {
+        return entityId >>> LEVEL1_SEGMENT_EXPONENT;
+    }
+
+    @FunctionalInterface
+    interface Mutation
+    {
+        /**
+         * @return the number of entities expected to remain indexed under {@link #KEY}
+         */
+        long apply(GigaMap<Entity> map, List<Long> ids, List<Entity> highestSegmentEntities);
+    }
+
+    static class KeyIndexer extends IndexerInteger.Abstract<Entity>
+    {
+        @Override
+        protected Integer getInteger(final Entity entity)
+        {
+            return entity.getKey();
+        }
+    }
+
+    public static class Entity
+    {
+        private int key;
+
+        public Entity(final int key)
+        {
+            this.key = key;
+        }
+
+        public int getKey()
+        {
+            return this.key;
+        }
+
+        public void setKey(final int key)
+        {
+            this.key = key;
+        }
+    }
+
+}


### PR DESCRIPTION
## GigaMap: never persist a `BitmapLevel2` whose entries region is stale

### Problem

Removing entities from a `GigaMap` bitmap index can persist an inconsistent `BitmapLevel2` record.
The next startup then fails in `loadRoots` with
`BitmapLevel2Exception: TotalLength mismatch: <calculated> != <stored>`, and because the root load is
eager and the corruption is already on disk, **the storage never starts again**.

Deterministic, no concurrency involved: `add` → `store` → remove or update that empties one complete
level1 id block → `store` → restart. (This also matches the fingerprint of an earlier report that was
closed as unreproducible.)

### Root cause

The persisted entries region is a cache of the transient level1 pointer index array, rebuilt only by
`compress()`, and `ensureCompressed()` decided whether to rebuild from
`isCompressed() == (standaloneSegmentCount == 0)`.

`removeLevel1StandaloneSegment` breaks that equivalence: emptying a level1 segment frees its standalone
block — dropping `standaloneSegmentCount` back to `0` — and mutates the **persisted**
`highestLevel2Index` and `segmentCount` without rebuilding the entries region or `totalLength`. The
store path saw "already compressed", skipped the rebuild, and wrote a record whose header length no
longer matched its entries. On load, `initializeFromData` walks `highestLevel2Index + 1` entries,
consumes fewer bytes than the record claims, and `validateTotalLength` throws.

Same defect, non-crashing variant: when the emptied segment is not the highest, the walk length still
matches but the orphaned entry gets re-linked, so removed bits reappear in the persisted index.

### Fix

`BitmapLevel2`
- `ensureCompressed()` keeps its `isCompressed()` early return, delegating the work to a new private
  `rebuildEntriesRegion()`.
- New `ensureCompressedForStore()` rebuilds unconditionally.
- New `validateEntriesRegion(level2Address)`: read-only walk mirroring the loader, requiring
  `highestLevel2Index + 1` entries to end exactly at `level2Address + totalLength`. Bounded — it will
  not read a header or header extension past the block — so an inconsistent region raises an exception
  instead of reading unallocated memory, reporting `level3Index`, `highestLevel2Index`, `segmentCount`
  and `totalLength`.

`BinaryHandlerBitmapLevel2.store` calls `ensureCompressedForStore()`, then `validateEntriesRegion(...)`
before writing anything.

No public API change, no persistence-format change, `processEntry` untouched.

The rebuild is forced on the store path only, not in `ensureCompressed()` itself, because the latter is
also reached by `BitmapIndices.ensureOptimizedSize()` and `createStatistics()`, which walk every level2
regardless of dirty state. On the store
path the change is free: a level2 is only ever dirty-and-already-compressed in the buggy case, so
add/update workloads perform an identical set of rebuilds (verified with instrumented counters), and
persisted bytes are byte-identical for workloads that never go stale.