### PR TITLE
Add Javalin REST service integration tests

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -73,6 +73,12 @@
             <artifactId>cache</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.store</groupId>
+            <artifactId>storage-restservice-javalin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Eclipse Serializer -->
         <dependency>
@@ -148,6 +154,26 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- REST service integration tests -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/AbstractIntegrationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/AbstractIntegrationTest.java
@@ -1,0 +1,176 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.eclipse.store.storage.restservice.types.StorageRestService;
+import org.eclipse.store.storage.restservice.types.StorageRestServiceResolver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.gson.Gson;
+
+public class AbstractIntegrationTest {
+    static final String objectURL_noParams = "http://localhost:4567/store-data/object/";
+
+    @TempDir
+    static Path tempDir;
+    protected static EmbeddedStorageManager storage;
+    protected static StorageRestService service;
+    protected static TestGraph testData;
+
+    @BeforeAll
+    static void initAll() {
+        //testdata
+        testData = new TestGraph();
+
+        //create and start storage
+        storage = initSourceStorage(tempDir);
+
+        //start rest service
+        //service = new StorageRestService(storage);
+        service = StorageRestServiceResolver.resolve(storage);
+        service.start();
+    }
+
+    static EmbeddedStorageManager initSourceStorage(final Path directory) {
+        //testdata
+        testData = new TestGraph();
+
+        storage = EmbeddedStorage.start(directory);
+        storage.setRoot(testData);
+        storage.storeRoot();
+
+        return storage;
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        //stop service
+        service.stop();
+
+        //shutdown storage
+        storage.shutdown();
+    }
+
+    protected static void assertOid(final long expected, final String actual) {
+        assertEquals(expected, Long.parseLong(actual));
+    }
+
+    protected static void assertTid(final long expected, final String actual) {
+        assertEquals(expected, Long.parseLong(actual));
+    }
+
+    protected static void assertLength(final long expected, final String actual) {
+        assertEquals(expected, Long.parseLong(actual));
+    }
+
+    protected static long lookupTypeId(final Object obj) {
+        return storage.persistenceManager().typeDictionary().lookupTypeByName(obj.getClass().getName()).typeId();
+    }
+
+    protected static long lookupObjectId(final Object obj) {
+        return storage.persistenceManager().lookupObjectId(obj);
+    }
+
+    protected static ViewerObjectDescription requestObjectByUrl(final String url) throws IOException, ParseException
+	{
+        final CloseableHttpResponse response = get(url);
+        return as(response, ViewerObjectDescription.class);
+    }
+
+    static ViewerObjectDescription requestObjectDescription(final long oid) throws IOException, ParseException
+	{
+        final CloseableHttpResponse response = get(objectURL_noParams + oid);
+        return as(response, ViewerObjectDescription.class);
+    }
+
+    protected static ViewerObjectDescription testRequestNoParams(final Object obj) throws IOException, ParseException
+	{
+        final long oid = lookupObjectId(obj);
+        final long tid = lookupTypeId(obj);
+
+        final ViewerObjectDescription objectDescription = requestObjectDescription(oid);
+
+        assertOid(oid, objectDescription.getObjectId());
+        assertTid(tid, objectDescription.getTypeId());
+
+        return objectDescription;
+    }
+
+    static CloseableHttpResponse get(final String URL) throws IOException {
+        final HttpUriRequest request = new HttpGet(URL);
+		CloseableHttpResponse response = HttpClientBuilder.create().build().execute(request);
+        return response;
+    }
+
+    static CloseableHttpResponse options(final String URL) throws IOException {
+        final HttpUriRequest request = new HttpOptions(URL);
+        final CloseableHttpResponse response = HttpClientBuilder.create().build().execute(request);
+        return response;
+    }
+
+    static void checkStatusCodeAncContentForUrl(final String url, final int code, final String subString) throws IOException, ParseException
+	{
+        final CloseableHttpResponse httpResponse = get(url);
+        assertThat(httpResponse.getCode(), equalTo(code));
+        final String s = EntityUtils.toString(httpResponse.getEntity());
+        assertThat(s, containsString(subString));
+    }
+
+    static void checkStatusCodeForUrl(final String url, final int code) throws IOException {
+        final HttpResponse httpResponse = get(url);
+        assertThat(httpResponse.getCode(), equalTo(code));
+    }
+
+    static <T> T getAs(final String url, final Class<T> clazz) throws IOException, ParseException
+	{
+        final CloseableHttpResponse response = get(url);
+        return as(response, clazz);
+    }
+
+    static String getAsString(final String url) throws IOException, ParseException
+	{
+        final CloseableHttpResponse response = get(url);
+        return EntityUtils.toString(response.getEntity());
+    }
+
+
+    static <T> T as(final CloseableHttpResponse response, final Class<T> clazz) throws IOException, ParseException
+	{
+        final String jsonFromResponse = EntityUtils.toString(response.getEntity());
+        return new Gson().fromJson(jsonFromResponse, clazz);
+    }
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/CustomServerTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/CustomServerTest.java
@@ -1,0 +1,63 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.nio.file.Path;
+
+import org.apache.hc.core5.http.HttpStatus;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.restservice.types.StorageRestService;
+import org.eclipse.store.storage.restservice.types.StorageRestServiceResolver;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Javalin counterpart of the SparkJava {@code CustomServerTest}. The SparkJava service accepted a
+ * caller-provided {@code spark.Service} (and thus a custom port); the Javalin service is instead
+ * configured via system properties. This verifies a custom port + instance name and that the
+ * service stops cleanly afterwards.
+ */
+class CustomServerTest {
+    @TempDir
+    static Path tempDir;
+
+    @Test
+    void customServerStartStopTest() throws IOException {
+        final int port = 1234;
+        final String storageName = "custom";
+        final String url = "http://localhost:" + port + "/" + storageName + "/root";
+
+        System.setProperty("eclipse_store_rest_port", String.valueOf(port));
+        System.setProperty("eclipse_store_rest_storage_name", storageName);
+        try {
+            final EmbeddedStorageManager storage = AbstractIntegrationTest.initSourceStorage(tempDir);
+            final StorageRestService service = StorageRestServiceResolver.resolve(storage);
+            service.start();
+
+            AbstractIntegrationTest.checkStatusCodeForUrl(url, HttpStatus.SC_OK);
+
+            service.stop();
+            storage.shutdown();
+
+            Assertions.assertThrows(ConnectException.class, () -> AbstractIntegrationTest.get(url));
+        } finally {
+            System.clearProperty("eclipse_store_rest_port");
+            System.clearProperty("eclipse_store_rest_storage_name");
+        }
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/EmbeddedStorageViewerStartTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/EmbeddedStorageViewerStartTest.java
@@ -1,0 +1,74 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.hc.core5.http.HttpStatus;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.eclipse.store.storage.restservice.types.StorageRestService;
+import org.eclipse.store.storage.restservice.types.StorageRestServiceResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+class EmbeddedStorageViewerStartTest {
+
+    @TempDir
+    static Path tempDir;
+
+    @Test
+    void startWithDefaults() throws IOException {
+        Path first = tempDir.resolve("first");
+        final EmbeddedStorageManager storage = AbstractIntegrationTest.initSourceStorage(first);
+        final StorageRestService service = StorageRestServiceResolver.resolve(storage);
+
+        service.start();
+
+        final String url = "http://localhost:4567/store-data/root";
+
+        AbstractIntegrationTest.checkStatusCodeForUrl(url, HttpStatus.SC_OK);
+
+        service.stop();
+        storage.shutdown();
+    }
+
+    @Test
+    void startWithCustomName() throws IOException {
+        Path secondPath = tempDir.resolve("second");
+        final String storageName = "myMStorage";
+
+        // Unlike the SparkJava service (which had setInstanceName()), the Javalin service reads its
+        // instance name from a system property, evaluated when the service is constructed. Set it
+        // before resolve() and clear it afterwards so it does not leak into other tests.
+        System.setProperty("eclipse_store_rest_storage_name", storageName);
+        try {
+            final EmbeddedStorageManager storage = AbstractIntegrationTest.initSourceStorage(secondPath);
+            final StorageRestService service = StorageRestServiceResolver.resolve(storage);
+
+            service.start();
+
+            final String url = "http://localhost:4567/" + storageName + "/root";
+
+            AbstractIntegrationTest.checkStatusCodeForUrl(url, HttpStatus.SC_OK);
+
+            service.stop();
+            storage.shutdown();
+        } finally {
+            System.clearProperty("eclipse_store_rest_storage_name");
+        }
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/ExceptionsTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/ExceptionsTest.java
@@ -1,0 +1,61 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.io.IOException;
+
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
+
+class ExceptionsTest extends AbstractIntegrationTest {
+
+    @Test
+    void IntegrationTest_InvalidDataLength() throws IOException, ParseException
+	{
+        final Object testObject = testData;
+        final long oid = lookupObjectId(testObject);
+        final String url = new UrlBuilder(oid).setDataLength(-1).build();
+
+        checkStatusCodeAncContentForUrl(url, HttpStatus.SC_NOT_FOUND, "valueLength");
+    }
+
+    @Test
+    void IntegrationTest_InvalidObjectId() throws IOException, ParseException
+	{
+        final String url = "http://localhost:4567/store-data/object/NotALong";
+
+        checkStatusCodeAncContentForUrl(url, HttpStatus.SC_NOT_FOUND, "invalid url parameter ObjectId");
+    }
+
+    @Test
+    void IntegrationTest_InvalidLongValue() throws IOException, ParseException
+	{
+        final String url = "http://localhost:4567/store-data/object/00000?fixedOffset=hallo";
+
+        checkStatusCodeAncContentForUrl(url, HttpStatus.SC_NOT_FOUND, "invalid url parameter fixedOffset");
+    }
+
+    @Test
+	void IntegrationTest_InvalidReference() throws IOException, ParseException
+	{
+        final Object testObject = testData;
+        final long oid = lookupObjectId(testObject);
+        final String url = "http://localhost:4567/store-data/object/" + oid + "?references=hallo";
+
+        checkStatusCodeAncContentForUrl(url, HttpStatus.SC_NOT_FOUND, "invalid url parameter reference");
+    }
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/IntegrationTest_LiveDocumentationTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/IntegrationTest_LiveDocumentationTest.java
@@ -1,0 +1,85 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * The Javalin service exposes the available routes as a JSON array at the storage base path
+ * ({@code /store-data/}); each entry is a {@code {url, httpMethod}} object.
+ * <p>
+ * This is the Javalin counterpart of the SparkJava "live documentation": SparkJava listed the routes
+ * at the bare root ({@code /}) with {@code URL}/{@code HttpMethod} fields and served per-route
+ * descriptions via OPTIONS. The Javalin service does not implement that OPTIONS documentation, so
+ * those checks are intentionally omitted here.
+ */
+public class IntegrationTest_LiveDocumentationTest extends AbstractIntegrationTest {
+
+    static final String ALL_ROUTES_URL = "http://localhost:4567/store-data/";
+
+    @Test
+    void getAllRoutes_Header_Test() throws IOException
+    {
+        try (final CloseableHttpResponse httpResponse = get(ALL_ROUTES_URL)) {
+            assertThat(httpResponse.getCode(), equalTo(HttpStatus.SC_OK));
+
+            final Header header = httpResponse.getFirstHeader("Content-Type");
+            assertNotNull(header);
+            final String mimeType = header.getValue().split(";")[0].trim();
+            assertThat(mimeType, equalTo("application/json"));
+        }
+    }
+
+    @Test
+    void getAllRoutes_ListsExpectedRoutes_Test() throws IOException, ParseException
+    {
+        final List<String> urls = new ArrayList<>();
+        try (final CloseableHttpResponse httpResponse = get(ALL_ROUTES_URL)) {
+            final String content = EntityUtils.toString(httpResponse.getEntity());
+            final JsonArray routes = new Gson().fromJson(content, JsonArray.class);
+            for (final JsonElement element : routes) {
+                final JsonObject route = element.getAsJsonObject();
+                assertTrue(route.has("url"));
+                assertTrue(route.has("httpMethod"));
+                assertThat(route.get("httpMethod").getAsString(), equalTo("get"));
+                urls.add(route.get("url").getAsString());
+            }
+        }
+
+        assertTrue(urls.contains("/store-data/root"));
+        assertTrue(urls.contains("/store-data/dictionary"));
+        assertTrue(urls.contains("/store-data/object/{oid}"));
+        assertTrue(urls.contains("/store-data/maintenance/filesStatistics"));
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/ModifiyAndLoadTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/ModifiyAndLoadTest.java
@@ -1,0 +1,41 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.junit.jupiter.api.Test;
+
+
+class IntegrationTest_ModifyAndLoadTest extends AbstractIntegrationTest {
+
+    @Test
+    void modifyAndReLoad() throws IOException, ParseException
+	{
+        final ViewerObjectDescription objectDescriptionInitial = testRequestNoParams(testData.stringMember);
+        assertEquals("This is a string", objectDescriptionInitial.getData()[0]);
+
+        testData.stringMember = "This string contains some text";
+        storage.store(testData);
+
+        final ViewerObjectDescription objectDescriptionModified = testRequestNoParams(testData.stringMember);
+        assertEquals("This string contains some text", objectDescriptionModified.getData()[0]);
+    }
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/RestServiceResolverTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/RestServiceResolverTest.java
@@ -1,0 +1,32 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.eclipse.store.storage.restservice.types.StorageRestService;
+import org.eclipse.store.storage.restservice.types.StorageRestServiceResolver;
+import org.junit.jupiter.api.Test;
+
+
+class RestServiceResolverTest extends AbstractIntegrationTest {
+
+    @Test
+    void getFirst() {
+        final StorageRestService restService = StorageRestServiceResolver.resolve(storage);
+        assertNotNull(restService);
+    }
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/RootTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/RootTest.java
@@ -1,0 +1,41 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.store.storage.restadapter.types.ViewerRootDescription;
+import org.junit.jupiter.api.Test;
+
+class RootTest extends AbstractIntegrationTest {
+
+    @Test
+    void obtainRootTest() throws IOException, ParseException
+	{
+        final String url = "http://localhost:4567/store-data/root";
+
+        final ViewerRootDescription rootDescription = getAs(url, ViewerRootDescription.class);
+
+        assertEquals("ROOT", rootDescription.getName());
+
+        final long oid = lookupObjectId(storage.root());
+        assertEquals(oid, rootDescription.getObjectId());
+
+    }
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/StorageStatisticsTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/StorageStatisticsTest.java
@@ -1,0 +1,95 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.eclipse.store.storage.restadapter.types.ViewerStorageFileStatistics;
+import org.junit.jupiter.api.Test;
+
+
+class StorageStatisticsTest extends AbstractIntegrationTest {
+    final static String URL = "http://localhost:4567/store-data/maintenance/filesStatistics";
+
+    @Test
+    void responseStatusOK() throws IOException {
+        final HttpResponse response = get(URL);
+        assertThat(response.getCode(), equalTo(HttpStatus.SC_OK));
+    }
+
+	@Test
+	void contentTypeJSON_fix() throws IOException {
+		try (final CloseableHttpResponse response = get(URL)) {
+			final Header header = response.getFirstHeader("Content-Type");
+			assertNotNull(header);
+			final String mimeType = header.getValue().split(";")[0].trim();
+			assertEquals("application/json", mimeType);
+		}
+	}
+
+    @Test
+    void contentTypeJSON_explicit() throws IOException {
+        try (final CloseableHttpResponse response = get(URL + "?format=json")) {
+            final Header header = response.getFirstHeader("Content-Type");
+            assertNotNull(header);
+            final String mimeType = header.getValue().split(";")[0].trim();
+            assertEquals("application/json", mimeType);
+        }
+    }
+
+    @Test
+    void contentTypeFail() throws IOException, ParseException
+	{
+        try (final CloseableHttpResponse response = get(URL + "?format=NotExisting")) {
+            assertThat(response.getCode(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(EntityUtils.toString(response.getEntity()), containsString("invalid url parameter format"));
+        }
+    }
+
+    @Test
+    void deserializeAsObject() throws IOException, ParseException
+	{
+        final ViewerStorageFileStatistics statistics = getAs(URL, ViewerStorageFileStatistics.class);
+
+        assertTrue(0 < statistics.getFileCount());
+        assertTrue(0 < statistics.getLiveDataLength());
+        assertTrue(0 < statistics.getTotalDataLength());
+        assertNotNull(statistics.getCreationTime());
+
+        assertTrue(0 < statistics.getChannelStatistics().size());
+        assertEquals(0, statistics.getChannelStatistics().get(0).getChannelIndex());
+        assertTrue(0 < statistics.getChannelStatistics().get(0).getFileCount());
+
+        assertTrue(Files.exists(Paths.get(statistics.getChannelStatistics().get(0).getFiles().get(0).getFile())));
+        assertTrue(0 < statistics.getChannelStatistics().get(0).getFiles().get(0).getFileCount());
+        assertTrue(0 < statistics.getChannelStatistics().get(0).getFiles().get(0).getFileNumber());
+        assertTrue(0 < statistics.getChannelStatistics().get(0).getFiles().get(0).getLiveDataLength());
+        assertTrue(0 < statistics.getChannelStatistics().get(0).getFiles().get(0).getTotalDataLength());
+    }
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/TestGraph.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/TestGraph.java
@@ -1,0 +1,86 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.eclipse.serializer.collections.EqHashTable;
+
+
+public class TestGraph {
+    public String stringMember;
+    public String stringNullRef;
+    public String stringEmpty;
+    public BigDecimal bigDezEmpty;
+    public BigDecimal bigDezValue;
+    public BigDecimal bigDezValue2;
+    public HashMap<Long, String> hashMap;
+    public ArrayList<Integer> arrayList;
+
+    public int anInt = 42;
+    public Integer anIntegerConstant = 34;
+    public Integer anInteger = 1000;
+
+    public int[] intArray = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    public String[] stringArray = {"A", "String", "array", "with", "data"};
+
+    public EqHashTable<Integer, String> eqHashTable;
+
+    public Thread.State threadStateEnum = Thread.State.TERMINATED;
+    public char aChar = 'X';
+
+    public URL url;
+
+    public TestGraph()
+    {
+        this.stringMember = "This is a string";
+        this.stringNullRef = null;
+        this.stringEmpty = "";
+        this.bigDezValue = new BigDecimal("121314151617181920212223242526");
+        this.bigDezValue2 = new BigDecimal("111111111111111111111111.44444444444444444444");
+
+        this.hashMap = new HashMap<>(3);
+        this.hashMap.put(10101L, "hashmap entry 1");
+        this.hashMap.put(11111L, "hashmap entry 2");
+        this.hashMap.put(10001L, "hashmap entry 3");
+
+        this.arrayList = new ArrayList<>(5);
+        this.arrayList.add(1);
+        this.arrayList.add(2);
+        this.arrayList.add(3);
+        this.arrayList.add(4);
+        this.arrayList.add(5);
+
+        this.eqHashTable = EqHashTable.New();
+        this.eqHashTable.put(1, "text A");
+        this.eqHashTable.put(2, "text B");
+        this.eqHashTable.put(3, "text C");
+        this.eqHashTable.put(4, "text D");
+
+        try
+        {
+			this.url = new URL("http", "localhost", 2636, "/somerwhere");
+		}
+        catch (final MalformedURLException e)
+        {
+        	throw new RuntimeException(e.getMessage());
+		}
+
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/TypeDictionaryTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/TypeDictionaryTest.java
@@ -1,0 +1,83 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.serializer.collections.types.XGettingSequence;
+import org.eclipse.serializer.collections.types.XGettingTable;
+import org.eclipse.serializer.persistence.binary.types.BinaryFieldLengthResolver;
+import org.eclipse.serializer.persistence.types.*;
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
+import org.junit.jupiter.api.Test;
+
+class TypeDictionaryTest extends AbstractIntegrationTest
+{
+
+    static final String TypeDictionaryURL = "http://localhost:4567/store-data/dictionary";
+
+
+    @Test
+    void getTypeDictionary() throws IOException
+    {
+        AbstractIntegrationTest.checkStatusCodeForUrl(TypeDictionaryURL, HttpStatus.SC_OK);
+    }
+
+    @Test
+    void getAndParseTypeDictionary() throws IOException, ParseException
+	{
+        final String typeDictionaryString = getAsString(TypeDictionaryURL);
+
+        final ClassLoaderProvider classLoaderProvider = ClassLoaderProvider.System();
+        final PersistenceTypeResolver typeResolver = PersistenceTypeResolver.New(classLoaderProvider);
+        final PersistenceFieldLengthResolver fieldLengthResolver = new BinaryFieldLengthResolver.Default();
+        final PersistenceTypeDictionaryParser parser = PersistenceTypeDictionaryParser.New(typeResolver, fieldLengthResolver, PersistenceTypeNameMapper.New());
+        final XGettingSequence<? extends PersistenceTypeDictionaryEntry> parsedDictionaryEntries = parser.parseTypeDictionaryEntries(typeDictionaryString);
+
+        final Map<Long, PersistenceTypeDictionaryEntry> transferredTypeEntries = new HashMap<>();
+        for (PersistenceTypeDictionaryEntry parsedDictionaryEntry : parsedDictionaryEntries) {
+            transferredTypeEntries.put(parsedDictionaryEntry.typeId(), parsedDictionaryEntry);
+        }
+
+
+        final XGettingTable<Long, PersistenceTypeDefinition> org = storage.typeDictionary()
+                .allTypeDefinitions();
+
+        org.iterate(f -> {
+            final Long key = f.key();
+            final PersistenceTypeDefinition expected = f.value();
+
+            final PersistenceTypeDictionaryEntry actual = transferredTypeEntries.get(key);
+
+            final boolean descriptionEqual = PersistenceTypeDescription.equalDescription(actual, expected);
+            assertTrue(descriptionEqual, "TypeId: " + key + " descriptionEqual failed");
+
+            final boolean structureEqual = PersistenceTypeDescription.equalStructure(actual, expected);
+            assertTrue(structureEqual, "TypeId: " + key + " structureEqual failed");
+
+            final boolean typeIdEqual = actual.typeId() == expected.typeId();
+            assertTrue(typeIdEqual, "TypeId: " + key + " typeIdEqual failed");
+
+        });
+    }
+
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/UrlBuilder.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/UrlBuilder.java
@@ -1,0 +1,137 @@
+package test.eclipse.store.restservice.javalin;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+import java.util.Optional;
+import java.util.OptionalLong;
+
+public class UrlBuilder
+{
+	static final String urlBase				= "http://localhost:4567/store-data/object/";
+	static final String urlFixedOffset   	= "fixedOffset=";
+	static final String urlFixedLength   	= "fixedLength=";
+	static final String urlVariableOffset   = "variableOffset=";
+	static final String urlVariableLength   = "variableLength=";
+	static final String urlDataLength		= "valueLength=";
+	static final String urlFormat			= "format=";
+	static final String urlReferences		= "references=";
+	static final String urlReferenceOffset	= "referenceOffset=";
+	static final String urlReferenceLength	= "referenceLength=";
+
+	OptionalLong oid				= OptionalLong.empty();
+
+	OptionalLong fixedOffset		= OptionalLong.empty();
+	OptionalLong fixedLength		= OptionalLong.empty();
+
+	OptionalLong variableOffset		= OptionalLong.empty();
+	OptionalLong variableLength		= OptionalLong.empty();
+
+	OptionalLong dataLength			= OptionalLong.empty();
+	Optional<String> format			= Optional.empty();
+	Optional<Boolean> references	= Optional.empty();
+	OptionalLong referenceOffset	= OptionalLong.empty();
+	OptionalLong referenceLength	= OptionalLong.empty();
+	String url = UrlBuilder.urlBase;
+
+	private int appliedParameters = 0;
+
+	public UrlBuilder(final long oid)
+	{
+		this.setOid(oid);
+	}
+
+	public String build()
+	{
+		this.url = urlBase;
+		this.appliedParameters = 0;
+
+		this.oid.ifPresent( value -> this.url = this.url.concat(Long.toString(value)));
+		this.format.ifPresent( value -> this.appendStringParamter(urlFormat + value));
+
+		this.fixedOffset.ifPresent( value -> this.appendStringParamter(urlFixedOffset + Long.toString(value)));
+		this.fixedLength.ifPresent( value -> this.appendStringParamter(urlFixedLength + Long.toString(value)));
+
+		this.variableOffset.ifPresent( value -> this.appendStringParamter(urlVariableOffset + Long.toString(value)));
+		this.variableLength.ifPresent( value -> this.appendStringParamter(urlVariableLength + Long.toString(value)));
+
+		this.dataLength.ifPresent( value -> this.appendStringParamter(urlDataLength + Long.toString(value)));
+
+		this.references.ifPresent( value -> this.appendStringParamter(urlReferences + value.toString()));
+
+		return this.url;
+	}
+
+	public void appendStringParamter(final String paramter)
+	{
+		if(this.appliedParameters > 0)
+		{
+			this.url = this.url.concat("&");
+		}
+		else
+		{
+			this.url = this.url.concat("?");
+		}
+
+		this.url = this.url.concat(paramter);
+		this.appliedParameters++;
+	}
+
+	public UrlBuilder setOid(final long oid) {
+		this.oid = OptionalLong.of(oid);
+		return this;
+	}
+
+	public UrlBuilder setDataLength(final long dataLength) {
+		this.dataLength = OptionalLong.of(dataLength);
+		return this;
+	}
+
+	public UrlBuilder setFormat(final String format) {
+		this.format = Optional.of(format);
+		return this;
+	}
+
+	public UrlBuilder setFixedOffset(final long fixedOffset) {
+		this.fixedOffset = OptionalLong.of(fixedOffset);
+		return this;
+	}
+
+	public UrlBuilder setFixedLength(final long fixedLength) {
+		this.fixedLength = OptionalLong.of(fixedLength);
+		return this;
+	}
+
+	public UrlBuilder setVariableOffset(final long variableOffset) {
+		this.variableOffset = OptionalLong.of(variableOffset);
+		return this;
+	}
+
+	public UrlBuilder setVariableLength(final long variableLength) {
+		this.variableLength = OptionalLong.of(variableLength);
+		return this;
+	}
+
+	public UrlBuilder setReferences(final boolean references) {
+		this.references = Optional.of(references);
+		return this;
+	}
+
+	public UrlBuilder setUrl(final String url) {
+		this.url = url;
+		return this;
+	}
+
+
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/DataLengthDefaultTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/DataLengthDefaultTest.java
@@ -1,0 +1,56 @@
+package test.eclipse.store.restservice.javalin.getobject;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import test.eclipse.store.restservice.javalin.AbstractIntegrationTest;
+import test.eclipse.store.restservice.javalin.UrlBuilder;
+
+
+class DataLengthDefaultTest extends AbstractIntegrationTest {
+    @Test
+    void defaultDefaultValue() throws IOException, ParseException
+	{
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.testRequestNoParams(testData.stringMember);
+
+        assertEquals("This is a string", objectDescription.getData()[0]);
+    }
+
+    // Note: the SparkJava service exposed setDefaultDataLength() to change the server-side default
+    // value length; the Javalin service has no such setter (it is not configurable via system
+    // properties either), so the "defaultSet" scenario has no Javalin equivalent and is omitted.
+
+    @ParameterizedTest
+    @ValueSource(ints = {5, 13})
+    void requestValueLengthControlsDataLength(final int argument) throws IOException, ParseException
+	{
+        final Object testObject = testData.stringMember;
+        final long oid = storage.persistenceManager().lookupObjectId(testObject);
+        final String url = new UrlBuilder(oid).setDataLength(argument).build();
+
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.requestObjectByUrl(url);
+
+        assertEquals(argument, ((String) objectDescription.getData()[0]).length());
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/DataLengthTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/DataLengthTest.java
@@ -1,0 +1,117 @@
+package test.eclipse.store.restservice.javalin.getobject;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import test.eclipse.store.restservice.javalin.AbstractIntegrationTest;
+import test.eclipse.store.restservice.javalin.UrlBuilder;
+
+public class DataLengthTest extends AbstractIntegrationTest
+{
+    static int[] valueLengthTestArguments = {0, 1, 14, 15, 16};
+
+    static IntStream valueLength() {
+        return Arrays.stream(valueLengthTestArguments);
+    }
+
+    /*
+     * Test valueLength for simple string object
+     */
+    @ParameterizedTest
+    @MethodSource("valueLength")
+	public void testValueLength_String(final int argument) throws IOException, ParseException
+	{
+      final Object testObject = testData.stringMember;
+      final int dataLength = argument;
+
+      final long oid = lookupObjectId(testObject);
+      final String url = new UrlBuilder(oid).setDataLength(dataLength).build();
+      final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+      final String stringValue = testObject.toString();
+      final int expectedLength = Math.max(Math.min(stringValue.length(), dataLength), 0);
+      final int actualLength = ((String) objectDescription.getData()[0]).length();
+
+      assertEquals(expectedLength, actualLength);
+      final String expectedContent = stringValue.substring(0, Math.max(Math.min(dataLength, stringValue.length()), 0));
+
+      assertEquals(expectedContent, objectDescription.getData()[0]);
+	}
+
+    /*
+     * Test valueLength for simple string object as an included reference
+     */
+    @ParameterizedTest
+    @MethodSource("valueLength")
+	public void testValueLength_IncludeReferenceString(final int argument) throws IOException, ParseException
+	{
+      final Object testObject = testData;
+      final int dataLength = argument;
+
+      final long oid = lookupObjectId(testObject);
+      final String url = new UrlBuilder(oid).setDataLength(dataLength).setReferences(true).build();
+      final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+      final String stringValue = testData.stringMember;
+      final int expectedLength = Math.max(Math.min(stringValue.length(), dataLength), 0);
+      final int actualLength = ((String) objectDescription.getReferences()[0].getData()[0]).length();
+
+      assertEquals(expectedLength, actualLength);
+      final String expectedContent = stringValue.substring(0, Math.max(Math.min(dataLength, stringValue.length()), 0));
+
+      assertEquals(expectedContent, objectDescription.getReferences()[0].getData()[0]);
+	}
+
+    @ParameterizedTest
+    @CsvSource({
+    		" 0,	''",
+            " 1,	T",
+            "15, 	This is a strin",
+            "16, 	This is a string",
+            "17,	This is a string"
+    })
+    void testValueLength_Bounds(final int dataLength, final String result) throws IOException, ParseException
+	{
+        final Object testObject = testData.stringMember;
+        final long oid = lookupObjectId(testObject);
+        final String url = new UrlBuilder(oid).setDataLength(dataLength).build();
+        final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+        assertEquals(result, objectDescription.getData()[0]);
+    }
+
+    @Test
+    void testValueLength_MaxLong() throws IOException, ParseException
+	{
+        final Object testObject = testData.stringMember;
+        final long oid = lookupObjectId(testObject);
+        final String url = new UrlBuilder(oid).setDataLength(Long.MAX_VALUE).build();
+        final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+        assertEquals("This is a string", objectDescription.getData()[0]);
+    }
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/FixedAndVariableLengthTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/FixedAndVariableLengthTest.java
@@ -1,0 +1,113 @@
+package test.eclipse.store.restservice.javalin.getobject;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.junit.jupiter.api.Test;
+
+import test.eclipse.store.restservice.javalin.AbstractIntegrationTest;
+
+class FixedAndVariableLengthTest extends AbstractIntegrationTest {
+
+	@Test
+	void testGetStringObject() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.stringMember);
+
+		assertLength(1, objectDescription.getLength());
+		assertLength(0, objectDescription.getVariableLength()[0]);
+		assertEquals("This is a string", objectDescription.getData()[0]);
+	}
+
+
+	@Test
+	void testGetStringEmptyObject() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.stringEmpty);
+
+		assertLength(1, objectDescription.getLength());
+		assertEquals("", objectDescription.getData()[0]);
+	}
+
+	@Test
+	void testGetBigDezObject() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.bigDezValue);
+
+		assertLength(1, objectDescription.getLength());
+		assertLength(0, objectDescription.getVariableLength()[0]);
+		assertEquals(testData.bigDezValue, new BigDecimal((String) objectDescription.getData()[0]));
+	}
+
+	@Test
+	void testGetBigDez2Object() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.bigDezValue2);
+
+		assertLength(1, objectDescription.getLength());
+		assertLength(0, objectDescription.getVariableLength()[0]);
+		assertEquals(testData.bigDezValue2, new BigDecimal((String) objectDescription.getData()[0]));
+	}
+
+	@Test
+	void testGetHashMapObject() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.hashMap);
+
+		assertLength(0, objectDescription.getLength());
+		assertLength(3, objectDescription.getVariableLength()[0]);
+	}
+
+	@Test
+	void testGetArrayListObject() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.arrayList);
+
+		assertLength(0, objectDescription.getLength());
+		assertLength(5, objectDescription.getVariableLength()[0]);
+	}
+
+	@Test
+	void testGetIntArrayObject() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.intArray);
+
+		assertLength(10, objectDescription.getVariableLength()[0]);
+	}
+
+	@Test
+	void testGetIntConstant() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData.anIntegerConstant);
+
+		assertLength(1, objectDescription.getLength());
+	}
+
+	//@Test
+	void testGetRootClass() throws IOException, ParseException
+	{
+		final ViewerObjectDescription objectDescription = testRequestNoParams(testData);
+
+		final int fieldCount = testData.getClass().getDeclaredFields().length;
+		assertLength(fieldCount, objectDescription.getLength());
+	}
+}
+

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/FixedOffsetAndLengthTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/FixedOffsetAndLengthTest.java
@@ -1,0 +1,140 @@
+package test.eclipse.store.restservice.javalin.getobject;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.stream.IntStream;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.serializer.persistence.types.PersistenceTypeDefinition;
+import org.eclipse.serializer.persistence.types.PersistenceTypeDefinitionMember;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import test.eclipse.store.restservice.javalin.AbstractIntegrationTest;
+import test.eclipse.store.restservice.javalin.UrlBuilder;
+
+public class FixedOffsetAndLengthTest extends AbstractIntegrationTest {
+	static IntStream range_0_16() {
+		return IntStream.of(0,1,5,10,15,16);
+	}
+
+	/*
+	 * Test FixedOffset parameter
+	 */
+	@ParameterizedTest
+	@MethodSource("range_0_16")
+	void testFixedOffset_Object(final int argument) throws IllegalArgumentException, IllegalAccessException,
+			NoSuchFieldException, SecurityException, IOException, ParseException
+	{
+		this.testFixedOffset_Object(testData, argument);
+	}
+
+	@ParameterizedTest
+	@MethodSource("range_0_16")
+	void testFixedLength_Object(final int argument) throws IllegalArgumentException, IllegalAccessException,
+			NoSuchFieldException, SecurityException, IOException, ParseException
+	{
+		this.testFixedLength_Object(testData, argument);
+	}
+
+	private void testFixedLength_Object(final Object objectTested, final int fixedLength) throws IOException,
+			NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, ParseException
+	{
+		final long oid = lookupObjectId(objectTested);
+		final long tid = lookupTypeId(objectTested);
+
+		final String url = new UrlBuilder(oid).setFixedLength(fixedLength).build();
+		final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+		assertOid(oid, objectDescription.getObjectId());
+		assertTid(tid, objectDescription.getTypeId());
+
+		final PersistenceTypeDefinition ptd = storage.typeDictionary()
+				.lookupTypeById(Long.parseLong(objectDescription.getTypeId()));
+		final int numMembers = ptd.instanceMembers().intSize();
+
+		assertLength(numMembers, objectDescription.getLength());
+
+		final int expectedValueCount = Math.min(ptd.instanceMembers().intSize(),fixedLength);
+		assertEquals(expectedValueCount, objectDescription.getData().length);
+
+		final Object data[] = objectDescription.getData();
+		for (int i = 0; i < expectedValueCount; i++) {
+			final PersistenceTypeDefinitionMember m = ptd.instanceMembers().at(i);
+			final Object actual = data[i];
+
+			final String name = m.name();
+			final Field f = objectTested.getClass().getField(name);
+			final Object d = f.get(objectTested);
+
+			if (m.isReference()) {
+				if (d == null) {
+					assertEquals("0", actual);
+				} else {
+					final long id = lookupObjectId(d);
+					assertEquals(Long.toString(id), actual);
+				}
+			} else {
+				assertEquals(d.toString(), actual);
+			}
+		}
+
+	}
+
+	void testFixedOffset_Object(final Object objectTested, final long fixedOffset) throws IllegalArgumentException,
+			IllegalAccessException, NoSuchFieldException, SecurityException, IOException, ParseException
+	{
+		final long oid = lookupObjectId(objectTested);
+		final long tid = lookupTypeId(objectTested);
+
+		final String url = new UrlBuilder(oid).setFixedOffset(fixedOffset).build();
+		final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+		assertOid(oid, objectDescription.getObjectId());
+		assertTid(tid, objectDescription.getTypeId());
+
+		final PersistenceTypeDefinition ptd = storage.typeDictionary()
+				.lookupTypeById(Long.parseLong(objectDescription.getTypeId()));
+		final int numMembers = ptd.instanceMembers().intSize();
+
+		assertLength(numMembers, objectDescription.getLength());
+
+		final Object data[] = objectDescription.getData();
+		for (int i = (int) fixedOffset; i < numMembers; i++) {
+			final PersistenceTypeDefinitionMember m = ptd.instanceMembers().at(i);
+			final Object actual = data[i - (int) fixedOffset];
+
+			final String name = m.name();
+			final Field f = objectTested.getClass().getField(name);
+			final Object d = f.get(objectTested);
+
+			if (m.isReference()) {
+				if (d == null) {
+					assertEquals("0", actual);
+				} else {
+					final long id = lookupObjectId(d);
+					assertEquals(Long.toString(id), actual);
+				}
+			} else {
+				assertEquals(d.toString(), actual);
+			}
+		}
+	}
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/RootObjectTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/RootObjectTest.java
@@ -1,0 +1,44 @@
+package test.eclipse.store.restservice.javalin.getobject;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.junit.jupiter.api.Test;
+
+import test.eclipse.store.restservice.javalin.AbstractIntegrationTest;
+import test.eclipse.store.restservice.javalin.UrlBuilder;
+
+public class RootObjectTest extends AbstractIntegrationTest
+{
+	@Test
+	public void RootElementContentTest() throws IOException, ParseException
+	{
+		final long oid =1000000000000000001L;
+	    final String url = new UrlBuilder(oid).build();
+	    final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+	    assertEquals(0, Long.parseLong(objectDescription.getLength()));
+	    assertEquals(25, Long.parseLong(objectDescription.getVariableLength()[0]));
+	    assertEquals(25, Long.parseLong(objectDescription.getVariableLength()[1]));
+	    assertNull(objectDescription.getReferences());
+	}
+
+}

--- a/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/VariableOffsetAndLengthTest.java
+++ b/integration-tests/src/test/java/test/eclipse/store/restservice/javalin/getobject/VariableOffsetAndLengthTest.java
@@ -1,0 +1,205 @@
+package test.eclipse.store.restservice.javalin.getobject;
+
+/*-
+ * #%L
+ * EclipseStore Integration Tests
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.apache.hc.core5.http.ParseException;
+import org.eclipse.serializer.collections.EqHashTable;
+import org.eclipse.serializer.typing.KeyValue;
+import org.eclipse.store.storage.restadapter.types.ViewerObjectDescription;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import test.eclipse.store.restservice.javalin.AbstractIntegrationTest;
+import test.eclipse.store.restservice.javalin.UrlBuilder;
+
+public class VariableOffsetAndLengthTest extends AbstractIntegrationTest {
+    static Object[] input_noVariableLength = {testData, testData.threadStateEnum};
+
+    static Stream<Object> input_noVariableLength() {
+        return Arrays.stream(input_noVariableLength);
+    }
+
+    @ParameterizedTest
+    @MethodSource("input_noVariableLength")
+    public void noVariableLengthTest(final Object argument) throws IOException, ParseException
+	{
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.testRequestNoParams(argument);
+        assertNull(objectDescription.getVariableLength());
+    }
+
+    static Stream<Arguments> input_VariableLength() {
+        return Stream.of(
+                arguments(testData.stringEmpty, testData.stringEmpty.length()),
+                arguments(testData.hashMap, testData.hashMap.size()),
+                arguments(testData.arrayList, testData.arrayList.size()),
+                arguments(testData.stringArray, testData.stringArray.length),
+                arguments(testData.eqHashTable, testData.eqHashTable.intSize(),
+                        arguments(testData.intArray, testData.intArray.length))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("input_VariableLength")
+    public void variableLengthTest(final Object object, final int size) throws IOException, ParseException
+	{
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.testRequestNoParams(object);
+        assertNotNull(objectDescription.getVariableLength());
+        assertLength(size, objectDescription.getVariableLength()[0]);
+    }
+
+    @Test
+    public void variableLengthContent_StringArray_Test() throws IOException, ParseException
+	{
+        final int length = 1;
+        final String[] testObject = testData.stringArray;
+        final long oid = lookupObjectId(testObject);
+
+        final String url = new UrlBuilder(oid).setVariableLength(length).build();
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.requestObjectByUrl(url);
+
+        @SuppressWarnings("unchecked") final List<String> data = (List<String>) objectDescription.getData()[0];
+
+        assertEquals(lookupObjectId(testObject[0]), Long.parseLong(data.get(0)));
+    }
+
+    @Test
+    public void variableLengthOffsetContent_StringArray_Test() throws IOException, ParseException
+	{
+        final int length = 1;
+        final int offset = 1;
+
+        final String[] testObject = testData.stringArray;
+        final long oid = lookupObjectId(testObject);
+
+        final String url = new UrlBuilder(oid).setVariableLength(length).setVariableOffset(offset).build();
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.requestObjectByUrl(url);
+
+        @SuppressWarnings("unchecked") final List<String> data = (List<String>) objectDescription.getData()[0];
+
+        assertEquals(lookupObjectId(testObject[offset]), Long.parseLong(data.get(0)));
+    }
+
+    @Test
+    public void variableLengthContent_EqHashTable_Test() throws IOException, ParseException
+	{
+        final int length = 1;
+        final EqHashTable<Integer, String> testObject = testData.eqHashTable;
+        final long oid = lookupObjectId(testObject);
+
+        final String url = new UrlBuilder(oid).setVariableLength(length).build();
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.requestObjectByUrl(url);
+
+        @SuppressWarnings("unchecked") final List<List<String>> data = (List<List<String>>) objectDescription.getData()[Integer.parseInt(objectDescription.getLength())];
+
+        final String key = data.get(0).get(0);
+        final String value = data.get(0).get(1);
+
+        final KeyValue<Integer, String> x = testObject.at(0);
+
+        assertEquals(lookupObjectId(x.key()), Long.parseLong(key));
+        assertEquals(lookupObjectId(x.value()), Long.parseLong(value));
+    }
+
+    @Test
+    public void variableLengthOffsetContent_EqHashTable_Test() throws IOException, ParseException
+	{
+        final int length = 1;
+        final int offset = 1;
+
+        final EqHashTable<Integer, String> testObject = testData.eqHashTable;
+        final long oid = lookupObjectId(testObject);
+
+        final String url = new UrlBuilder(oid).setVariableLength(length).setVariableOffset(offset).build();
+        final ViewerObjectDescription objectDescription = AbstractIntegrationTest.requestObjectByUrl(url);
+
+        @SuppressWarnings("unchecked") final List<List<String>> data = (List<List<String>>) objectDescription.getData()[Integer.parseInt(objectDescription.getLength())];
+
+        final String key = data.get(0).get(0);
+        final String value = data.get(0).get(1);
+
+        final KeyValue<Integer, String> x = testObject.at(offset);
+
+        assertEquals(lookupObjectId(x.key()), Long.parseLong(key));
+        assertEquals(lookupObjectId(x.value()), Long.parseLong(value));
+    }
+
+
+    static IntStream range_0_16() {
+        return IntStream.of(0, 1, 5, 10, 15, 16);
+    }
+
+    @ParameterizedTest
+    @MethodSource("range_0_16")
+    void testVariableOffset_intArray(final int argument) throws IllegalArgumentException, SecurityException, IOException, ParseException
+	{
+        this.testVariableOffset_Array(testData.intArray, argument);
+    }
+
+    @ParameterizedTest
+    @MethodSource("range_0_16")
+    void testVariableLength_intArray(final int argument) throws IllegalArgumentException, SecurityException, IOException, ParseException
+	{
+        this.testVariableLength_Array(testData.intArray, argument);
+    }
+
+    private void testVariableOffset_Array(final int[] objectTested, final int VariableOffset) throws IOException, ParseException
+	{
+        final long oid = lookupObjectId(objectTested);
+        final String url = new UrlBuilder(oid).setVariableOffset(VariableOffset).build();
+        final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+        for (int i = VariableOffset; i < objectTested.length; i++) {
+            final int actual = objectTested[i];
+            @SuppressWarnings("unchecked") final ArrayList<String> data = (ArrayList<String>) objectDescription.getData()[0];
+            final int expected = Integer.parseInt(data.get(i - VariableOffset));
+            assertEquals(expected, actual);
+        }
+    }
+
+    private void testVariableLength_Array(final int[] objectTested, final int VariableLength) throws IOException, ParseException
+	{
+        final long oid = lookupObjectId(objectTested);
+        final String url = new UrlBuilder(oid).setVariableLength(VariableLength).build();
+        final ViewerObjectDescription objectDescription = requestObjectByUrl(url);
+
+        @SuppressWarnings("unchecked") final ArrayList<String> data = (ArrayList<String>) objectDescription.getData()[0];
+
+        for (int i = 0; i < objectTested.length; i++) {
+            if (i < VariableLength) {
+                final int actual = objectTested[i];
+                final int expected = Integer.parseInt(data.get(i));
+                assertEquals(expected, actual);
+            } else {
+                final int x = i;
+                assertThrows(IndexOutOfBoundsException.class, () -> {
+                    @SuppressWarnings("unused") final String notFound = data.get(x);
+                });
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request significantly expands the integration test coverage for the Javalin-based REST service in EclipseStore. It introduces a suite of new integration tests that verify server startup, configuration, error handling, live documentation endpoints, object modification, and service resolution. To support these tests, several new test dependencies are added to the Maven configuration.

**Test Infrastructure and Utilities:**

- Added `AbstractIntegrationTest.java` providing shared setup, teardown, and utility methods for REST integration tests, including HTTP request helpers and assertion utilities.

**Integration Test Coverage:**

- **Server Startup & Configuration:**
  - Added `EmbeddedStorageViewerStartTest.java` to verify REST service startup with default and custom storage names, using system properties for configuration.
  - Added `CustomServerTest.java` to test starting the REST service on a custom port and instance name, and to ensure clean shutdown.

- **REST API Functionality:**
  - Added `RootTest.java` to verify the `/root` endpoint returns correct root object information.
  - Added `IntegrationTest_ModifyAndLoadTest.java` to check that object modifications are persisted and reloaded correctly via the REST API.
  - Added `IntegrationTest_LiveDocumentationTest.java` to validate that the service exposes live route documentation at the expected endpoint.
  - Added `ExceptionsTest.java` to test REST API error handling for invalid parameters and requests.
  - Added `RestServiceResolverTest.java` to confirm resolution of the REST service instance from storage.

**Build and Dependency Updates:**

- **Maven (`pom.xml`):**
  - Added test dependencies for Javalin REST service, Apache HttpClient 5, Gson, and Hamcrest to support the new integration tests. [[1]](diffhunk://#diff-3b7c131fb9becff591ff3eb25a6b91b29420703e244fadc2096277504d3a2ae1R76-R81) [[2]](diffhunk://#diff-3b7c131fb9becff591ff3eb25a6b91b29420703e244fadc2096277504d3a2ae1R159-R178)