### PR TITLE
GigaMap/jvector: persisting an empty vector index is a no-op instead of an NPE

### DIFF
--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/DiskIndexManager.java
@@ -142,6 +142,20 @@ interface DiskIndexManager extends Closeable
     ) throws IOException;
 
     /**
+     * Removes the persisted {@code .graph} and {@code .meta} files, if present.
+     * <p>
+     * Used when the index holds no vectors any more and therefore has nothing to persist: the
+     * files left over from an earlier, non-empty state describe content that no longer exists.
+     * Correctness does not depend on this removal - {@link #tryLoad(MetaState)} rejects a stale
+     * pair through its witness comparison - it only keeps dead files from occupying disk space.
+     * <p>
+     * Never throws: a failed deletion is logged and leaves a harmless stale file behind, which the
+     * next successful write replaces. This is called from the persist path, including on shutdown,
+     * where a cleanup failure must not mask or replace the outcome of the persist itself.
+     */
+    public void deleteIndexFiles();
+
+    /**
      * Closes disk-related resources.
      */
     public void close();
@@ -421,27 +435,54 @@ interface DiskIndexManager extends Closeable
                 // Remove any temp file left behind by a failed or interrupted write. Swallow cleanup
                 // errors so they cannot mask an in-flight write/move exception (which carries the real
                 // root cause); a leftover temp file is harmless and overwritten on the next persist.
-                this.deleteTempQuietly(graphTempPath);
-                this.deleteTempQuietly(metaTempPath);
+                this.deleteQuietly(graphTempPath);
+                this.deleteQuietly(metaTempPath);
             }
 
             LOG.info("Persisted index '{}' to disk with {} vectors", this.name, index.size(0));
         }
 
+        @Override
+        public void deleteIndexFiles()
+        {
+            if(this.indexDirectory == null)
+            {
+                return;
+            }
+
+            // Release the reader before unlinking: on Windows an open mapping makes the delete fail.
+            // A no-op unless a disk index is currently loaded.
+            this.close();
+
+            final boolean graphDeleted = this.deleteQuietly(this.indexDirectory.resolve(this.name + GRAPH_FILE_EXT));
+            final boolean metaDeleted  = this.deleteQuietly(this.indexDirectory.resolve(this.name + META_FILE_EXT ));
+
+            // Stays silent for the common case of an index that never wrote anything, so that an
+            // empty index does not log on every persist.
+            if(graphDeleted || metaDeleted)
+            {
+                LOG.info("Removed on-disk index '{}': it holds no vectors any more", this.name);
+            }
+        }
+
         /**
-         * Deletes a temp file if present, logging (never throwing) on failure. Used from the cleanup
+         * Deletes a file if present, logging (never throwing) on failure. Used from the cleanup
          * {@code finally} of {@link #writeIndex}, where a thrown cleanup error would mask the real
-         * write/move failure.
+         * write/move failure, and from {@link #deleteIndexFiles()}.
+         *
+         * @param path the file to delete
+         * @return {@code true} if the file existed and was deleted
          */
-        private void deleteTempQuietly(final Path tempPath)
+        private boolean deleteQuietly(final Path path)
         {
             try
             {
-                Files.deleteIfExists(tempPath);
+                return Files.deleteIfExists(path);
             }
             catch(final IOException e)
             {
-                LOG.warn("Failed to delete temp file '{}' after persist: {}", tempPath, e.getMessage());
+                LOG.warn("Failed to delete file '{}': {}", path, e.getMessage());
+                return false;
             }
         }
 

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -544,6 +544,9 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
      * compressed vectors are embedded in the graph file.
      * <p>
      * For in-memory indices ({@link #isOnDisk()} returns false), this method is a no-op.
+     * <p>
+     * An index that holds no vectors has nothing to write: any files from an earlier, non-empty
+     * state are removed instead, so the next load rebuilds from the stored vectors.
      *
      * <h4>Files Created</h4>
      * <ul>
@@ -935,8 +938,7 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          */
         void initializeAfterLoad()
         {
-            final boolean diskLoaded = this.diskManager != null && this.diskManager.isLoaded();
-            if(this.builder == null && !diskLoaded)
+            if(!this.isIndexPresent())
             {
                 this.initializeIndex();
             }
@@ -949,13 +951,26 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          */
         void ensureIndexInitialized()
         {
-            final boolean diskLoaded = this.diskManager != null && this.diskManager.isLoaded();
-            if(this.builder == null && !diskLoaded)
+            if(!this.isIndexPresent())
             {
                 this.initializeIndex();
             }
 
             this.ensureGraphRebuilt();
+        }
+
+        /**
+         * Returns whether the transient index state exists, i.e. whether there is either an
+         * in-memory builder or a loaded disk index. {@code false} before the first
+         * {@link #initializeIndex()} and after {@link #closeInternalResources()} has torn the
+         * state down again.
+         *
+         * @return {@code true} if an in-memory builder or a loaded disk index is present
+         */
+        private boolean isIndexPresent()
+        {
+            final boolean diskLoaded = this.diskManager != null && this.diskManager.isLoaded();
+            return this.builder != null || diskLoaded;
         }
 
         /**
@@ -2542,8 +2557,10 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          * @param onShutdown {@code true} when invoked on the shutdown path. In incremental mode a
          *                   shutdown persist skips the O(n) full-graph consolidation entirely and
          *                   relies on the load-time self-heal, so shutdown is never blocked by a
-         *                   rebuild that would be discarded anyway. {@code false} for
-         *                   background/explicit persistence, which consolidates as before.
+         *                   rebuild that would be discarded anyway. It also never (re-)creates the
+         *                   transient index state, which would restart the background task manager
+         *                   mid-{@code close()}. {@code false} for background/explicit persistence,
+         *                   which consolidates and initializes as before.
          */
         @Override
         public void doPersistToDisk(final boolean onShutdown)
@@ -2583,6 +2600,20 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                     // New mutations see cleanupInProgress=true and defer.
                     synchronized(this.parentMap())
                     {
+                        if(onShutdown && !this.isIndexPresent())
+                        {
+                            // Nothing to persist, and nothing to (re-)create here. On the shutdown
+                            // path ensureIndexInitialized() must not run initializeIndex(): that
+                            // ends in startBackgroundManagersIfEnabled(), so an index already torn
+                            // down by closeInternalResources() would get a fresh background task
+                            // manager after its predecessor was shut down, and the caller does
+                            // not re-check the field, so that executor thread would outlive
+                            // close(). An index without builder and without a loaded disk index
+                            // holds nothing the store does not already have.
+                            LOG.debug("No index present for '{}' on shutdown, skipping persist", this.name);
+                            return;
+                        }
+
                         this.ensureIndexInitialized();
 
                         // If in incremental mode, exit it first by rebuilding the full graph.
@@ -2622,6 +2653,23 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                                 this.configuration.maxDegree(),
                                 this.configuration.parallelOnDiskWrite()
                             );
+                        }
+
+                        // An empty graph cannot be written: jvector's header writer dereferences
+                        // view.entryNode(), which is null while the graph holds no node, so the
+                        // write would fail with a NullPointerException.
+                        //
+                        // Reaching this point means the store itself holds no vectors: either none
+                        // were ever added, or the incremental exit above consolidated a graph
+                        // that is now empty: exitIncrementalMode() rebuilds from the store, the
+                        // source of truth. Any files written earlier therefore describe content
+                        // that no longer exists and are removed rather than left behind.
+                        if(this.index.size(0) == 0)
+                        {
+                            LOG.debug("Index '{}' holds no vectors, removing any on-disk index "
+                                + "instead of persisting", this.name);
+                            this.diskManager.deleteIndexFiles();
+                            return;
                         }
 
                         // Capture references for use outside the synchronized block.
@@ -2923,6 +2971,19 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                 catch(final Exception e)
                 {
                     LOG.error("Shutdown persistence failed for '{}': {}", this.name, e.getMessage(), e);
+                }
+
+                // Belt and braces: the persist above no longer initializes the index, so nothing
+                // should have created a manager behind this method's null check. Should a future
+                // change reintroduce that, shut the manager down here rather than let its executor
+                // thread outlive close().
+                if(this.backgroundTaskManager != null)
+                {
+                    LOG.warn("Background task manager for '{}' was recreated during shutdown "
+                        + "persistence, shutting it down again", this.name);
+                    this.backgroundTaskManager.discardQueue();
+                    this.backgroundTaskManager.shutdown(false, false, false);
+                    this.backgroundTaskManager = null;
                 }
             }
         }

--- a/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
+++ b/gigamap/jvector/src/main/java/org/eclipse/store/gigamap/jvector/VectorIndex.java
@@ -546,7 +546,9 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
      * For in-memory indices ({@link #isOnDisk()} returns false), this method is a no-op.
      * <p>
      * An index that holds no vectors has nothing to write: any files from an earlier, non-empty
-     * state are removed instead, so the next load rebuilds from the stored vectors.
+     * state are removed instead, so the next load rebuilds from the stored vectors. This applies to
+     * this explicit persist and to background persistence. A persist on the shutdown path may
+     * instead leave those files in place, see {@link #close()}.
      *
      * <h4>Files Created</h4>
      * <ul>
@@ -2557,10 +2559,15 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
          * @param onShutdown {@code true} when invoked on the shutdown path. In incremental mode a
          *                   shutdown persist skips the O(n) full-graph consolidation entirely and
          *                   relies on the load-time self-heal, so shutdown is never blocked by a
-         *                   rebuild that would be discarded anyway. It also never (re-)creates the
-         *                   transient index state, which would restart the background task manager
-         *                   mid-{@code close()}. {@code false} for background/explicit persistence,
-         *                   which consolidates and initializes as before.
+         *                   rebuild that would be discarded anyway. Because that return happens
+         *                   before the empty-graph handling below, a shutdown persist in incremental
+         *                   mode also leaves an earlier, now stale on-disk index in place instead of
+         *                   removing it - harmless, since the same self-heal rejects it on load and
+         *                   the next non-shutdown persist replaces or removes it. A shutdown persist
+         *                   also never (re-)creates the transient index state, which would restart
+         *                   the background task manager mid-{@code close()}. {@code false} for
+         *                   background/explicit persistence, which consolidates and initializes as
+         *                   before.
          */
         @Override
         public void doPersistToDisk(final boolean onShutdown)
@@ -2629,6 +2636,11 @@ public interface VectorIndex<E> extends GigaIndex<E>, Closeable
                                 // source of truth — on the next boot. No vectors are lost, and
                                 // shutdown is not blocked by a rebuild that would be discarded
                                 // anyway. Full consolidation stays a background/explicit operation.
+                                //
+                                // This returns before the empty-graph handling below, so an index
+                                // emptied while in incremental mode keeps its now stale files until
+                                // the next non-shutdown persist. That is the same trade as skipping
+                                // the consolidation: the self-heal rejects them on load.
                                 LOG.info("Skipping full-graph consolidation for '{}' on shutdown; "
                                     + "on-disk index self-heals from store on next load", this.name);
                                 return;

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexEmptyPersistTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexEmptyPersistTest.java
@@ -1,0 +1,200 @@
+package org.eclipse.store.gigamap.jvector;
+
+/*-
+ * #%L
+ * EclipseStore GigaMap JVector
+ * %%
+ * Copyright (C) 2023 - 2026 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * #L%
+ */
+
+import org.eclipse.store.gigamap.types.GigaMap;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Persisting an index that holds no vectors must be a no-op instead of a failure: jvector's header
+ * writer dereferences {@code view.entryNode()}, which is null for a graph with zero nodes, so a
+ * write attempt used to fail with a NullPointerException: thrown to the caller of
+ * {@code persistToDisk()}, and logged as an ERROR on every shutdown of such an index.
+ */
+class VectorIndexEmptyPersistTest
+{
+    private static final String INDEX_NAME = "embedding";
+    private static final int    DIMENSION  = 8;
+
+    record Document(String content, float[] embedding) {}
+
+    static class DocumentVectorizer extends Vectorizer<Document>
+    {
+        @Override
+        public float[] vectorize(final Document entity)
+        {
+            return entity.embedding();
+        }
+    }
+
+    private static VectorIndexConfiguration configuration(
+        final Path indexDirectory        ,
+        final long optimizationIntervalMs
+    )
+    {
+        return VectorIndexConfiguration.builder()
+            .dimension(DIMENSION)
+            .similarityFunction(VectorSimilarityFunction.COSINE)
+            .onDisk(true)
+            .indexDirectory(indexDirectory)
+            .optimizationIntervalMs(optimizationIntervalMs)
+            .build();
+    }
+
+    private static VectorIndex<Document> registerIndex(
+        final GigaMap<Document> gigaMap       ,
+        final Path              indexDirectory,
+        final long              optimizationIntervalMs
+    )
+    {
+        return gigaMap.index()
+            .register(VectorIndices.Category())
+            .add(INDEX_NAME, configuration(indexDirectory, optimizationIntervalMs), new DocumentVectorizer());
+    }
+
+    private static Document document(final int seed)
+    {
+        final float[] embedding = new float[DIMENSION];
+        for(int i = 0; i < DIMENSION; i++)
+        {
+            embedding[i] = (i == seed % DIMENSION) ? 1.0f : 0.0f;
+        }
+        return new Document("doc_" + seed, embedding);
+    }
+
+    private static boolean indexFilesExist(final Path indexDirectory)
+    {
+        return Files.exists(indexDirectory.resolve(INDEX_NAME + DiskIndexManager.GRAPH_FILE_EXT))
+            || Files.exists(indexDirectory.resolve(INDEX_NAME + DiskIndexManager.META_FILE_EXT ));
+    }
+
+    private static List<String> backgroundThreadNames()
+    {
+        return Thread.getAllStackTraces().keySet().stream()
+            .map(Thread::getName)
+            .filter(name -> name.startsWith("VectorIndex-Background-" + INDEX_NAME))
+            .sorted()
+            .toList();
+    }
+
+    @Test
+    void persistToDisk_neverPopulatedIndex_writesNoFiles(@TempDir final Path tempDir)
+    {
+        final Path indexDirectory = tempDir.resolve("index");
+
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir.resolve("storage")))
+        {
+            final GigaMap<Document> gigaMap = GigaMap.New();
+            storage.setRoot(gigaMap);
+
+            final VectorIndex<Document> index = registerIndex(gigaMap, indexDirectory, 0);
+            assertEquals(0, gigaMap.size());
+
+            index.persistToDisk();
+
+            assertFalse(indexFilesExist(indexDirectory), "an empty index must not write index files");
+        }
+    }
+
+    @Test
+    void close_neverPopulatedIndex_persistsOnShutdownWithoutFailing(@TempDir final Path tempDir)
+    {
+        final Path indexDirectory = tempDir.resolve("index");
+        final Path storageDirectory = tempDir.resolve("storage");
+
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDirectory))
+        {
+            final GigaMap<Document> gigaMap = GigaMap.New();
+            storage.setRoot(gigaMap);
+            registerIndex(gigaMap, indexDirectory, 0);
+            storage.storeRoot();
+        }
+
+        assertFalse(indexFilesExist(indexDirectory), "an empty index must not write index files on shutdown");
+
+        // The index is still usable after the restart that follows such a shutdown.
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(storageDirectory))
+        {
+            final GigaMap<Document> gigaMap = storage.root();
+            gigaMap.add(document(1));
+
+            final VectorIndex<Document> index = gigaMap.index().get(VectorIndices.Category()).get(INDEX_NAME);
+            assertFalse(index.search(document(1).embedding(), 10).isEmpty());
+        }
+    }
+
+    @Test
+    void persistToDisk_afterAllEntriesRemoved_removesStaleIndexFiles(@TempDir final Path tempDir)
+    {
+        final Path indexDirectory = tempDir.resolve("index");
+
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir.resolve("storage")))
+        {
+            final GigaMap<Document> gigaMap = GigaMap.New();
+            storage.setRoot(gigaMap);
+
+            final VectorIndex<Document> index = registerIndex(gigaMap, indexDirectory, 0);
+            for(int i = 0; i < 10; i++)
+            {
+                gigaMap.add(document(i));
+            }
+            storage.storeRoot();
+
+            index.persistToDisk();
+            assertTrue(indexFilesExist(indexDirectory), "a populated index must write index files");
+
+            gigaMap.removeAll();
+            storage.storeRoot();
+
+            index.persistToDisk();
+
+            assertFalse(
+                indexFilesExist(indexDirectory),
+                "files describing removed content must not survive the persist"
+            );
+        }
+    }
+
+    @Test
+    void close_calledTwice_leavesNoBackgroundThreadBehind(@TempDir final Path tempDir)
+    {
+        try(final EmbeddedStorageManager storage = EmbeddedStorage.start(tempDir.resolve("storage")))
+        {
+            final GigaMap<Document> gigaMap = GigaMap.New();
+            storage.setRoot(gigaMap);
+
+            // A configured optimization interval is what makes the resurrected manager observable
+            // as a live thread; the re-initialization itself happens regardless of the interval.
+            final VectorIndex<Document> index = registerIndex(gigaMap, tempDir.resolve("index"), 60_000);
+
+            index.close();
+            assertEquals(List.of(), backgroundThreadNames(), "close() must stop the background thread");
+
+            index.close();
+            assertEquals(List.of(), backgroundThreadNames(), "close() must not restart the background thread");
+        }
+    }
+}

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexEmptyPersistTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexEmptyPersistTest.java
@@ -93,9 +93,12 @@ class VectorIndexEmptyPersistTest
 
     private static List<String> backgroundThreadNames()
     {
+        // BackgroundTaskManager names its executor thread "VectorIndex-Background-" + index name.
+        final String threadName = "VectorIndex-Background-" + INDEX_NAME;
+
         return Thread.getAllStackTraces().keySet().stream()
             .map(Thread::getName)
-            .filter(name -> name.startsWith("VectorIndex-Background-" + INDEX_NAME))
+            .filter(threadName::equals)
             .sorted()
             .toList();
     }

--- a/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexEmptyPersistTest.java
+++ b/gigamap/jvector/src/test/java/org/eclipse/store/gigamap/jvector/VectorIndexEmptyPersistTest.java
@@ -136,6 +136,15 @@ class VectorIndexEmptyPersistTest
             storage.storeRoot();
         }
 
+        // writeIndex() opens with Files.createDirectories(indexDirectory), and nothing else on the
+        // persist path creates it, so an untouched directory is the proof that the shutdown persist
+        // did not even attempt the write. Asserting on the files alone would not catch the defect:
+        // the write failed inside jvector after writing to temp paths only, and the shutdown path
+        // swallows the exception into a log this module has no SLF4J binding to capture.
+        assertFalse(
+            Files.exists(indexDirectory),
+            "an empty index must not attempt a write on shutdown"
+        );
         assertFalse(indexFilesExist(indexDirectory), "an empty index must not write index files on shutdown");
 
         // The index is still usable after the restart that follows such a shutdown.


### PR DESCRIPTION
## Problem

Persisting an on-disk `VectorIndex` that holds no vectors fails with a `NullPointerException` from jvector:

```
java.lang.NullPointerException: Cannot read field "node" because the return value of
"io.github.jbellis.jvector.graph.ImmutableGraphIndex$View.entryNode()" is null
	at io.github.jbellis.jvector.graph.disk.AbstractGraphIndexWriter.writeHeader(AbstractGraphIndexWriter.java:201)
	at io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex.write(OnDiskGraphIndex.java:722)
	at org.eclipse.store.gigamap.jvector.DiskIndexManager$Default.writeIndex(DiskIndexManager.java:405)
	at org.eclipse.store.gigamap.jvector.VectorIndex$Default.doPersistToDisk(VectorIndex.java:2664)
```

`OnHeapGraphIndex.View.entryNode()` returns `null` until the first node is added, and jvector's header writer dereferences it unconditionally. `doPersistToDisk` guarded against a null builder and a null index, but not against an empty one, so the empty graph was handed straight to the writer.

Two ways to hit it, both on the default on-disk configuration (`onDisk(true)` plus `persistOnShutdown`, which defaults to `true`):

- A vector index that was registered but never received a vector - `persistToDisk()` throws to the caller, and every `close()` logs `Shutdown persistence failed for '<name>'` with a stack trace. No index file is ever written, so the next boot logs `Could not load disk index` and repeats.
- A populated index whose entries were all removed - the incremental exit rebuilds an empty graph from the store, and the write fails the same way.

While tracking this down, a second defect surfaced on the same path. `doPersistToDisk` opened with `ensureIndexInitialized()`, which re-runs the full `initializeIndex()` whenever the index has already been torn down by `closeInternalResources()`. That method ends in `startBackgroundManagersIfEnabled()`, and `shutdownBackgroundTaskManager` does not re-check the field afterwards, so a fresh background executor was created during `close()` and outlived it. The liveness watchdog does not reclaim it either: it self-terminates only once the index has been garbage collected, and a closed index is still referenced by the `GigaMap`.

## Changes

**An empty graph skips the disk write** (`VectorIndex.doPersistToDisk`). Reaching that point means the store itself holds no vectors - either none were ever added, or `exitIncrementalMode()` just rebuilt from the store, the source of truth, and the result is empty. Files from an earlier non-empty state therefore describe content that no longer exists, so they are removed through the new `DiskIndexManager.deleteIndexFiles()` rather than left behind. Correctness never depended on that removal, since `tryLoad` rejects a stale pair through its witness comparison, but it stops dead files from occupying disk space. The removal closes the reader first, because Windows will not unlink an open mapping, and logs only when it actually deleted something, so an empty index stays quiet.

**The shutdown path no longer initializes the index.** `doPersistToDisk(true)` returns early when there is neither a builder nor a loaded disk index, instead of re-creating the transient state and with it the background task manager. The `builder == null && !diskLoaded` test existed in three places and is now `isIndexPresent()`.

**`shutdownBackgroundTaskManager` re-checks the field** after its inline persist and shuts down a manager that reappeared. Nothing can create one there any more, so this is a second line of defence that keeps `close()` idempotent if a future change reintroduces the initialization.

## Tests

`VectorIndexEmptyPersistTest`, untagged so it runs in the default build:

| Test | Guards |
|---|---|
| `persistToDisk_neverPopulatedIndex_writesNoFiles` | the reported NPE, on the explicit persist |
| `close_neverPopulatedIndex_persistsOnShutdownWithoutFailing` | the same on shutdown, plus a usable index after the restart that follows |
| `persistToDisk_afterAllEntriesRemoved_removesStaleIndexFiles` | the removal path, and that files describing removed content do not survive |
| `close_calledTwice_leavesNoBackgroundThreadBehind` | no `VectorIndex-Background-*` thread outlives `close()` |

Verified against the unfixed code: three of the four fail there - two with the NPE above, one with `expected: <[]> but was: <[VectorIndex-Background-embedding]>`. The fourth passes either way, because the shutdown NPE is swallowed into a log the test module has no SLF4J binding to capture; it covers the reported scenario end to end instead.

`gigamap/jvector` is green both ways: 243 tests in the default profile (the 9 skipped are the pre-existing benchmark and performance classes) and 125 under `-Pslow-tests`.
